### PR TITLE
Add support for specifing RTOS for build

### DIFF
--- a/CMake/Modules/Hack_SetGitSearchPath.cmake
+++ b/CMake/Modules/Hack_SetGitSearchPath.cmake
@@ -1,0 +1,18 @@
+# this hack is required to make the search for Git path to work in Windows platforms
+# it can safelly be removed after:
+# https://gitlab.kitware.com/cmake/cmake/merge_requests/332 is MERGED
+# and makes it to a release version of CMake, then we need to have that version as minimum required
+# 
+
+if(CMAKE_HOST_WIN32)
+  if(NOT CMAKE_GENERATOR MATCHES "MSYS")
+    set(git_names git.cmd git eg.cmd eg)
+    # GitHub search path for Windows
+    file(GLOB github_path
+      "$ENV{LOCALAPPDATA}/Github/PortableGit*/cmd"
+      "$ENV{LOCALAPPDATA}/Github/PortableGit*/bin"
+      )
+    # SourceTree search path for Windows
+    set(_git_sourcetree_path "$ENV{LOCALAPPDATA}/Atlassian/SourceTree/git_local/bin" CACHE STRING "caching Git source tree path for latter use in FindGit" FORCE)
+  endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 include(CMakeToolsHelpers OPTIONAL)
+include(ExternalProject)
 
 # the following prevents launchin a build in the source tree
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
@@ -88,6 +89,104 @@ if(CHIP_VENDOR_STM32_CHECK)
 #
 #     # vendor is ?? and toolchain is GCC
 #     add_subdirectory("???")
+endif()
+
+#######################
+# handle RTOSes stuff
+
+string(COMPARE EQUAL "FREERTOS" "${RTOS}" RTOS_FREERTOS_CHECK)
+string(COMPARE EQUAL "MBEDRTOS" "${RTOS}" RTOS_MBED_RTOS_CHECK)
+
+#######################
+# FreeRTOS
+if(RTOS_FREERTOS_CHECK)
+
+    # check for SVN (needed here for advanced warning to user if it's not installed)
+    find_package(Subversion)
+
+    #  check is SVN was found, if not report to user and abort
+    if(NOT Subversion_SVN_EXECUTABLE)
+      message(FATAL_ERROR "error: could not find SVN, make sure you have it installed.")
+    endif()
+
+    # check if build was requested with a specifc FreeRTOS version
+    if(DEFINED FREERTOS_VERSION)
+
+        if("${FREERTOS_VERSION}" STREQUAL "")
+            set(FREERTOS_VERSION_EMPTY TRUE)
+        endif()
+
+        if(FREERTOS_VERSION_EMPTY)
+            # no FreeRTOS version actualy specified, must be empty which is fine, we'll grab the code from the trunk
+            message(STATUS "RTOS is: FreeRTOS (latest available code from trunk)")
+            set(FREERTOS_SVN_REPOSITORY "https://svn.code.sf.net/p/freertos/code/trunk")
+        else()
+            message(STATUS "RTOS is: FreeRTOS v${FREERTOS_VERSION}")
+            set(FREERTOS_SVN_REPOSITORY "https://svn.code.sf.net/p/freertos/code/tags/V${FREERTOS_VERSION}")
+        endif()
+        
+    endif()
+
+    # download FreeRTOS source from official SVN repo
+    ExternalProject_Add( 
+        FreeRTOS
+        PREFIX FreeRTOS
+        SOURCE_DIR ${CMAKE_BINARY_DIR}/FreeRTOS-Source
+        SVN_REPOSITORY ${FREERTOS_SVN_REPOSITORY}/FreeRTOS/Source
+        TIMEOUT 10
+        LOG_DOWNLOAD 1
+        # Disable all other steps
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+    )
+
+    # get source dir for FreeRTOS CMake project
+    ExternalProject_Get_Property(FreeRTOS SOURCE_DIR)
+    set(FREERTOS_INCLUDE_DIRS ${FREERTOS_SOURCE_DIR})
+
+#######################
+# mBed RTOS
+elseif(RTOS_MBED_RTOS_CHECK)
+
+    # hack to make the FindGit to work in Windows platforms (check the module comment for details)
+    include(Hack_SetGitSearchPath)
+
+    # check for Git (needed here for advanced warning to user if it's not installed)
+    find_package(Git)
+
+    #  check if Git was found, if not report to user and abort
+    if(NOT GIT_EXECUTABLE)
+      message(FATAL_ERROR "error: could not find Git, make sure you have it installed.")
+    endif()
+
+    # download FreeRTOS source from official SVN repo
+    ExternalProject_Add( 
+        mBedRTOS
+        PREFIX mBed-RTOS
+        SOURCE_DIR ${CMAKE_BINARY_DIR}/mBed-RTOS-Source
+        GIT_REPOSITORY  https://github.com/ARMmbed/mbed-os/
+        GIT_TAG master  # target master branch
+        GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
+        TIMEOUT 10
+        LOG_DOWNLOAD 1
+        
+        # Disable all other steps
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+    )
+
+    # get source dir for mBed RTOS CMake project
+    ExternalProject_Get_Property(mBedRTOS SOURCE_DIR)
+    set(MBEDRTOS_INCLUDE_DIRS ${MBEDRTOS_SOURCE_DIR})
+
+#######################
+# no RTOS specifed
+else()
+
+    message(STATUS "NO RTOS was specified")
+
 endif()
 
 # add source directory

