### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 [![Build Status](https://travis-ci.org/nanoframework/nf-interpreter.svg?branch=master)](https://travis-ci.org/nanoframework/nf-interpreter)
-[![Join the chat at https://gitter.im/nf-interpreter](https://badges.gitter.im/nf-interpreter/nf-interpreter.svg)](https://gitter.im/nf-interpreter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://nanoframework.slack.com/](https://img.shields.io/badge/join%20us-on%20slack-orange.svg)](https://nanoframework.slack.com/)
 
 
 Welcome to the nanoFramework Interpreter repository!
@@ -10,12 +10,12 @@ Welcome to the nanoFramework Interpreter repository!
 ## How to Engage, Contribute and Provide Feedback
 
 Some of the best ways to contribute are to try things out, file bugs, and join in design conversations. 
-If you are having issues or need a clarification about something, instead of opening an issue the best way is to start a conversation in one of our Gitter rooms.
+If you are having issues or need a clarification about something, instead of opening an issue the best way is to start a conversation in one of our Slack channels.
 Please select the one that's most appropriate to the matter you are facing.
 
 
-If you've find a bug or can't use Gitter please open an issue at [Issues](https://github.com/nanoframework/nf-interpreter/issues).
-We ask you to open an issue only when you have a real and confirmed one. Don't open an issue for support requests or to start a discussion. For that you'll get a better (and quicker!) support/feedback in one of the Gitter rooms.
+If you've find a bug or can't use Slack, please open an issue at [Issues](https://github.com/nanoframework/nf-interpreter/issues).
+We ask you to open an issue only when you have a real and confirmed one. Don't open an issue for support requests or to start a discussion. For that you'll get a better (and quicker!) support/feedback in one of the Slack channels.
 
 Looking for something to work on? The list of [up-for-grabs issues](https://github.com/nanoframework/nf-interpreter/labels/up-for-grabs)
 is a great place to start. Or take a look at our [documentation](docs/).


### PR DESCRIPTION
Gitter links changed to Slack links.

This fixes #191 .

Signed-off-by: Christophe Gerbier <christophe@mikrobusnet.org>
