### PR TITLE
Fix linker file for ST_STM32F769I_DISCOVERY

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/STM32F76xx_booter.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/STM32F76xx_booter.ld
@@ -24,7 +24,7 @@ MEMORY
     ram0        : org = 0x20020000, len = 384k    /* SRAM1 + SRAM2 */
     ram1        : org = 0x20020000, len = 368k    /* SRAM1 */
     ram2        : org = 0x2007C000, len = 16k     /* SRAM2 */
-    ram3        : org = 0x20000000, len = 64k     /* DTCM-RAM */
+    ram3        : org = 0x20000000, len = 128k    /* DTCM-RAM */
     ram4        : org = 0x00000000, len = 16k     /* ITCM-RAM */
     ram5        : org = 0x40024000, len = 4k      /* BCKP SRAM */
     ram6        : org = 0x00000000, len = 0

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/STM32F76xx_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/STM32F76xx_CLR.ld
@@ -24,7 +24,7 @@ MEMORY
     ram0        : org = 0x20020000, len = 384k              /* SRAM1 + SRAM2 */
     ram1        : org = 0x20020000, len = 368k              /* SRAM1 */
     ram2        : org = 0x2007C000, len = 16k               /* SRAM2 */
-    ram3        : org = 0x20000000, len = 64k               /* DTCM-RAM */
+    ram3        : org = 0x20000000, len = 128k              /* DTCM-RAM */
     ram4        : org = 0x00000000, len = 16k               /* ITCM-RAM */
     ram5        : org = 0x40024000, len = 4k                /* BCKP SRAM */
     ram6        : org = 0x00000000, len = 0


### PR DESCRIPTION
## Description
- RAM region 3 size was wrong

## Motivation and Context
- obvious

## How Has This Been Tested? (if applicable)
- load images in blank target board and check proper boot and USB enumeration

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>