### PR TITLE
Update Runtime.Events

### DIFF
--- a/CMake/Modules/FindnanoFramework.Runtime.Events.cmake
+++ b/CMake/Modules/FindnanoFramework.Runtime.Events.cmake
@@ -21,6 +21,7 @@ set(nanoFramework.Runtime.Events_SRCS
     # source files of the assembly
     nf_rt_events_native_nanoFramework_Runtime_Events_EventSink.cpp
     nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDispatcher.cpp
+    nf_rt_events_native_nanoFramework_Runtime_Events_WeakDelegate.cpp    
     nf_rt_events_native.cpp
 
     # source files

--- a/CMake/Modules/NF_API_Namespaces.cmake
+++ b/CMake/Modules/NF_API_Namespaces.cmake
@@ -73,6 +73,14 @@ macro(ParseApiOptions)
     if(API_nanoFramework.Runtime.Events)
         ##### API name here (doted name)
         PerformSettingsForApiEntry("nanoFramework.Runtime.Events")
+
+        # this one is special because it requires also another assembly for events that is internal (doens't have a managed end)
+
+        # append to list of declaration for Interop Assemblies table
+        list(APPEND CLR_RT_NativeAssemblyDataList "extern const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_Runtime_Events_EventSink_DriverProcs;")
+        # append to list of entries for Interop Assemblies table
+        list(APPEND CLR_RT_NativeAssemblyDataTableEntriesList "&g_CLR_AssemblyNative_nanoFramework_Runtime_Events_EventSink_DriverProcs,")
+
     endif()
 
     

--- a/src/CLR/Core/InterruptHandler/InterruptHandler.cpp
+++ b/src/CLR/Core/InterruptHandler/InterruptHandler.cpp
@@ -50,7 +50,7 @@ HRESULT CLR_HW_Hardware::SpawnDispatcher()
     interrupt->Unlink();
 
     interruptData = &interrupt->m_interruptPortInterrupt;
-    ioPort = interruptData->m_context;
+    ioPort = interruptData->context;
 
     CLR_RT_ProtectFromGC gc1 ( *ioPort );
     
@@ -87,11 +87,11 @@ HRESULT CLR_HW_Hardware::TransferAllInterruptsToApplicationQueue()
 
         CLR_RT_ApplicationInterrupt* queueRec = (CLR_RT_ApplicationInterrupt*)CLR_RT_Memory::Allocate_And_Erase( sizeof(CLR_RT_ApplicationInterrupt), CLR_RT_HeapBlock::HB_CompactOnFailure );  CHECK_ALLOCATION(queueRec);
 
-        queueRec->m_interruptPortInterrupt.m_data1   =                                          rec->m_data1;
-        queueRec->m_interruptPortInterrupt.m_data2   =                                          rec->m_data2;
-        queueRec->m_interruptPortInterrupt.m_data3   =                                          rec->m_data3;
-        queueRec->m_interruptPortInterrupt.m_time    =                                          rec->m_time;
-        queueRec->m_interruptPortInterrupt.m_context = (CLR_RT_HeapBlock_NativeEventDispatcher*)rec->m_context;
+        queueRec->m_interruptPortInterrupt.data1   =                                          rec->m_data1;
+        queueRec->m_interruptPortInterrupt.data2   =                                          rec->m_data2;
+        queueRec->m_interruptPortInterrupt.data3   =                                          rec->m_data3;
+        queueRec->m_interruptPortInterrupt.time    =                                          rec->m_time;
+        queueRec->m_interruptPortInterrupt.context = (CLR_RT_HeapBlock_NativeEventDispatcher*)rec->m_context;
 
         m_interruptData.m_applicationQueue.LinkAtBack( queueRec ); ++m_interruptData.m_queuedInterrupts;
 
@@ -136,4 +136,3 @@ HRESULT CLR_HW_Hardware::ProcessInterrupts()
 
     NANOCLR_NOCLEANUP();
 }
-

--- a/src/CLR/Core/NativeEventDispatcher/NativeEventDispatcher.cpp
+++ b/src/CLR/Core/NativeEventDispatcher/NativeEventDispatcher.cpp
@@ -4,7 +4,6 @@
 // See LICENSE file in the project root for full license information.
 //
 #include <nanoCLR_Hardware.h>
