### PR TITLE
Aligned CMakes for reference boards

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(
     # executables for project, project sources
     ${NANOCLR_PROJECT_NAME}.elf
 
-    # ${COMMON_PROJECT_SOURCES}
+    ${COMMON_PROJECT_SOURCES}
     ${NANOCLR_PROJECT_SOURCES}
 
     ${TARGET_CMSIS_COMMON_SOURCES}
@@ -81,7 +81,7 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
-    # ${WireProtocol_SOURCES}
+    ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(
     # executables for project, project sources
     ${NANOCLR_PROJECT_NAME}.elf
 
-    # ${COMMON_PROJECT_SOURCES}
+    ${COMMON_PROJECT_SOURCES}
     ${NANOCLR_PROJECT_SOURCES}
 
     ${TARGET_CMSIS_COMMON_SOURCES}
@@ -81,7 +81,7 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
-    # ${WireProtocol_SOURCES}
+    ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(
     # executables for project, project sources
     ${NANOCLR_PROJECT_NAME}.elf
 
-    # ${COMMON_PROJECT_SOURCES}
+    ${COMMON_PROJECT_SOURCES}
     ${NANOCLR_PROJECT_SOURCES}
 
     ${TARGET_CMSIS_COMMON_SOURCES}
@@ -81,7 +81,7 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
-    # ${WireProtocol_SOURCES}
+    ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
@@ -68,7 +68,7 @@ add_executable(
     # executables for project, project sources
     ${NANOCLR_PROJECT_NAME}.elf
 
-    # ${COMMON_PROJECT_SOURCES}
+    ${COMMON_PROJECT_SOURCES}
     ${NANOCLR_PROJECT_SOURCES}
 
     ${TARGET_CMSIS_COMMON_SOURCES}
@@ -80,7 +80,7 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
-    # ${WireProtocol_SOURCES}
+    ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"


### PR DESCRIPTION
- this is regarding WireProtocol for nanoBooter

Signed-off-by: José Simões <jose.simoes@eclo.solutions>