### PR TITLE
Improvements with linker files

### DIFF
--- a/CMake/Modules/CHIBIOS_STM32F0xx_sources.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F0xx_sources.cmake
@@ -97,18 +97,6 @@ list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/hal/por
 list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/hal/ports/STM32/LLD/xWDGv1)
 
 
-#######################################################################################################################################
-# WHEN ADDING A NEW BOARD add the respective IF clause bellow along with the default linker file name (without extension)
-#######################################################################################################################################
-
-# linker file
-if(${CHIBIOS_BOARD} STREQUAL "ST_NUCLEO_F072RB")
-    set(DEFAULT_LINKER_FILE_NAME "STM32F072xB")
-elseif(${CHIBIOS_BOARD} STREQUAL "ST_NUCLEO_F091RC")
-    set(DEFAULT_LINKER_FILE_NAME "STM32F091xC")
-endif()
-
-
 ####################################################################################
 # WHEN ADDING A NEW CHIBIOS OVERLAY component add the include directory(ies) bellow 
 ####################################################################################
@@ -138,23 +126,7 @@ list(APPEND ChibiOSnfOverlay_SOURCES ${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/Chib
 
 
 #######################################################################################################################################
-# this function sets the linker options including the default linker file
-# if the target uses a specific linker file use the function CHIBIOS_SET_LINKER_OPTIONS_AND_FILE
-function(CHIBIOS_SET_LINKER_OPTIONS TARGET)
-
-    get_target_property(TARGET_LD_FLAGS ${TARGET} LINK_FLAGS)
-    if(TARGET_LD_FLAGS)
-        set(TARGET_LD_FLAGS "-T${PROJECT_BINARY_DIR}/ChibiOS_Source/os/common/ports/ARMCMx/compilers/GCC/ld/${DEFAULT_LINKER_FILE_NAME}.ld ${TARGET_LD_FLAGS}")
-    else()
-        set(TARGET_LD_FLAGS "-T${PROJECT_BINARY_DIR}/ChibiOS_Source/os/common/ports/ARMCMx/compilers/GCC/ld/${DEFAULT_LINKER_FILE_NAME}.ld")
-    endif()
-    set_target_properties(${TARGET} PROPERTIES LINK_FLAGS ${TARGET_LD_FLAGS})
-
-endfunction()
-
-#######################################################################################################################################
 # this function sets the linker options AND a specific linker file (full path and name, including extension)
-# if the target uses the default linker file use the function CHIBIOS_SET_LINKER_OPTIONS
 function(CHIBIOS_SET_LINKER_OPTIONS_AND_FILE TARGET LINKER_FILE_NAME)
 
     get_target_property(TARGET_LD_FLAGS ${TARGET} LINK_FLAGS)

--- a/CMake/Modules/CHIBIOS_STM32F4xx_sources.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F4xx_sources.cmake
@@ -109,18 +109,6 @@ list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/hal/por
 list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/hal/ports/STM32/LLD/xWDGv1)
 
 
-#######################################################################################################################################
-# WHEN ADDING A NEW BOARD add the respective IF clause bellow along with the default linker file name (without extension)
-#######################################################################################################################################
-
-# linker file
-if(${CHIBIOS_BOARD} STREQUAL "ST_STM32F4_DISCOVERY")
-    set(DEFAULT_LINKER_FILE_NAME "STM32F407xG")
-elseif(${CHIBIOS_BOARD} STREQUAL "ST_STM32F429I_DISCOVERY")    
-    set(DEFAULT_LINKER_FILE_NAME "STM32F429xI")
-endif()
-
-
 ####################################################################################
 # WHEN ADDING A NEW CHIBIOS OVERLAY component add the include directory(ies) bellow 
 ####################################################################################
@@ -150,23 +138,7 @@ list(APPEND ChibiOSnfOverlay_SOURCES ${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/Chib
 
 
 #######################################################################################################################################
-# this function sets the linker options including the default linker file
-# if the target uses a specific linker file use the function CHIBIOS_SET_LINKER_OPTIONS_AND_FILE
-function(CHIBIOS_SET_LINKER_OPTIONS TARGET)
-
-    get_target_property(TARGET_LD_FLAGS ${TARGET} LINK_FLAGS)
-    if(TARGET_LD_FLAGS)
-        set(TARGET_LD_FLAGS "-T${PROJECT_BINARY_DIR}/ChibiOS_Source/os/common/ports/ARMCMx/compilers/GCC/ld/${DEFAULT_LINKER_FILE_NAME}.ld ${TARGET_LD_FLAGS}")
-    else()
-        set(TARGET_LD_FLAGS "-T${PROJECT_BINARY_DIR}/ChibiOS_Source/os/common/ports/ARMCMx/compilers/GCC/ld/${DEFAULT_LINKER_FILE_NAME}.ld")
-    endif()
-    set_target_properties(${TARGET} PROPERTIES LINK_FLAGS ${TARGET_LD_FLAGS})
-
-endfunction()
-
-#######################################################################################################################################
 # this function sets the linker options AND a specific linker file (full path and name, including extension)
-# if the target uses the default linker file use the function CHIBIOS_SET_LINKER_OPTIONS
 function(CHIBIOS_SET_LINKER_OPTIONS_AND_FILE TARGET LINKER_FILE_NAME)
 
     get_target_property(TARGET_LD_FLAGS ${TARGET} LINK_FLAGS)

--- a/CMake/Modules/CHIBIOS_STM32F7xx_sources.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F7xx_sources.cmake
@@ -105,34 +105,8 @@ list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/hal/por
 list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/hal/ports/STM32/LLD/USARTv2)
 list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/hal/ports/STM32/LLD/xWDGv1)
 
-
-#######################################################################################################################################
-# WHEN ADDING A NEW BOARD add the respective IF clause bellow along with the default linker file name (without extension)
-#######################################################################################################################################
-
-# linker file
-if(${CHIBIOS_BOARD} STREQUAL "ST_NUCLEO144_F746ZG")
-    set(DEFAULT_LINKER_FILE_NAME "STM32F746xG")
-endif()
-
-#######################################################################################################################################
-# this function sets the linker options including the default linker file
-# if the target uses a specific linker file use the function CHIBIOS_SET_LINKER_OPTIONS_AND_FILE
-function(CHIBIOS_SET_LINKER_OPTIONS TARGET)
-
-    get_target_property(TARGET_LD_FLAGS ${TARGET} LINK_FLAGS)
-    if(TARGET_LD_FLAGS)
-        set(TARGET_LD_FLAGS "-T${PROJECT_BINARY_DIR}/ChibiOS_Source/os/common/ports/ARMCMx/compilers/GCC/ld/${DEFAULT_LINKER_FILE_NAME}.ld ${TARGET_LD_FLAGS}")
-    else()
-        set(TARGET_LD_FLAGS "-T${PROJECT_BINARY_DIR}/ChibiOS_Source/os/common/ports/ARMCMx/compilers/GCC/ld/${DEFAULT_LINKER_FILE_NAME}.ld")
-    endif()
-    set_target_properties(${TARGET} PROPERTIES LINK_FLAGS ${TARGET_LD_FLAGS})
-
-endfunction()
-
 #######################################################################################################################################
 # this function sets the linker options AND a specific linker file (full path and name, including extension)
-# if the target uses the default linker file use the function CHIBIOS_SET_LINKER_OPTIONS
 function(CHIBIOS_SET_LINKER_OPTIONS_AND_FILE TARGET LINKER_FILE_NAME)
 
     get_target_property(TARGET_LD_FLAGS ${TARGET} LINK_FLAGS)

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
@@ -122,15 +122,11 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
     "${NF_WireProtocol_INCLUDE_DIRS}"
 )
 
