### PR TITLE
Remove endianess checking of assemblies

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Reflection_Assembly.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Reflection_Assembly.cpp
@@ -271,8 +271,6 @@ HRESULT Library_corlib_native_System_Reflection_Assembly::Load___STATIC__SystemR
     array = stack.Arg0().DereferenceArray(); FAULT_ON_NULL(array);
 
     header = (CLR_RECORD_ASSEMBLY*)array->GetFirstElement();
-    
-    NANOCLR_CHECK_HRESULT(CLR_RT_Assembly::VerifyEndian(header));
 
     if(header->GoodAssembly())
     {

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1333,12 +1333,6 @@ bool CLR_RECORD_ASSEMBLY::GoodHeader() const
     NATIVE_PROFILE_CLR_CORE();
     CLR_RECORD_ASSEMBLY header = *this; header.headerCRC = 0;
 
-    if ( (header.flags & CLR_RECORD_ASSEMBLY::c_Flags_BigEndian) == CLR_RECORD_ASSEMBLY::c_Flags_BigEndian)
-    {
-        // Incorrect endianness
-        return false;
-    }
-
     if(SUPPORT_ComputeCRC( &header, sizeof(header), 0 ) != this->headerCRC) return false;
 
     if(this->stringTableVersion != c_CLR_StringTable_Version) return false;
@@ -3241,38 +3235,6 @@ void CLR_RT_Assembly::Relocate()
     CLR_RT_GarbageCollector::Heap_Relocate( (void**)&m_szName     );
     CLR_RT_GarbageCollector::Heap_Relocate( (void**)&m_pFile      );
     CLR_RT_GarbageCollector::Heap_Relocate( (void**)&m_nativeCode );
-}
-
-HRESULT CLR_RT_Assembly::VerifyEndian(CLR_RECORD_ASSEMBLY* header)
-{
-    unsigned int u = 0x1234567;
-    unsigned char *t = (unsigned char*)&u;
-    bool  localIsBE = false;
-    bool  assyIsBE = false;
-
-    NANOCLR_HEADER();
-    
-    // Is this a Big Endian system?
-    if ( 0x12!=*t)
-    {
-        localIsBE=true;
-    }
-
-    if( (header->flags & CLR_RECORD_ASSEMBLY::c_Flags_BigEndian) == CLR_RECORD_ASSEMBLY::c_Flags_BigEndian )
-    {
-        assyIsBE=true;
-    }
-    
-    if (assyIsBE==localIsBE)
-    {
-        NANOCLR_SET_AND_LEAVE(S_OK);
-    }
-    else
-    {
-        NANOCLR_SET_AND_LEAVE(S_FALSE);
-    }
-
-    NANOCLR_NOCLEANUP();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -977,8 +977,6 @@ struct CLR_RT_Assembly : public CLR_RT_HeapBlock_Node // EVENT HEAP - NO RELOCAT
     HRESULT Resolve_ComputeHashes         (              );
     HRESULT Resolve_AllocateStaticFields  ( CLR_RT_HeapBlock* pStaticFields );
 
-    static HRESULT VerifyEndian(CLR_RECORD_ASSEMBLY* header);
-
     HRESULT PrepareForExecution();
 
     CLR_UINT32 ComputeAssemblyHash(                                  );

--- a/src/CLR/Include/nanoCLR_Types.h
+++ b/src/CLR/Include/nanoCLR_Types.h
@@ -825,7 +825,6 @@ struct CLR_RECORD_ASSEMBLY
 {
     static const CLR_UINT32 c_Flags_NeedReboot = 0x00000001;
     static const CLR_UINT32 c_Flags_Patch      = 0x00000002;
-    static const CLR_UINT32 c_Flags_BigEndian  = 0x80000080;
 
     CLR_UINT8          marker[ 8 ];
     //


### PR DESCRIPTION
- nanoFramework don't handle target endianess

Signed-off-by: José Simões <jose.simoes@eclo.solutions>