### PR TITLE
Add code to check for valid CLR image and launch it

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/Include/LaunchCLR.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/LaunchCLR.h
@@ -7,6 +7,7 @@
 #define _LAUNCHCLR_H_
 
 void LaunchCLR(uint32_t address);
+bool CheckValidCLRImage(uint32_t address);
 
 #endif //_LAUNCHCLR_H_
 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/main.c
@@ -55,6 +55,21 @@ int main(void) {
   // and performs the board-specific initializations.
   halInit();
 
+  // the following IF is not mandatory, it's just providing a way for a user to 'force'
+  // the board to remain in nanoBooter and not launching nanoCLR
+
+  // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
+  if (palReadPad(GPIOC, GPIOC_BUTTON))
+  {
+    // check for valid CLR image 
+    if(CheckValidCLRImage(0x08008000))
+    {
+      // there seems to be a valid CLR image
+      // launch nanoCLR
+      LaunchCLR(0x08008000);
+    }
+  }
+
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
@@ -81,23 +96,6 @@ int main(void) {
 
   //  Normal main() thread
   while (true) {
-
-    // check for button pressed
-    if (palReadPad(GPIOC, GPIOC_BUTTON))
-    {
-      // Start the shutdown sequence
-
-      // terminate threads
-      osThreadTerminate(receiverThreadId);
-      osThreadTerminate(blinkerThreadId);
-      
-      // stop the serial-over-USB CDC driver
-      sduStop(&SDU1);
-      
-      // launch nanoCLR
-      LaunchCLR(0x08008000);
-    }
-    
     osDelay(500);
   }
 }

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/main.c
@@ -40,6 +40,21 @@ int main(void) {
   // and performs the board-specific initializations.
   halInit();
 
+  // the following IF is not mandatory, it's just providing a way for a user to 'force'
+  // the board to remain in nanoBooter and not launching nanoCLR
+
+  // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
+  if (palReadPad(GPIOC, GPIOC_BUTTON))
+  {
+    // check for valid CLR image 
+    if(CheckValidCLRImage(0x08004000))
+    {
+      // there seems to be a valid CLR image
+      // launch nanoCLR
+      LaunchCLR(0x08004000);
+    }
+  }
+
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
@@ -60,24 +75,6 @@ int main(void) {
 
   //  Normal main() thread
   while (true) {
-
-    // check for button pressed
-    if (!palReadPad(GPIOC, GPIOC_BUTTON))
-    {
-      // Start the shutdown sequence
-
-      // terminate threads
-      osThreadTerminate(receiverThreadId);
-      osThreadTerminate(blinkerThreadId);
-      
-      // stop serial driver 2
-      sdStop(&SD2);
-      
-      // launch nanoCLR
-      LaunchCLR(0x08004000);
-    }
-    
     osDelay(500);
   }
 }
-

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
@@ -46,6 +46,21 @@ int main(void) {
   // and performs the board-specific initializations.
   halInit();
 
+  // the following IF is not mandatory, it's just providing a way for a user to 'force'
+  // the board to remain in nanoBooter and not launching nanoCLR
+
+  // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
+  if (palReadPad(GPIOA, GPIOA_BUTTON))
+  {
+    // check for valid CLR image 
+    if(CheckValidCLRImage(0x08008000))
+    {
+      // there seems to be a valid CLR image
+      // launch nanoCLR
+      LaunchCLR(0x08008000);
+    }
+  }
+
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
@@ -72,23 +87,6 @@ int main(void) {
 
   //  Normal main() thread
   while (true) {
-
-    // check for button pressed
-    if (palReadPad(GPIOA, GPIOA_BUTTON))
-    {
-      // Start the shutdown sequence
-
-      // terminate threads
-      osThreadTerminate(receiverThreadId);
-      osThreadTerminate(blinkerThreadId);
-      
-      // stop the serial-over-USB CDC driver
-      sduStop(&SDU1);
-      
-      // launch nanoCLR
-      LaunchCLR(0x08008000);
-    }
-    
     osDelay(500);
   }
 }

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
@@ -54,6 +54,21 @@ int main(void) {
   // and performs the board-specific initializations.
   halInit();
 
+  // the following IF is not mandatory, it's just providing a way for a user to 'force'
+  // the board to remain in nanoBooter and not launching nanoCLR
+
+  // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
+  if (palReadPad(GPIOA, GPIOA_BUTTON))
+  {
+    // check for valid CLR image 
+    if(CheckValidCLRImage(0x08008000))
+    {
+      // there seems to be a valid CLR image
+      // launch nanoCLR
+      LaunchCLR(0x08008000);
+    }
+  }
+
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
@@ -80,23 +95,6 @@ int main(void) {
 
   //  Normal main() thread
   while (true) {
-
-    // check for button pressed
-    if (palReadPad(GPIOA, GPIOA_BUTTON))
-    {
-      // Start the shutdown sequence
-
-      // terminate threads
-      osThreadTerminate(receiverThreadId);
-      osThreadTerminate(blinkerThreadId);
-      
-      // stop the serial-over-USB CDC driver
-      sduStop(&SDU1);
-      
-      // launch nanoCLR
-      LaunchCLR(0x08008000);
-    }
-    
     osDelay(500);
   }
 }

--- a/targets/CMSIS-OS/ChibiOS/common/LaunchCLR.c
+++ b/targets/CMSIS-OS/ChibiOS/common/LaunchCLR.c
@@ -33,3 +33,41 @@ void LaunchCLR(uint32_t address)
     JumpToNanoCLR();
 }
 
+bool CheckValidCLRImage(uint32_t address)
+{
+    // load nanoCLR vector table
+    const vectors_t* nanoCLRVectorTable = (vectors_t*) address;
+
+    // 1st check: the flash content pointed by the address can't be all 0's neither all F's
+    // meaning that the Flash is neither 'all burnt' or erased
+    
+    // the stack pointer is at the 1st position of vectors_t
+    if(nanoCLRVectorTable->init_stack == 0xFFFFFFFF ||
+       nanoCLRVectorTable->init_stack == 0x00000000)
+    {
+        // check failed, there is no valid CLR image
+        //return false;
+    }
+
+    // volatile uint16_t* temp1 = (uint16_t*)nanoCLRVectorTable->reset_handler;
+    // temp1 = ((uint8_t*)temp1) - 0x1;
+    // volatile uint16_t temp = (uint16_t)(*temp1);
+
+    
+    // 2nd check: the content pointed by the reset vector has to be 0xB672 
+    // this is the opcode for 'CPSID I' which is the very 1st assembly instruction of a ChibiOS nanoCLR image
+    // the casts bellow are there because the opcode is a 16 bit value and we need to subtract 1 from the reset vector address pointing to it
+    uint16_t* opCodeAddress = (uint16_t*)nanoCLRVectorTable->reset_handler;
+    opCodeAddress = (uint8_t*)opCodeAddress - 0x1;
+
+    if((uint16_t)*opCodeAddress == 0xB672)
+    {
+        // check, there seems to be a valid CLR image
+        return true;
+    }
+    else
+    {
+        // got here, assume that there isn't a valid CLR imaged flashed
+        return false;
+    }
+}


### PR DESCRIPTION
- add simple and expedited check if a CLR image is flashed
- if that check passes nanoBooter launches the CLR

Fixes #116

Signed-off-by: José Simões <jose.simoes@eclo.solutions>