### PR TITLE
Fix #259

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO_F091RC/nanoCLR/main.c
@@ -45,6 +45,7 @@ osThreadDef(BlinkerThread, osPriorityNormal, 128);
 // need to declare the Receiver thread here
 osThreadDef(ReceiverThread, osPriorityNormal, 1024);
 
+// declare CLRStartup thread here
 osThreadDef(CLRStartupThread, osPriorityNormal, 1024);
 
 //  Application entry point.

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/main.c
@@ -8,7 +8,7 @@
 #include <cmsis_os.h>
 
 #include "usbcfg.h"
-#include <nanoCLR_Application.h>
+#include <CLR_Startup_Thread.h>
 #include <WireProtocol_ReceiverThread.h>
 
 void BlinkerThread(void const * argument)
@@ -52,6 +52,9 @@ osThreadDef(BlinkerThread, osPriorityNormal, 128);
 // need to declare the Receiver thread here
 osThreadDef(ReceiverThread, osPriorityNormal, 1024);
 
+// declare CLRStartup thread here
+osThreadDef(CLRStartupThread, osPriorityNormal, 1024);
+
 //  Application entry point.
 int main(void) {
 
@@ -63,35 +66,28 @@ int main(void) {
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
 
-  // //  Initializes a serial-over-USB CDC driver.
-  // sduObjectInit(&SDU1);
-  // sduStart(&SDU1, &serusbcfg);
+  //  Initializes a serial-over-USB CDC driver.
+  sduObjectInit(&SDU1);
+  sduStart(&SDU1, &serusbcfg);
 
-  // // Activates the USB driver and then the USB bus pull-up on D+.
-  // // Note, a delay is inserted in order to not have to disconnect the cable after a reset
-  // usbDisconnectBus(serusbcfg.usbp);
-  // chThdSleepMilliseconds(1500);
-  // usbStart(serusbcfg.usbp, &usbcfg);
-  // usbConnectBus(serusbcfg.usbp);
+  // Activates the USB driver and then the USB bus pull-up on D+.
+  // Note, a delay is inserted in order to not have to disconnect the cable after a reset
+  usbDisconnectBus(serusbcfg.usbp);
+  chThdSleepMilliseconds(1500);
+  usbStart(serusbcfg.usbp, &usbcfg);
+  usbConnectBus(serusbcfg.usbp);
 
   // Creates the blinker thread, it does not start immediately.
   osThreadCreate(osThread(BlinkerThread), NULL);
 
   // create the receiver thread
   osThreadCreate(osThread(ReceiverThread), NULL);
+  
+  // create the CLR Startup thread
+  osThreadCreate(osThread(CLRStartupThread), NULL);
 
   // start kernel, after this the main() thread has priority osPriorityNormal by default
   osKernelStart();
-
-  CLR_SETTINGS clrSettings;
-
-  memset(&clrSettings, 0, sizeof(CLR_SETTINGS));
-
-  clrSettings.MaxContextSwitches         = 50;
-  clrSettings.WaitForDebugger            = false;
-  clrSettings.EnterDebuggerLoopAfterExit = true;
-
-  ClrStartup(clrSettings);
 
   while (true) {
     osDelay(1000);


### PR DESCRIPTION
- turns out that the code configuring and starting USB was commented out
- add missing code to launch the CLRStartup
- add missing comment in F091
- clean-up code

Signed-off-by: José Simões <jose.simoes@eclo.solutions>