### PR TITLE
Fix ContiguousBlockAssemblies

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/CLRStartup.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/CLRStartup.cpp
@@ -173,8 +173,15 @@ struct Settings
         signed int  headerInBytes = sizeof(CLR_RECORD_ASSEMBLY);
         unsigned char * headerBuffer  = NULL;
 
-        while(TRUE)
+        while(stream.CurrentIndex < stream.Length)
         {
+            // check if there is enough stream length to continue
+            if((stream.Length - stream.CurrentIndex ) < headerInBytes)
+            {
+                // not enough stream to read, leave now
+                break;
+            }
+
             if(!BlockStorageStream_Read(&stream, &headerBuffer, headerInBytes )) break;
 
             header = (const CLR_RECORD_ASSEMBLY*)headerBuffer;


### PR DESCRIPTION
- execution wasn't ever leaving the while loop

Signed-off-by: José Simões <jose.simoes@eclo.solutions>