### PR TITLE
Improvements in SPI HAL subsystem selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,13 @@ endif()
 #################################################################
 include(NF_API_Namespaces)
 
+# for some APIs we need to enable the device in the HAL config
+if(API_Windows.Devices.Spi)
+    set(HAL_USE_SPI_OPTION TRUE CACHE INTERNAL "HAL SPI for Windows.Devices.Spi")
+else()    
+    set(HAL_USE_SPI_OPTION FALSE CACHE INTERNAL "HAL SPI for Windows.Devices.Spi")
+endif()
+
 #######################
 # ChibiOS
 if(RTOS_CHIBIOS_CHECK)

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/halconf.h
@@ -137,9 +137,10 @@
 /**
  * @brief   Enables the SPI subsystem.
  */
-#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
-#define HAL_USE_SPI                 TRUE
-#endif
+// this option is set at target_board.h (from config file)
+// #if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+// #define HAL_USE_SPI                 TRUE
+// #endif
 
 /**
  * @brief   Enables the UART subsystem.

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/halconf.h
@@ -144,9 +144,10 @@
 /**
  * @brief   Enables the SPI subsystem.
  */
-#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
-#define HAL_USE_SPI                 FALSE
-#endif
+// this option is set at target_board.h (from config file)
+// #if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+// #define HAL_USE_SPI                 FALSE
+// #endif
 
 /**
  * @brief   Enables the UART subsystem.

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/halconf.h
@@ -137,9 +137,10 @@
 /**
  * @brief   Enables the SPI subsystem.
  */
-#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
-#define HAL_USE_SPI                 FALSE
-#endif
+// this option is set at target_board.h (from config file)
+// #if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+// #define HAL_USE_SPI                 FALSE
+// #endif
 
 /**
  * @brief   Enables the UART subsystem.

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf.h
@@ -137,9 +137,10 @@
 /**
  * @brief   Enables the SPI subsystem.
  */
-#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
-#define HAL_USE_SPI                 FALSE
-#endif
+// this option is set at target_board.h (from config file)
+// #if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+// #define HAL_USE_SPI                 FALSE
+// #endif
 
 /**
  * @brief   Enables the UART subsystem.

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/halconf.h
@@ -137,9 +137,10 @@
 /**
  * @brief   Enables the SPI subsystem.
  */
-#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
-#define HAL_USE_SPI                 FALSE
-#endif
+// this option is set at target_board.h (from config file)
+// #if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+// #define HAL_USE_SPI                 FALSE
+// #endif
 
 /**
  * @brief   Enables the UART subsystem.

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf.h
@@ -144,9 +144,10 @@
 /**
  * @brief   Enables the SPI subsystem.
  */
-#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
-#define HAL_USE_SPI                 FALSE
-#endif
+// this option is set at target_board.h (from config file)
+// #if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+// #define HAL_USE_SPI                 FALSE
+// #endif
 
 /**
  * @brief   Enables the UART subsystem.

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/target_platform.h.in
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/target_platform.h.in
@@ -14,4 +14,7 @@
 // set preference to enable (or not) the RTC subsystem
 #define HAL_USE_RTC @HAL_USE_RTC_OPTION@
 
+// takes care of enabling the HAL subsystems required for API options
+#define HAL_USE_SPI @HAL_USE_SPI_OPTION@
+
 #endif /* _TARGET_CHIBIOS_NANOCLR_H_ */


### PR DESCRIPTION
- SPI subsystem in ChibiOS HAL is now enabled if the Windows.Devices.Spi API is enabled

Signed-off-by: José Simões <jose.simoes@eclo.solutions>