### PR TITLE
Improve assembly loading

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_AppDomain.cpp
+++ b/src/CLR/CorLib/corlib_native_System_AppDomain.cpp
@@ -109,10 +109,14 @@ HRESULT Library_corlib_native_System_AppDomain::CreateDomain___STATIC__SystemApp
     NANOCLR_CHECK_HRESULT(CLR_RT_AppDomain::CreateInstance( szName, appDomain ));
 
     //load mscorlib
-    NANOCLR_CHECK_HRESULT(appDomain->LoadAssembly( g_CLR_RT_TypeSystem.m_assemblyMscorlib ));        
-    //load Native
-    NANOCLR_CHECK_HRESULT(appDomain->LoadAssembly( g_CLR_RT_TypeSystem.m_assemblyNative   ));
-    
+    NANOCLR_CHECK_HRESULT(appDomain->LoadAssembly( g_CLR_RT_TypeSystem.m_assemblyMscorlib ));
+
+    //load Runtime.Native
+    if(g_CLR_RT_TypeSystem.m_assemblyNative != NULL)
+    {
+        NANOCLR_CHECK_HRESULT(appDomain->LoadAssembly( g_CLR_RT_TypeSystem.m_assemblyNative   ));
+    }
+
     NANOCLR_CHECK_HRESULT(appDomain->GetManagedObject( res ));
 
     //Marshal the new AD to the calling AD.

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -3287,7 +3287,7 @@ void CLR_RT_TypeSystem::PostLinkageProcessing( CLR_RT_Assembly* assm )
     {
         m_assemblyMscorlib = assm;
     }
-    if(!strcmp( assm->m_szName, "Microsoft.SPOT.Native" ))
+    if(!strcmp( assm->m_szName, "nanoFramework.Runtime.Native" ))
     {
         m_assemblyNative = assm;
     }


### PR DESCRIPTION
- now assembly for "Native" is loaded on AppDomain only if it's deployed
- correct name of native assembly

Signed-off-by: José Simões <jose.simoes@eclo.solutions>