### PR TITLE
Update gitignore for VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ cmake-variants.json
 .vscode/launch.json
 .vscode/.cmaketools.json
 .vscode/settings.json
+.vscode/tasks.json
+.vscode/extensions.json
 
 # Visual Studio
 ## Ignore Visual Studio temporary files, build results, and


### PR DESCRIPTION
Using https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore model.

This fixes issue #91 

Signed-off-by: Christophe Gerbier <christophe@mikrobusnet.org>