### PR TITLE
Corrections for F69I (deployment still fails)

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/common/Device_BlockStorage.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/common/Device_BlockStorage.c
@@ -6,20 +6,20 @@
 #include <nanoHAL_Types.h>
 #include <nanoPAL_BlockStorage.h>
 
-const BlockRange BlockRange1[] = 
+const BlockRange BlockRange1[] = // 32KB blocks
 {
-    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 0 },            // 08000000 nanoBooter          
+    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 0 },            // 08000000 nanoBooter         
     { BlockRange_BLOCKTYPE_CODE      ,   1, 3 }             // 08008000 nanoCLR          
 };
 
-const BlockRange BlockRange2[] = 
+const BlockRange BlockRange2[] = //128KB block
 {
     { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08020000 nanoCLR          
 };
 
-const BlockRange BlockRange3[] =
+const BlockRange BlockRange3[] = // 256KB blocks
 {
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 6 } //<- other examples dont use all sectors, why?            // 08040000 deployment  
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 6 }             // 08040000 deployment  
 };
 
 const BlockRegionInfo BlockRegions[] = 
@@ -27,7 +27,7 @@ const BlockRegionInfo BlockRegions[] =
     {
         0x08000000,                         // start address for block region
         4,                                  // total number of blocks in this region
-        0x018000,//<- or should it be 0x020000, why should it be missing 32k?   // total number of bytes per block
+        0x8000,                             // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange1),
         BlockRange1,
     },
@@ -35,7 +35,7 @@ const BlockRegionInfo BlockRegions[] =
     {
         0x08020000,                         // start address for block region
         1,                                  // total number of blocks in this region
-        0x020000,                            // total number of bytes per block
+        0x20000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange2),
         BlockRange2,
     },
@@ -43,41 +43,13 @@ const BlockRegionInfo BlockRegions[] =
     {
         0x08040000,                         // start address for block region
         7,                                  // total number of blocks in this region
-        0x1C0000,                           // total number of bytes per block
+        0x40000,                           // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange3),
         BlockRange3,
     },
 
 };
 
-//Would possibly be used for dual bank setup ->
-// const BlockRegionInfo BlockRegions[] = 
-// {
-//     {
-//         0x08000000,                         // start address for block region
-//         4,                                  // total number of blocks in this region
-//         0x10000,                            // total number of bytes per block
-//         ARRAYSIZE_CONST_EXPR(BlockRange1),
-//         BlockRange1,
-//     },
-
-//     {
-//         0x08010000,                         // start address for block region
-//         1,                                  // total number of blocks in this region
-//         0x10000,                            // total number of bytes per block
-//         ARRAYSIZE_CONST_EXPR(BlockRange2),
-//         BlockRange2,
-//     },
-
-//     {
-//         0x08020000,                         // start address for block region
-//         3,                                  // total number of blocks in this region
-//         0x20000,                            // total number of bytes per block
-//         ARRAYSIZE_CONST_EXPR(BlockRange3),
-//         BlockRange3,
-//     },
-
-// };
 
 const DeviceBlockInfo Device_BlockInfo =
 {

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/STM32F76xx_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/STM32F76xx_CLR.ld
@@ -17,9 +17,9 @@
  */
 MEMORY
 {
-    flash       : org = 0x08008000, len = 2M - 32k - 768k   /* flash size less the space reserved for nanoBooter and application deployment*/
-    flash_itcm  : org = 0x00208000, len = 2M - 32k - 768k
-    deployment  : org = 0x08040000, len = 768k              /* space reserved for application deployment */
+    flash       : org = 0x08008000, len = 2M - 32k - 1792k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    flash_itcm  : org = 0x00208000, len = 2M - 32k - 1792k
+    deployment  : org = 0x08040000, len = 1792k              /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0                 /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20020000, len = 384k              /* SRAM1 + SRAM2 */
     ram1        : org = 0x20020000, len = 368k              /* SRAM1 */

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/mcuconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/mcuconf.h
@@ -377,4 +377,7 @@
  */
 #define STM32_WDG_USE_IWDG                  FALSE
 
+// header for nanoFramework overlay drivers
+#include "mcuconf_nf.h"
+
 #endif /* MCUCONF_H */


### PR DESCRIPTION
corrected block storage
corrected linker memory
added include to mcuconfig

More changes are made in the old branch which maybe needed (https://github.com/networkfusion/nf-interpreter/commit/748b4fc03b80ff35811d1b0bc8bd7e43feaaf5b4) but have not been included as I am unsure.
