### PR TITLE
Tweaks related with ChibiOS LwIP

### DIFF
--- a/CMake/Modules/FindCHIBIOS_LWIP.cmake
+++ b/CMake/Modules/FindCHIBIOS_LWIP.cmake
@@ -1,8 +1,12 @@
+#
+# Copyright (c) 2017 The nanoFramework project contributors
+# See LICENSE file in the project root for full license information.
+#
 
 execute_process(
     COMMAND ${CMAKE_COMMAND} -E tar xvf ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip-1.4.1_patched.7z
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/
-    )
+)
 
 
 # List of the required lwIp include files.
@@ -13,68 +17,69 @@ list(APPEND CHIBIOS_LWIP_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/l
 
 
 set(LWIP_SRCS
-# bindings
-lwipthread.c
-sys_arch.c
+    # bindings
+    lwipthread.c
+    sys_arch.c
 
-# netif
-etharp.c
+    # netif
+    etharp.c
 
-# core
-dhcp.c
-dns.c
-init.c
-mem.c
-memp.c
-netif.c
-pbuf.c
-raw.c
-stats.c
-sys.c
-tcp.c
-tcp_in.c
-tcp_out.c
-udp.c
+    # core
+    dhcp.c
+    dns.c
+    init.c
+    mem.c
+    memp.c
+    netif.c
+    pbuf.c
+    raw.c
+    stats.c
+    sys.c
+    tcp.c
+    tcp_in.c
+    tcp_out.c
+    udp.c
 
-# ipv4
-autoip.c
-icmp.c
-igmp.c
-inet.c
-inet_chksum.c
-ip.c
-ip_addr.c
-ip_frag.c
-def.c
-timers.c
+    # ipv4
+    autoip.c
+    icmp.c
+    igmp.c
+    inet.c
+    inet_chksum.c
+    ip.c
+    ip_addr.c
+    ip_frag.c
+    def.c
+    timers.c
 
-# api
-api_lib.c
-api_msg.c
-err.c
-netbuf.c
-netdb.c
-netifapi.c
-sockets.c
-tcpip.c
+    # api
+    api_lib.c
+    api_msg.c
+    err.c
+    netbuf.c
+    netdb.c
+    netifapi.c
+    sockets.c
+    tcpip.c
 )
 
 
 foreach(SRC_FILE ${LWIP_SRCS})
-set(LWIP_SRC_FILE SRC_FILE -NOTFOUND)
-find_file(LWIP_SRC_FILE ${SRC_FILE}
-    PATHS 
-        ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/various/lwip_bindings
-        ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/various/lwip_bindings/arch
-        ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip/src/netif
-        ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip/src/core
-        ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip/src/core/ipv4
-        ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip/src/api
+    set(LWIP_SRC_FILE SRC_FILE -NOTFOUND)
+    find_file(LWIP_SRC_FILE ${SRC_FILE}
+        PATHS 
 
-    CMAKE_FIND_ROOT_PATH_BOTH
-)
-# message("${SRC_FILE} >> ${LWIP_SRC_FILE}") # debug helper
-list(APPEND CHIBIOS_LWIP_SOURCES ${LWIP_SRC_FILE})
+            ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/various/lwip_bindings
+            ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/various/lwip_bindings/arch
+            ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip/src/netif
+            ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip/src/core
+            ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip/src/core/ipv4
+            ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip/src/api
+
+        CMAKE_FIND_ROOT_PATH_BOTH
+    )
+    # message("${SRC_FILE} >> ${LWIP_SRC_FILE}") # debug helper
+    list(APPEND CHIBIOS_LWIP_SOURCES ${LWIP_SRC_FILE})
 endforeach()
 
 

--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -38,9 +38,9 @@
             "NF_FEATURE_DEBUGGER" : "TRUE-to-include-nF-debugger",
             "NF_FEATURE_RTC" : "OFF-default-ON-to-enable-hardware-RTC",
             "NF_FEATURE_USE_APPDOMAINS" : "OFF-default-ON-to-enable-support-for-Application-Domains",
+            "NF_FEATURE_USE_NETWORKING" : "OFF-default-ON-to-enable-support",
             "API_Windows.Devices.Gpio" : "OFF-default-ON-to-add-this-API",
-            "API_Windows.Devices.Spi" : "OFF-default-ON-to-add-this-API",
-            "NF_FEATURE_USE_NETWORKING" : "OFF-default-ON-to-enable-support"
+            "API_Windows.Devices.Spi" : "OFF-default-ON-to-add-this-API"
         }
       },
       "OPTION2_NAME_HERE": {
@@ -57,9 +57,9 @@
             "NF_FEATURE_DEBUGGER" : "TRUE-to-include-nF-debugger",
             "NF_FEATURE_RTC" : "OFF-default-ON-to-enable-hardware-RTC",
             "NF_FEATURE_USE_APPDOMAINS" : "OFF-default-ON-to-enable-support-for-Application-Domains",
+            "NF_FEATURE_USE_NETWORKING" : "OFF-default-ON-to-enable-support",
             "API_Windows.Devices.Gpio" : "OFF-default-ON-to-add-this-API",
-            "API_Windows.Devices.Spi" : "OFF-default-ON-to-add-this-API",
-            "NF_FEATURE_USE_NETWORKING" : "OFF-default-ON-to-enable-support"
+            "API_Windows.Devices.Spi" : "OFF-default-ON-to-add-this-API"
         }
       },
       "default$": "",

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -136,6 +136,9 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
 
     # includes for nanoFramework APIs
     "${TARGET_NANO_APIS_INCLUDES}"
+
+    # includes for ChibiOS LwIP
+    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
 )
 
 ###################

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
@@ -136,6 +136,9 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
 
     # includes for nanoFramework APIs
     "${TARGET_NANO_APIS_INCLUDES}"
+
+    # includes for ChibiOS LwIP
+    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
 )
 
 ###################

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
@@ -135,6 +135,9 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
 
     # includes for nanoFramework APIs
     "${TARGET_NANO_APIS_INCLUDES}"
+
+    # includes for ChibiOS LwIP
+    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
 )
 
 ###################

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -136,6 +136,9 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
 
     # includes for nanoFramework APIs
     "${TARGET_NANO_APIS_INCLUDES}"
+
+    # includes for ChibiOS LwIP
+    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
 )
 
 ###################
@@ -191,7 +194,7 @@ set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAG
 # the size of the CLR managed heap is defined here
 ###################################################
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--library-path=${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/common,--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x0")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--library-path=${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/common,--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x2A000")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--library-path=${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/common,--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x29920")
 
 
 set(NANOBOOTER_HEX_FILE ${PROJECT_SOURCE_DIR}/build/${NANOBOOTER_PROJECT_NAME}.hex)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
@@ -136,6 +136,9 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
 
     # includes for nanoFramework APIs
     "${TARGET_NANO_APIS_INCLUDES}"
+
+    # includes for ChibiOS LwIP
+    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
 )
 
 ###################

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
@@ -136,6 +136,9 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
 
     # includes for nanoFramework APIs
     "${TARGET_NANO_APIS_INCLUDES}"
+
+    # includes for ChibiOS LwIP
+    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
 )
 
 ###################


### PR DESCRIPTION
- improve document formating, add missing empty line at end, add missing copyright header
- add missing inclusion of include dirs for LwIP on targets CMake.txt
- rearrange order of options in cmake.variants template

Signed-off-by: José Simões <jose.simoes@eclo.solutions>