### PR TITLE
Update test app in nanoCLR

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.c
@@ -113,11 +113,10 @@ bool flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buff
         CLEAR_BIT(FLASH->CR, FLASH_CR_PG);
         
         // lock the FLASH
-        if(HAL_FLASH_Lock())
-        {
-            // lock succesfull, done here
-            return true;
-        }
+        HAL_FLASH_Lock();
+        
+        // done here
+        return true;
     }
 
     // default to false
@@ -167,11 +166,10 @@ bool flash_lld_erase(uint32_t address) {
         CLEAR_BIT(FLASH->CR, FLASH_CR_PER);
 
         // lock the FLASH
-        if(HAL_FLASH_Lock())
-        {
-            // lock succesfull, done here
-            return true;
-        }
+        HAL_FLASH_Lock();
+
+        // done here
+        return true;
     }
 
     // default to false

--- a/targets/os/win32/nanoCLR/CLRStartup.cpp
+++ b/targets/os/win32/nanoCLR/CLRStartup.cpp
@@ -140,7 +140,14 @@ struct Settings
 		// just need to update the path on the package folder as the version changes //
 		// ************************************************************************* //
 		vec.push_back(L"-load");
-        vec.push_back(L"..\\packages\\nanoFramework.CoreLibrary.1.0.0-preview016\\build\\mscorlib.pe");
+        vec.push_back(L"..\\packages\\nanoFramework.CoreLibrary.1.0.0-preview022\\lib\\mscorlib.pe");
+		
+		// grab Windows.Devices.Gpio.pe from the packages folder (it has to be there because the NF.TestApplication has just build)
+		// ************************************************************************* //
+		// just need to update the path on the package folder as the version changes //
+		// ************************************************************************* //
+		vec.push_back(L"-load");
+		vec.push_back(L"..\\packages\\nanoFramework.Windows.Devices.Gpio.1.0.0-preview006\\lib\\Windows.Devices.Gpio.pe");
 
         //vec.push_back(L"-load");
         //vec.push_back(L"C:\\Program Files (x86)\\Microsoft .NET Micro Framework\\v4.4\\Assemblies\\le\\Microsoft.SPOT.Native.pe");

--- a/targets/os/win32/netnf/TestApplication/NF.TestApplication.nfproj
+++ b/targets/os/win32/netnf/TestApplication/NF.TestApplication.nfproj
@@ -22,8 +22,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview021\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview022\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="Windows.Devices.Gpio, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6df87852110734f7">
+      <HintPath>..\..\packages\nanoFramework.Windows.Devices.Gpio.1.0.0-preview006\lib\Windows.Devices.Gpio.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/targets/os/win32/netnf/TestApplication/packages.config
+++ b/targets/os/win32/netnf/TestApplication/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview021" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview022" />
+  <package id="nanoFramework.Windows.Devices.Gpio" version="1.0.0-preview006" />
 </packages>

--- a/targets/os/win32/packages.config
+++ b/targets/os/win32/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview021" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview022" />
+  <package id="nanoFramework.Windows.Devices.Gpio" version="1.0.0-preview006" />
 </packages>


### PR DESCRIPTION
- update Nuget packages to latest version
- add reference to Windows.Device.Gpio (improving testability with references and multiple assemblies)

Signed-off-by: José Simões <jose.simoes@eclo.solutions>