### PR TITLE
Correct issue when checking for user button pressed

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/main.c
@@ -58,7 +58,8 @@ int main(void) {
   // the board to remain in nanoBooter and not launching nanoCLR
 
   // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
-  if (palReadPad(GPIOC, GPIOC_BUTTON))
+  // the user button in this board has a pull-up resistor so the check has to be inverted
+  if (!palReadPad(GPIOC, GPIOC_BUTTON))
   {
     // check for valid CLR image 
     if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
@@ -49,7 +49,8 @@ int main(void) {
   // the board to remain in nanoBooter and not launching nanoCLR
 
   // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
-  if (palReadPad(GPIOA, GPIOA_BUTTON))
+  // the user button in this board has a pull-up resistor so the check has to be inverted
+  if (!palReadPad(GPIOA, GPIOA_BUTTON))
   {
     // check for valid CLR image 
     if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
@@ -57,6 +57,7 @@ int main(void) {
   // the board to remain in nanoBooter and not launching nanoCLR
 
   // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
+  // the user button in this board has a pull-up resistor so the check has to be inverted
   if (!palReadPad(GPIOA, GPIOA_BUTTON))
   {
     // check for valid CLR image 


### PR DESCRIPTION
- the user button in these boards has a pull-up resistor so the check has to be inverted
- fix #268
- fix #269
- add comment to Discover44 target to make it clear

Signed-off-by: José Simões <jose.simoes@eclo.solutions>