### PR TITLE
Remove setting of PB3 for SWO

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/main.c
@@ -44,13 +44,7 @@ int main(void) {
 
   // init SWO as soon as possible to make it available to output ASAP
   #if (SWO_OUTPUT == TRUE)
-
-  // need to set SWO pin (PB3) to alternate mode (0 == the status after RESET) 
-  // because it's being to a different function in board config
-  palSetPadMode(GPIOB, 0x03, PAL_MODE_ALTERNATE(0) );
-  
   SwoInit();
-
   #endif
 
   // the following IF is not mandatory, it's just providing a way for a user to 'force'

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/main.c
@@ -57,13 +57,7 @@ int main(void) {
 
   // init SWO as soon as possible to make it available to output ASAP
   #if (SWO_OUTPUT == TRUE)
-
-  // need to set SWO pin (PB3) to alternate mode (0 == the status after RESET) 
-  // because it's being to a different function in board config
-  palSetPadMode(GPIOB, 0x03, PAL_MODE_ALTERNATE(0) );
-
   SwoInit();
-  
   #endif
 
   // The kernel is initialized but not started yet, this means that


### PR DESCRIPTION
## Description
Removing unnecessary setting 

## Motivation and Context
- not required anymore as this is now handled in SwoInit()

Signed-off-by: José Simões <jose.simoes@eclo.solutions>