### PR TITLE
Start support for Base64 native implementation

### DIFF
--- a/CMake/Modules/FindNF_CoreCLR.cmake
+++ b/CMake/Modules/FindNF_CoreCLR.cmake
@@ -77,6 +77,7 @@ set(NF_CoreCLR_SRCS
     corlib_native_System_Collections_ArrayList.cpp
     corlib_native_System_Collections_Queue.cpp
     corlib_native_System_Collections_Stack.cpp
+    corlib_native_System_Convert.cpp
     corlib_native_System_DateTime.cpp
     corlib_native_System_Delegate.cpp
     corlib_native_System_Diagnostics_Debugger.cpp

--- a/src/CLR/CorLib/CorLib.vcxproj
+++ b/src/CLR/CorLib/CorLib.vcxproj
@@ -32,6 +32,7 @@
     <ClCompile Include="corlib_native_System_Collections_ArrayList.cpp" />
     <ClCompile Include="corlib_native_System_Collections_Queue.cpp" />
     <ClCompile Include="corlib_native_System_Collections_Stack.cpp" />
+    <ClCompile Include="corlib_native_System_Convert.cpp" />
     <ClCompile Include="corlib_native_System_DateTime.cpp" />
     <ClCompile Include="corlib_native_System_Delegate.cpp" />
     <ClCompile Include="corlib_native_System_Diagnostics_Debugger.cpp" />

--- a/src/CLR/CorLib/CorLib.vcxproj.filters
+++ b/src/CLR/CorLib/CorLib.vcxproj.filters
@@ -185,5 +185,8 @@
     <ClCompile Include="corlib_native_System_Threading_ThreadAbortException.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="corlib_native_System_Convert.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/CLR/CorLib/CorLib_Native.h
+++ b/src/CLR/CorLib/CorLib_Native.h
@@ -329,11 +329,8 @@ struct Library_corlib_native_System_Collections_Stack
 
 struct Library_corlib_native_System_Convert
 {
-    static const int FIELD_STATIC__s_rgchBase64EncodingDefault = 6;
-    static const int FIELD_STATIC__s_rgchBase64EncodingRFC4648 = 7;
-    static const int FIELD_STATIC__s_rgchBase64Encoding        = 8;
-    static const int FIELD_STATIC__s_rgbBase64Decode           = 9;
-
+    NANOCLR_NATIVE_DECLARE(ToBase64String___STATIC__STRING__SZARRAY_U1__I4__I4__BOOLEAN);
+    NANOCLR_NATIVE_DECLARE(FromBase64CharArray___STATIC__SZARRAY_U1__SZARRAY_CHAR__I4);
 
     //--//
 

--- a/src/CLR/CorLib/corlib_native.cpp
+++ b/src/CLR/CorLib/corlib_native.cpp
@@ -297,9 +297,10 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    Library_corlib_native_System_Convert::ToBase64String___STATIC__STRING__SZARRAY_U1__I4__I4__BOOLEAN,
     NULL,
     NULL,
-    NULL,
+    Library_corlib_native_System_Convert::FromBase64CharArray___STATIC__SZARRAY_U1__SZARRAY_CHAR__I4,
     NULL,
     NULL,
     NULL,
@@ -929,6 +930,6 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_mscorlib =
 {
     "mscorlib", 
-    0x82FE3C9C,
+    0xED5347F9,
     method_lookup
 };

--- a/src/CLR/CorLib/corlib_native.h
+++ b/src/CLR/CorLib/corlib_native.h
@@ -329,11 +329,8 @@ struct Library_corlib_native_System_Collections_Stack
 
 struct Library_corlib_native_System_Convert
 {
-    static const int FIELD_STATIC__s_rgchBase64EncodingDefault = 6;
-    static const int FIELD_STATIC__s_rgchBase64EncodingRFC4648 = 7;
-    static const int FIELD_STATIC__s_rgchBase64Encoding        = 8;
-    static const int FIELD_STATIC__s_rgbBase64Decode           = 9;
-
+    NANOCLR_NATIVE_DECLARE(ToBase64String___STATIC__STRING__SZARRAY_U1__I4__I4__BOOLEAN);
+    NANOCLR_NATIVE_DECLARE(FromBase64CharArray___STATIC__SZARRAY_U1__SZARRAY_CHAR__I4);
 
     //--//
 

--- a/src/CLR/CorLib/corlib_native_System_Convert.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Convert.cpp
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+#include "CorLib.h"
+
+
+HRESULT Library_corlib_native_System_Convert::ToBase64String___STATIC__STRING__SZARRAY_U1__I4__I4__BOOLEAN( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_corlib_native_System_Convert::FromBase64CharArray___STATIC__SZARRAY_U1__SZARRAY_CHAR__I4( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
+
+    NANOCLR_NOCLEANUP();
+}

--- a/targets/os/win32/nanoCLR/CLRStartup.cpp
+++ b/targets/os/win32/nanoCLR/CLRStartup.cpp
@@ -129,7 +129,7 @@ struct Settings
         CLR_RT_StringVector vec;
 
         vec.push_back(L"-load");
-#if defined DEBUG
+#if defined _DEBUG
 		vec.push_back(L"..\\netnf\\TestApplication\\bin\\Debug\\TestApplication.pe");
 #else
 		vec.push_back(L"..\\netnf\\TestApplication\\bin\\Release\\TestApplication.pe");
@@ -140,7 +140,7 @@ struct Settings
 		// just need to update the path on the package folder as the version changes //
 		// ************************************************************************* //
 		vec.push_back(L"-load");
-        vec.push_back(L"..\\packages\\nanoFramework.CoreLibrary.1.0.0-preview014\\build\\mscorlib.pe");
+        vec.push_back(L"..\\packages\\nanoFramework.CoreLibrary.1.0.0-preview015\\build\\mscorlib.pe");
 
         //vec.push_back(L"-load");
         //vec.push_back(L"C:\\Program Files (x86)\\Microsoft .NET Micro Framework\\v4.4\\Assemblies\\le\\Microsoft.SPOT.Native.pe");

--- a/targets/os/win32/netnf/TestApplication/NF.TestApplication.csproj
+++ b/targets/os/win32/netnf/TestApplication/NF.TestApplication.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0038\build\nanoFramework.Tools.MSBuildSystem.props" Condition="Exists('..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0038\build\nanoFramework.Tools.MSBuildSystem.props')" />
+  <Import Project="..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.props" Condition="Exists('..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup Label="Globals">
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -50,14 +50,14 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview014\build\nanoFramework.CoreLibrary.targets" Condition="Exists('..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview014\build\nanoFramework.CoreLibrary.targets')" />
+  <Import Project="..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview015\build\nanoFramework.CoreLibrary.targets" Condition="Exists('..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview015\build\nanoFramework.CoreLibrary.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview014\build\nanoFramework.CoreLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview014\build\nanoFramework.CoreLibrary.targets'))" />
-    <Error Condition="!Exists('..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0038\build\nanoFramework.Tools.MSBuildSystem.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0038\build\nanoFramework.Tools.MSBuildSystem.props'))" />
-    <Error Condition="!Exists('..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0038\build\nanoFramework.Tools.MSBuildSystem.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0038\build\nanoFramework.Tools.MSBuildSystem.targets'))" />
+    <Error Condition="!Exists('..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview015\build\nanoFramework.CoreLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview015\build\nanoFramework.CoreLibrary.targets'))" />
+    <Error Condition="!Exists('..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.props'))" />
+    <Error Condition="!Exists('..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.targets'))" />
   </Target>
-  <Import Project="..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0038\build\nanoFramework.Tools.MSBuildSystem.targets" Condition="Exists('..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0038\build\nanoFramework.Tools.MSBuildSystem.targets')" />
+  <Import Project="..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.targets" Condition="Exists('..\..\packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0039\build\nanoFramework.Tools.MSBuildSystem.targets')" />
 </Project>

--- a/targets/os/win32/netnf/TestApplication/Program.cs
+++ b/targets/os/win32/netnf/TestApplication/Program.cs
@@ -6,7 +6,10 @@ namespace TestApplication
     {
         public static void Main()
         {
-
+            while(true)
+            {
+                int i = 0;
+            }
         }
     }
 }

--- a/targets/os/win32/netnf/TestApplication/packages.config
+++ b/targets/os/win32/netnf/TestApplication/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview014" targetFramework="net46" />
-  <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0038" targetFramework="net46" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview015" targetFramework="net46" />
+  <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0039" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
- add stubs for Base64 functions on System.Convert
- update mscolib header and assembly declaration
- update debug define in CLRStartup of nanoCLR project
- update Nuget for Core Library and MSBuild System
- update nanoCLR accordingly
- update nF test application to include some code
- initial work on #321

Signed-off-by: José Simões <jose.simoes@eclo.solutions>