### PR TITLE
Add stdafx.h include

### DIFF
--- a/src/CLR/Core/StringTable.cpp
+++ b/src/CLR/Core/StringTable.cpp
@@ -3,6 +3,9 @@
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
 //
+
+#include "stdafx.h"
+
 #include "Core.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -3,6 +3,8 @@
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
 //
+#include "stdafx.h"
+
 #include "Core.h"
 #include "corhdr_private.h"
 


### PR DESCRIPTION
- required for file reuse in MetaDataProcessor VS solution

Signed-off-by: José Simões <jose.simoes@eclo.solutions>