### PR TITLE
Various fixes for MBN_QUAIL

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/common/Device_BlockStorage.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/common/Device_BlockStorage.c
@@ -8,34 +8,34 @@
 
 const BlockRange BlockRange1[] = 
 {
-    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 1 },            // 08000000 nanoBooter          
-    { BlockRange_BLOCKTYPE_CODE      ,   2, 3 }             // 08008000 nanoCLR          
+    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 1 },            // 08000000 nanoBooter
+    { BlockRange_BLOCKTYPE_CODE      ,   2, 3 }             // 08008000 nanoCLR
 };
 
 const BlockRange BlockRange2[] = 
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08010000 nanoCLR          
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08010000 nanoCLR
 };
 
 const BlockRange BlockRange3[] =
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 6 },            // 08020000 nanoCLR         
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 3 },            // 08020000 nanoCLR
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   4, 6 },            // 080A0000 deployment
 };
 
 const BlockRange BlockRange4[] = 
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 3 }             // 08100000 nanoCLR          
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 3 }             // 08100000 deployment
 };
 
 const BlockRange BlockRange5[] = 
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08110000 nanoCLR          
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 0 }             // 08110000 deployment
 };
 
 const BlockRange BlockRange6[] =
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 },            // 08120000 nanoCLR         
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   1, 6 }             // 08140000 deployment  
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 6 }             // 08120000 deployment
 };
 
 const BlockRegionInfo BlockRegions[] = 

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/chconf.h
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/chconf.h
@@ -38,7 +38,7 @@
  * @details Frequency of the system timer that drives the system ticks. This
  *          setting also defines the system tick time unit.
  */
-#define CH_CFG_ST_FREQUENCY                 10000
+#define CH_CFG_ST_FREQUENCY                 10000 // this is 1 millisecond
 
 /**
  * @brief   Time delta constant for the tick-less mode.
@@ -130,7 +130,7 @@
  *
  * @note    The default is @p TRUE.
  */
-#define CH_CFG_USE_TM                       FALSE
+#define CH_CFG_USE_TM                       TRUE
 
 /**
  * @brief   Threads registry APIs.
@@ -174,7 +174,7 @@
  *
  * @note    The default is @p TRUE.
  */
-#define CH_CFG_USE_MUTEXES                  FALSE
+#define CH_CFG_USE_MUTEXES                  TRUE
 
 /**
  * @brief   Enables recursive behavior on mutexes.
@@ -194,7 +194,7 @@
  * @note    The default is @p TRUE.
  * @note    Requires @p CH_CFG_USE_MUTEXES.
  */
-#define CH_CFG_USE_CONDVARS                 FALSE
+#define CH_CFG_USE_CONDVARS                 TRUE
 
 /**
  * @brief   Conditional Variables APIs with timeout.
@@ -204,7 +204,7 @@
  * @note    The default is @p TRUE.
  * @note    Requires @p CH_CFG_USE_CONDVARS.
  */
-#define CH_CFG_USE_CONDVARS_TIMEOUT         FALSE
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
 
 /**
  * @brief   Events Flags APIs.
@@ -508,4 +508,3 @@
 #endif  /* CHCONF_H */
 
 /** @} */
-

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/main.c
@@ -7,6 +7,7 @@
 #include <hal.h>
 #include <cmsis_os.h>
 
+#include <usbcfg.h>
 #include <targetHAL.h>
 #include <WireProtocol_ReceiverThread.h>
 #include <LaunchCLR.h>
@@ -15,22 +16,25 @@ void BlinkerThread(void const * argument)
 {
   (void)argument;
   
-    palClearPad(GPIOE, GPIOE_LED1);
-    palClearPad(GPIOE, GPIOE_LED2);
-    palClearPad(GPIOC, GPIOC_LED3);
+  palClearPad(GPIOE, GPIOE_LED1);
+  palClearPad(GPIOE, GPIOE_LED2);
+  palClearPad(GPIOC, GPIOC_LED3);
 
   while (!chThdShouldTerminateX()) 
   {
     palSetPad(GPIOE, GPIOE_LED1);
-    palSetPad(GPIOE, GPIOE_LED2);
-    palSetPad(GPIOC, GPIOC_LED3);
-    chThdSleepMilliseconds(100);
+    chThdSleepMilliseconds(250);
     palClearPad(GPIOE, GPIOE_LED1);
+
+    palSetPad(GPIOE, GPIOE_LED2);
+    chThdSleepMilliseconds(250);
     palClearPad(GPIOE, GPIOE_LED2);
+
+    palSetPad(GPIOC, GPIOC_LED3);
+    chThdSleepMilliseconds(250);
     palClearPad(GPIOC, GPIOC_LED3);
-    chThdSleepMilliseconds(100);
   }
-  chThdSleepMilliseconds(100);
+  // nothing to deinitialize or cleanup, so it's safe to return  
 }
 
 osThreadDef(BlinkerThread, osPriorityNormal, 128, "BlinkerThread");
