### PR TITLE
Moved linker symbols to targetHAL

### DIFF
--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -85,9 +85,4 @@ typedef struct HAL_SYSTEM_CONFIG
 
 extern HAL_SYSTEM_CONFIG  HalSystemConfig;
 
-extern uint32_t __nanoImage_start__;
-extern uint32_t __nanoImage_end__;
-extern uint32_t __deployment_start__;
-extern uint32_t __deployment_end__;
-
 #endif // _NANOHAL_V2_H_

--- a/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
@@ -43,4 +43,9 @@ extern int HeapEnd;
 // extern char * nanoCLR_Dat_Start;
 // extern char * nanoCLR_Dat_End;
 
+extern uint32_t __nanoImage_start__;
+extern uint32_t __nanoImage_end__;
+extern uint32_t __deployment_start__;
+extern uint32_t __deployment_end__;
+
 #endif //_TARGET_HAL_H_

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/main.c
@@ -8,7 +8,7 @@
 #include <cmsis_os.h>
 
 #include <usbcfg.h>
-#include <nanoHAL_v2.h>
+#include <targetHAL.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <LaunchCLR.h>
 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoBooter/main.c
@@ -7,7 +7,7 @@
 #include <hal.h>
 #include <cmsis_os.h>
 
-#include <nanoHAL_v2.h>
+#include <targetHAL.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <LaunchCLR.h>
 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
@@ -7,7 +7,7 @@
 #include <hal.h>
 #include <cmsis_os.h>
 
-#include <nanoHAL_v2.h>
+#include <targetHAL.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <CLR_Startup_Thread.h>
 

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
@@ -8,7 +8,7 @@
 #include <cmsis_os.h>
 
 #include <usbcfg.h>
-#include <nanoHAL_v2.h>
+#include <targetHAL.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <LaunchCLR.h>
 

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
@@ -8,7 +8,7 @@
 #include <cmsis_os.h>
 
 #include <usbcfg.h>
-#include <nanoHAL_v2.h>
+#include <targetHAL.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <LaunchCLR.h>
 


### PR DESCRIPTION
- those are specific for the target, so shouldn't be at nanoHAL layer

Signed-off-by: José Simões <jose.simoes@eclo.solutions>