### PR TITLE
Work on CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,22 +129,6 @@ endif()
 ##########################################
 
 
-#################################################################
-# ARM Cortex-M Single Wire Output (SWO) 
-# (default is OFF so no SWO output)
-
-option(SWO_OUPUT "option to enable SWO")
-
-if(SWO_OUPUT)
-    set(SWO_OUPUT_OPTION TRUE CACHE INTERNAL "Single Wire Output Option")
-    message(STATUS "Single Wire Output (SWO) enabled")
-else()    
-    set(SWO_OUPUT_OPTION FALSE CACHE INTERNAL "Single Wire Output Option")
-endif()
-
-#################################################################
-
-
 ##########################################
 # set default toolchain to GCC
 set(TOOLCHAIN GCC)
@@ -260,15 +244,31 @@ endif()
 #################################################################
 
 #################################################################
+# ARM Cortex-M Single Wire Output (SWO) 
+# (default is OFF so no SWO output)
+
+option(SWO_OUPUT "option to enable SWO")
+
+if(SWO_OUPUT)
+    set(SWO_OUPUT_OPTION TRUE CACHE INTERNAL "Single Wire Output Option")
+    message(STATUS "Single Wire Output (SWO) enabled")
+else()    
+    set(SWO_OUPUT_OPTION FALSE CACHE INTERNAL "Single Wire Output Option")
+endif()
+
+#################################################################
+
+#################################################################
 # enables Networking support in nanoCLR
 # (default is OFF so Networking is NOT supported)
 option(NF_FEATURE_USE_NETWORKING "option to use networking")
 
 if(NF_FEATURE_USE_NETWORKING)
-    set(NF_FEATURE_USE_NETWORKING TRUE CACHE INTERNAL "NF feature NETWORKING")
+    set(USE_NETWORKING_OPTION TRUE CACHE INTERNAL "NF feature NETWORKING")
     set(HAL_USE_MAC_OPTION TRUE CACHE INTERNAL "HAL MAC for NF_FEATURE_USE_NETWORKING")
+    message(STATUS "Support for networking enabled")
 else()    
-    set(NF_FEATURE_USE_NETWORKING FALSE CACHE INTERNAL "NF feature NETWORKING")
+    set(USE_NETWORKING_OPTION FALSE CACHE INTERNAL "NF feature NETWORKING")
     set(HAL_USE_MAC_OPTION FALSE CACHE INTERNAL "HAL MAC for NF_FEATURE_USE_NETWORKING")
 endif()
 
@@ -303,11 +303,13 @@ else()
     set(HAL_USE_SPI_OPTION FALSE CACHE INTERNAL "HAL SPI for Windows.Devices.Spi")
 endif()
 
+
 if(API_Windows.Devices.I2c)
     set(HAL_USE_I2C_OPTION TRUE CACHE INTERNAL "HAL I2C for Windows.Devices.I2c")
 else()    
     set(HAL_USE_I2C_OPTION FALSE CACHE INTERNAL "HAL I2C for Windows.Devices.I2c")
 endif()
+
 
 #######################
 # ChibiOS

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -22,19 +22,24 @@ find_package(ChibiOSnfOverlay REQUIRED)
 find_package(WireProtocol REQUIRED)
 
 # packages for nanoFramework libraries
+#######################################
 # mandatory 
 find_package(NF_CoreCLR REQUIRED)
 
+#######################################
+# optional
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
-    find_package(NF_Debugger REQUIRED)
+find_package(NF_Debugger REQUIRED)
 endif()
 
-# optional
 # nF feature: networking
-if(NF_FEATURE_USE_NETWORKING)
-find_package(CHIBIOS_LWIP REQUIRED)
+if(USE_NETWORKING_OPTION)
+    find_package(CHIBIOS_LWIP REQUIRED)
 endif()
+
+#######################################
 
 
 add_subdirectory("common")

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
@@ -22,19 +22,24 @@ find_package(ChibiOSnfOverlay REQUIRED)
 find_package(WireProtocol REQUIRED)
 
 # packages for nanoFramework libraries
+#######################################
 # mandatory 
 find_package(NF_CoreCLR REQUIRED)
 
+#######################################
+# optional
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
-    find_package(NF_Debugger REQUIRED)
+find_package(NF_Debugger REQUIRED)
 endif()
 
-# optional
 # nF feature: networking
-if(NF_FEATURE_USE_NETWORKING)
-find_package(CHIBIOS_LWIP REQUIRED)
+if(USE_NETWORKING_OPTION)
+    find_package(CHIBIOS_LWIP REQUIRED)
 endif()