-#include <corlib_native.h>
 #include <nf_rt_events_native.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/CLR/Core/NativeEventDispatcher/NativeEventDispatcher.vcxproj
+++ b/src/CLR/Core/NativeEventDispatcher/NativeEventDispatcher.vcxproj
@@ -18,6 +18,9 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="NativeEventDispatcher.cpp" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6DD5CA4F-2AE9-44D3-B9D7-A2A4A35FC5B2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -96,7 +99,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\Include;..\..\CorLib;..\..\..\HAL\Include;..\..\..\PAL\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Include;..\..\CorLib;..\..\..\HAL\Include;..\..\..\PAL\Include;..\..\nanoFramework.Runtime.Events</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/CLR/Core/NativeEventDispatcher/NativeEventDispatcher.vcxproj.filters
+++ b/src/CLR/Core/NativeEventDispatcher/NativeEventDispatcher.vcxproj.filters
@@ -14,4 +14,9 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="NativeEventDispatcher.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
 </Project>

--- a/src/CLR/Include/nanoCLR_Interop.h
+++ b/src/CLR/Include/nanoCLR_Interop.h
@@ -438,9 +438,9 @@ typedef HRESULT (*InterruptServiceProc)( CLR_RT_HeapBlock_NativeEventDispatcher 
 struct CLR_RT_DriverInterruptMethods
 
 {
-    InitializeInterruptsProc      m_InitProc;
-    EnableorDisableInterruptsProc m_EnableProc;
-    CleanupInterruptsProc         m_CleanupProc;
+    InitializeInterruptsProc      initProcessor;
+    EnableorDisableInterruptsProc enableProcessor;
+    CleanupInterruptsProc         cleanupProcessor;
 };
 
 // Randomly generated 32 bit number.
@@ -452,7 +452,7 @@ CLR_RT_HeapBlock_NativeEventDispatcher *CreateNativeEventInstance( CLR_RT_StackF
 
 // Saves data from ISR. The data from this queue is used to call managed callbacks.
 // Should be called from ISR.
-__nfweak void SaveNativeEventToHALQueue( CLR_RT_HeapBlock_NativeEventDispatcher *pContext, unsigned int data1, unsigned int data2 );
+__nfweak void SaveNativeEventToHALQueue( CLR_RT_HeapBlock_NativeEventDispatcher *pContext, uint32_t data1, uint32_t data2 );
 
 // Cleans up the data in the queue after interrupts were closed and no managed callbacks are expected.
 __nfweak void CleanupNativeEventsFromHALQueue( CLR_RT_HeapBlock_NativeEventDispatcher *pContext );

--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -2261,23 +2261,23 @@ struct CLR_RT_HeapBlock_NativeEventDispatcher : public CLR_RT_ObjectToEvent_Dest
     __nfweak static void HandlerMethod_RecoverFromGC ();
     __nfweak static void HandlerMethod_CleanUp ();
 
-    static CLR_RT_DblLinkedList m_ioPorts; 
+    static CLR_RT_DblLinkedList eventList; 
 
 
     struct InterruptPortInterrupt
     {
-        CLR_INT64                 m_time;
-        CLR_RT_HeapBlock_NativeEventDispatcher*  m_context;
-        CLR_UINT32                m_data1;
-        CLR_UINT32                m_data2;
-        CLR_UINT32                m_data3;
+        CLR_INT64                 time;
+        CLR_RT_HeapBlock_NativeEventDispatcher*  context;
+        CLR_UINT32                data1;
+        CLR_UINT32                data2;
+        CLR_UINT32                data3;
     };
 
     // Pointer to Hardware driver methods
-    CLR_RT_DriverInterruptMethods  *m_DriverMethods;
+    CLR_RT_DriverInterruptMethods  *driverMethods;
     //--//
-    // Poiner to custom data used by device drivers.
-    void  *m_pDrvCustomData;
+    // Pointer to custom data used by device drivers.
+    void  *pDrvCustomData;
 
 
 
@@ -2290,7 +2290,7 @@ struct CLR_RT_HeapBlock_NativeEventDispatcher : public CLR_RT_ObjectToEvent_Dest
     __nfweak HRESULT RecoverManagedObject( CLR_RT_HeapBlock*& port                                   );
 
     __nfweak static void ThreadTerminationCallback( void* arg                                  );
-    __nfweak void SaveToHALQueue( unsigned int data1, unsigned int data2 );
+    __nfweak void SaveToHALQueue( uint32_t data1, uint32_t data2 );
     __nfweak void RemoveFromHALQueue();
 
     __nfweak void RecoverFromGC    ();

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native.cpp
@@ -42,11 +42,16 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
+    NULL,
+    NULL,
+    Library_nf_rt_events_native_nanoFramework_Runtime_Events_WeakDelegate::Combine___STATIC__mscorlibSystemDelegate__mscorlibSystemDelegate__mscorlibSystemDelegate,
+    Library_nf_rt_events_native_nanoFramework_Runtime_Events_WeakDelegate::Remove___STATIC__mscorlibSystemDelegate__mscorlibSystemDelegate__mscorlibSystemDelegate,
 };
 
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_Runtime_Events =
 {
     "nanoFramework.Runtime.Events", 
-    0x9AFF4455,
+    0x9ACFB207,
     method_lookup
 };

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native.h
@@ -28,7 +28,7 @@ struct Library_nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDispa
 
     //--//
     static CLR_RT_ObjectToEvent_Source*             GetEventDispReference( CLR_RT_StackFrame& stack                                  );
-    static HRESULT                                  GetEventDispatcher   ( CLR_RT_StackFrame& stack, CLR_RT_HeapBlock_NativeEventDispatcher*& port  );
+    static HRESULT                                  GetEventDispatcher   ( CLR_RT_StackFrame& stack, CLR_RT_HeapBlock_NativeEventDispatcher*& event  );
     static CLR_RT_HeapBlock_NativeEventDispatcher*  GetEventDispatcher   ( CLR_RT_StackFrame& stack                                  );
 };
 