-############################################################
-# use default linker options and linker file for nanoBooter
-CHIBIOS_SET_LINKER_OPTIONS(${NANOBOOTER_PROJECT_NAME}.elf)
-############################################################
-
-#######################################################
-# need to use a specific linker file for nanoCLR
+###################
+# set linker files
+CHIBIOS_SET_LINKER_OPTIONS_AND_FILE(${NANOBOOTER_PROJECT_NAME}.elf ${CMAKE_CURRENT_SOURCE_DIR}/nanoBooter/STM32F746xG.ld)
 CHIBIOS_SET_LINKER_OPTIONS_AND_FILE(${NANOCLR_PROJECT_NAME}.elf ${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR/STM32F746xG.ld)
-#######################################################
+###################
 
 CHIBIOS_ADD_HEX_BIN_DUMP_TARGETS(${NANOBOOTER_PROJECT_NAME}.elf)
 CHIBIOS_ADD_HEX_BIN_DUMP_TARGETS(${NANOCLR_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/STM32F746xG.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/STM32F746xG.ld
@@ -1,0 +1,58 @@
+/*
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) 2006..2015 Giovanni Di Sirio. All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+*/
+
+/*
+ * STM32F746xG generic setup.
+ * 
+ * RAM0 - Data, Heap.
+ * RAM3 - Main Stack, Process Stack, BSS, NOCACHE, ETH.
+ *
+ * Notes:
+ * BSS is placed in DTCM RAM in order to simplify DMA buffers management.
+ */
+MEMORY
+{
+    flash       : org = 0x08008000, len = 1M - 0x7FFF /* flash size less the space reserved for bootloader (1st two sectors 0x08000000 to 0x08007FFF)*/
+    flash_itcm  : org = 0x00200000, len = 1M
+    ram0        : org = 0x20010000, len = 256k    /* SRAM1 + SRAM2 */
+    ram1        : org = 0x20010000, len = 240k    /* SRAM1 */
+    ram2        : org = 0x2004C000, len = 16k     /* SRAM2 */
+    ram3        : org = 0x20000000, len = 64k     /* DTCM-RAM */
+    ram4        : org = 0x00000000, len = 16k     /* ITCM-RAM */
+    ram5        : org = 0x40024000, len = 4k      /* BCKP SRAM */
+    ram6        : org = 0x00000000, len = 0
+    ram7        : org = 0x00000000, len = 0
+}
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts*/
+REGION_ALIAS("MAIN_STACK_RAM", ram3);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("PROCESS_STACK_RAM", ram3);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ram0);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ram3);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ram0);
+
+/* RAM region to be used for nocache segment.*/
+REGION_ALIAS("NOCACHE_RAM", ram3);
+
+/* RAM region to be used for eth segment.*/
+REGION_ALIAS("ETH_RAM", ram3);
+
+/* RAM region to be used for the nanoFramework CLR managed heap.*/
+REGION_ALIAS("CLR_MANAGED_HEAP_RAM", ram0);
+
+INCLUDE rules_STM32F7xx.ld

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/CMakeLists.txt
@@ -122,15 +122,11 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
     "${NF_WireProtocol_INCLUDE_DIRS}"
 )
 
