### PR TITLE
Revert ChibiOS setting for using classic periodic timer

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/chconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/chconf.h
@@ -46,7 +46,7 @@
  *          The value one is not valid, timeouts are rounded up to
  *          this value.
  */
-#define CH_CFG_ST_TIMEDELTA                 0
+#define CH_CFG_ST_TIMEDELTA                 2
 
 /** @} */
 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/main.c
@@ -92,7 +92,7 @@ int main(void) {
 
   //ClrStartup(clrSettings);
 
-  // while (true) {
-  //   osDelay(1000);
-  // }
+  while (true) {
+    osDelay(1000);
+  }
 }

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/chconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/chconf.h
@@ -52,7 +52,7 @@
  *          The value one is not valid, timeouts are rounded up to
  *          this value.
  */
-#define CH_CFG_ST_TIMEDELTA                 0
+#define CH_CFG_ST_TIMEDELTA                 2
 
 /** @} */
 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
@@ -72,7 +72,7 @@ int main(void) {
 
   //ClrStartup(clrSettings);
 
-  // while (true) {
-  //   osDelay(1000);
-  // }
+  while (true) {
+    osDelay(1000);
+  }
 }

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/chconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/chconf.h
@@ -52,7 +52,7 @@
  *          The value one is not valid, timeouts are rounded up to
  *          this value.
  */
-#define CH_CFG_ST_TIMEDELTA                 0
+#define CH_CFG_ST_TIMEDELTA                 2
 
 /** @} */
 

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/chconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/chconf.h
@@ -52,7 +52,7 @@
  *          The value one is not valid, timeouts are rounded up to
  *          this value.
  */
-#define CH_CFG_ST_TIMEDELTA                 0
+#define CH_CFG_ST_TIMEDELTA                 2
 
 /** @} */
 

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/main.c
@@ -93,7 +93,7 @@ int main(void) {
 
   //ClrStartup(clrSettings);
 
-  // while (true) {
-  //   osDelay(1000);
-  // }
+  while (true) {
+    osDelay(1000);
+  }
 }

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/mcuconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/mcuconf.h
@@ -34,10 +34,10 @@
 #define STM32_CLOCK48_REQUIRED              TRUE
 #define STM32_SW                            STM32_SW_PLL
 #define STM32_PLLSRC                        STM32_PLLSRC_HSE
-#define STM32_PLLM_VALUE                    8
-#define STM32_PLLN_VALUE                    336
+#define STM32_PLLM_VALUE                    4
+#define STM32_PLLN_VALUE                    120
 #define STM32_PLLP_VALUE                    2
-#define STM32_PLLQ_VALUE                    7
+#define STM32_PLLQ_VALUE                    5
 #define STM32_HPRE                          STM32_HPRE_DIV1
 #define STM32_PPRE1                         STM32_PPRE1_DIV4
 #define STM32_PPRE2                         STM32_PPRE2_DIV2


### PR DESCRIPTION
- for some reason ChibiOS is not happy working with a periodic sys tick, it has to be set to tick-less mode
- the root cause for this is not worth investigating as we want nanoFramework working in that mode anyways
- uncomment osDelay loop in main for some reference boards
- correct PLL settings for Discovery4 reference board

Fixes #152

Signed-off-by: José Simões <jose.simoes@eclo.solutions>