### PR TITLE
Fix definitions for VERSION and OEM strings

### DIFF
--- a/CMake/ChibiOS_target_os.h.in
+++ b/CMake/ChibiOS_target_os.h.in
@@ -11,8 +11,8 @@
 #ifndef _TARGET_OS_H_
 #define _TARGET_OS_H_
 
-#define NANOFRAMEWORK_VERSION_MAJOR @nanoFramework_VERSION_MAJOR@U
-#define NANOFRAMEWORK_VERSION_MINOR @nanoFramework_VERSION_MINOR@U
-#define NANOFRAMEWORK_VERSION_BUILD @nanoFramework_VERSION_PATCH@U
+#define VERSION_MAJOR @nanoFramework_VERSION_MAJOR@U
+#define VERSION_MINOR @nanoFramework_VERSION_MINOR@U
+#define VERSION_BUILD @nanoFramework_VERSION_PATCH@U
 
 #endif /* _TARGET_OS_H_ */

--- a/src/CLR/Debugger/Debugger.vcxproj
+++ b/src/CLR/Debugger/Debugger.vcxproj
@@ -106,7 +106,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;VERSION_MAJOR=0;VERSION_MINOR=0;VERSION_BUILD=0;VERSION_REVISION=0;OEMSYSTEMINFOSTRING="WIN_32";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\Include;..\CorLib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -119,7 +119,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;VERSION_MAJOR=0;VERSION_MINOR=0;VERSION_BUILD=0;VERSION_REVISION=0;OEMSYSTEMINFOSTRING="WIN_32";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\Include;..\CorLib</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/src/CLR/Include/nanoHAL.h
+++ b/src/CLR/Include/nanoHAL.h
@@ -1616,13 +1616,4 @@ void CPU_Reset();
 #error Unsupported platform
 #endif
 
-// UNDONE: FIXME: VERSION_XXX
-#define VERSION_MAJOR       0
-#define VERSION_MINOR       1
-#define VERSION_BUILD       0
-#define VERSION_REVISION    0
-
-#define OEMSYSTEMINFOSTRING "OEM"  // UNDONE: FIXME: OEMSYSTEMINFOSTRING
-
 #endif  // _NANOHAL_H_
-

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/target_board.h.in
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/target_board.h.in
@@ -13,6 +13,6 @@
 
 #include <target_common.h>
 
-#define OEMINFO_STRING "nanoFramework RULES!! Booter Running @ @CHIBIOS_BOARD@"
+#define OEMSYSTEMINFOSTRING "nanoFramework RULES!! Booter Running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/target_board.h.in
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/target_board.h.in
@@ -13,6 +13,6 @@
 
 #include <target_common.h>
 
-#define OEMINFO_STRING "nanoFramework RULES!! CLR running @ @CHIBIOS_BOARD@"
+#define OEMSYSTEMINFOSTRING "nanoFramework RULES!! CLR running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/target_board.h.in
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/target_board.h.in
@@ -13,6 +13,6 @@
 
 #include <target_common.h>
 
-#define OEMINFO_STRING "nanoFramework RULES! Running @ @CHIBIOS_BOARD@                    "
+#define OEMSYSTEMINFOSTRING "nanoFramework RULES! Running @ @CHIBIOS_BOARD@                    "
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/target_board.h.in
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/target_board.h.in
@@ -13,6 +13,6 @@
 
 #include <target_common.h>
 
-#define OEMINFO_STRING "nanoFramework RULES! CLR running @ @CHIBIOS_BOARD@                "
+#define OEMSYSTEMINFOSTRING "nanoFramework RULES! CLR running @ @CHIBIOS_BOARD@                "
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/target_board.h.in
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/target_board.h.in
@@ -13,6 +13,6 @@
 
 #include <target_common.h>
 
-#define OEMINFO_STRING "nanoFramework RULES! Running @ @CHIBIOS_BOARD@                    "
+#define OEMSYSTEMINFOSTRING "nanoFramework RULES! Running @ @CHIBIOS_BOARD@                    "
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/target_board.h.in
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/target_board.h.in
@@ -13,6 +13,6 @@
 
 #include <target_common.h>
 
-#define OEMINFO_STRING "nanoFramework RULES! CLR running @ @CHIBIOS_BOARD@                "
+#define OEMSYSTEMINFOSTRING "nanoFramework RULES! CLR running @ @CHIBIOS_BOARD@                "
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */

--- a/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
@@ -21,12 +21,12 @@ static const int AccessMemory_Mask     = 0x0F;
 
 bool NanoBooter_GetReleaseInfo(ReleaseInfo* releaseInfo)
 {
-    releaseInfo->version.usMajor = NANOFRAMEWORK_VERSION_MAJOR;
-    releaseInfo->version.usMinor = NANOFRAMEWORK_VERSION_MINOR;
-    releaseInfo->version.usBuild = NANOFRAMEWORK_VERSION_BUILD;
+    releaseInfo->version.usMajor = VERSION_MAJOR;
+    releaseInfo->version.usMinor = VERSION_MINOR;
+    releaseInfo->version.usBuild = VERSION_BUILD;
     releaseInfo->version.usRevision = 0;
 
-    memcpy(&releaseInfo->infoString, OEMINFO_STRING, sizeof(releaseInfo->infoString));
+    memcpy(&releaseInfo->infoString, OEMSYSTEMINFOSTRING, sizeof(releaseInfo->infoString));
 
     return true;
 }

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/WireProtocol_MonitorCommands.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/WireProtocol_MonitorCommands.c
@@ -13,12 +13,12 @@
 
 bool NanoCLR_GetReleaseInfo(ReleaseInfo* releaseInfo)
 {
-    releaseInfo->version.usMajor = NANOFRAMEWORK_VERSION_MAJOR;
-    releaseInfo->version.usMinor = NANOFRAMEWORK_VERSION_MINOR;
-    releaseInfo->version.usBuild = NANOFRAMEWORK_VERSION_BUILD;
+    releaseInfo->version.usMajor = VERSION_MAJOR;
+    releaseInfo->version.usMinor = VERSION_MINOR;
+    releaseInfo->version.usBuild = VERSION_BUILD;
     releaseInfo->version.usRevision = 0;
 
-    memcpy(&releaseInfo->infoString, OEMINFO_STRING, sizeof(releaseInfo->infoString));
+    memcpy(&releaseInfo->infoString, OEMSYSTEMINFOSTRING, sizeof(releaseInfo->infoString));
 
     return true;
 }


### PR DESCRIPTION
- these preprocessor definitions are now defined in project properties
(because for native compilation these are set at target/board level)

Signed-off-by: José Simões <jose.simoes@eclo.solutions>