-############################################################
-# use default linker options and linker file for nanoBooter
-CHIBIOS_SET_LINKER_OPTIONS(${NANOBOOTER_PROJECT_NAME}.elf)
-############################################################
-
-#######################################################
-# need to use a specific linker file for nanoCLR
+###################
+# set linker files
+CHIBIOS_SET_LINKER_OPTIONS_AND_FILE(${NANOBOOTER_PROJECT_NAME}.elf ${CMAKE_CURRENT_SOURCE_DIR}/nanoBooter/STM32F091xC.ld)
 CHIBIOS_SET_LINKER_OPTIONS_AND_FILE(${NANOCLR_PROJECT_NAME}.elf ${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR/STM32F091xC.ld)
-#######################################################
+###################
 
 CHIBIOS_ADD_HEX_BIN_DUMP_TARGETS(${NANOBOOTER_PROJECT_NAME}.elf)
 CHIBIOS_ADD_HEX_BIN_DUMP_TARGETS(${NANOCLR_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/STM32F091xC.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/STM32F091xC.ld
@@ -1,0 +1,46 @@
+/*
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) 2006..2015 Giovanni Di Sirio.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+*/
+
+
+/*
+ * STM32F091xC memory setup.
+ */
+MEMORY
+{
+    flash : org = 0x08000000, len = 0x3FFF /* space reserved for bootloader (1st eight sectors 0x08000000 to 0x08003FFF)*/
+    ram0  : org = 0x20000000, len = 32k
+    ram1  : org = 0x00000000, len = 0
+    ram2  : org = 0x00000000, len = 0
+    ram3  : org = 0x00000000, len = 0
+    ram4  : org = 0x00000000, len = 0
+    ram5  : org = 0x00000000, len = 0
+    ram6  : org = 0x00000000, len = 0
+    ram7  : org = 0x00000000, len = 0
+}
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts*/
+REGION_ALIAS("MAIN_STACK_RAM", ram0);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("PROCESS_STACK_RAM", ram0);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ram0);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ram0);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ram0);
+
+/* RAM region to be used for the nanoFramework CLR managed heap.*/
+REGION_ALIAS("CLR_MANAGED_HEAP_RAM", ram0);
+
+INCLUDE rules.ld

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -122,15 +122,11 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
     "${NF_WireProtocol_INCLUDE_DIRS}"
 )
 
