### PR TITLE
Add missing CLRStartup thread to reference boards

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/halconf_nf.h
@@ -4,7 +4,7 @@
 //
 
 #ifndef _HALCONF_NF_H_
-#define _HALCONF_NF_H_
+#define _HALCONF_NF_H_ 1
 
 // Enables the ChibiOS community overlay.
 #if !defined(HAL_USE_COMMUNITY) 
@@ -13,7 +13,7 @@
 
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
-#define HAL_USE_STM32_FLASH         FALSE
+#define HAL_USE_STM32_FLASH         TRUE
 #endif
 
 #endif // _HALCONF_NF_H_

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/main.c
@@ -8,7 +8,7 @@
 #include <cmsis_os.h>
 
 #include "usbcfg.h"
-#include <nanoCLR_Application.h>
+#include <CLR_Startup_Thread.h>
 #include <WireProtocol_ReceiverThread.h>
 
 void BlinkerThread(void const * argument)
@@ -51,6 +51,9 @@ osThreadDef(BlinkerThread, osPriorityNormal, 128);
 // need to declare the Receiver thread here
 osThreadDef(ReceiverThread, osPriorityNormal, 1024);
 
+// declare CLRStartup thread here
+osThreadDef(CLRStartupThread, osPriorityNormal, 1024);
+
 //  Application entry point.
 int main(void) {
 
@@ -62,35 +65,28 @@ int main(void) {
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
 
-  // //  Initializes a serial-over-USB CDC driver.
-  // sduObjectInit(&SDU1);
-  // sduStart(&SDU1, &serusbcfg);
+  //  Initializes a serial-over-USB CDC driver.
+  sduObjectInit(&SDU1);
+  sduStart(&SDU1, &serusbcfg);
 
-  // // Activates the USB driver and then the USB bus pull-up on D+.
-  // // Note, a delay is inserted in order to not have to disconnect the cable after a reset
-  // usbDisconnectBus(serusbcfg.usbp);
-  // chThdSleepMilliseconds(1500);
-  // usbStart(serusbcfg.usbp, &usbcfg);
-  // usbConnectBus(serusbcfg.usbp);
+  // Activates the USB driver and then the USB bus pull-up on D+.
+  // Note, a delay is inserted in order to not have to disconnect the cable after a reset
+  usbDisconnectBus(serusbcfg.usbp);
+  chThdSleepMilliseconds(1500);
+  usbStart(serusbcfg.usbp, &usbcfg);
+  usbConnectBus(serusbcfg.usbp);
 
   // Creates the blinker thread, it does not start immediately.
   osThreadCreate(osThread(BlinkerThread), NULL);
 
   // create the receiver thread
   osThreadCreate(osThread(ReceiverThread), NULL);
+  
+  // create the CLR Startup thread
+  osThreadCreate(osThread(CLRStartupThread), NULL);
 
   // start kernel, after this the main() thread has priority osPriorityNormal by default
   osKernelStart();
-
-  CLR_SETTINGS clrSettings;
-
-  memset(&clrSettings, 0, sizeof(CLR_SETTINGS));
-
-  clrSettings.MaxContextSwitches         = 50;
-  clrSettings.WaitForDebugger            = false;
-  clrSettings.EnterDebuggerLoopAfterExit = true;
-
-  ClrStartup(clrSettings);
 
   while (true) {
     osDelay(1000);

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/main.c
@@ -8,7 +8,7 @@
 #include <cmsis_os.h>
 
 #include "usbcfg.h"
-#include <nanoCLR_Application.h>
+#include <CLR_Startup_Thread.h>
 #include <WireProtocol_ReceiverThread.h>
 
 void BlinkerThread(void const * argument)
@@ -40,6 +40,9 @@ osThreadDef(BlinkerThread, osPriorityNormal, 128);
 // need to declare the Receiver thread here
 osThreadDef(ReceiverThread, osPriorityNormal, 1024);
 
+// declare CLRStartup thread here
+osThreadDef(CLRStartupThread, osPriorityNormal, 1024);
+
 //  Application entry point.
 int main(void) {
 
@@ -51,35 +54,28 @@ int main(void) {
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
 
-  // //  Initializes a serial-over-USB CDC driver.
-  // sduObjectInit(&SDU1);
-  // sduStart(&SDU1, &serusbcfg);
+  //  Initializes a serial-over-USB CDC driver.
+  sduObjectInit(&SDU1);
+  sduStart(&SDU1, &serusbcfg);
 
-  // // Activates the USB driver and then the USB bus pull-up on D+.
-  // // Note, a delay is inserted in order to not have to disconnect the cable after a reset
-  // usbDisconnectBus(serusbcfg.usbp);
-  // chThdSleepMilliseconds(1500);
-  // usbStart(serusbcfg.usbp, &usbcfg);
-  // usbConnectBus(serusbcfg.usbp);
+  // Activates the USB driver and then the USB bus pull-up on D+.
+  // Note, a delay is inserted in order to not have to disconnect the cable after a reset
+  usbDisconnectBus(serusbcfg.usbp);
+  chThdSleepMilliseconds(1500);
+  usbStart(serusbcfg.usbp, &usbcfg);
+  usbConnectBus(serusbcfg.usbp);
 
   // Creates the blinker thread, it does not start immediately.
   osThreadCreate(osThread(BlinkerThread), NULL);
 
   // create the receiver thread
   osThreadCreate(osThread(ReceiverThread), NULL);
+  
+  // create the CLR Startup thread
+  osThreadCreate(osThread(CLRStartupThread), NULL);
 
   // start kernel, after this the main() thread has priority osPriorityNormal by default
   osKernelStart();
-
-  CLR_SETTINGS clrSettings;
-
-  memset(&clrSettings, 0, sizeof(CLR_SETTINGS));
-
-  clrSettings.MaxContextSwitches         = 50;
-  clrSettings.WaitForDebugger            = false;
-  clrSettings.EnterDebuggerLoopAfterExit = true;
-
-  ClrStartup(clrSettings);
 
   while (true) {
     osDelay(1000);


### PR DESCRIPTION
- also enable USB config and start on some of them
- code clean up

Signed-off-by: José Simões <jose.simoes@eclo.solutions>