### PR TITLE
Moved weak definition to common header

### DIFF
--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -12,18 +12,7 @@
 #include <nanoCLR_Interop.h>
 #include <nanoCLR_ErrorCodes.h>
 #include <nanoSupport.h>
-
-// definition of WEAK attribute for stub functions
-#if defined(_MSC_VER)
-// because VC++ doesn't support this attribute it's definition end up being an empty one
-#define __nfweak 
-
-#elif defined(__GNUC__)
-#define __nfweak __attribute__((weak))
-
-#else
-#error "Unknow platform. Please add definition for weak attribute."
-#endif
+#include <nanoWeak.h>
 
 struct CLR_RADIAN
 {

--- a/src/CLR/Include/nanoWeak.h
+++ b/src/CLR/Include/nanoWeak.h
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+#ifndef _NANO_WEAK_H_
+#define _NANO_WEAK_H_ 1
+
+// definition of WEAK attribute for stub functions
+#if defined(_MSC_VER)
+// because VC++ doesn't support this attribute it's definition end up being an empty one
+#define __nfweak 
+
+#elif defined(__GNUC__)
+#define __nfweak __attribute__((weak))
+
+#else
+#error "Unknow platform. Please add definition for weak attribute."
+#endif
+
+#endif // _NANO_WEAK_H_

--- a/src/HAL/Include/nanoHAL.h
+++ b/src/HAL/Include/nanoHAL.h
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
-
+#include <nanoWeak.h>
 
 
 
@@ -36,18 +36,6 @@
 #include <targetHAL.h>
 #include <nanoHAL_Types.h>
 #include <nanoHAL_ReleaseInfo.h>
-
-// definition of WEAK attribute for stub functions
-#if defined(_MSC_VER)
-// because VC++ doesn't support this attribute it's definition end up being an empty one
-#define __nfweak
-
-#elif defined(__GNUC__)
-#define __nfweak __attribute__((weak))
-
-#else
-#error "Unknow platform. Please add definition for weak attribute."
-#endif
 
 //#if !defined(_WIN32) && !defined(FIQ_SAMPLING_PROFILER) && !defined(HAL_REDUCESIZE) && defined(PROFILE_BUILD)
 //#define ENABLE_NATIVE_PROFILER


### PR DESCRIPTION
- follows DRY and improves reuse

Signed-off-by: José Simões <jose.simoes@eclo.solutions>