### PR TITLE
Add option to choose inclusion of Application Domains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,19 @@ endif()
 #################################################################
 
 #################################################################
+# enables Application Domains support in nanoCLR
+# (default is OFF so Application Domains is NOT supported)
+option(NF_FEATURE_USE_APPDOMAINS "option to use hardware RTC")
+
+if(NF_FEATURE_USE_APPDOMAINS)
+    message(STATUS "Application Domains support is included")
+else()    
+    message(STATUS "Application Domains support IS NOT included")
+endif()
+
+#################################################################
+
+#################################################################
 # manage nanoFramework API namespaces
 #################################################################
 include(NF_API_Namespaces)

--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -37,6 +37,7 @@
             "CHIBIOS_BOARD" : "<valid-chibios-board-name-from-boards-collection>",
             "NF_FEATURE_DEBUGGER" : "TRUE-to-include-nF-debugger",
             "NF_FEATURE_RTC" : "OFF-default-ON-to-enable-hardware-RTC",
+            "NF_FEATURE_USE_APPDOMAINS" : "OFF-default-ON-to-enable-support-for-Application-Domains",
             "API_Windows.Devices.Gpio" : "OFF-default-ON-to-add-this-API",
             "API_Windows.Devices.Spi" : "OFF-default-ON-to-add-this-API"
         }
@@ -54,6 +55,7 @@
             "CHIBIOS_BOARD" : "<valid-chibios-board-name-from-boards-collection>",
             "NF_FEATURE_DEBUGGER" : "TRUE-to-include-nF-debugger",
             "NF_FEATURE_RTC" : "OFF-default-ON-to-enable-hardware-RTC",
+            "NF_FEATURE_USE_APPDOMAINS" : "OFF-default-ON-to-enable-support-for-Application-Domains",
             "API_Windows.Devices.Gpio" : "OFF-default-ON-to-add-this-API",
             "API_Windows.Devices.Spi" : "OFF-default-ON-to-add-this-API"
         }

--- a/docs/cmake-tools-cmake-variants.md
+++ b/docs/cmake-tools-cmake-variants.md
@@ -66,6 +66,8 @@ The following explains each line of the *linkage* section. Text highlighted in *
 	- A boolean switch to specify whether the debugger feature is to be included.
 - "NF_FEATURE_RTC" : "**<OFF-default-ON-to-enable-hardware-RTC>**"
 	- Allows you to specify whether the board contains a real time clock that can be used for date & time functions.
+- "NF_FEATURE_USE_APPDOMAINS" : "**<OFF-default-ON-to-enable-support-for-Application-Domains>**"
+	- Allows you to specify whether to include, or not, support for Application Domains. More information about this is available in the documentation [here](https://msdn.microsoft.com/en-us/library/cxk374d9(v=vs.90).aspx). ***Note that the complete removal of support for this feature is being considered (see issue [here](https://github.com/nanoframework/nf-interpreter/issues/303)).***
 - "API_Windows.Devices.Gpio" : "**<OFF-default-ON-to-add-this-API>**"
 	- Allows you to specify whether GPIO functions are available to your application.
 - "FREERTOS_VERSION" : "**<N.N.N>**"
@@ -97,6 +99,7 @@ The following linkage section is a real example used to build nanoFramework for 
             "CHIBIOS_BOARD" : "MBN_QUAIL"
 			"NF_FEATURE_DEBUGGER" : "TRUE",
             "NF_FEATURE_RTC" : "ON",
+			"NF_FEATURE_USE_APPDOMAINS" : "OFF",			
             "API_Windows.Devices.Gpio" : "ON"
         },
         "buildType": "Debug"

--- a/src/CLR/Include/nanoCLR_PlatformDef.h
+++ b/src/CLR/Include/nanoCLR_PlatformDef.h
@@ -26,7 +26,7 @@
 #define NANOCLR_EMULATED_FLOATINGPOINT    // use the fixed point floating point notation in the clr ocdes 
 #endif
 
-#if !defined(NANOCLR_NO_APPDOMAINS)
+#if defined(NANOCLR_USE_APPDOMAINS)
 #define NANOCLR_APPDOMAINS           // enables application doman support
 #endif
 #define NANOCLR_TRACE_EXCEPTIONS     // enables exception dump support

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -161,6 +161,12 @@ endif()
 target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DCORTEX_USE_FPU=$<$<BOOL:USE_FPU_IS_TRUE>:TRUE>$<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:FALSE>)
 target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DCORTEX_USE_FPU=$<$<BOOL:USE_FPU_IS_TRUE>:TRUE>$<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:FALSE>)
 
+# set compiler definition for using Application Domains feature
+if(NF_FEATURE_USE_APPDOMAINS)
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+endif()
+
 # set extra linker flags for DEBUG
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")
 set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
@@ -161,6 +161,12 @@ endif()
 target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DCORTEX_USE_FPU=$<$<BOOL:USE_FPU_IS_TRUE>:TRUE>$<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:FALSE>)
 target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DCORTEX_USE_FPU=$<$<BOOL:USE_FPU_IS_TRUE>:TRUE>$<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:FALSE>)
 
+# set compiler definition for using Application Domains feature
+if(NF_FEATURE_USE_APPDOMAINS)
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+endif()
+
 # set extra linker flags for DEBUG
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")
 set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
@@ -156,6 +156,12 @@ else()
     target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
 endif()
 
+# set compiler definition for using Application Domains feature
+if(NF_FEATURE_USE_APPDOMAINS)
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+endif()
+
 # set extra linker flags for DEBUG
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")
 set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -161,6 +161,12 @@ endif()
 target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DCORTEX_USE_FPU=$<$<BOOL:USE_FPU_IS_TRUE>:TRUE>$<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:FALSE>)
 target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DCORTEX_USE_FPU=$<$<BOOL:USE_FPU_IS_TRUE>:TRUE>$<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:FALSE>)
 
+# set compiler definition for using Application Domains feature
+if(NF_FEATURE_USE_APPDOMAINS)
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+endif()
+
 # set extra linker flags for DEBUG
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")
 set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
@@ -161,6 +161,12 @@ endif()
 target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DCORTEX_USE_FPU=$<$<BOOL:USE_FPU_IS_TRUE>:TRUE>$<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:FALSE>)
 target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DCORTEX_USE_FPU=$<$<BOOL:USE_FPU_IS_TRUE>:TRUE>$<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:FALSE>)
 
+# set compiler definition for using Application Domains feature
+if(NF_FEATURE_USE_APPDOMAINS)
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+endif()
+
 # set extra linker flags for DEBUG
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")
 set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
@@ -161,6 +161,12 @@ endif()
 target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DCORTEX_USE_FPU=$<$<BOOL:USE_FPU_IS_TRUE>:TRUE>$<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:FALSE>)
 target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DCORTEX_USE_FPU=$<$<BOOL:USE_FPU_IS_TRUE>:TRUE>$<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:FALSE>)
 
+# set compiler definition for using Application Domains feature
+if(NF_FEATURE_USE_APPDOMAINS)
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC -DNANOCLR_USE_APPDOMAINS)
+endif()
+
 # set extra linker flags for DEBUG
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")
 set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "")


### PR DESCRIPTION
- add option to CMake to choose the inclusion (or not which is the default) of support for Application Domains
- work on CMakes to handle this
- update documentation regarding this
- update template for cmake.variants
- this is related with #303
- NOT including support for Application Domains reduces the image size in 6936 bytes (build in debug)

Signed-off-by: José Simões <jose.simoes@eclo.solutions>