### PR TITLE
Fix regions on F746ZG (#391)

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/common/Device_BlockStorage.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/common/Device_BlockStorage.c
@@ -14,7 +14,7 @@ const BlockRange BlockRange1[] =
 
 const BlockRange BlockRange2[] = 
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08010000 nanoCLR          
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08020000 nanoCLR          
 };
 
 const BlockRange BlockRange3[] =
@@ -33,7 +33,7 @@ const BlockRegionInfo BlockRegions[] =
     },
 
     {
-        0x08010000,                         // start address for block region
+        0x08020000,                         // start address for block region
         1,                                  // total number of blocks in this region
         0x20000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange2),
@@ -41,7 +41,7 @@ const BlockRegionInfo BlockRegions[] =
     },
 
     {
-        0x08020000,                         // start address for block region
+        0x08040000,                         // start address for block region
         3,                                  // total number of blocks in this region
         0x40000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange3),

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/STM32F746xG_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/STM32F746xG_CLR.ld
@@ -47,11 +47,11 @@ REGION_ALIAS("TEXT_FLASH", flash_itcm);
 REGION_ALIAS("TEXT_FLASH_LMA", flash);
 
 /* Flash region to be used for read only data.*/
-REGION_ALIAS("RODATA_FLASH", flash_itcm);
+REGION_ALIAS("RODATA_FLASH", flash);
 REGION_ALIAS("RODATA_FLASH_LMA", flash);
 
 /* Flash region to be used for various.*/
-REGION_ALIAS("VARIOUS_FLASH", flash_itcm);
+REGION_ALIAS("VARIOUS_FLASH", flash);
 REGION_ALIAS("VARIOUS_FLASH_LMA", flash);
 
 /* Flash region to be used for RAM(n) initialization data.*/


### PR DESCRIPTION
- Block regions corrected
- Memory regions corrected

Set GPIO API to true in cmake-variants, build in VS Code.
Performed a full erase and deploy of generated hex binaries.
Connected an external LED on PC10 to have a small VS17 solution make a blinky.

Signed-off-by: piwi1263 <piwi1263@gmail.com>