### PR TITLE
Add weak stub functions

### DIFF
--- a/CMake/Modules/FindNF_CoreCLR.cmake
+++ b/CMake/Modules/FindNF_CoreCLR.cmake
@@ -73,7 +73,20 @@ set(NF_CoreCLR_SRCS
     CorLib_Native_System_TimeSpan.cpp
 
     # CLR startup
-    CLRStartup.cpp   
+    CLRStartup.cpp
+
+    # Core stubs
+    Hardware_stub.cpp
+    Heap_Persistence_stub.cpp
+    InterruptHandler_stub.cpp
+    IOPort_stub.cpp
+    RPC_stub.cpp
+    BinaryFormatter_stub.cpp
+
+    # CLR stubs
+    Debugger_stub.cpp
+    Diagnostics_stub.cpp
+    Messaging_stub.cpp
 )
 
 foreach(SRC_FILE ${NF_CoreCLR_SRCS})
@@ -89,6 +102,19 @@ foreach(SRC_FILE ${NF_CoreCLR_SRCS})
 
             # CLR startup
             ${PROJECT_SOURCE_DIR}/src/CLR/Startup
+
+            # Core stubs
+            ${PROJECT_SOURCE_DIR}/src/CLR/Core/Hardware
+            ${PROJECT_SOURCE_DIR}/src/CLR/Core/HeapPersistence
+            ${PROJECT_SOURCE_DIR}/src/CLR/Core/InterruptHandler
+            ${PROJECT_SOURCE_DIR}/src/CLR/Core/IOPort
+            ${PROJECT_SOURCE_DIR}/src/CLR/Core/RPC
+            ${PROJECT_SOURCE_DIR}/src/CLR/Core/Serialization
+
+            # CLR stubs
+            ${PROJECT_SOURCE_DIR}/src/CLR/Debugger
+            ${PROJECT_SOURCE_DIR}/src/CLR/Diagnostics
+            ${PROJECT_SOURCE_DIR}/src/CLR/Messaging
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )

--- a/src/CLR/Diagnostics/Diagnostics_stub.cpp
+++ b/src/CLR/Diagnostics/Diagnostics_stub.cpp
@@ -26,15 +26,17 @@ __nfweak HRESULT NANOCLR_DEBUG_PROCESS_EXCEPTION( HRESULT hr, LPCSTR szFunc, LPC
 __nfweak bool CLR_SafeSprintfV( LPSTR& szBuffer, size_t& iBuffer, LPCSTR format, va_list arg )
 {
     NATIVE_PROFILE_CLR_DIAGNOSTICS();
-    int  chars = hal_vsnprintf( szBuffer, iBuffer, format, arg );
-    bool fRes  = (chars >= 0);
+    // UNDO FIXME 
+    // int  chars = hal_vsnprintf( szBuffer, iBuffer, format, arg );
+    // bool fRes  = (chars >= 0);
 
-    if(fRes == false) chars = (int)iBuffer;
+    // if(fRes == false) chars = (int)iBuffer;
 
-    szBuffer += chars; szBuffer[ 0 ] = 0;
-    iBuffer  -= chars;
+    // szBuffer += chars; szBuffer[ 0 ] = 0;
+    // iBuffer  -= chars;
 
-    return fRes;
+    // return fRes;
+    return true;
 }
 
 __nfweak bool CLR_SafeSprintf( LPSTR& szBuffer, size_t& iBuffer, LPCSTR format, ... )


### PR DESCRIPTION
- WIP for #165
- commented code block calling hal stuff not yet available
- impact in image size is minimal (as expected): nanoCLR debug build for Nucleo091RC is 84688 bytes vs 84400 bytes before adding weak stubs

Signed-off-by: José Simões <jose.simoes@eclo.solutions>