### PR TITLE
Update CorLib with latest managed version

### DIFF
--- a/src/CLR/CorLib/corlib_native.cpp
+++ b/src/CLR/CorLib/corlib_native.cpp
@@ -367,6 +367,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     Library_corlib_native_System_Globalization_CultureInfo::get_CurrentUICultureInternal___STATIC__SystemGlobalizationCultureInfo,
+    Library_corlib_native_System_Globalization_CultureInfo::set_CurrentUICultureInternal___STATIC__VOID__SystemGlobalizationCultureInfo,
     Library_corlib_native_System_Globalization_DateTimeFormat::FormatDigits___STATIC__STRING__I4__I4,
     NULL,
     NULL,
@@ -900,6 +901,6 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_mscorlib =
 {
     "mscorlib", 
-    0x138C738A,
+    0x964C8465,
     method_lookup
 };

--- a/src/CLR/CorLib/corlib_native.h
+++ b/src/CLR/CorLib/corlib_native.h
@@ -398,10 +398,11 @@ struct Library_corlib_native_System_Globalization_CultureInfo
     static const int FIELD___numInfo = 1;
     static const int FIELD___dateTimeInfo = 2;
     static const int FIELD___cultureInfoName = 3;
-    static const int FIELD___cultureInfoResourceManager = 4;
+    static const int FIELD___name = 4;
     static const int FIELD___parent = 5;
 
     NANOCLR_NATIVE_DECLARE(get_CurrentUICultureInternal___STATIC__SystemGlobalizationCultureInfo);
+    NANOCLR_NATIVE_DECLARE(set_CurrentUICultureInternal___STATIC__VOID__SystemGlobalizationCultureInfo);
 
     //--//
 

--- a/src/CLR/CorLib/corlib_native_System_Globalization_CultureInfo.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Globalization_CultureInfo.cpp
@@ -15,3 +15,13 @@ HRESULT Library_corlib_native_System_Globalization_CultureInfo::get_CurrentUICul
 
     NANOCLR_NOCLEANUP_NOLABEL();
 }
+
+HRESULT Library_corlib_native_System_Globalization_CultureInfo::set_CurrentUICultureInternal___STATIC__VOID__SystemGlobalizationCultureInfo( CLR_RT_StackFrame& stack )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_HEADER();
+
+    g_CLR_RT_ExecutionEngine.m_currentUICulture = stack.Arg0().Dereference();    
+
+    NANOCLR_NOCLEANUP_NOLABEL();
+}

--- a/targets/os/win32/nanoCLR/CLRStartup.cpp
+++ b/targets/os/win32/nanoCLR/CLRStartup.cpp
@@ -140,7 +140,7 @@ struct Settings
 		// just need to update the path on the package folder as the version changes //
 		// ************************************************************************* //
 		vec.push_back(L"-load");
-        vec.push_back(L"..\\packages\\nanoFramework.CoreLibrary.1.0.0-preview025\\lib\\mscorlib.pe");
+        vec.push_back(L"..\\packages\\nanoFramework.CoreLibrary.1.0.0-preview026\\lib\\mscorlib.pe");
 		
 		//// grab Windows.Devices.Gpio.pe from the packages folder (it has to be there because the NF.TestApplication has just build)
 		//// ************************************************************************* //

--- a/targets/os/win32/netnf/TestApplication/NF.TestApplication.nfproj
+++ b/targets/os/win32/netnf/TestApplication/NF.TestApplication.nfproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview025\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview026\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/targets/os/win32/netnf/TestApplication/packages.config
+++ b/targets/os/win32/netnf/TestApplication/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview025" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview026" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
- udpate native code and declarations
- update test app for nanoCLR
- fixes nanoframework/nf-class-libraries#131

Signed-off-by: José Simões <jose.simoes@eclo.solutions>