### PR TITLE
Remove support for CPP threads in ChibiOS

### DIFF
--- a/CMake/Modules/FindCHIBIOS.cmake
+++ b/CMake/Modules/FindCHIBIOS.cmake
@@ -75,7 +75,6 @@ list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/common/por
 list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/common/ports/ARMCMx/compilers/GCC)
 list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/hal/ports/STM32/${CHIBIOS_BOARD_SERIES})
 list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/rt/ports/ARMCMx/cmsis_os)
-list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/various/cpp_wrappers)
 
 # source files and GCC options according to target vendor and series
 
@@ -138,10 +137,6 @@ set(CHIBIOS_SRCS
 
     # CMSIS
     cmsis_os.c
-
-    # CPP wrappers
-    ch.cpp
-    syscalls_cpp.cpp
 )
 
 foreach(SRC_FILE ${CHIBIOS_SRCS})
@@ -152,7 +147,6 @@ foreach(SRC_FILE ${CHIBIOS_SRCS})
             ${PROJECT_BINARY_DIR}/ChibiOS_Source/hal/osal/rt
             ${PROJECT_BINARY_DIR}/ChibiOS_Source/rt/src
             ${PROJECT_BINARY_DIR}/ChibiOS_Source/rt/ports/ARMCMx/cmsis_os
-            ${PROJECT_BINARY_DIR}/ChibiOS_Source/various/cpp_wrappers
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )

--- a/targets/os/chibios/nanoBooter-cdc/README.md
+++ b/targets/os/chibios/nanoBooter-cdc/README.md
@@ -1,0 +1,16 @@
+For the ChibiOS test app to build succesfully the following changes are required:
+
+In _halconf.g_ (when compared with a default file)
+- HAL_USE_SERIAL to TRUE
+- HAL_USE_SERIAL_USB to TRUE
+- HAL_USE_USB to TRUE
+- SERIAL_DEFAULT_BITRATE to 115200
+
+In _mcuconf.h_ (when compared with a default file)
+- STM32_SERIAL_USE_USART2 to TRUE
+- STM32_USB_USE_OTG1 to TRUE
+
+When making the build the first time it will fail with an error about a duplicate definition of __dso_handle.
+Edit the file _../various/cpp_wrappers/syscalls_cpp.hpp_ located in the ChibiOS source folder and comment the line where it's being defined there.
+
+NOTE: this configuration was sucessfully tested in a ST_STM32F4_DISCOVERY board using the Serial over USB connection on USB port 1 that creates a virtual COM port.

--- a/targets/os/chibios/nanoBooter/README.md
+++ b/targets/os/chibios/nanoBooter/README.md
@@ -7,7 +7,4 @@ In _halconf.g_ (when compared with a default file)
 In _mcuconf.h_ (when compared with a default file)
 - STM32_SERIAL_USE_USART2 to TRUE
 
-When making the build the first time it will fail with an error about a duplicate definition of __dso_handle.
-Edit the file _../various/cpp_wrappers/syscalls_cpp.hpp_ located in the ChibiOS source folder and comment the line where it's being defined there.
-
 NOTE: this configuration was sucessfully tested in a NUCLEO_F091RC board using the virtual COM port through the ST Link USB connection.


### PR DESCRIPTION
- after settling that nano Framework would be using plain C RTOS Threads
support for C++ Threads is not required anymore so the wrappers can be
removed
- update documenation accordingly

Signed-off-by: José Simões <jose.simoes@eclo.solutions>