### PR TITLE
Improve SWO config

### DIFF
--- a/targets/CMSIS-OS/common/swo.cpp
+++ b/targets/CMSIS-OS/common/swo.cpp
@@ -10,6 +10,10 @@
 
 extern "C" void SwoInit()
 {
+    // set SWO pin (PB3) to alternate mode (0 == the status after RESET) 
+    // in case it's being set to a different function in board config
+    palSetPadMode(GPIOB, 0x03, PAL_MODE_ALTERNATE(0) );
+      
     // enable trace in core debug register
     CoreDebug->DEMCR = CoreDebug_DEMCR_TRCENA_Msk;
 


### PR DESCRIPTION
## Description
- on some ChibiOS boards the defaul for PB3 is an alternate funtion other than the RESET state which prevents the use of the pin for SWO

## How Has This Been Tested? (if applicable)
- confirmed output on SWO viewr in ST-Link with STM32F769I-DISCO board

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

