### PR TITLE
Correct declaration of HalSystemConfig

### DIFF
--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -81,9 +81,6 @@ typedef struct HAL_SYSTEM_CONFIG
     HAL_SYSTEM_MEMORY_CONFIG RAM1;
     HAL_SYSTEM_MEMORY_CONFIG FLASH1;
 
-    //--//
-
-    //LPCSTR GetDriverName() { return "HAL_SYSTEM"; }
 }HAL_SYSTEM_CONFIG;
 
 extern HAL_SYSTEM_CONFIG  HalSystemConfig;

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_common.c
@@ -15,17 +15,17 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // UINT32      DebuggerPorts[MAX_DEBUGGERS];
-        //ConvertCOM_DebugHandle(0),
+        0//ConvertCOM_DebugHandle(0),
     },
 
     {
-        //ConvertCOM_DebugHandle(0),
+        0//ConvertCOM_DebugHandle(0),
     },
 
-    //ConvertCOM_DebugHandle(0),
+    0,//ConvertCOM_DebugHandle(0),
     115200,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
-    { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size },
+    { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_common.h.in
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_common.h.in
@@ -18,14 +18,14 @@
 // they also must be coherent with what's in the linker file for nanoBooter and nanoCLR
 
 // RAM base address 
-#define RAM1_MEMORY_StartAddress        0x200000C0
+#define RAM1_MEMORY_StartAddress        ((uint32_t)0x200000C0)
 // RAM size 
-#define RAM1_MEMORY_Size                0x00030000
+#define RAM1_MEMORY_Size                ((uint32_t)0x00030000)
 
 // FLASH base address
-#define FLASH1_MEMORY_StartAddress      0x08000000
+#define FLASH1_MEMORY_StartAddress      ((uint32_t)0x08000000)
 // FLASH size
-#define FLASH1_MEMORY_Size              0x00200000
+#define FLASH1_MEMORY_Size              ((uint32_t)0x00200000)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_common.c
@@ -15,17 +15,17 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // UINT32      DebuggerPorts[MAX_DEBUGGERS];
-        //ConvertCOM_DebugHandle(0),
+        0//ConvertCOM_DebugHandle(0),
     },
 
     {
-        //ConvertCOM_DebugHandle(0),
+        0//ConvertCOM_DebugHandle(0),
     },
 
-    //ConvertCOM_DebugHandle(0),
+    0,//ConvertCOM_DebugHandle(0),
     115200,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
-    { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size },
+    { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_common.h.in
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_common.h.in
@@ -18,14 +18,14 @@
 // they also must be coherent with what's in the linker file for nanoBooter and nanoCLR
 
 // RAM base address 
-#define RAM1_MEMORY_StartAddress        0x200000C0
+#define RAM1_MEMORY_StartAddress        ((uint32_t)0x200000C0)
 // RAM size 
-#define RAM1_MEMORY_Size                0x00040000
+#define RAM1_MEMORY_Size                ((uint32_t)0x00040000)
 
 // FLASH base address
-#define FLASH1_MEMORY_StartAddress      0x08000000
+#define FLASH1_MEMORY_StartAddress      ((uint32_t)0x08000000)
 // FLASH size
-#define FLASH1_MEMORY_Size              0x00100000
+#define FLASH1_MEMORY_Size              ((uint32_t)0x00100000)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/target_common.c
@@ -15,17 +15,17 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // UINT32      DebuggerPorts[MAX_DEBUGGERS];
-        //ConvertCOM_DebugHandle(0),
+        0//ConvertCOM_DebugHandle(0),
     },
 
     {
-        //ConvertCOM_DebugHandle(0),
+        0//ConvertCOM_DebugHandle(0),
     },
 
-    //ConvertCOM_DebugHandle(0),
+    0,//ConvertCOM_DebugHandle(0),
     115200,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
-    { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size },
+    { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/target_common.h.in
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/target_common.h.in
@@ -18,14 +18,14 @@
 // they also must be coherent with what's in the linker file for nanoBooter and nanoCLR
 
 // RAM base address 
-#define RAM1_MEMORY_StartAddress        0x200000C0
+#define RAM1_MEMORY_StartAddress        ((uint32_t)0x20000000)
 // RAM size 
-#define RAM1_MEMORY_Size                0x00007F40
+#define RAM1_MEMORY_Size                ((uint32_t)0x00008000)
 
 // FLASH base address
-#define FLASH1_MEMORY_StartAddress      0x08000000
+#define FLASH1_MEMORY_StartAddress      ((uint32_t)0x08000000)
 // FLASH size
-#define FLASH1_MEMORY_Size              0x00040000
+#define FLASH1_MEMORY_Size              ((uint32_t)0x00040000)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_common.c
@@ -15,17 +15,17 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // UINT32      DebuggerPorts[MAX_DEBUGGERS];
-        //ConvertCOM_DebugHandle(0),
+        0//ConvertCOM_DebugHandle(0),
     },
 
     {
-        //ConvertCOM_DebugHandle(0),
+        0//ConvertCOM_DebugHandle(0),
     },
 
-    //ConvertCOM_DebugHandle(0),
+    0,//ConvertCOM_DebugHandle(0),
     115200,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
-    { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size },
+    { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_common.h.in
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_common.h.in
@@ -18,14 +18,14 @@
 // they also must be coherent with what's in the linker file for nanoBooter and nanoCLR
 
 // RAM base address 
-#define RAM1_MEMORY_StartAddress        0x200000C0
+#define RAM1_MEMORY_StartAddress        ((uint32_t)0x200000C0)
 // RAM size 
-#define RAM1_MEMORY_Size                0x00030000
+#define RAM1_MEMORY_Size                ((uint32_t)0x00030000)
 
 // FLASH base address
-#define FLASH1_MEMORY_StartAddress      0x08000000
+#define FLASH1_MEMORY_StartAddress      ((uint32_t)0x08000000)
 // FLASH size
-#define FLASH1_MEMORY_Size              0x00200000
+#define FLASH1_MEMORY_Size              ((uint32_t)0x00200000)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_common.c
@@ -15,17 +15,17 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // UINT32      DebuggerPorts[MAX_DEBUGGERS];
-        //ConvertCOM_DebugHandle(0),
+        0//ConvertCOM_DebugHandle(0),
     },
 
     {
-        //ConvertCOM_DebugHandle(0),
+        0//ConvertCOM_DebugHandle(0),
     },
 
-    //ConvertCOM_DebugHandle(0),
+    0,//ConvertCOM_DebugHandle(0),
     115200,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
-    { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size },
+    { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_common.h.in
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_common.h.in
@@ -18,14 +18,14 @@
 // they also must be coherent with what's in the linker file for nanoBooter and nanoCLR
 
 // RAM base address 
-#define RAM1_MEMORY_StartAddress        0x200000C0
+#define RAM1_MEMORY_StartAddress        ((uint32_t)0x200000C0)
 // RAM size 
-#define RAM1_MEMORY_Size                0x00020000
+#define RAM1_MEMORY_Size                ((uint32_t)0x00020000)
 
 // FLASH base address
-#define FLASH1_MEMORY_StartAddress      0x08000000
+#define FLASH1_MEMORY_StartAddress      ((uint32_t)0x08000000)
 // FLASH size
-#define FLASH1_MEMORY_Size              0x00100000
+#define FLASH1_MEMORY_Size              ((uint32_t)0x00100000)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
- wasn't setting all the structure fields thus they were missalinged
- remove GetDriverName() from struct declaration
- add cast with type to addresses and size defines
- fixes #209

Signed-off-by: José Simões <jose.simoes@eclo.solutions>