+
+#######################################
 
 
 add_subdirectory("common")

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
@@ -22,19 +22,24 @@ find_package(ChibiOSnfOverlay REQUIRED)
 find_package(WireProtocol REQUIRED)
 
 # packages for nanoFramework libraries
+#######################################
 # mandatory 
 find_package(NF_CoreCLR REQUIRED)
 
+#######################################
+# optional
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
-    find_package(NF_Debugger REQUIRED)
+find_package(NF_Debugger REQUIRED)
 endif()
 
-# optional
 # nF feature: networking
-if(NF_FEATURE_USE_NETWORKING)
-find_package(CHIBIOS_LWIP REQUIRED)
+if(USE_NETWORKING_OPTION)
+    find_package(CHIBIOS_LWIP REQUIRED)
 endif()
+
+#######################################
 
 
 add_subdirectory("common")

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -22,19 +22,24 @@ find_package(ChibiOSnfOverlay REQUIRED)
 find_package(WireProtocol REQUIRED)
 
 # packages for nanoFramework libraries
+#######################################
 # mandatory 
 find_package(NF_CoreCLR REQUIRED)
 
+#######################################
+# optional
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
-    find_package(NF_Debugger REQUIRED)
+find_package(NF_Debugger REQUIRED)
 endif()
 
-# optional
 # nF feature: networking
-if(NF_FEATURE_USE_NETWORKING)
-find_package(CHIBIOS_LWIP REQUIRED)
+if(USE_NETWORKING_OPTION)
+    find_package(CHIBIOS_LWIP REQUIRED)
 endif()
+
+#######################################
 
 
 add_subdirectory("common")

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
@@ -22,19 +22,24 @@ find_package(ChibiOSnfOverlay REQUIRED)
 find_package(WireProtocol REQUIRED)
 
 # packages for nanoFramework libraries
+#######################################
 # mandatory 
 find_package(NF_CoreCLR REQUIRED)
 
+#######################################
+# optional
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
-    find_package(NF_Debugger REQUIRED)
+find_package(NF_Debugger REQUIRED)
 endif()
 
-# optional
 # nF feature: networking
-if(NF_FEATURE_USE_NETWORKING)
-find_package(CHIBIOS_LWIP REQUIRED)
+if(USE_NETWORKING_OPTION)
+    find_package(CHIBIOS_LWIP REQUIRED)
 endif()
+
+#######################################
 
 
 add_subdirectory("common")

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
@@ -22,19 +22,24 @@ find_package(ChibiOSnfOverlay REQUIRED)
 find_package(WireProtocol REQUIRED)
 
 # packages for nanoFramework libraries
+#######################################
 # mandatory 
 find_package(NF_CoreCLR REQUIRED)
 
+#######################################
+# optional
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
-    find_package(NF_Debugger REQUIRED)
+find_package(NF_Debugger REQUIRED)
 endif()
 
-# optional
 # nF feature: networking
-if(NF_FEATURE_USE_NETWORKING)
-find_package(CHIBIOS_LWIP REQUIRED)
+if(USE_NETWORKING_OPTION)
+    find_package(CHIBIOS_LWIP REQUIRED)
 endif()
+
+#######################################
 
 
 add_subdirectory("common")

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/target_platform.h.in
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/target_platform.h.in
@@ -14,16 +14,18 @@
 // set preference to enable (or not) the RTC subsystem
 #define HAL_USE_RTC @HAL_USE_RTC_OPTION@
 
-// set when networking is enabled
-#define HAL_USE_MAC @HAL_USE_MAC_OPTION@
-
 // takes care of enabling the HAL subsystems required for API options
 
 // enable SPI
 #define HAL_USE_SPI @HAL_USE_SPI_OPTION@
+
+// enable I2C
 #define HAL_USE_I2C @HAL_USE_I2C_OPTION@
 
 // enable EXT subsystem because it's required for interrupt handling when GPIO is enable
 #define HAL_USE_EXT @HAL_USE_GPIO_OPTION@
+
+// set when networking is enabled
+#define HAL_USE_MAC @HAL_USE_MAC_OPTION@
 
 #endif /* _TARGET_CHIBIOS_NANOCLR_H_ */


### PR DESCRIPTION
- reorder options to improve messages output
- add USE_NETWORKING_OPTION to make it clear and distinct of using the argument option NF_FEATURE_USE_NETWORKING

Signed-off-by: José Simões <jose.simoes@eclo.solutions>