### PR TITLE
Correct linker scripts to aling deployment

### DIFF
--- a/docs/ChibiOS HAL/gcc-linker-script.md
+++ b/docs/ChibiOS HAL/gcc-linker-script.md
@@ -40,7 +40,7 @@ To illustrate this we are going to look into the linker script for the ST_NUCLEO
 The `flash` region configuration depends on two factors: the space reserved for nanoBooter image and the space reserved for application deployment.
 In the example it can be seen that nanoCLR image will start at address 0x08004000 and has a maximum size of 256k - 16k - 100k. That's the size reserved for nanoBooter and the size reserved for the application deployment.
 
-On this particular example (because this SoC requires that the vector table is copied to RAM) the `ram0` region needs to be tweaked so it starts after the space reserved for the vector table. The end result is `ram0` starts at 0x200000C0 with a length of 32k - 0xC0.
+On this particular example (because this SoC requires that the vector table is copied to RAM) the `ram0` region needs to be tweaked so it starts after the space reserved for the vector table. The end result is `ram0` starting at 0x200000C0 with a length of 32k - 0xC0.
 
 
 ### Tips
@@ -48,6 +48,6 @@ On this particular example (because this SoC requires that the vector table is c
 - When designing the address map make sure that the address region boundaries **match the FLASH memory blocks**. This is very important in order to be able to perform image updates. This is valid for nanoBooter, nanoCLR and application deployment.
 
 - The link script accepts several number format. Use the one that is convenient for what you are specifying. 
-Follow some examples. For an absolute address (such as the start of a FLASH block) use the hexadecimal notation like in 0x08000000. When specifying the size of a region use the _K_ and _M_ suffixes, like 16K for a block with 16k Bytes (4096 bytes), or 1M. This makes it much easier to copy/paste from the device data sheet.
+Follow some examples. For an absolute address (such as the start of a FLASH block) use the hexadecimal notation like in 0x08000000. When specifying the size of a region use the _k_ and _M_ suffixes, like 16k for a block with 16k Bytes (4096 bytes), or 1M. This makes it much easier to copy/paste from the device data sheet.
 
 - It's OK to use mathematical expressions. For example, when setting the available space for the nanoCLR image don't bother with doing the math, just put there 1M - 16k.

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/mbn_quail_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/mbn_quail_CLR.ld
@@ -12,8 +12,8 @@
  */
 MEMORY
 {
-    flash       : org = 0x08008000, len = 2M - 32k - 800k   /* flash size less the space reserved for nanoBooter and application deployment*/
-    deployment  : org = 0x08140000, len = 800k              /* space reserved for application deployment */
+    flash       : org = 0x08008000, len = 2M - 32k - 768k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    deployment  : org = 0x08140000, len = 768k              /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0                 /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20000000, len = 192k              /* SRAM1 + SRAM2 + SRAM3 */
     ram1        : org = 0x20000000, len = 112k              /* SRAM1 */

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/STM32F746xG_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/STM32F746xG_CLR.ld
@@ -17,9 +17,9 @@
  */
 MEMORY
 {
-    flash       : org = 0x08008000, len = 1M - 32k - 800k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    flash       : org = 0x08008000, len = 1M - 32k - 768k   /* flash size less the space reserved for nanoBooter and application deployment*/
     flash_itcm  : org = 0x00200000, len = 1M
-    deployment  : org = 0x08040000, len = 800k              /* space reserved for application deployment */
+    deployment  : org = 0x08040000, len = 768k              /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0                 /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20010000, len = 256k              /* SRAM1 + SRAM2 */
     ram1        : org = 0x20010000, len = 240k              /* SRAM1 */

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
@@ -12,8 +12,8 @@
  */
 MEMORY
 {
-    flash       : org = 0x08008000, len = 2M - 32k - 800k       /* flash size less the space reserved for nanoBooter and application deployment*/
-    deployment  : org = 0x08140000, len = 800k                  /* space reserved for application deployment */
+    flash       : org = 0x08008000, len = 2M - 32k - 768k       /* flash size less the space reserved for nanoBooter and application deployment*/
+    deployment  : org = 0x08140000, len = 768k                  /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0                     /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20000000, len = 192k                  /* SRAM1 + SRAM2 + SRAM3 */
     ram1        : org = 0x20000000, len = 112k                  /* SRAM1 */

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/STM32F407xG_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/STM32F407xG_CLR.ld
@@ -12,9 +12,9 @@
  */
 MEMORY
 {
-    flash       : org = 0x08008000, len = 1M - 32k - 800k     /* flash size less the space reserved for nanoBooter and application deployment*/
-    deployment  : org = 0x08040000, len = 800k                /* space reserved for application deployment */
-    ramvt       : org = 0x20000000, len = 0xC0                /* initial RAM address is reserved for a copy of the vector table */
+    flash       : org = 0x08008000, len = 1M - 32k - 768k     /* flash size less the space reserved for nanoBooter and application deployment*/
+    deployment  : org = 0x08040000, len = 768k                /* space reserved for application deployment */
+    ramvt       : org = 0x20000000, len = 0                   /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20000000, len = 128k                /* SRAM1 + SRAM2 */
     ram1        : org = 0x20000000, len = 112k                /* SRAM1 */
     ram2        : org = 0x2001C000, len = 16k                 /* SRAM2 */


### PR DESCRIPTION
- the start address and total size are now propely aligned with flash sector boundaries
- minor improvement in document

Signed-off-by: José Simões <jose.simoes@eclo.solutions>