-############################################################
-# use default linker options and linker file for nanoBooter
-CHIBIOS_SET_LINKER_OPTIONS(${NANOBOOTER_PROJECT_NAME}.elf)
-############################################################
-
-#######################################################
-# need to use a specific linker file for nanoCLR
+###################
+# set linker files
+CHIBIOS_SET_LINKER_OPTIONS_AND_FILE(${NANOBOOTER_PROJECT_NAME}.elf ${CMAKE_CURRENT_SOURCE_DIR}/nanoBooter/STM32F429xI.ld)
 CHIBIOS_SET_LINKER_OPTIONS_AND_FILE(${NANOCLR_PROJECT_NAME}.elf ${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR/STM32F429xI.ld)
-#######################################################
+###################
 
 CHIBIOS_ADD_HEX_BIN_DUMP_TARGETS(${NANOBOOTER_PROJECT_NAME}.elf)
 CHIBIOS_ADD_HEX_BIN_DUMP_TARGETS(${NANOCLR_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/STM32F429xI.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/STM32F429xI.ld
@@ -1,0 +1,46 @@
+/*
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) 2006..2015 Giovanni Di Sirio.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+*/
+
+/*
+ * ST32F429xI memory setup.
+ * Note: Use of ram1, ram2 and ram3 is mutually exclusive with use of ram0.
+ */
+MEMORY
+{
+    flash : org = 0x08000000, len = 0x8000 /* space reserved for bootloader (1st two sectors 0x08000000 to 0x08007FFF)*/
+    ram0  : org = 0x20000000, len = 192k    /* SRAM1 + SRAM2 + SRAM3 */
+    ram1  : org = 0x20000000, len = 112k    /* SRAM1 */
+    ram2  : org = 0x2001C000, len = 16k     /* SRAM2 */
+    ram3  : org = 0x20020000, len = 64k     /* SRAM3 */
+    ram4  : org = 0x10000000, len = 64k     /* CCM SRAM */
+    ram5  : org = 0x40024000, len = 4k      /* BCKP SRAM */
+    ram6  : org = 0x00000000, len = 0
+    ram7  : org = 0x00000000, len = 0
+}
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts*/
+REGION_ALIAS("MAIN_STACK_RAM", ram0);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("PROCESS_STACK_RAM", ram0);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ram0);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ram0);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ram0);
+
+/* RAM region to be used for the nanoFramework CLR managed heap.*/
+REGION_ALIAS("CLR_MANAGED_HEAP_RAM", ram0);
+
+INCLUDE rules.ld

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
@@ -122,15 +122,11 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
     "${NF_WireProtocol_INCLUDE_DIRS}"
 )
 
-############################################################
-# use default linker options and linker file for nanoBooter
-CHIBIOS_SET_LINKER_OPTIONS(${NANOBOOTER_PROJECT_NAME}.elf)
-############################################################
-
-#######################################################
-# need to use a specific linker file for nanoCLR
+###################
+# set linker files
+CHIBIOS_SET_LINKER_OPTIONS_AND_FILE(${NANOBOOTER_PROJECT_NAME}.elf ${CMAKE_CURRENT_SOURCE_DIR}/nanoBooter/STM32F407xG.ld)
 CHIBIOS_SET_LINKER_OPTIONS_AND_FILE(${NANOCLR_PROJECT_NAME}.elf ${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR/STM32F407xG.ld)
-#######################################################
+###################
 
 CHIBIOS_ADD_HEX_BIN_DUMP_TARGETS(${NANOBOOTER_PROJECT_NAME}.elf)
 CHIBIOS_ADD_HEX_BIN_DUMP_TARGETS(${NANOCLR_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/STM32F407xG.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/STM32F407xG.ld
@@ -1,0 +1,46 @@
+/*
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) 2006..2015 Giovanni Di Sirio.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+*/
+
+/*
+ * STM32F407xG memory setup.
+ * Note: Use of ram1 and ram2 is mutually exclusive with use of ram0.
+ */
+MEMORY
+{
+    flash : org = 0x08000000, len = 0x8000 /* space reserved for bootloader (1st two sectors 0x08000000 to 0x08007FFF)*/
+    ram0  : org = 0x20000000, len = 128k    /* SRAM1 + SRAM2 */
+    ram1  : org = 0x20000000, len = 112k    /* SRAM1 */
+    ram2  : org = 0x2001C000, len = 16k     /* SRAM2 */
+    ram3  : org = 0x00000000, len = 0
+    ram4  : org = 0x10000000, len = 64k     /* CCM SRAM */
+    ram5  : org = 0x40024000, len = 4k      /* BCKP SRAM */
+    ram6  : org = 0x00000000, len = 0
+    ram7  : org = 0x00000000, len = 0
+}
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts*/
+REGION_ALIAS("MAIN_STACK_RAM", ram0);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("PROCESS_STACK_RAM", ram0);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ram0);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ram0);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ram0);
+
+/* RAM region to be used for the nanoFramework CLR managed heap.*/
+REGION_ALIAS("CLR_MANAGED_HEAP_RAM", ram0);
+
+INCLUDE rules.ld


### PR DESCRIPTION
- now both nanoBooter and nanoCLR have their own linker files on each reference board
- nanoBooter linker files now have the correct size for flash to check if the image doesn't exceed the expected size
- update CMake files for reference boards and STM32 for all series accordingly

Fixes #154

Signed-off-by: José Simões <jose.simoes@eclo.solutions>