### PR TITLE
Rework PAL and BlockStorage

### DIFF
--- a/CMake/Modules/FindNF_Debugger.cmake
+++ b/CMake/Modules/FindNF_Debugger.cmake
@@ -12,11 +12,16 @@ list(APPEND NF_Debugger_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/src/CLR/Include)
 # source files for nanoFramework Debugger
 set(NF_Debugger_SRCS
 
-    Debugger.cpp
-    Debugger_full.cpp
+    # Debugger.cpp
+    # Debugger_full.cpp
 
-    Messaging.cpp
-    WireProtocol.cpp
+    # Messaging.cpp
+    # WireProtocol.cpp
+    
+    WireProtocol_Message.c
+    WireProtocol_MonitorCommands.c
+    WireProtocol_HAL_Interface.c
+    WireProtocol_App_Interface.c
 
     nanoSupport_CRC32.c
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,9 +198,9 @@ message(STATUS "")
 # debugger (default is TRUE to include debugger in release image
 if(NOT NF_FEATURE_DEBUGGER OR
    NOT "${NF_FEATURE_DEBUGGER}" STREQUAL "TRUE")
-    set(NF_FEATURE_DEBUGGER TRUE)
+    set(NF_FEATURE_DEBUGGER TRUE CACHE INTERNAL "NF Feature debugger")
 else()
-    set(NF_FEATURE_DEBUGGER FALSE)
+    set(NF_FEATURE_DEBUGGER FALSE CACHE INTERNAL "NF Feature debugger")
 endif()
 
 #################################################################

--- a/src/CLR/Core/HeapPersistence/Heap_Persistence.cpp
+++ b/src/CLR/Core/HeapPersistence/Heap_Persistence.cpp
@@ -643,8 +643,8 @@ void CLR_RT_Persistence_Manager::Initialize()
                                                   // UINT32                          m_margin_BurstWrite;
                                                   // UINT32                          m_margin_BlockErase;
                                                   //
-    if(!m_bankA.Initialize( BlockUsage::STORAGE_A )) return; // Bank                            m_bankA;
-    if(!m_bankB.Initialize( BlockUsage::STORAGE_B )) return; // Bank                            m_bankB;
+    if(!m_bankA.Initialize( BlockUsage_STORAGE_A )) return; // Bank                            m_bankA;
+    if(!m_bankB.Initialize( BlockUsage_STORAGE_B )) return; // Bank                            m_bankB;
                                                   //
     m_state = STATE_FlushNextObject;              // CLR_UINT32                      m_state;
                                                   //

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -131,7 +131,7 @@ HRESULT CLR_DBG_Debugger::CreateInstance()
 
     BlockStorageStream stream;
 
-    if (stream.Initialize( BlockUsage::DEPLOYMENT ))
+    if (stream.Initialize( BlockUsage_DEPLOYMENT ))
     {
         m_deploymentStorageDevice = stream.Device;
     }
@@ -3078,7 +3078,7 @@ bool CLR_DBG_Debugger::Debugging_Deployment_Status( WP_Message* msg, void* owner
     {
         BlockStorageStream stream;
 
-        if(stream.Initialize( BlockUsage::DEPLOYMENT, m_deploymentStorageDevice ))
+        if(stream.Initialize( BlockUsage_DEPLOYMENT, m_deploymentStorageDevice ))
         {
             do
             {
@@ -3113,7 +3113,7 @@ bool CLR_DBG_Debugger::Debugging_Deployment_Status( WP_Message* msg, void* owner
 
         bool fDone = false;
 
-        if(stream.Initialize( BlockUsage::DEPLOYMENT, m_deploymentStorageDevice ))
+        if(stream.Initialize( BlockUsage_DEPLOYMENT, m_deploymentStorageDevice ))
         {
             do
             {

--- a/src/PAL/Include/nanoPAL.h
+++ b/src/PAL/Include/nanoPAL.h
@@ -379,7 +379,7 @@ int hal_strncmp_s( const char* str1, const char* str2, size_t num );
 //#include <Analog_decl.h>
 //#include <AnalogOut_decl.h>
 //
-#include "BlockStorage_decl.h"
+#include "TargetPAL_BlockStorage.h"
 
 //#include <SD_decl.h>
 

--- a/src/PAL/Include/nanoPAL_BlockStorage.h
+++ b/src/PAL/Include/nanoPAL_BlockStorage.h
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+#ifndef _NANOPAL_BLOCKSTORAGE_H_
+#define _NANOPAL_BLOCKSTORAGE_H_ 1
+
+//////////////////////////////////////////////////////////
+// Description:
+//   Flags to Indicate the status of a particular block in
+//   flash. ALL sectors for a block *MUST* share the same
+//   status.
+//
+// Remarks:
+//   When the block is reserved the lower 16 bits specifies a
+//   USAGE_XXXX value to indicate the purpose of the block.
+// 
+//   The BlockRange information is technically dynamic in the 
+//   sense that it is not fixed or defined in hardware. Rather,
+//   it is defined by the system designer. However, the BlockRange
+//   info does not and *MUST* not change at run-time.  The only
+//   exceptions to this rule is in the boot loader where the
+//   storage device is being formated or re-laid out as part
+//   of an update etc... and when an FS discovers a bad block
+//   it should mark it as bad. WIthout this restriction
+//   implementing an FS is virtually impossible since the FS
+//   would have to deal with the possibility that the usage for
+//   a Block could change at any point in time.
+//
+typedef enum BlockUsage
+{
+    BlockUsage_BOOTSTRAP   = 0x0010,
+    BlockUsage_CODE        = 0x0020,
+    BlockUsage_CONFIG      = 0x0030,
+    BlockUsage_FILESYSTEM  = 0x0040,    
+
+    BlockUsage_DEPLOYMENT  = 0x0050, 
+
+    BlockUsage_UPDATE      = 0x0060,
+
+    BlockUsage_SIMPLE_A    = 0x0090,
+    BlockUsage_SIMPLE_B    = 0x00A0,
+    
+    BlockUsage_STORAGE_A   = 0x00E0,
+    BlockUsage_STORAGE_B   = 0x00F0,
+
+
+    ANY         = 0x0000,
+    
+}BlockUsage;
+
+#endif // _NANOPAL_BLOCKSTORAGE_H_

--- a/targets/CMSIS-OS/ChibiOS/Include/TargetPAL_BlockStorage.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/TargetPAL_BlockStorage.h
@@ -4,13 +4,14 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#ifndef _DRIVERS_PAL_BLOCKSTORAGE_H_
-#define _DRIVERS_PAL_BLOCKSTORAGE_H_ 1
+#ifndef _TARGET_PAL_BLOCKSTORAGE_H_
+#define _TARGET_PAL_BLOCKSTORAGE_H_ 1
 
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
 #include <nanoWeak.h>
+#include <nanoPAL_BlockStorage.h>
 
 typedef struct BLOCKRANGE BlockRange;
 
@@ -203,4 +204,4 @@ struct BLOCKSTORAGESTREAM
 
 /////////////////////////////////////////////////////
 
-#endif  // _DRIVERS_PAL_BLOCKSTORAGE_H_
+#endif  // _TARGET_PAL_BLOCKSTORAGE_H_

--- a/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
@@ -7,7 +7,7 @@
 #define _TARGET_HAL_H_
 
 #include <target_board.h>
-#include "BlockStorage_decl.h"
+#include "TargetPAL_BlockStorage.h"
 
 #if !defined(BUILD_RTM)
 

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -28,8 +28,6 @@ find_package(NF_CoreCLR REQUIRED)
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
-    find_package(NF_WireProtocol REQUIRED)
-    else()
 endif()
 
 # optional
@@ -85,12 +83,9 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
-    ${WireProtocol_SOURCES}
-
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"
     "${NF_Debugger_SOURCES}"
-    "${NF_WireProtocol_SOURCES}"
 )
 
 
@@ -101,7 +96,8 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${PROJECT_SOURCE_DIR}/src/CLR/Include
     ${PROJECT_SOURCE_DIR}/src/HAL/Include
-    
+    ${PROJECT_SOURCE_DIR}/src/PAL/Include
+
     ${WireProtocol_INCLUDE_DIRS}
     ${CHIBIOS_INCLUDE_DIRS}
     ${ChibiOSnfOverlay_INCLUDE_DIRS}

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
@@ -28,8 +28,6 @@ find_package(NF_CoreCLR REQUIRED)
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
-    find_package(NF_WireProtocol REQUIRED)
-    else()
 endif()
 
 # optional
@@ -85,12 +83,9 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
-    ${WireProtocol_SOURCES}
-
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"
     "${NF_Debugger_SOURCES}"
-    "${NF_WireProtocol_SOURCES}"
 )
 
 
@@ -101,7 +96,8 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${PROJECT_SOURCE_DIR}/src/CLR/Include
     ${PROJECT_SOURCE_DIR}/src/HAL/Include
-    
+    ${PROJECT_SOURCE_DIR}/src/PAL/Include
+
     ${WireProtocol_INCLUDE_DIRS}
     ${CHIBIOS_INCLUDE_DIRS}
     ${ChibiOSnfOverlay_INCLUDE_DIRS}
@@ -130,7 +126,6 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
     # directories for nanoFramework libraries
     "${NF_CoreCLR_INCLUDE_DIRS}"
     "${NF_Debugger_INCLUDE_DIRS}"
-    "${NF_WireProtocol_INCLUDE_DIRS}"
 )
 
 ###################

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/CMakeLists.txt
@@ -28,8 +28,6 @@ find_package(NF_CoreCLR REQUIRED)
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
-    find_package(NF_WireProtocol REQUIRED)
-    else()
 endif()
 
 # optional
@@ -85,14 +83,10 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
-    ${WireProtocol_SOURCES}
-
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"
     "${NF_Debugger_SOURCES}"
-    "${NF_WireProtocol_SOURCES}"
 )
-
 
 # include common directories
 include_directories(
@@ -101,6 +95,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${PROJECT_SOURCE_DIR}/src/CLR/Include
     ${PROJECT_SOURCE_DIR}/src/HAL/Include
+    ${PROJECT_SOURCE_DIR}/src/PAL/Include
     
     ${WireProtocol_INCLUDE_DIRS}
     ${CHIBIOS_INCLUDE_DIRS}
@@ -130,7 +125,6 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
     # directories for nanoFramework libraries
     "${NF_CoreCLR_INCLUDE_DIRS}"
     "${NF_Debugger_INCLUDE_DIRS}"
-    "${NF_WireProtocol_INCLUDE_DIRS}"
 )
 
 ###################

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -28,7 +28,6 @@ find_package(NF_CoreCLR REQUIRED)
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
-    else()
 endif()
 
 # optional
@@ -84,12 +83,9 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
-    ${WireProtocol_SOURCES}
-
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"
     "${NF_Debugger_SOURCES}"
-    "${NF_WireProtocol_SOURCES}"
 )
 
 
@@ -100,7 +96,8 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${PROJECT_SOURCE_DIR}/src/CLR/Include
     ${PROJECT_SOURCE_DIR}/src/HAL/Include
-    
+    ${PROJECT_SOURCE_DIR}/src/PAL/Include
+
     ${WireProtocol_INCLUDE_DIRS}
     ${CHIBIOS_INCLUDE_DIRS}
     ${ChibiOSnfOverlay_INCLUDE_DIRS}
@@ -129,7 +126,6 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
     # directories for nanoFramework libraries
     "${NF_CoreCLR_INCLUDE_DIRS}"
     "${NF_Debugger_INCLUDE_DIRS}"
-    "${NF_WireProtocol_INCLUDE_DIRS}"
 )
 
 ###################

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
@@ -28,7 +28,6 @@ find_package(NF_CoreCLR REQUIRED)
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
-    else()
 endif()
 
 # optional
@@ -84,12 +83,9 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
-    ${WireProtocol_SOURCES}
-
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"
     "${NF_Debugger_SOURCES}"
-    "${NF_WireProtocol_SOURCES}"
 )
 
 
@@ -100,6 +96,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${PROJECT_SOURCE_DIR}/src/CLR/Include
     ${PROJECT_SOURCE_DIR}/src/HAL/Include
+    ${PROJECT_SOURCE_DIR}/src/PAL/Include
 
     ${WireProtocol_INCLUDE_DIRS}
     ${CHIBIOS_INCLUDE_DIRS}
@@ -129,7 +126,6 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
     # directories for nanoFramework libraries
     "${NF_CoreCLR_INCLUDE_DIRS}"
     "${NF_Debugger_INCLUDE_DIRS}"
-    "${NF_WireProtocol_INCLUDE_DIRS}"
 )
 
 ###################

--- a/targets/os/win32/nanoCLR/CLRStartup.cpp
+++ b/targets/os/win32/nanoCLR/CLRStartup.cpp
@@ -173,7 +173,7 @@ struct Settings
         CLR_Debug::Printf( "Loading Deployment Assemblies.\r\n" );
 #endif
 
-        LoadDeploymentAssemblies( BlockUsage::DEPLOYMENT );
+        LoadDeploymentAssemblies( BlockUsage_DEPLOYMENT );
 
         //--//
 


### PR DESCRIPTION
- rearrange structs and rework files to ease spliting of platform specifics and common definitions
- rename header files to make them clear

Signed-off-by: José Simões <jose.simoes@eclo.solutions>