@@ -65,17 +65,36 @@ struct Library_nf_rt_events_native_nanoFramework_Runtime_Events_BaseEvent
 
 };
 
-struct Library_nf_rt_events_native_nanoFramework_Runtime_Events_GenericEvent
+struct Library_nf_rt_events_native_nanoFramework_Runtime_Events_EventArgs
 {
-    static const int FIELD__Category = 3;
-    static const int FIELD__Data = 4;
-    static const int FIELD__Tag = 5;
-    static const int FIELD__Time = 6;
+    static const int FIELD_STATIC__Empty = 2;
 
 
     //--//
 
 };
+
+struct Library_nf_rt_events_native_nanoFramework_Runtime_Events_GenericEvent
+{
+    static const int FIELD__Category = 3;
+    static const int FIELD__Data = 4;
+    static const int FIELD__Time = 5;
+
+
+    //--//
+
+};
+
+struct Library_nf_rt_events_native_nanoFramework_Runtime_Events_WeakDelegate
+{
+    NANOCLR_NATIVE_DECLARE(Combine___STATIC__mscorlibSystemDelegate__mscorlibSystemDelegate__mscorlibSystemDelegate);
+    NANOCLR_NATIVE_DECLARE(Remove___STATIC__mscorlibSystemDelegate__mscorlibSystemDelegate__mscorlibSystemDelegate);
+
+    //--//
+
+};
+
+extern const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_Runtime_Events_EventSink_DriverProcs;
 
 extern const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_Runtime_Events;
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native_nanoFramework_Runtime_Events_EventSink.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native_nanoFramework_Runtime_Events_EventSink.cpp
@@ -8,21 +8,17 @@
 
 static CLR_RT_HeapBlock_NativeEventDispatcher *g_Context = NULL;
 
-void PostManagedEvent(unsigned char category, unsigned char subCategory, unsigned short data1, unsigned int data2)
+void PostManagedEvent(uint8_t category, uint8_t subCategory, uint16_t data1, uint32_t data2)
 {
     if(g_Context != NULL)
     {
-        chSysLock();   
-
-        unsigned int d = ((unsigned int)data1 << 16) | (category << 8) | subCategory;
+        uint16_t d = ((uint16_t)data1 << 16) | (category << 8) | subCategory;
 
         SaveNativeEventToHALQueue( g_Context, d, data2 );
-
-        chSysUnlock();
     }
 }
 
