### PR TITLE
HAL config was missing the  USE_SERIAL definition

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -28,7 +28,6 @@ find_package(NF_CoreCLR REQUIRED)
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
-    find_package(NF_WireProtocol REQUIRED)
     else()
 endif()
 

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/halconf.h
@@ -122,7 +122,7 @@
  * @brief   Enables the SERIAL subsystem.
  */
 #if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL              FALSE
+#define HAL_USE_SERIAL              TRUE
 #endif
 
 /**
@@ -277,7 +277,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE      38400
+#define SERIAL_DEFAULT_BITRATE      115200
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf.h
@@ -122,7 +122,7 @@
  * @brief   Enables the SERIAL subsystem.
  */
 #if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL              FALSE
+#define HAL_USE_SERIAL              TRUE
 #endif
 
 /**
@@ -277,7 +277,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE      38400
+#define SERIAL_DEFAULT_BITRATE      115200
 #endif
 
 /**


### PR DESCRIPTION
Fixes #192 

Signed-off-by: José Simões <jose.simoes@eclo.solutions>