### PR TITLE
Work on Execution

### DIFF
--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -1234,6 +1234,9 @@ HRESULT CLR_RT_ExecutionEngine::ScheduleThreads( int maxContextSwitch )
         UpdateTime();
 
         (void)ProcessTimer();
+
+        // relinquish execution to OS
+        NANOCLR_RELINQUISHEXECUTIONCONTROL();
     }
 
     NANOCLR_SET_AND_LEAVE(CLR_S_QUANTUM_EXPIRED);

--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -85,4 +85,8 @@ typedef struct HAL_SYSTEM_CONFIG
 
 extern HAL_SYSTEM_CONFIG  HalSystemConfig;
 
+// declaration of call to function that relinquishes execution control to OS
+// this has to be provided at target level
+void NANOCLR_RELINQUISHEXECUTIONCONTROL();
+
 #endif // _NANOHAL_V2_H_

--- a/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
@@ -8,6 +8,9 @@
 
 #include <target_board.h>
 
+// call to CMSIS osDelay to allow other threads to run
+#define NANOCLR_RELINQUISHEXECUTIONCONTROL()       osDelay(1);
+
 #if !defined(BUILD_RTM)
 
 // FIXME IMPLEMENT

--- a/targets/os/win32/Include/targetHAL.h
+++ b/targets/os/win32/Include/targetHAL.h
@@ -9,6 +9,9 @@
 // #include <nanoHAL_Time.h>
 // #include <nanoHAL_Power.h>
 
+// empty implementation for WIN32
+#define NANOCLR_RELINQUISHEXECUTIONCONTROL()
+
 #if defined(_WIN32)
 #define NANOCLR_STOP() ::DebugBreak()
 #pragma warning( error : 4706 ) // error C4706: assignment within conditional expression


### PR DESCRIPTION
The CLR Interpreter runs on it's own OS thread (then jumping from one nanoFramework thread to the next) it leaves no time slot for other OS threads to execute on OSes that relly on cooperative execution (menaning that a thread has to relinquish execution control to the OS so other threads can run). Because of this, on nF thread switching, there is a call to NANOCLR_RELINQUISHEXECUTIONCONTROL to allow this to happen on OSes that require that. ChibiOS is one of those when it's running on cooperative mode.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>