### PR TITLE
Moved nanoCLR_ParseOptions file to src folder (#277)

### DIFF
--- a/src/CLR/Include/nanoCLR_ParseOptions.h
+++ b/src/CLR/Include/nanoCLR_ParseOptions.h
@@ -6,7 +6,7 @@
 #ifndef _NANOCLR_PARSEOPTIONS_H_
 #define _NANOCLR_PARSEOPTIONS_H_
 
-//#include <nanoCLR_Runtime.h>
+#include <nanoCLR_Runtime.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -134,4 +134,3 @@ struct CLR_RT_ParseOptions
 #endif
 
 #endif // _NANOCLR_PARSEOPTIONS_H_
-

--- a/targets/os/win32/nanoCLR/nanoCLR.vcxproj
+++ b/targets/os/win32/nanoCLR/nanoCLR.vcxproj
@@ -156,7 +156,6 @@
     <ClInclude Include="platform_selector.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
-    <ClInclude Include="nanoCLR_ParseOptions.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CLRStartup.cpp" />

--- a/targets/os/win32/nanoCLR/nanoCLR.vcxproj.filters
+++ b/targets/os/win32/nanoCLR/nanoCLR.vcxproj.filters
@@ -30,9 +30,6 @@
     <ClInclude Include="platform_selector.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="nanoCLR_ParseOptions.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\Include\nanoHAL_Time.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
- required for MetaDataProcessor

Signed-off-by: José Simões <jose.simoes@eclo.solutions>