### PR TITLE
Add linker symbols for image and deployment

### DIFF
--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -86,7 +86,7 @@ typedef struct HAL_SYSTEM_CONFIG
 extern HAL_SYSTEM_CONFIG  HalSystemConfig;
 
 extern uint32_t __nanoImage_start__;
-extern uint32_t __nanoImage_start__;
+extern uint32_t __nanoImage_end__;
 extern uint32_t __deployment_start__;
 extern uint32_t __deployment_end__;
 

--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -85,4 +85,9 @@ typedef struct HAL_SYSTEM_CONFIG
 
 extern HAL_SYSTEM_CONFIG  HalSystemConfig;
 
+extern uint32_t __nanoImage_start__;
+extern uint32_t __nanoImage_start__;
+extern uint32_t __deployment_start__;
+extern uint32_t __deployment_end__;
+
 #endif // _NANOHAL_V2_H_

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/mbn_quail_booter.ld
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/mbn_quail_booter.ld
@@ -12,15 +12,17 @@
  */
 MEMORY
 {
-    flash : org = 0x08000000, len = 32k     /* space reserved for bootloader (1st two sectors 0x08000000 to 0x08007FFF)*/
-    ram0  : org = 0x20000000, len = 192k    /* SRAM1 + SRAM2 + SRAM3 */
-    ram1  : org = 0x20000000, len = 112k    /* SRAM1 */
-    ram2  : org = 0x2001C000, len = 16k     /* SRAM2 */
-    ram3  : org = 0x20020000, len = 64k     /* SRAM3 */
-    ram4  : org = 0x10000000, len = 64k     /* CCM SRAM */
-    ram5  : org = 0x40024000, len = 4k      /* BCKP SRAM */
-    ram6  : org = 0x00000000, len = 0
-    ram7  : org = 0x00000000, len = 0
+    flash       : org = 0x08000000, len = 32k     /* space reserved for nanoBooter (1st two sectors 0x08000000 to 0x08008000)*/
+    deployment  : org = 0x00000000, len = 0       /* space reserved for application deployment */
+    ramvt       : org = 0x00000000, len = 0       /* initial RAM address is reserved for a copy of the vector table */
+    ram0        : org = 0x20000000, len = 192k    /* SRAM1 + SRAM2 + SRAM3 */
+    ram1        : org = 0x20000000, len = 112k    /* SRAM1 */
+    ram2        : org = 0x2001C000, len = 16k     /* SRAM2 */
+    ram3        : org = 0x20020000, len = 64k     /* SRAM3 */
+    ram4        : org = 0x10000000, len = 64k     /* CCM SRAM */
+    ram5        : org = 0x40024000, len = 4k      /* BCKP SRAM */
+    ram6        : org = 0x00000000, len = 0
+    ram7        : org = 0x00000000, len = 0
 }
 
 /* RAM region to be used for Main stack. This stack accommodates the processing

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/mbn_quail_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/mbn_quail_CLR.ld
@@ -12,15 +12,17 @@
  */
 MEMORY
 {
-    flash : org = 0x08008000, len = 2M - 32k - 800k /* flash size less the space reserved for nanoBooter and application deployment*/
-    ram0  : org = 0x20000000, len = 192k            /* SRAM1 + SRAM2 + SRAM3 */
-    ram1  : org = 0x20000000, len = 112k            /* SRAM1 */
-    ram2  : org = 0x2001C000, len = 16k             /* SRAM2 */
-    ram3  : org = 0x20020000, len = 64k             /* SRAM3 */
-    ram4  : org = 0x10000000, len = 64k             /* CCM SRAM */
-    ram5  : org = 0x40024000, len = 4k              /* BCKP SRAM */
-    ram6  : org = 0x00000000, len = 0
-    ram7  : org = 0x00000000, len = 0
+    flash       : org = 0x08008000, len = 2M - 32k - 800k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    deployment  : org = 0x08138000, len = 800k              /* space reserved for application deployment */
+    ramvt       : org = 0x00000000, len = 0                 /* initial RAM address is reserved for a copy of the vector table */
+    ram0        : org = 0x20000000, len = 192k              /* SRAM1 + SRAM2 + SRAM3 */
+    ram1        : org = 0x20000000, len = 112k              /* SRAM1 */
+    ram2        : org = 0x2001C000, len = 16k               /* SRAM2 */
+    ram3        : org = 0x20020000, len = 64k               /* SRAM3 */
+    ram4        : org = 0x10000000, len = 64k               /* CCM SRAM */
+    ram5        : org = 0x40024000, len = 4k                /* BCKP SRAM */
+    ram6        : org = 0x00000000, len = 0
+    ram7        : org = 0x00000000, len = 0
 }
 
 /* RAM region to be used for Main stack. This stack accommodates the processing

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/STM32F746xG_booter.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/STM32F746xG_booter.ld
@@ -17,8 +17,10 @@
  */
 MEMORY
 {
-    flash       : org = 0x08000000, len = 32k     /* space reserved for bootloader (1st two sectors 0x08000000 to 0x08007FFF)*/
+    flash       : org = 0x08000000, len = 32k     /* space reserved for nanoBooter (1st two sectors 0x08000000 to 0x08008000)*/
     flash_itcm  : org = 0x00200000, len = 1M
+    deployment  : org = 0x00000000, len = 0       /* space reserved for application deployment */
+    ramvt       : org = 0x00000000, len = 0       /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20010000, len = 256k    /* SRAM1 + SRAM2 */
     ram1        : org = 0x20010000, len = 240k    /* SRAM1 */
     ram2        : org = 0x2004C000, len = 16k     /* SRAM2 */

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/main.c
@@ -8,6 +8,7 @@
 #include <cmsis_os.h>
 
 #include <usbcfg.h>
+#include <nanoHAL_v2.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <LaunchCLR.h>
 
@@ -62,11 +63,11 @@ int main(void) {
   if (palReadPad(GPIOC, GPIOC_BUTTON))
   {
     // check for valid CLR image 
-    if(CheckValidCLRImage(0x08008000))
+    if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
     {
       // there seems to be a valid CLR image
       // launch nanoCLR
-      LaunchCLR(0x08008000);
+      LaunchCLR((uint32_t)&__nanoImage_end__);
     }
   }
 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/STM32F746xG_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/STM32F746xG_CLR.ld
@@ -19,6 +19,8 @@ MEMORY
 {
     flash       : org = 0x08008000, len = 1M - 32k - 800k   /* flash size less the space reserved for nanoBooter and application deployment*/
     flash_itcm  : org = 0x00200000, len = 1M
+    deployment  : org = 0x08038000, len = 800k              /* space reserved for application deployment */
+    ramvt       : org = 0x00000000, len = 0                 /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20010000, len = 256k              /* SRAM1 + SRAM2 */
     ram1        : org = 0x20010000, len = 240k              /* SRAM1 */
     ram2        : org = 0x2004C000, len = 16k               /* SRAM2 */

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/STM32F091xC_booter.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/STM32F091xC_booter.ld
@@ -12,15 +12,17 @@
  */
 MEMORY
 {
-    flash : org = 0x08000000, len = 16k     /* space reserved for bootloader (1st eight sectors 0x08000000 to 0x08003FFF)*/
-    ram0  : org = 0x20000000, len = 32k
-    ram1  : org = 0x00000000, len = 0
-    ram2  : org = 0x00000000, len = 0
-    ram3  : org = 0x00000000, len = 0
-    ram4  : org = 0x00000000, len = 0
-    ram5  : org = 0x00000000, len = 0
-    ram6  : org = 0x00000000, len = 0
-    ram7  : org = 0x00000000, len = 0
+    flash       : org = 0x08000000, len = 16k     /* space reserved for nanoBooter (1st eight sectors 0x08000000 to 0x08004000)*/
+    deployment  : org = 0x00000000, len = 0       /* space reserved for application deployment */
+    ramvt       : org = 0x00000000, len = 0       /* initial RAM address is reserved for a copy of the vector table */
+    ram0        : org = 0x20000000, len = 32k
+    ram1        : org = 0x00000000, len = 0
+    ram2        : org = 0x00000000, len = 0
+    ram3        : org = 0x00000000, len = 0
+    ram4        : org = 0x00000000, len = 0
+    ram5        : org = 0x00000000, len = 0
+    ram6        : org = 0x00000000, len = 0
+    ram7        : org = 0x00000000, len = 0
 }
 
 /* RAM region to be used for Main stack. This stack accommodates the processing

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/main.c
@@ -7,6 +7,7 @@
 #include <hal.h>
 #include <cmsis_os.h>
 
+#include <nanoHAL_v2.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <LaunchCLR.h>
 
@@ -46,12 +47,12 @@ int main(void) {
   // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
   if (palReadPad(GPIOC, GPIOC_BUTTON))
   {
-    // check for valid CLR image 
-    if(CheckValidCLRImage(0x08004000))
+    // check for valid CLR image at address contiguous to nanoBooter
+    if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
     {
       // there seems to be a valid CLR image
       // launch nanoCLR
-      LaunchCLR(0x08004000);
+      LaunchCLR((uint32_t)&__nanoImage_end__);
     }
   }
 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/STM32F091xC_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/STM32F091xC_CLR.ld
@@ -12,16 +12,17 @@
  */
 MEMORY
 {
-    flash : org = 0x08004000, len = 256k - 16k - 100k   /* flash size less the space reserved for nanoBooter and application deployment*/
-    ramvt : org = 0x20000000, len = 0xC0                /* initial RAM address is reserved for a copy of the vector table */
-    ram0  : org = 0x200000C0, len = 32k - 0xC0          /* remaining RAM is free for use */
-    ram1  : org = 0x00000000, len = 0
-    ram2  : org = 0x00000000, len = 0
-    ram3  : org = 0x00000000, len = 0
-    ram4  : org = 0x00000000, len = 0
-    ram5  : org = 0x00000000, len = 0
-    ram6  : org = 0x00000000, len = 0
-    ram7  : org = 0x00000000, len = 0
+    flash       : org = 0x08004000, len = 256k - 16k - 100k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    deployment  : org = 0x08027000, len = 100k                /* space reserved for application deployment */
+    ramvt       : org = 0x20000000, len = 0xC0                /* initial RAM address is reserved for a copy of the vector table */
+    ram0        : org = 0x200000C0, len = 32k - 0xC0          /* remaining RAM is free for use */
+    ram1        : org = 0x00000000, len = 0
+    ram2        : org = 0x00000000, len = 0
+    ram3        : org = 0x00000000, len = 0
+    ram4        : org = 0x00000000, len = 0
+    ram5        : org = 0x00000000, len = 0
+    ram6        : org = 0x00000000, len = 0
+    ram7        : org = 0x00000000, len = 0
 }
 
 /* RAM region to be used for Main stack. This stack accommodates the processing

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
@@ -7,6 +7,7 @@
 #include <hal.h>
 #include <cmsis_os.h>
 
+#include <nanoHAL_v2.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <CLR_Startup_Thread.h>
 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
@@ -14,10 +14,6 @@
 // RAM vector table declaration (valid for GCC only)
 __IO uint32_t vectorTable[48] __attribute__((section(".RAMVectorTable")));
 
-
-// need to change this address if nanoCLR is to be located at a different address 
-// has to match the start address of flash region in STM32F091xC.ld
-#define APPLICATION_ADDRESS         (uint32_t)0x08004000
 #define SYSCFG_MemoryRemap_SRAM     ((uint8_t)0x03)
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -59,10 +55,10 @@ int main(void) {
 
   // relocate the vector table to RAM
   // Copy the vector table from the Flash (mapped at the base of the application
-  // load address APPLICATION_ADDRESS) to the base address of the SRAM at 0x20000000.
+  // load address) to the base address of the SRAM at 0x20000000.
   for(int i = 0; i < 48; i++)
   {
-    vectorTable[i] = *(__IO uint32_t*)(APPLICATION_ADDRESS + (i<<2));
+    vectorTable[i] = *(__IO uint32_t*)((uint32_t)&__nanoImage_start__ + (i<<2));
   } 
 
   // set CFGR1 register MEM_MODE bits value as "memory remap to SRAM"

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
@@ -53,7 +53,6 @@ osThreadDef(CLRStartupThread, osPriorityNormal, 1024);
 //  Application entry point.
 int main(void) {
 
-
   // HAL initialization, this also initializes the configured device drivers
   // and performs the board-specific initializations.
   halInit();

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/STM32F429xI_booter.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/STM32F429xI_booter.ld
@@ -12,15 +12,17 @@
  */
 MEMORY
 {
-    flash : org = 0x08000000, len = 32k     /* space reserved for bootloader (1st two sectors 0x08000000 to 0x08007FFF)*/
-    ram0  : org = 0x20000000, len = 192k    /* SRAM1 + SRAM2 + SRAM3 */
-    ram1  : org = 0x20000000, len = 112k    /* SRAM1 */
-    ram2  : org = 0x2001C000, len = 16k     /* SRAM2 */
-    ram3  : org = 0x20020000, len = 64k     /* SRAM3 */
-    ram4  : org = 0x10000000, len = 64k     /* CCM SRAM */
-    ram5  : org = 0x40024000, len = 4k      /* BCKP SRAM */
-    ram6  : org = 0x00000000, len = 0
-    ram7  : org = 0x00000000, len = 0
+    flash       : org = 0x08000000, len = 32k     /* space reserved for nanoBooter (1st two sectors 0x08000000 to 0x08008000)*/
+    deployment  : org = 0x00000000, len = 0       /* space reserved for application deployment */
+    ramvt       : org = 0x00000000, len = 0       /* initial RAM address is reserved for a copy of the vector table */
+    ram0        : org = 0x20000000, len = 192k    /* SRAM1 + SRAM2 + SRAM3 */
+    ram1        : org = 0x20000000, len = 112k    /* SRAM1 */
+    ram2        : org = 0x2001C000, len = 16k     /* SRAM2 */
+    ram3        : org = 0x20020000, len = 64k     /* SRAM3 */
+    ram4        : org = 0x10000000, len = 64k     /* CCM SRAM */
+    ram5        : org = 0x40024000, len = 4k      /* BCKP SRAM */
+    ram6        : org = 0x00000000, len = 0
+    ram7        : org = 0x00000000, len = 0
 }
 
 /* RAM region to be used for Main stack. This stack accommodates the processing

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
@@ -8,6 +8,7 @@
 #include <cmsis_os.h>
 
 #include <usbcfg.h>
+#include <nanoHAL_v2.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <LaunchCLR.h>
 
@@ -53,11 +54,11 @@ int main(void) {
   if (palReadPad(GPIOA, GPIOA_BUTTON))
   {
     // check for valid CLR image 
-    if(CheckValidCLRImage(0x08008000))
+    if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
     {
       // there seems to be a valid CLR image
       // launch nanoCLR
-      LaunchCLR(0x08008000);
+      LaunchCLR((uint32_t)&__nanoImage_end__);
     }
   }
 

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
@@ -12,15 +12,17 @@
  */
 MEMORY
 {
-    flash : org = 0x08008000, len = 2M - 32k - 800k     /* flash size less the space reserved for nanoBooter and application deployment*/
-    ram0  : org = 0x20000000, len = 192k                /* SRAM1 + SRAM2 + SRAM3 */
-    ram1  : org = 0x20000000, len = 112k                /* SRAM1 */
-    ram2  : org = 0x2001C000, len = 16k                 /* SRAM2 */
-    ram3  : org = 0x20020000, len = 64k                 /* SRAM3 */
-    ram4  : org = 0x10000000, len = 64k                 /* CCM SRAM */
-    ram5  : org = 0x40024000, len = 4k                  /* BCKP SRAM */
-    ram6  : org = 0x00000000, len = 0
-    ram7  : org = 0x00000000, len = 0
+    flash       : org = 0x08008000, len = 2M - 32k - 800k       /* flash size less the space reserved for nanoBooter and application deployment*/
+    deployment  : org = 0x08138000, len = 800k                  /* space reserved for application deployment */
+    ramvt       : org = 0x00000000, len = 0                     /* initial RAM address is reserved for a copy of the vector table */
+    ram0        : org = 0x20000000, len = 192k                  /* SRAM1 + SRAM2 + SRAM3 */
+    ram1        : org = 0x20000000, len = 112k                  /* SRAM1 */
+    ram2        : org = 0x2001C000, len = 16k                   /* SRAM2 */
+    ram3        : org = 0x20020000, len = 64k                   /* SRAM3 */
+    ram4        : org = 0x10000000, len = 64k                   /* CCM SRAM */
+    ram5        : org = 0x40024000, len = 4k                    /* BCKP SRAM */
+    ram6        : org = 0x00000000, len = 0
+    ram7        : org = 0x00000000, len = 0
 }
 
 /* RAM region to be used for Main stack. This stack accommodates the processing

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/STM32F407xG_booter.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/STM32F407xG_booter.ld
@@ -12,15 +12,17 @@
  */
 MEMORY
 {
-    flash : org = 0x08000000, len = 32k     /* space reserved for bootloader (1st two sectors 0x08000000 to 0x08007FFF)*/
-    ram0  : org = 0x20000000, len = 128k    /* SRAM1 + SRAM2 */
-    ram1  : org = 0x20000000, len = 112k    /* SRAM1 */
-    ram2  : org = 0x2001C000, len = 16k     /* SRAM2 */
-    ram3  : org = 0x00000000, len = 0
-    ram4  : org = 0x10000000, len = 64k     /* CCM SRAM */
-    ram5  : org = 0x40024000, len = 4k      /* BCKP SRAM */
-    ram6  : org = 0x00000000, len = 0
-    ram7  : org = 0x00000000, len = 0
+    flash       : org = 0x08000000, len = 32k     /* space reserved for nanoBooter (1st two sectors 0x08000000 to 0x08008000)*/
+    deployment  : org = 0x00000000, len = 0       /* space reserved for application deployment */
+    ramvt       : org = 0x00000000, len = 0       /* initial RAM address is reserved for a copy of the vector table */
+    ram0        : org = 0x20000000, len = 128k    /* SRAM1 + SRAM2 */
+    ram1        : org = 0x20000000, len = 112k    /* SRAM1 */
+    ram2        : org = 0x2001C000, len = 16k     /* SRAM2 */
+    ram3        : org = 0x00000000, len = 0
+    ram4        : org = 0x10000000, len = 64k     /* CCM SRAM */
+    ram5        : org = 0x40024000, len = 4k      /* BCKP SRAM */
+    ram6        : org = 0x00000000, len = 0
+    ram7        : org = 0x00000000, len = 0
 }
 
 /* RAM region to be used for Main stack. This stack accommodates the processing

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
@@ -8,6 +8,7 @@
 #include <cmsis_os.h>
 
 #include <usbcfg.h>
+#include <nanoHAL_v2.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <LaunchCLR.h>
 
@@ -61,11 +62,11 @@ int main(void) {
   if (palReadPad(GPIOA, GPIOA_BUTTON))
   {
     // check for valid CLR image 
-    if(CheckValidCLRImage(0x08008000))
+    if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
     {
       // there seems to be a valid CLR image
       // launch nanoCLR
-      LaunchCLR(0x08008000);
+      LaunchCLR((uint32_t)&__nanoImage_end__);
     }
   }
 

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/STM32F407xG_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/STM32F407xG_CLR.ld
@@ -12,15 +12,17 @@
  */
 MEMORY
 {
-    flash : org = 0x08008000, len = 1M - 32k - 800k     /* flash size less the space reserved for nanoBooter and application deployment*/
-    ram0  : org = 0x20000000, len = 128k                /* SRAM1 + SRAM2 */
-    ram1  : org = 0x20000000, len = 112k                /* SRAM1 */
-    ram2  : org = 0x2001C000, len = 16k                 /* SRAM2 */
-    ram3  : org = 0x00000000, len = 0
-    ram4  : org = 0x10000000, len = 64k                 /* CCM SRAM */
-    ram5  : org = 0x40024000, len = 4k                  /* BCKP SRAM */
-    ram6  : org = 0x00000000, len = 0
-    ram7  : org = 0x00000000, len = 0
+    flash       : org = 0x08008000, len = 1M - 32k - 800k     /* flash size less the space reserved for nanoBooter and application deployment*/
+    deployment  : org = 0x08038000, len = 800k                /* space reserved for application deployment */
+    ramvt       : org = 0x20000000, len = 0xC0                /* initial RAM address is reserved for a copy of the vector table */
+    ram0        : org = 0x20000000, len = 128k                /* SRAM1 + SRAM2 */
+    ram1        : org = 0x20000000, len = 112k                /* SRAM1 */
+    ram2        : org = 0x2001C000, len = 16k                 /* SRAM2 */
+    ram3        : org = 0x00000000, len = 0
+    ram4        : org = 0x10000000, len = 64k                 /* CCM SRAM */
+    ram5        : org = 0x40024000, len = 4k                  /* BCKP SRAM */
+    ram6        : org = 0x00000000, len = 0
+    ram7        : org = 0x00000000, len = 0
 }
 
 /* RAM region to be used for Main stack. This stack accommodates the processing

--- a/targets/CMSIS-OS/ChibiOS/common/rules.ld
+++ b/targets/CMSIS-OS/ChibiOS/common/rules.ld
@@ -32,6 +32,11 @@ __ram7_start__          = ORIGIN(ram7);
 __ram7_size__           = LENGTH(ram7);
 __ram7_end__            = __ram7_start__ + __ram7_size__;
 
+__nanoImage_start__     = ORIGIN(flash);
+__nanoImage_end__       = __nanoImage_start__ + LENGTH(flash);
+__deployment_start__    = ORIGIN(deployment);
+__deployment_end__      = __deployment_start__ + LENGTH(deployment);
+
 ENTRY(Reset_Handler)
 
 SECTIONS

--- a/targets/CMSIS-OS/ChibiOS/common/rules_STM32F7xx.ld
+++ b/targets/CMSIS-OS/ChibiOS/common/rules_STM32F7xx.ld
@@ -32,6 +32,11 @@ __ram7_start__          = ORIGIN(ram7);
 __ram7_size__           = LENGTH(ram7);
 __ram7_end__            = __ram7_start__ + __ram7_size__;
 
+__nanoImage_start__     = ORIGIN(flash);
+__nanoImage_end__       = __nanoImage_start__ + LENGTH(flash);
+__deployment_start__    = ORIGIN(deployment);
+__deployment_end__      = __deployment_start__ + LENGTH(deployment);
+
 ENTRY(Reset_Handler)
 
 SECTIONS


### PR DESCRIPTION
- add new regions to linker scripts for deployment
- add missing regions for RAM virtual table
- add symbols to linker scripts to expose region addresses automaticaly as vars
- add externals to nanoHAL_v2 to access region addresses

Signed-off-by: José Simões <jose.simoes@eclo.solutions>