### PR TITLE
Fix issues with assemblies loading at startup

### DIFF
--- a/docs/ChibiOS HAL/clr-managed-heap.md
+++ b/docs/ChibiOS HAL/clr-managed-heap.md
@@ -32,7 +32,7 @@ Locate the line containing `--defsym=__clr_managed_heap_size__=0x7000`. On the e
 
 When defining this size you need to take into account several factors:
 - the total available size of the region here it's being placed
-- if there are initialized variables assigned to this region how much space of ot they are taking
+- if there are initialized variables assigned to this region how much space of it they are taking
 - if the CRT heap is to be located in this region what will be the size left for it and if that is enough
 
 The linker will only be able to check if there is enough room for all these and it will complain if there isn't. But it can not check if the CRT heap is large enough for the running requirements. That is up to the target board developer.

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
@@ -182,7 +182,7 @@ set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAG
 # the size of the CLR managed heap is defined here
 ###################################################
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--library-path=${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/common,--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x0")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--library-path=${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/common,--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x9000")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--library-path=${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/common,--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x1A680")
 
 
 set(NANOBOOTER_HEX_FILE ${PROJECT_SOURCE_DIR}/build/${NANOBOOTER_PROJECT_NAME}.hex)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/STM32F407xG_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/STM32F407xG_CLR.ld
@@ -67,7 +67,7 @@ REGION_ALIAS("DATA_RAM_LMA", flash);
 REGION_ALIAS("BSS_RAM", ram0);
 
 /* RAM region to be used for the default heap.*/
-REGION_ALIAS("HEAP_RAM", ram0);
+REGION_ALIAS("HEAP_RAM", ram4);
 
 /* RAM region to be used for the nanoFramework CLR managed heap.*/
 REGION_ALIAS("CLR_MANAGED_HEAP_RAM", ram0);

--- a/targets/CMSIS-OS/ChibiOS/common/rules.ld
+++ b/targets/CMSIS-OS/ChibiOS/common/rules.ld
@@ -12,6 +12,16 @@ INCLUDE rules_stacks.ld
 /* Code rules inclusion.*/
 INCLUDE rules_code.ld
 
+
+/* 
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// rules_clr.ld have to be included **BEFORE** the rules_data.ld
+// this is because the CRT heap (processed in rules_data.ld) takes up all the remaining free space of the memory region where it's assigned
+// the size of the managed heap (processed in rules_clr.ld) is set in each target configuration
+// in case it shares the same region as the CRT heap it won't have any room left if the CRT heap is assigned first
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/* 
+
 /* nanoCLR rules inclusion.*/
 INCLUDE rules_clr.ld
 


### PR DESCRIPTION
- ContiguousBlockAssemblies was missing the proper memory allocation for several vars
- Managed heap size was too short in Discovery4 target
- improve documentation about managed heap
- correct typo

Signed-off-by: José Simões <jose.simoes@eclo.solutions>