### PR TITLE
Enable WireProtocol in nanoBooter

### DIFF
--- a/CMake/Modules/FindNF_Debugger.cmake
+++ b/CMake/Modules/FindNF_Debugger.cmake
@@ -5,6 +5,8 @@
 
 # set include directories for nanoFramework Debugger
 list(APPEND NF_Debugger_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/src/CLR/Debugger)
+list(APPEND NF_Debugger_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/src/CLR/Messaging)
+list(APPEND NF_Debugger_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/src/CLR/WireProtocol)
 list(APPEND NF_Debugger_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/src/CLR/Include)
 
 # source files for nanoFramework Debugger
@@ -13,6 +15,10 @@ set(NF_Debugger_SRCS
     Debugger.cpp
     Debugger_full.cpp
 
+    Messaging.cpp
+    WireProtocol.cpp
+
+    nanoSupport_CRC32.c
 )
 
 foreach(SRC_FILE ${NF_Debugger_SRCS})
@@ -20,6 +26,9 @@ foreach(SRC_FILE ${NF_Debugger_SRCS})
     find_file(NF_Debugger_SRC_FILE ${SRC_FILE}
         PATHS 
             ${PROJECT_SOURCE_DIR}/src/CLR/Debugger
+            ${PROJECT_SOURCE_DIR}/src/CLR/Messaging
+            ${PROJECT_SOURCE_DIR}/src/CLR/WireProtocol
+            ${PROJECT_SOURCE_DIR}/src/CLR/Core
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )

--- a/CMake/Modules/FindWireProtocol.cmake
+++ b/CMake/Modules/FindWireProtocol.cmake
@@ -9,6 +9,7 @@ set(WireProtocol_SRCS
     WireProtocol_HAL_Interface.c
     WireProtocol_App_Interface.c
 
+    nanoSupport_CRC32.c
 )
 
 foreach(SRC_FILE ${WireProtocol_SRCS})
@@ -16,6 +17,7 @@ foreach(SRC_FILE ${WireProtocol_SRCS})
     find_file(WireProtocol_SRC_FILE ${SRC_FILE}
         PATHS 
             ${PROJECT_SOURCE_DIR}/src/CLR/WireProtocol
+            ${PROJECT_SOURCE_DIR}/src/CLR/Core
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )

--- a/src/CLR/CorLib/CorLib_Native_System_TimeSpan.cpp
+++ b/src/CLR/CorLib/CorLib_Native_System_TimeSpan.cpp
@@ -32,7 +32,7 @@ HRESULT Library_corlib_native_System_TimeSpan::ToString___STRING( CLR_RT_StackFr
     size_t     iBuffer  = ARRAYSIZE(rgBuffer);
     CLR_INT64* val      = GetValuePtr( stack ); FAULT_ON_NULL(val);
 
-    HAL_Time_TimeSpanToStringEx( *val, szBuffer, iBuffer );
+    // FIXME UNDONE HAL_Time_TimeSpanToStringEx( *val, szBuffer, iBuffer );
 
     NANOCLR_SET_AND_LEAVE(stack.SetResult_String( rgBuffer ));
 

--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -4,6 +4,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include <nanoHAL_Time.h>
+#include <nanoSupport.h>
 #include "WireProtocol_Message.h"
 
 uint8_t receptionBuffer[2048];

--- a/src/CLR/WireProtocol/WireProtocol_Message.h
+++ b/src/CLR/WireProtocol/WireProtocol_Message.h
@@ -29,7 +29,4 @@ bool WP_Message_Process(WP_Message* message);
 // helper functions
 void ReplyToCommand(WP_Message* message, bool fSuccess, bool fCritical, void* ptr, int size);
 
-//uint32_t SUPPORT_ComputeCRC(const void* rgBlock, int nLength, uint32_t crc);
-
 #endif // _WIREPROTOCOL_MESSAGE_H_
-

--- a/src/HAL/Include/nanoHAL_Time.h
+++ b/src/HAL/Include/nanoHAL_Time.h
@@ -101,7 +101,7 @@ HRESULT HAL_Time_AccDaysInMonth(INT32 year, INT32 month, INT32* days);
 INT64 HAL_Time_FromSystemTime(const SYSTEMTIME* systemTime);
 
 /// APIs to convert between types
-BOOL     HAL_Time_TimeSpanToStringEx( const INT64& ticks, LPSTR& buf, size_t& len );
+// FIXME BOOL     HAL_Time_TimeSpanToStringEx( const INT64& ticks, LPSTR& buf, size_t& len );
 LPCSTR   HAL_Time_CurrentDateTimeToString();
 
 #endif //_NANOHAL_TIME_H_

--- a/targets/CMSIS-OS/ChibiOS/common/WireProtocol_ReceiverThread.c
+++ b/targets/CMSIS-OS/ChibiOS/common/WireProtocol_ReceiverThread.c
@@ -19,7 +19,7 @@ void ReceiverThread(void const * argument)
   // loop until thread receives a request to terminate
   while (!chThdShouldTerminateX()) {
     
-//    WP_CheckAvailableIncomingData();
+    WP_CheckAvailableIncomingData();
     
     osDelay(500);
   }


### PR DESCRIPTION
- this was disabled when working on the HAL
- update CMake's
- cleanup code
- comment HAL time function because the declaration wasn't working in C

Signed-off-by: José Simões <jose.simoes@eclo.solutions>