--- a/cmake-variants.json
+++ b/cmake-variants.json
@@ -30,7 +30,9 @@
         "settings": {
             "TOOLCHAIN_PREFIX" : "E:/GNU_Tools_ARM_Embedded/5_4_2016q3",
             "TARGET_CHIP" : "STM32F091RC",
-            "PACKAGE_VERSION" : "1.6.0"
+            "PACKAGE_VERSION" : "1.6.0",
+            "RTOS" : "", 
+            "FREERTOS_VERSION" : ""
         },
         "buildType": "Debug"
       },
@@ -40,7 +42,9 @@
         "settings": {
             "TOOLCHAIN_PREFIX" : "E:/GNU_Tools_ARM_Embedded/5_4_2016q3",
             "TARGET_CHIP" : "STM32F407VG",
-            "PACKAGE_VERSION" : "1.13.1"
+            "PACKAGE_VERSION" : "1.13.1",
+            "RTOS" : "", 
+            "FREERTOS_VERSION" : ""
         },
         "buildType": "Debug"
       },

--- a/docs/build-instructions.md
+++ b/docs/build-instructions.md
@@ -44,6 +44,8 @@ The build script accepts the following parameters (some of them are mandatory).
 - TOOLCHAIN: the toolchain to use in the build. The default (and only option at this time) is GCC.
 - TOOLCHAIN_PREFIX: path to the install directory of the toolchain. E.g.: "E:/GNU_Tools_ARM_Embedded/5_4_2016q3". Mind the forward slash on the path for all platforms.
 - CMAKE_BUILD_TYPE: build type (Debug, Release, etc). The default is Release.
+- RTOS: specifies the RTOS to add to the image. This will download the appropriate files from the respective repository. Current valid RTOSes are FreeRTOS (FREERTOS) and mBed RTOS (MBEDRTOS).
+- FREERTOS_VERSION: specifies the FreeRTOS version to grab the source files. It has to match one of the official versions from the FreeRTOS repository. If none is specified it will download the 'trunk' version.
 
 You can specify any generator that is supported in the platform where you are building.
 For more information on this check CMake documentation [here](https://cmake.org/cmake/help/v3.7/manual/cmake-generators.7.html?highlight=generator).
@@ -53,7 +55,15 @@ For more information on this check CMake documentation [here](https://cmake.org/
 If you are building from the command prompt, just go to your *build* directory and run CMake from there with the appropriate parameters. 
 The following is a working example:
 
-```cmake -DTOOLCHAIN_PREFIX="E:/GNU_Tools_ARM_Embedded/5_4_2016q3" -DTARGET_CHIP=STM32F407VG -DPACKAGE_VERSION=1.13.1 -G "NMake Makefiles" ../```
+```
+cmake \
+-DTOOLCHAIN_PREFIX="E:/GNU_Tools_ARM_Embedded/5_4_2016q3" \
+-DTARGET_CHIP=STM32F407VG \
+-DPACKAGE_VERSION=1.13.1 \
+-RTOS=FREERTOS \
+-FREERTOS_VERSION=9.0.0 \
+-G "NMake Makefiles" ../ 
+```
 
 This will call CMake (on your *build* directory that is assumed to be under the repository root) specifing the location of the toolchain install, targeting STM32F407VG, asking for the ST Cube package version 1.13.1 to be used and that the build files suitable for NMake are to be generated.
 After succesfull completion you'll have the build files ready to be used in the target build tool.


### PR DESCRIPTION
- update CMake to accept RTOS as argument
- update CMake to download RTOS source from the respective repository
(support for FreeRTOS and mBed RTOS at this time)
- update documentation accordingly

related with #5 