@@ -48,20 +52,28 @@ int main(void) {
   // and performs the board-specific initializations.
   halInit();
 
+  // check for valid CLR image at address contiguous to nanoBooter
+  if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
+  {
+    // there seems to be a valid CLR image
+    // launch nanoCLR
+    LaunchCLR((uint32_t)&__nanoImage_end__);
+  }
+
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
 
   //  Initializes a serial-over-USB CDC driver.
-  //sduObjectInit(&SDU1);
-  //sduStart(&SDU1, &serusbcfg);
+  sduObjectInit(&SDU1);
+  sduStart(&SDU1, &serusbcfg);
 
   // Activates the USB driver and then the USB bus pull-up on D+.
   // Note, a delay is inserted in order to not have to disconnect the cable after a reset.
-  //usbDisconnectBus(serusbcfg.usbp);
-  //chThdSleepMilliseconds(1500);
-  //usbStart(serusbcfg.usbp, &usbcfg);
-  //usbConnectBus(serusbcfg.usbp);
+  usbDisconnectBus(serusbcfg.usbp);
+  chThdSleepMilliseconds(1500);
+  usbStart(serusbcfg.usbp, &usbcfg);
+  usbConnectBus(serusbcfg.usbp);
 
   // Creates the blinker thread, it does not start immediately.
   blinkerThreadId = osThreadCreate(osThread(BlinkerThread), NULL);
@@ -72,23 +84,8 @@ int main(void) {
   // start kernel, after this the main() thread has priority osPriorityNormal by default
   osKernelStart();
 
-  osDelay(2000);
-
-      // Start the shutdown sequence
-
-      // terminate threads
-      osThreadTerminate(receiverThreadId);
-      osThreadTerminate(blinkerThreadId);
-      
-      // stop the serial-over-USB CDC driver
-      //sduStop(&SDU1);
-      
-      // check for valid CLR image at address contiguous to nanoBooter
-    if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
-    {
-      // there seems to be a valid CLR image
-      // launch nanoCLR
-      LaunchCLR((uint32_t)&__nanoImage_end__);
-    }
+  //  Normal main() thread
+  while (true) {
+    osDelay(500);
+  }
 }
-

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/mbn_quail_booter.ld
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/mbn_quail_booter.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash       : org = 0x08000000, len = 32k     /* space reserved for nanoBooter (1st two sectors 0x08000000 to 0x08008000)*/
+    flash       : org = 0x08000000, len = 32k     /* space reserved for nanoBooter (1st two sectors 0x08000000 to 0x08007FFF)*/
     deployment  : org = 0x00000000, len = 0       /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0       /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20000000, len = 192k    /* SRAM1 + SRAM2 + SRAM3 */
@@ -67,7 +67,7 @@ REGION_ALIAS("DATA_RAM_LMA", flash);
 REGION_ALIAS("BSS_RAM", ram0);
 
 /* RAM region to be used for the default heap.*/
-REGION_ALIAS("HEAP_RAM", ram0);
+REGION_ALIAS("HEAP_RAM", ram4);
 
 /* Stacks rules inclusion.*/
 INCLUDE rules_stacks.ld

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/mcuconf.h
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/mcuconf.h
@@ -27,8 +27,8 @@
  * HAL driver system settings.
  */
 #define STM32_NO_INIT                       FALSE
-#define STM32_HSI_ENABLED                   FALSE
-#define STM32_LSI_ENABLED                   FALSE
+#define STM32_HSI_ENABLED                   TRUE
+#define STM32_LSI_ENABLED                   TRUE
 #define STM32_HSE_ENABLED                   TRUE
 #define STM32_LSE_ENABLED                   TRUE
 #define STM32_CLOCK48_REQUIRED              TRUE
@@ -42,8 +42,8 @@
 #define STM32_PPRE1                         STM32_PPRE1_DIV4
 #define STM32_PPRE2                         STM32_PPRE2_DIV2
 #define STM32_RTCSEL                        STM32_RTCSEL_LSE
-#define STM32_RTCPRE_VALUE                  8
-#define STM32_MCO1SEL                       STM32_MCO1SEL_HSE
+#define STM32_RTCPRE_VALUE                  2
+#define STM32_MCO1SEL                       STM32_MCO1SEL_HSI
 #define STM32_MCO1PRE                       STM32_MCO1PRE_DIV1
 #define STM32_MCO2SEL                       STM32_MCO2SEL_SYSCLK
 #define STM32_MCO2PRE                       STM32_MCO2PRE_DIV1
@@ -237,12 +237,12 @@
 /*
  * SERIAL driver system settings.
  */
-#define STM32_SERIAL_USE_USART1             TRUE
+#define STM32_SERIAL_USE_USART1             FALSE
 #define STM32_SERIAL_USE_USART2             TRUE
-#define STM32_SERIAL_USE_USART3             TRUE
+#define STM32_SERIAL_USE_USART3             FALSE
 #define STM32_SERIAL_USE_UART4              FALSE
 #define STM32_SERIAL_USE_UART5              FALSE
-#define STM32_SERIAL_USE_USART6             TRUE
+#define STM32_SERIAL_USE_USART6             FALSE
 #define STM32_SERIAL_USART1_PRIORITY        12
 #define STM32_SERIAL_USART2_PRIORITY        12
 #define STM32_SERIAL_USART3_PRIORITY        12
@@ -279,12 +279,12 @@
 /*
  * UART driver system settings.
  */
-#define STM32_UART_USE_USART1               TRUE
-#define STM32_UART_USE_USART2               TRUE
-#define STM32_UART_USE_USART3               TRUE
+#define STM32_UART_USE_USART1               FALSE
+#define STM32_UART_USE_USART2               FALSE
+#define STM32_UART_USE_USART3               FALSE
 #define STM32_UART_USE_UART4                FALSE
 #define STM32_UART_USE_UART5                FALSE
-#define STM32_UART_USE_USART6               TRUE
+#define STM32_UART_USE_USART6               FALSE
 #define STM32_UART_USART1_RX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 2)
 #define STM32_UART_USART1_TX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 7)
 #define STM32_UART_USART2_RX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 5)

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/main.c
@@ -20,21 +20,20 @@ void BlinkerThread()
 	palClearPad(GPIOC, GPIOC_LED3);
 	palClearPad(GPIOA, GPIOA_INT1);
 	
-	// loop until thread receives a request to terminate
-	while (!chThdShouldTerminateX()) 
-	{
-		//palClearPad(GPIOC, GPIOC_LED3);
-		//palSetPad(GPIOE, GPIOE_LED1);
-    palClearLine(LINE_LED3);
-    palSetLine(LINE_LED1);
-		osDelay(200);
-		palClearPad(GPIOE, GPIOE_LED1);
-		palSetPad(GPIOE, GPIOE_LED2);
-		osDelay(200);
-		palClearPad(GPIOE, GPIOE_LED2);
-		palSetPad(GPIOC, GPIOC_LED3);
-		osDelay(200);
-	}
+  while (!chThdShouldTerminateX()) 
+  {
+    palSetPad(GPIOC, GPIOC_LED3);
+    chThdSleepMilliseconds(100);
+    palClearPad(GPIOC, GPIOC_LED3);
+
+    palSetPad(GPIOE, GPIOE_LED2);
+    chThdSleepMilliseconds(100);
+    palClearPad(GPIOE, GPIOE_LED2);
+
+    palSetPad(GPIOE, GPIOE_LED1);
+    chThdSleepMilliseconds(100);
+    palClearPad(GPIOE, GPIOE_LED1);
+  }
 }
 
 void DisplayClear(uint8_t backLight)
