### PR TITLE
Improve CMake so that is not required to list each suported board name

### DIFF
--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -30,6 +30,7 @@
         "settings": {
             "TOOLCHAIN_PREFIX" : "<path-to-gcc-toolchain-mind-the-forward-slash>",
             "TARGET_CHIP" : "<target-chip-with-official-vendor-reference>",
+            "TARGET_SERIES" : "<series-name-of-the-target-chip>",
             "USE_FPU" : "<TRUE-for-using-hardware-floating-point-unit>",
             "CHIBIOS_VERSION" : "<N.N.N>",
             "CHIBIOS_SOURCE" : "<path-to-chibios-source-mind-the-forward-slash>",
@@ -43,6 +44,7 @@
         "settings": {
             "TOOLCHAIN_PREFIX" : "<path-to-gcc-toolchain-mind-the-forward-slash>",
             "TARGET_CHIP" : "<target-chip-with-official-vendor-reference>",
+            "TARGET_SERIES" : "<series-name-of-the-target-chip>",
             "USE_FPU" : "<TRUE-for-using-hardware-floating-point-unit>",
             "CHIBIOS_VERSION" : "<N.N.N>",
             "CHIBIOS_SOURCE" : "<path-to-chibios-source-mind-the-forward-slash>",

--- a/docs/CMake/chibios-build.md
+++ b/docs/CMake/chibios-build.md
@@ -20,9 +20,15 @@ _Note: when specifying the location of a local clone make sure that the correct 
 
 # Workflow
 
-ChibiOS HAL is based on _boards_. There collection of supported boards and the respective configurations live in hal/boards directory. 
+ChibiOS HAL is based on _boards_. The collection of supported boards and the respective configurations live in hal/boards directory.
+**nanoFramework** includes an 'overlay' for ChibiOS were supported boards can be added. This collection is also checked for the target board. The collection of supported boards and the respective configurations implemented in the 'overlay' live in /targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/boards directory.
 
-After successfully finding the board directory CMake tries to figure out the vendor and the series for later use. Please check the code at [FindCHIBIOS.cmake](../../CMake/Modules/FindCHIBIOS.cmake) for details.
+A **nanoFramework** target can also include the ChibiOS board definitions. This is the advisable approach for OEM boards. 
+In this case the board.c and board.h files have to be included right in the target directory.
+
+Support for each board in **nanoFramework** is required. This is were the configuration details and components/features are specified and/or configured. CMakes checks if the target board is available in the targets collection. The collection of board support is at /targets/CMSIS-OS/ChibiOS.
+
+After successfully finding the board support in both ChibiOS and **nanoFramework** targets, CMake checks the TARGET_SERIES in the list of supported series in order to figure out the series for later use. Please check the code at [FindCHIBIOS.cmake](../../CMake/Modules/FindCHIBIOS.cmake) for details.
 (NOTE: the current code has been validated for STM boards only)
 
 The _FindCHIBIOS.cmake_ includes the specifics for the target series and the respective GCC options.
@@ -33,5 +39,5 @@ The file naming logic is:
 When adding a new vendor/series/board follow these general guidelines:
 1. When in doubt try to follow the make files of the repo. They'll give you all the details that you need in order to replicate that in the CMake files.
 2. Check if the series file exists. If not, create it and add the source files and include directories.
-3. Check if the series list (e.g. STM32_F0xx_BOARDS) contains the board name. If not add the board there or, if the series list doesn't exist at all, add it along with the respective logic.
-4. Check if the linker file name is listed in the series file. If not, add them.
+3. Check if the target series name is contained in the `CHIBIOS_SUPPORTED_SERIES` list. If not add the series name there.
+4. Check if the linker file name is listed in the series file. If not, add it.

--- a/docs/build-instructions.md
+++ b/docs/build-instructions.md
@@ -44,6 +44,7 @@ The build script accepts the following parameters (some of them are mandatory).
 - TOOLCHAIN_PREFIX: path to the install directory of the toolchain. E.g.: "E:/GNU_Tools_ARM_Embedded/5_4_2016q3". Mind the forward slash on the path for all platforms.
 - CMAKE_BUILD_TYPE: build type (Debug, Release, etc). The default is Release.
 - USE_FPU: specifies if the hardware floating point unit (if available at the platform) is to be used. If this doesn't apply, this parameter is simply ignored. The default is false.
+- TARGET_SERIES: specifies the series name for the target board. This parameter is mandatory and has to be in the list of the supported series for the target OS.
 - CHIBIOS_SOURCE: specifies the path for the location of the ChibiOS source code. If this parameter is specified the code on that path will be used and no download is performed. For this parameter to be valid RTOS parameter must be specified with CHIBIOS option. 
 - CHIBIOS_VERSION: specifies the ChibiOS version to grab the source files. It has to match one of the official versions from the ChibiOS repository. If none is specified it will download the 'trunk' version. This parameter is ignored if CHIBIOS_SOURCE is specified. 
 - CHIBIOS_BOARD: specifies the ChibiOS board. This parameter is mandatory when specifying CHIBIOS as the RTOS choice parameter above. It has to be a valid board listed in ChibiOS boards folder.
@@ -65,10 +66,11 @@ cmake \
 -DTOOLCHAIN_PREFIX="E:/GNU_Tools_ARM_Embedded/5_4_2016q3" \
 -DCHIBIOS_VERSION=16.1.7 \
 -DCHIBIOS_BOARD=ST_NUCLEO_F091RC \
+-DTARGET_SERIES=STM32F0xx \
 -G "NMake Makefiles" ../ 
 ```
 
-This will call CMake (on your *build* directory that is assumed to be under the repository root) specifying the location of the toolchain install, specifying ChibiOS v16.1.7 as the RTOS version, that the target board is named ST_NUCLEO_F091RC and that the build files suitable for NMake are to be generated.
+This will call CMake (on your *build* directory that is assumed to be under the repository root) specifying the location of the toolchain install, specifying ChibiOS v16.1.7 as the RTOS version, that the target board is named ST_NUCLEO_F091RC, that STM32F0xx is the series name that it belongs to, and that the build files suitable for NMake are to be generated.
 
 Another example:
 
@@ -77,11 +79,12 @@ cmake \
 -DTOOLCHAIN_PREFIX="E:/GNU_Tools_ARM_Embedded/5_4_2016q3" \
 -DCHIBIOS_SOURCE=E:/GitHub/ChibiOS \
 -DCHIBIOS_BOARD=ST_NUCLEO144_F746ZG \
+-DTARGET_SERIES=STM32F7xx \
 -DUSE_FPU=TRUE \
 -G "NMake Makefiles" ../ 
 ```
 
-This will call CMake (on your *build* directory that is assumed to be under the repository root) specifying the location of the toolchain install, specifying that ChibiOS sources to be used are located in the designated path (mind the forward slash and no ending slash),  that the target board is named ST_NUCLEO144_F746ZG, hardware floating point unit is to be used and that the build files suitable for NMake are to be generated.
+This will call CMake (on your *build* directory that is assumed to be under the repository root) specifying the location of the toolchain install, specifying that ChibiOS sources to be used are located in the designated path (mind the forward slash and no ending slash),  that the target board is named ST_NUCLEO144_F746ZG, that STM32F7xx is the series name that it belongs to, hardware floating point unit is to be used and that the build files suitable for NMake are to be generated.
 
 After successful completion you'll have the build files ready to be used in the target build tool.
 


### PR DESCRIPTION
- now only the series name is required
- also improve CMake to support OEM boards that include the board definitions right on the target directory

Fixes #148

Signed-off-by: José Simões <jose.simoes@eclo.solutions>