### PR TITLE
Various fixes in ST_STM32F429I_DISCOVERY

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -182,7 +182,7 @@ set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAG
 # the size of the CLR managed heap is defined here
 ###################################################
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--library-path=${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/common,--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x0")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--library-path=${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/common,--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x2A748")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--library-path=${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/common,--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x2A650")
 
 
 set(NANOBOOTER_HEX_FILE ${PROJECT_SOURCE_DIR}/build/${NANOBOOTER_PROJECT_NAME}.hex)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/common/Device_BlockStorage.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/common/Device_BlockStorage.c
@@ -8,34 +8,34 @@
 
 const BlockRange BlockRange1[] = 
 {
-    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 1 },            // 08000000 nanoBooter          
-    { BlockRange_BLOCKTYPE_CODE      ,   2, 3 }             // 08008000 nanoCLR          
+    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 1 },            // 08000000 nanoBooter
+    { BlockRange_BLOCKTYPE_CODE      ,   2, 3 }             // 08008000 nanoCLR
 };
 
 const BlockRange BlockRange2[] = 
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08010000 nanoCLR          
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08010000 nanoCLR
 };
 
 const BlockRange BlockRange3[] =
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 6 },            // 08020000 nanoCLR         
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 3 },            // 08020000 nanoCLR
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   4, 6 },            // 080A0000 deployment
 };
 
 const BlockRange BlockRange4[] = 
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 3 }             // 08100000 nanoCLR          
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 3 }             // 08100000 deployment
 };
 
 const BlockRange BlockRange5[] = 
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08110000 nanoCLR          
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 0 }             // 08110000 deployment
 };
 
 const BlockRange BlockRange6[] =
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 },            // 08120000 nanoCLR         
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   1, 6 }             // 08140000 deployment  
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 6 }             // 08120000 deployment
 };
 
 const BlockRegionInfo BlockRegions[] = 

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/STM32F429xI_booter.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/STM32F429xI_booter.ld
@@ -67,7 +67,7 @@ REGION_ALIAS("DATA_RAM_LMA", flash);
 REGION_ALIAS("BSS_RAM", ram0);
 
 /* RAM region to be used for the default heap.*/
-REGION_ALIAS("HEAP_RAM", ram0);
+REGION_ALIAS("HEAP_RAM", ram4);
 
 /* Stacks rules inclusion.*/
 INCLUDE rules_stacks.ld

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
@@ -12,8 +12,8 @@
  */
 MEMORY
 {
-    flash       : org = 0x08008000, len = 2M - 32k - 768k       /* flash size less the space reserved for nanoBooter and application deployment*/
-    deployment  : org = 0x08140000, len = 768k                  /* space reserved for application deployment */
+    flash       : org = 0x08008000, len = 2M - 32k - 1408k      /* flash size less the space reserved for nanoBooter and application deployment*/
+    deployment  : org = 0x080A0000, len = 1408k                 /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0                     /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20000000, len = 192k                  /* SRAM1 + SRAM2 + SRAM3 */
     ram1        : org = 0x20000000, len = 112k                  /* SRAM1 */


### PR DESCRIPTION
- fixed (and improved) device block storage as it was wasting too much flash for CLR
- fixed CLR linker file (was setting deployment region to wrong address)
- move CRT heap to CCM RAM
- adjust managed heap size (required when including Windows.Devices.Gpio)

Signed-off-by: José Simões <jose.simoes@eclo.solutions>