### PR TITLE
Improve communication responsiveness

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
@@ -9,7 +9,7 @@
 #include <target_board.h>
 
 // call to CMSIS osDelay to allow other threads to run
-#define NANOCLR_RELINQUISHEXECUTIONCONTROL()       osDelay(1);
+#define NANOCLR_RELINQUISHEXECUTIONCONTROL()       osDelay(10);
 
 #define GLOBAL_LOCK(x)              chSysLock();
 #define GLOBAL_UNLOCK(x);           chSysUnlock();


### PR DESCRIPTION
- the relinquish execution control was too tight, increased it to 10ms
- fixes #422

Signed-off-by: José Simões <jose.simoes@eclo.solutions>