### PR TITLE
Add GetSector in STM32 flash driver

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.c
@@ -144,6 +144,11 @@ bool flash_lld_isErased(uint32_t startAddress, uint32_t length) {
     return true;
 }
 
+uint8_t flash_lld_getSector(uint32_t address)
+{
+  return (address - FLASH_BASE) / F0_SERIES_SECTOR_SIZE;
+}
+
 bool flash_lld_erase(uint32_t address) {
 
     // unlock the FLASH
@@ -174,4 +179,3 @@ bool flash_lld_erase(uint32_t address) {
 }
 
 #endif
-

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.h
@@ -44,6 +44,7 @@ typedef struct SMT32FlashDriver {
 #define HAL_IS_BIT_SET(REG, BIT)    (((REG) & (BIT)) != RESET)
 #define FLASH_FLAG_BSY              FLASH_SR_BSY  // FLASH Busy flag
 
+#define F0_SERIES_SECTOR_SIZE       ((uint32_t)0x00001000U)
 
 ///////////////////////////////////////////////////////////////////////////////
 // External declarations.                                                    //
@@ -62,6 +63,7 @@ extern "C" {
   bool flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer);
   bool flash_lld_isErased(uint32_t startAddress, uint32_t length);
   bool flash_lld_erase(uint32_t address);
+  uint8_t flash_lld_getSector(uint32_t address);
 
 #ifdef __cplusplus
 }
@@ -70,4 +72,3 @@ extern "C" {
 #endif // HAL_USE_STM32_FLASH
 
 #endif // FLASH_LLD_H
-

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
@@ -55,25 +55,6 @@ bool HAL_FLASH_Lock(void)
   return true;  
 }
 
-static uint8_t GetSector(uint32_t address)
-{
-  uint8_t sector = 0;
-  bool sectorInBank2 = false;
-
-  if ((address - FLASH_BASE) >= 0x100000) {
-    sectorInBank2 = true;
-  } 
-
-  // clever algorithm to find out the sector number knowing the address
-  sector = sectorInBank2 ? ((address - 0x100000 - FLASH_BASE) >> 14) : ((address - FLASH_BASE) >> 14);
-  
-  if (sector >= 4) {
-    sector = (sector >> 3) + 4;
-  }
-
-  return sector;
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // Driver exported functions.                                                //
 ///////////////////////////////////////////////////////////////////////////////
@@ -163,6 +144,25 @@ bool flash_lld_isErased(uint32_t startAddress, uint32_t length) {
     return true;
 }
 
+uint8_t flash_lld_getSector(uint32_t address)
+{
+  uint8_t sector = 0;
+  bool sectorInBank2 = false;
+
+  if ((address - FLASH_BASE) >= 0x100000) {
+    sectorInBank2 = true;
+  } 
+
+  // clever algorithm to find out the sector number knowing the address
+  sector = sectorInBank2 ? ((address - 0x100000 - FLASH_BASE) >> 14) : ((address - FLASH_BASE) >> 14);
+  
+  if (sector >= 4) {
+    sector = (sector >> 3) + 4;
+  }
+
+  return sector;
+}
+
 bool flash_lld_erase(uint32_t address) {
     
     uint32_t tmp_psize = 0;
@@ -171,7 +171,7 @@ bool flash_lld_erase(uint32_t address) {
     if(HAL_FLASH_Unlock())
     {
         // get the sector number to erase
-        uint8_t sectorNumber = GetSector(address);
+        uint8_t sectorNumber = flash_lld_getSector(address);
 
         /* Need to add offset of 4 when sector higher than FLASH_SECTOR_11 */
         if(sectorNumber > FLASH_SECTOR_11) 
@@ -208,4 +208,3 @@ bool flash_lld_erase(uint32_t address) {
 }
 
 #endif
-

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.h
@@ -185,6 +185,7 @@ extern "C" {
   bool flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer);
   bool flash_lld_isErased(uint32_t startAddress, uint32_t length);
   bool flash_lld_erase(uint32_t address);
+  uint8_t flash_lld_getSector(uint32_t address);
 
 #ifdef __cplusplus
 }
@@ -193,4 +194,3 @@ extern "C" {
 #endif // HAL_USE_STM32_FLASH
 
 #endif // FLASH_LLD_H
-

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_flash/hal_stm32_flash.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_flash/hal_stm32_flash.c
@@ -60,6 +60,10 @@ bool stm32FlashErase(uint32_t address) {
   return flash_lld_erase(address);
 }
 
+uint8_t stm32FlashGetSector(uint32_t address) {
+  return flash_lld_getSector(address);
+}
+
 
 #endif
 


### PR DESCRIPTION
- this is to retrieve the sector number given a flash address
- implemented this for both version of the driver
- remove extra empty line at file end

Signed-off-by: José Simões <jose.simoes@eclo.solutions>