-static HRESULT InitializeEventSink( CLR_RT_HeapBlock_NativeEventDispatcher *pContext, unsigned __int64 userData )
+static HRESULT InitializeEventSink( CLR_RT_HeapBlock_NativeEventDispatcher *pContext, uint64_t userData )
 {
    g_Context  = pContext;
 
@@ -45,11 +41,7 @@ static HRESULT CleanupEventSink( CLR_RT_HeapBlock_NativeEventDispatcher *pContex
 
 HRESULT Library_nf_rt_events_native_nanoFramework_Runtime_Events_EventSink::EventConfig___VOID( CLR_RT_StackFrame& stack )
 {
-    NANOCLR_HEADER();
-
-    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
-
-    NANOCLR_NOCLEANUP();
+    return S_OK;
 }
 
 static const CLR_RT_DriverInterruptMethods g_CLR_AssemblyNative_nanoFramework_Runtime_Events_EventSink = 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDispatcher.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDispatcher.cpp
@@ -25,12 +25,12 @@ HRESULT Library_nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDisp
 
     // Calls driver to enable interrupts.  Consider that there could be no driver 
     // associated to this object so check that the driver methods are set 
-    if(pNativeDisp->m_DriverMethods == NULL)
+    if(pNativeDisp->driverMethods == NULL)
     {
         NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_OPERATION);
     }
     
-    NANOCLR_CHECK_HRESULT(pNativeDisp->m_DriverMethods->m_EnableProc( pNativeDisp, true ));
+    NANOCLR_CHECK_HRESULT(pNativeDisp->driverMethods->enableProcessor( pNativeDisp, true ));
     
     NANOCLR_NOCLEANUP();
 }
@@ -53,9 +53,9 @@ HRESULT Library_nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDisp
     // Calls driver to enable interrupts.  Consider that there could be no driver 
     // associated to this object so check that the driver methods are set 
     // we will be tolerant in this case and not throw any exception
-    if(pNativeDisp->m_DriverMethods != NULL)
+    if(pNativeDisp->driverMethods != NULL)
     {
-        NANOCLR_CHECK_HRESULT(pNativeDisp->m_DriverMethods->m_EnableProc( pNativeDisp, false ));
+        NANOCLR_CHECK_HRESULT(pNativeDisp->driverMethods->enableProcessor( pNativeDisp, false ));
     }
     
     NANOCLR_NOCLEANUP();
@@ -77,9 +77,9 @@ HRESULT Library_nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDisp
     // Calls driver to enable interrupts.  Consider that there could be no driver 
     // associated to this object so check that the driver methods are set 
     // we will be tolerant in this case and not throw any exception
-    if(pNativeDisp->m_DriverMethods != NULL)
+    if(pNativeDisp->driverMethods != NULL)
     {
-        NANOCLR_CHECK_HRESULT(pNativeDisp->m_DriverMethods->m_CleanupProc( pNativeDisp )); 
+        NANOCLR_CHECK_HRESULT(pNativeDisp->driverMethods->cleanupProcessor( pNativeDisp )); 
     }
     
     NANOCLR_NOCLEANUP();
@@ -125,7 +125,7 @@ HRESULT Library_nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDisp
     pDriverMethods = (CLR_RT_DriverInterruptMethods *)pNativeDriverData->m_pNativeMethods;
     
     // Check that all methods are present:
-    if(pDriverMethods->m_InitProc == NULL || pDriverMethods->m_EnableProc == NULL || pDriverMethods->m_CleanupProc == NULL)
+    if(pDriverMethods->initProcessor == NULL || pDriverMethods->enableProcessor == NULL || pDriverMethods->cleanupProcessor == NULL)
     {
        NANOCLR_CHECK_HRESULT(CLR_E_DRIVER_NOT_REGISTERED);
     }
@@ -137,8 +137,8 @@ HRESULT Library_nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDisp
     NANOCLR_CHECK_HRESULT(GetEventDispatcher( stack, pNativeDisp ));
 
     // Now call the driver. First save pointer to driver data.