@@ -116,7 +115,6 @@ int main(void) {
   
   osDelay(3000);
   DisplayClear (0);
-
 
   while (true)
   {

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/mbn_quail_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/mbn_quail_CLR.ld
@@ -12,8 +12,8 @@
  */
 MEMORY
 {
-    flash       : org = 0x08008000, len = 2M - 32k - 768k   /* flash size less the space reserved for nanoBooter and application deployment*/
-    deployment  : org = 0x08140000, len = 768k              /* space reserved for application deployment */
+    flash       : org = 0x08008000, len = 2M - 32k - 1408k  /* flash size less the space reserved for nanoBooter and application deployment*/
+    deployment  : org = 0x080A0000, len = 1408k             /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0                 /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20000000, len = 192k              /* SRAM1 + SRAM2 + SRAM3 */
     ram1        : org = 0x20000000, len = 112k              /* SRAM1 */

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/mcuconf.h
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/mcuconf.h
@@ -27,8 +27,8 @@
  * HAL driver system settings.
  */
 #define STM32_NO_INIT                       FALSE
-#define STM32_HSI_ENABLED                   FALSE
-#define STM32_LSI_ENABLED                   FALSE
+#define STM32_HSI_ENABLED                   TRUE
+#define STM32_LSI_ENABLED                   TRUE
 #define STM32_HSE_ENABLED                   TRUE
 #define STM32_LSE_ENABLED                   TRUE
 #define STM32_CLOCK48_REQUIRED              TRUE
@@ -42,8 +42,8 @@
 #define STM32_PPRE1                         STM32_PPRE1_DIV4
 #define STM32_PPRE2                         STM32_PPRE2_DIV2
 #define STM32_RTCSEL                        STM32_RTCSEL_LSE
-#define STM32_RTCPRE_VALUE                  8
-#define STM32_MCO1SEL                       STM32_MCO1SEL_HSE
+#define STM32_RTCPRE_VALUE                  2
+#define STM32_MCO1SEL                       STM32_MCO1SEL_HSI
 #define STM32_MCO1PRE                       STM32_MCO1PRE_DIV1
 #define STM32_MCO2SEL                       STM32_MCO2SEL_SYSCLK
 #define STM32_MCO2PRE                       STM32_MCO2PRE_DIV1


### PR DESCRIPTION
- correct and improve block storage declaration (was wasting too much flash for CLR)
- correct various mcu configs
- correct linker files
- correct sequence for CLR launch detection on nanoBooter
- enable USB in nanoBooter (needs to be active for CLR update/deployment)
- improve blinker threads to make it clear on what stage the device is in

Signed-off-by: José Simões <jose.simoes@eclo.solutions>