### PR TITLE
Minimum required CMake is 3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.7)
 include(CMakeToolsHelpers OPTIONAL)
 include(ExternalProject)
 

--- a/docs/build-instructions.md
+++ b/docs/build-instructions.md
@@ -16,7 +16,7 @@ The build is based on CMake tool to ease the development in all major platforms.
 
 You'll need:
 - [GNU ARM Embedded Toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads)
-- [CMake](https://cmake.org/)
+- [CMake](https://cmake.org/) (Minimum required version is 3.7)
 
 If you are using VS Code as your development platform we suggest that you use the CMake Tools extension. This will allow you to run the builds without leaving VS Code.
 - [Visual Studio Code](http://code.visualstudio.com/)


### PR DESCRIPTION
Fixes #82 

- Changed the minimum required version for CMake to 3.7
- Modified the documentation in the build instructions accordingly.

Signed-off-by: Peter Wessel piwi1263@gmail.com