-    pNativeDisp->m_DriverMethods = pDriverMethods;
-    NANOCLR_CHECK_HRESULT(pDriverMethods->m_InitProc( pNativeDisp, driverData ));
+    pNativeDisp->driverMethods = pDriverMethods;
+    NANOCLR_CHECK_HRESULT(pDriverMethods->initProcessor( pNativeDisp, driverData ));
     
     NANOCLR_NOCLEANUP();
 }
@@ -153,13 +153,13 @@ CLR_RT_ObjectToEvent_Source* Library_nf_rt_events_native_nanoFramework_Runtime_E
     return CLR_RT_ObjectToEvent_Source::ExtractInstance( pThis[ FIELD___NativeEventDispatcher ] );
 }
 
-HRESULT Library_nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDispatcher::GetEventDispatcher( CLR_RT_StackFrame& stack, CLR_RT_HeapBlock_NativeEventDispatcher*& port )
+HRESULT Library_nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDispatcher::GetEventDispatcher( CLR_RT_StackFrame& stack, CLR_RT_HeapBlock_NativeEventDispatcher*& event )
 {
     NATIVE_PROFILE_CLR_HARDWARE();
     NANOCLR_HEADER();
 
-    port = GetEventDispatcher( stack );
-    if(port == NULL)
+    event = GetEventDispatcher( stack );
+    if(event == NULL)
     {
         NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
     }
@@ -173,23 +173,4 @@ CLR_RT_HeapBlock_NativeEventDispatcher* Library_nf_rt_events_native_nanoFramewor
     CLR_RT_ObjectToEvent_Source* src = GetEventDispReference( stack );
 
     return (src == NULL) ? NULL : (CLR_RT_HeapBlock_NativeEventDispatcher*)src->m_eventPtr;
-}
-
-CLR_RT_HeapBlock_NativeEventDispatcher *CreateNativeEventInstance( CLR_RT_StackFrame& stack )
-{  
-    NATIVE_PROFILE_CLR_IOPORT();
-
-    CLR_RT_HeapBlock_NativeEventDispatcher *pNativeDisp = NULL;
-    CLR_RT_HeapBlock* pThis = stack.This();
-    
-    // Creates intstance of CLR_RT_HeapBlock_NativeEventDispatcher and saves it in pThis
-    if(FAILED(CLR_RT_HeapBlock_NativeEventDispatcher::CreateInstance( *pThis, pThis[ Library_nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDispatcher::FIELD___NativeEventDispatcher ] )))
-    {
-        return NULL;
-    }
-
-    // Retrieves instance of 
-    Library_nf_rt_events_native_nanoFramework_Runtime_Events_NativeEventDispatcher::GetEventDispatcher( stack, pNativeDisp );
-    
-    return pNativeDisp;
 }

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native_nanoFramework_Runtime_Events_WeakDelegate.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native_nanoFramework_Runtime_Events_WeakDelegate.cpp
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+
+#include "nf_rt_events_native.h"
+
+
+HRESULT Library_nf_rt_events_native_nanoFramework_Runtime_Events_WeakDelegate::Combine___STATIC__mscorlibSystemDelegate__mscorlibSystemDelegate__mscorlibSystemDelegate( CLR_RT_StackFrame& stack )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(CLR_RT_HeapBlock_Delegate_List::Combine( stack.PushValue(), stack.Arg0(), stack.Arg1(), true ));
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_nf_rt_events_native_nanoFramework_Runtime_Events_WeakDelegate::Remove___STATIC__mscorlibSystemDelegate__mscorlibSystemDelegate__mscorlibSystemDelegate( CLR_RT_StackFrame& stack )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(CLR_RT_HeapBlock_Delegate_List::Remove( stack.PushValue(), stack.Arg0(), stack.Arg1() ));
+
+    NANOCLR_NOCLEANUP();
+}


### PR DESCRIPTION
- add WeakDelegate and related declarations
- update CMakes accordingly
- rename fields in CLR_RT_DriverInterruptMethods (to remove the m_ prefix) and update code accordingly
- correct declaration of SaveToHALQueue to use standard types
- change names of CLR_RT_HeapBlock_NativeEventDispatcher to make those in sync with IOPort renaming

Signed-off-by: José Simões <jose.simoes@eclo.solutions>