### PR TITLE
Work on Debugging_Deployment_Status

### DIFF
--- a/src/CLR/Core/HeapPersistence/Heap_Persistence.cpp
+++ b/src/CLR/Core/HeapPersistence/Heap_Persistence.cpp
@@ -656,8 +656,8 @@ void CLR_RT_Persistence_Manager::Initialize()
 
     m_completion.InitializeForUserMode( CLR_RT_Persistence_Manager::Callback );
 
-    m_margin_BurstWrite  = (BlockStorageDevice_MaxSectorWrite_uSec(m_bankA.m_stream.Device) * (c_MaxWriteBurst / sizeof(FLASH_WORD)) * 2 + 1000 - 1) / 1000;
-    m_margin_BlockErase  = (BlockStorageDevice_MaxBlockErase_uSec(m_bankA.m_stream.Device)  *                                          2 + 1000 - 1) / 1000;
+    m_margin_BurstWrite  = (500 * (c_MaxWriteBurst / sizeof(FLASH_WORD)) * 2 + 1000 - 1) / 1000;
+    m_margin_BlockErase  = (500 *                                          2 + 1000 - 1) / 1000;
     if(m_bankB.IsGood())
     {
         if(m_bankA.IsGood() == false || m_bankA.GetBankHeader()->m_sequenceNumber < m_bankB.GetBankHeader()->m_sequenceNumber)

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -131,7 +131,10 @@ HRESULT CLR_DBG_Debugger::CreateInstance()
 
     if (BlockStorageStream_Initialize(&stream, BlockUsage_DEPLOYMENT ))
     {
-        m_deploymentStorageDevice = stream.Device;
+        //m_deploymentStorageDevice = stream.Device;
+        // TODO replacing this for now with a call to GetFirstDevice
+        // until the block storage is redesigned 
+        m_deploymentStorageDevice = BlockStorageList_GetFirstDevice();
     }
     else
     {
@@ -995,7 +998,10 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
             reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_SourceLevelDebugging;
-            reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_IncrementalDeployment;
+
+            // TODO temporary implementation without support for incremental deployment
+            // reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_IncrementalDeployment;
+
             reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_ThreadCreateEx;
 #endif
 
@@ -3037,125 +3043,140 @@ bool CLR_DBG_Debugger::Debugging_Resolve_VirtualMethod( WP_Message* msg)
 
 //--//
 
-#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
 bool CLR_DBG_Debugger::Debugging_Deployment_Status( WP_Message* msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Deployment_Status::Reply* cmdReply;
-    CLR_UINT32                                            totLength;
-    CLR_UINT32                                            deploySectorsNum  = 0;
-    CLR_UINT32                                            deploySectorStart = 0;
-    CLR_UINT32                                            deployLength      = 0;
 
-    const DeviceBlockInfo*                                deviceInfo;
+    // temporary implementation without support for incremental deployment
+    CLR_DBG_Commands::Debugging_Deployment_Status::Reply cmdReply;
 
-    // find the first device in list with DEPLOYMENT blocks
-    if (m_deploymentStorageDevice != NULL)
-    {
-        BlockStorageStream stream;
 
-        if(BlockStorageStream_InitializeWithBlockStorageDevice(&stream, BlockUsage_DEPLOYMENT, m_deploymentStorageDevice ))
-        {
-            do
-            {
-                if(deploySectorsNum == 0)
-                {
-                    deploySectorStart = BlockStorageStream_CurrentAddress(&stream);
-                }
-                deployLength     += stream.Length;
-                deploySectorsNum ++;
-            }
-            while(BlockStorageStream_NextStream(&stream) && stream.BaseAddress == (deploySectorStart + deployLength));
-        }
+    cmdReply.m_entryPoint          = g_CLR_RT_TypeSystem.m_entryPoint.m_data;
+    cmdReply.m_storageStart        = (uint32_t)&__deployment_start__;
+    // need to cast the pointers to make sure the compiler implements the correct math
+    cmdReply.m_storageLength       = ((uint32_t)&__deployment_end__) - ((uint32_t)&__deployment_start__);
 
-        deviceInfo = BlockStorageDevice_GetDeviceInfo(m_deploymentStorageDevice);
 
-        totLength = sizeof(CLR_DBG_Commands::Debugging_Deployment_Status::Reply) + (deploySectorsNum) * sizeof(CLR_DBG_Commands::Debugging_Deployment_Status::FlashSector);
+    WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
 
-        cmdReply = (CLR_DBG_Commands::Debugging_Deployment_Status::Reply*)CLR_RT_Memory::Allocate( totLength, true );
+    return true;
 
-        if(!cmdReply) return false;
+    // /////////////////////////////////////////////////////////////////////////
 
-        CLR_RT_Memory::ZeroFill( cmdReply, totLength );
+    // CLR_DBG_Commands::Debugging_Deployment_Status::Reply* cmdReply;
+    // CLR_UINT32                                            totLength;
+    // CLR_UINT32                                            deploySectorsNum  = 0;
+    // CLR_UINT32                                            deploySectorStart = 0;
+    // CLR_UINT32                                            deployLength      = 0;
 
-        cmdReply->m_entryPoint          = g_CLR_RT_TypeSystem.m_entryPoint.m_data;
-        cmdReply->m_storageStart        = deploySectorStart;
-        cmdReply->m_storageLength       = deployLength;
-        cmdReply->m_eraseWord           = 0xffffffff; //Is this true for all current devices?
-        cmdReply->m_maxSectorErase_uSec = BlockStorageDevice_MaxBlockErase_uSec(m_deploymentStorageDevice);
-        cmdReply->m_maxWordWrite_uSec   = BlockStorageDevice_MaxSectorWrite_uSec(m_deploymentStorageDevice);
+    // const DeviceBlockInfo*                                deviceInfo;
 
-        int index = 0;
+    // // find the first device in list with DEPLOYMENT blocks
+    // if (m_deploymentStorageDevice != NULL)
+    // {
+    //     BlockStorageStream stream;
 
-        bool fDone = false;
+    //     if(BlockStorageStream_InitializeWithBlockStorageDevice(&stream, BlockUsage_DEPLOYMENT, m_deploymentStorageDevice ))
+    //     {
+    //         do
+    //         {
+    //             if(deploySectorsNum == 0)
+    //             {
+    //                 deploySectorStart = BlockStorageStream_CurrentAddress(&stream);
+    //             }
+    //             deployLength     += stream.Length;
+    //             deploySectorsNum ++;
+    //         }
+    //         while(BlockStorageStream_NextStream(&stream) && stream.BaseAddress == (deploySectorStart + deployLength));
+    //     }
 
-        if(BlockStorageStream_InitializeWithBlockStorageDevice(&stream, BlockUsage_DEPLOYMENT, m_deploymentStorageDevice))
-        {
-            do
-            {
-                FLASH_WORD  * dataBuf = NULL;
-                CLR_UINT32 crc=0;
+    //     deviceInfo = BlockStorageDevice_GetDeviceInfo(m_deploymentStorageDevice);
 
-                if (!(deviceInfo->Attribute & MediaAttribute_SupportsXIP))
-                {
-                    // length for each block can be different, so should malloc and free at each block
-                    dataBuf = (FLASH_WORD* )CLR_RT_Memory::Allocate( stream.BlockLength, true );  if(!dataBuf) return false;
-                }
+    //     totLength = sizeof(CLR_DBG_Commands::Debugging_Deployment_Status::Reply) + (deploySectorsNum) * sizeof(CLR_DBG_Commands::Debugging_Deployment_Status::FlashSector);
 
-                //or should the PC have to calculate this??
-                // need to read the data to a buffer first.
-                if (BlockStorageDevice_IsBlockErased(m_deploymentStorageDevice, BlockStorageStream_CurrentAddress(&stream), stream.Length ))
-                {
-                     crc = CLR_DBG_Commands::Monitor_DeploymentMap::c_CRC_Erased_Sentinel;
-                }
-                else
-                {
-                    int len = stream.Length;
-                    while(len > 0)
-                    {
-						BlockStorageStream_Read(&stream, (unsigned char **)&dataBuf, stream.BlockLength );
+    //     cmdReply = (CLR_DBG_Commands::Debugging_Deployment_Status::Reply*)CLR_RT_Memory::Allocate( totLength, true );
+
+    //     if(!cmdReply) return false;
+
+    //     CLR_RT_Memory::ZeroFill( cmdReply, totLength );
+
+    //     cmdReply->m_entryPoint          = g_CLR_RT_TypeSystem.m_entryPoint.m_data;
+    //     cmdReply->m_storageStart        = deploySectorStart;
+    //     cmdReply->m_storageLength       = deployLength;
+    //     cmdReply->m_eraseWord           = 0xffffffff; //Is this true for all current devices?
+
+    //     int index = 0;
+
+    //     bool fDone = false;
+
+    //     if(BlockStorageStream_InitializeWithBlockStorageDevice(&stream, BlockUsage_DEPLOYMENT, m_deploymentStorageDevice))
+    //     {
+    //         do
+    //         {
+    //             FLASH_WORD  * dataBuf = NULL;
+    //             CLR_UINT32 crc=0;
+
+    //             if (!(deviceInfo->Attribute & MediaAttribute_SupportsXIP))
+    //             {
+    //                 // length for each block can be different, so should malloc and free at each block
+    //                 dataBuf = (FLASH_WORD* )CLR_RT_Memory::Allocate( stream.BlockLength, true );  if(!dataBuf) return false;
+    //             }
+
+    //             //or should the PC have to calculate this??
+    //             // need to read the data to a buffer first.
+    //             if (BlockStorageDevice_IsBlockErased(m_deploymentStorageDevice, BlockStorageStream_CurrentAddress(&stream), stream.Length ))
+    //             {
+    //                  crc = CLR_DBG_Commands::Monitor_DeploymentMap::c_CRC_Erased_Sentinel;
+    //             }
+    //             else
+    //             {
+    //                 int len = stream.Length;
+    //                 while(len > 0)
+    //                 {
+	// 					BlockStorageStream_Read(&stream, (unsigned char **)&dataBuf, stream.BlockLength );
                         
-                        crc = SUPPORT_ComputeCRC( dataBuf, stream.BlockLength, crc );
+    //                     crc = SUPPORT_ComputeCRC( dataBuf, stream.BlockLength, crc );
 
-                        len -= stream.BlockLength;
-                    }
-                }
+    //                     len -= stream.BlockLength;
+    //                 }
+    //             }
 
-                if (!(deviceInfo->Attribute & MediaAttribute_SupportsXIP))
-                {
-                    CLR_RT_Memory::Release( dataBuf );
-                }
+    //             if (!(deviceInfo->Attribute & MediaAttribute_SupportsXIP))
+    //             {
+    //                 CLR_RT_Memory::Release( dataBuf );
+    //             }
 
-                // need real address
-                cmdReply->m_data[ index ].m_start  = stream.BaseAddress;
-                cmdReply->m_data[ index ].m_length = stream.Length;
-                cmdReply->m_data[ index ].m_crc    = crc;
-                index ++;
+    //             // need real address
+    //             cmdReply->m_data[ index ].m_start  = stream.BaseAddress;
+    //             cmdReply->m_data[ index ].m_length = stream.Length;
+    //             cmdReply->m_data[ index ].m_crc    = crc;
+    //             index ++;
 
-                if(index >= (signed int)deploySectorsNum)
-                {
-                    fDone = true;
-                    break;
-                }
+    //             if(index >= (signed int)deploySectorsNum)
+    //             {
+    //                 fDone = true;
+    //                 break;
+    //             }
 
-            }
-            while(BlockStorageStream_NextStream(&stream));
-        }
+    //         }
+    //         while(BlockStorageStream_NextStream(&stream));
+    //     }
 
-        WP_ReplyToCommand( msg, true, false, cmdReply, totLength );
+    //     WP_ReplyToCommand( msg, true, false, cmdReply, totLength );
 
-        CLR_RT_Memory::Release( cmdReply );
+    //     CLR_RT_Memory::Release( cmdReply );
 
-        return true;
-    }
-    else
-    {
-        WP_ReplyToCommand( msg, false, false, NULL, 0 );
-        return false;
-    }
+    //     return true;
+    // }
+    // else
+    // {
+    //     WP_ReplyToCommand( msg, false, false, NULL, 0 );
+    //     return false;
+    // }
 }
+
+#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
 bool CLR_DBG_Debugger::Debugging_Info_SetJMC_Method( const CLR_RT_MethodDef_Index& idx, bool fJMC )
 {

--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -946,10 +946,9 @@ struct CLR_DBG_Commands
             CLR_UINT32 m_storageStart;
             CLR_UINT32 m_storageLength;
             
-            CLR_UINT32  m_eraseWord;
-            CLR_UINT32  m_maxSectorErase_uSec;
-            CLR_UINT32  m_maxWordWrite_uSec;
-            FlashSector m_data[ 1 ];
+            // TODO temporary implementation without support for incremental deployment, is not using these
+            // CLR_UINT32  m_eraseWord;
+            // FlashSector m_data[ 1 ];
         };
     };
 
@@ -1120,8 +1119,9 @@ public:
     static bool Debugging_Resolve_VirtualMethod         ( WP_Message* msg );
 #endif //#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
-#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
     static bool Debugging_Deployment_Status             ( WP_Message* msg );
+
+#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
     static bool Debugging_Info_SetJMC                   ( WP_Message* msg );
     
     bool Debugging_Info_SetJMC_Type                     ( const CLR_RT_TypeDef_Index&   idx, bool fJMC );

--- a/src/PAL/Include/nanoPAL_BlockStorage.h
+++ b/src/PAL/Include/nanoPAL_BlockStorage.h
@@ -427,8 +427,6 @@ __nfweak void BlockStorageDevice_SetPowerState(BlockStorageDevice* device, unsig
 __nfweak bool BlockStorageDevice_FindRegionFromAddress(BlockStorageDevice* device, unsigned int address, unsigned int* blockRegionIndex, unsigned int* blockRangeIndex);
 __nfweak bool BlockStorageDevice_FindForBlockUsage(BlockStorageDevice* device, unsigned int blockUsage, unsigned int* address, unsigned int* blockRegionIndex, unsigned int* blockRangeIndex);
 __nfweak bool BlockStorageDevice_FindNextUsageBlock(BlockStorageDevice* device, unsigned int blockUsage, unsigned int* address, unsigned int* blockRegionIndex, unsigned int* blockRangeIndex);
-__nfweak unsigned int BlockStorageDevice_MaxSectorWrite_uSec(BlockStorageDevice* device);
-__nfweak unsigned int BlockStorageDevice_MaxBlockErase_uSec(BlockStorageDevice* device);
 
 #ifdef __cplusplus
 }

--- a/targets/os/win32/nanoCLR/Target_BlockStorage.cpp
+++ b/targets/os/win32/nanoCLR/Target_BlockStorage.cpp
@@ -358,14 +358,4 @@ __nfweak bool BlockStorageDevice_FindNextUsageBlock(BlockStorageDevice* device, 
 	return false;
 }
 
-__nfweak unsigned int BlockStorageDevice_MaxSectorWrite_uSec(BlockStorageDevice* device)
-{
-	return 0;
-}
-
-__nfweak unsigned int BlockStorageDevice_MaxBlockErase_uSec(BlockStorageDevice* device)
-{
-	return 0;
-}
-
 /////////////////////////////////////////////////////


### PR DESCRIPTION
- extract command and related code from compiler define NANOCLR_ENABLE_SOURCELEVELDEBUGGING (doesn't make sense to be related, we need to get deployment status regardless of debugging at source level)
- remove BlockStorageDevice_MaxSectorWrite_uSec and BlockStorageDevice_MaxBlockErase_uSec (these can be ditched, the 'worst' case application for these was the removable storage which nanoFramework is not handling in the HAL/PAL anymore)
- remove 'extended' fields from Debugging_Deployment_Status.Reply (we are not supporting incremental deployment at this time
-

Signed-off-by: José Simões <jose.simoes@eclo.solutions>