### PR TITLE
SetResult - Fix bytes return values

### DIFF
--- a/src/CLR/Core/CLR_RT_StackFrame.cpp
+++ b/src/CLR/Core/CLR_RT_StackFrame.cpp
@@ -1001,7 +1001,7 @@ void CLR_RT_StackFrame::SetResult_R8( CLR_INT64 val )
 
 #endif
 
-void CLR_RT_StackFrame::SetResult_I1( CLR_INT8 val )
+void CLR_RT_StackFrame::SetResult_I1( CLR_UINT8 val )
 {
     NATIVE_PROFILE_CLR_CORE();
     CLR_RT_HeapBlock& top = PushValue();
@@ -1033,7 +1033,7 @@ void CLR_RT_StackFrame::SetResult_I8( CLR_INT64& val )
     top.SetInteger( val );
 }
 
-void CLR_RT_StackFrame::SetResult_U1( CLR_UINT8  val )
+void CLR_RT_StackFrame::SetResult_U1( CLR_INT8  val )
 {
     NATIVE_PROFILE_CLR_CORE();
     CLR_RT_HeapBlock& top = PushValue();

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -1909,11 +1909,11 @@ struct CLR_RT_StackFrame : public CLR_RT_HeapBlock_Node // EVENT HEAP - NO RELOC
     HRESULT HandleSynchronized( bool fAcquire, bool fGlobal );
 
     void    SetResult        ( CLR_INT32         val, CLR_DataType dataType );
-    void    SetResult_I1     ( CLR_INT8          val                        );
+    void    SetResult_I1     ( CLR_UINT8         val                        );
     void    SetResult_I2     ( CLR_INT16         val                        );
     void    SetResult_I4     ( CLR_INT32         val                        );
     void    SetResult_I8     ( CLR_INT64&        val                        );
-    void    SetResult_U1     ( CLR_UINT8         val                        );
+    void    SetResult_U1     ( CLR_INT8          val                        );
     void    SetResult_U2     ( CLR_UINT16        val                        );
     void    SetResult_U4     ( CLR_UINT32        val                        );
     void    SetResult_U8     ( CLR_UINT64&       val                        );


### PR DESCRIPTION
Byte ("sbyte") and unsigned byte ("byte") were swapped for SetResult_I1/U1

Signed-off-by: Christophe Gerbier <christophe@mikrobusnet.org>