### PR TITLE
Fix debugger wait loop

### DIFF
--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -2931,8 +2931,8 @@ void CLR_RT_ExecutionEngine::DebuggerLoop()
 
     UpdateTime();
 
-    // UNDONE: FIXME
-    // WaitSystemEvents( SLEEP_LEVEL__SLEEP, g_CLR_HW_Hardware.m_wakeupEvents, TIME_CONVERSION__TO_MILLISECONDS * 100 );
+    // relinquish execution to OS
+    NANOCLR_RELINQUISHEXECUTIONCONTROL();
 }
 
 


### PR DESCRIPTION
- this loop doesn't do anything except waiting, so on CMSIS target qw need to relinquish execution control back to RTOS

Signed-off-by: José Simões <jose.simoes@eclo.solutions>