### PR TITLE
Add exception handlers for debug

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/common/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/common/CMakeLists.txt
@@ -12,6 +12,11 @@ list(APPEND TARGET_CHIBIOS_COMMON_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/Target_Bl
 # append Target files
 list(APPEND TARGET_CHIBIOS_COMMON_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/Target_BlockStorage.c")
 
+# append hard fault handler if the build type is to include debug info
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    list(APPEND TARGET_CHIBIOS_COMMON_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/hard_fault_handler.c")
+endif()
+
 # make var global
 set(TARGET_CHIBIOS_COMMON_SOURCES ${TARGET_CHIBIOS_COMMON_SOURCES} CACHE INTERNAL "make global")
 

--- a/targets/CMSIS-OS/ChibiOS/common/hard_fault_handler.c
+++ b/targets/CMSIS-OS/ChibiOS/common/hard_fault_handler.c
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <string.h>
+#include <ch.h>
+
+//See http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/BABBGBEC.html
+typedef enum {
+    Reset = 1,
+    NMI = 2,
+    HardFault = 3,
+    MemManage = 4,
+    BusFault = 5,
+    UsageFault = 6,
+} FaultType;
+
+void NMI_Handler(void) {
+    while(1);
+}
+
+// dev note: on all the following the variables need to be declared as volatile so they don't get optimized out by the linker
+
+void HardFault_Handler(void) {                                                                                   
+
+    //Copy to local variables (not pointers) to allow GDB "i loc" to directly show the info
+    struct port_extctx ctx;
+
+    //Get thread context. Contains main registers including PC and LR
+    memcpy(&ctx, (void*)__get_PSP(), sizeof(struct port_extctx));
+    (void)ctx;
+
+    //Interrupt status register: Which interrupt have we encountered, e.g. HardFault?
+    volatile FaultType faultType = (FaultType)__get_IPSR();
+    
+    //Flags about hardfault / busfault
+    //See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/Cihdjcfc.html for reference
+    volatile bool isFaultPrecise = ((SCB->CFSR >> SCB_CFSR_BUSFAULTSR_Pos) & (1 << 1) ? true : false);
+    volatile bool isFaultImprecise = ((SCB->CFSR >> SCB_CFSR_BUSFAULTSR_Pos) & (1 << 2) ? true : false);
+    volatile bool isFaultOnUnstacking = ((SCB->CFSR >> SCB_CFSR_BUSFAULTSR_Pos) & (1 << 3) ? true : false);
+    volatile bool isFaultOnStacking = ((SCB->CFSR >> SCB_CFSR_BUSFAULTSR_Pos) & (1 << 4) ? true : false);
+    volatile bool isFaultAddressValid = ((SCB->CFSR >> SCB_CFSR_BUSFAULTSR_Pos) & (1 << 7) ? true : false);
+
+    // Hard Fault Status Register
+    volatile unsigned long _HFSR = (*((volatile unsigned long *)(0xE000ED2C))) ;
+
+    // Debug Fault Status Register
+    volatile unsigned long _DFSR = (*((volatile unsigned long *)(0xE000ED30))) ;
+
+    // Auxiliary Fault Status Register
+    volatile unsigned long _AFSR = (*((volatile unsigned long *)(0xE000ED3C))) ;
+
+    // Read the Fault Address Registers. These may not contain valid values.
+    // Check BFARVALID/MMARVALID to see if they are valid values
+    
+    // MemManage Fault Address Register
+    volatile unsigned long _MMAR = (*((volatile unsigned long *)(0xE000ED34))) ;
+    
+    //For HardFault/BusFault this is the address that was accessed causing the error
+    volatile uint32_t faultAddress = SCB->BFAR;
+
+    // forces a breakpoint causing the debugger to stop
+    // if no debugger is attached this is ignored
+    __asm volatile("BKPT #0\n");
+
+    // If no debugger connected, just reset the board
+    NVIC_SystemReset();
+}
+
+void BusFault_Handler(void) __attribute__((alias("HardFault_Handler")));
+
+void UsageFault_Handler(void) {
+
+    //Copy to local variables (not pointers) to allow GDB "i loc" to directly show the info
+    //Get thread context. Contains main registers including PC and LR
+    struct port_extctx ctx;
+    memcpy(&ctx, (void*)__get_PSP(), sizeof(struct port_extctx));
+    (void)ctx;
+
+    //Interrupt status register: Which interrupt have we encountered, e.g. HardFault?
+    FaultType faultType = (FaultType)__get_IPSR();
+    (void)faultType;
+
+    //Flags about hardfault / busfault
+    //See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/Cihdjcfc.html for reference
+    volatile bool isUndefinedInstructionFault = ((SCB->CFSR >> SCB_CFSR_USGFAULTSR_Pos) & (1 << 0) ? true : false);
+    volatile bool isEPSRUsageFault = ((SCB->CFSR >> SCB_CFSR_USGFAULTSR_Pos) & (1 << 1) ? true : false);
+    volatile bool isInvalidPCFault = ((SCB->CFSR >> SCB_CFSR_USGFAULTSR_Pos) & (1 << 2) ? true : false);
+    volatile bool isNoCoprocessorFault = ((SCB->CFSR >> SCB_CFSR_USGFAULTSR_Pos) & (1 << 3) ? true : false);
+    volatile bool isUnalignedAccessFault = ((SCB->CFSR >> SCB_CFSR_USGFAULTSR_Pos) & (1 << 8) ? true : false);
+    volatile bool isDivideByZeroFault = ((SCB->CFSR >> SCB_CFSR_USGFAULTSR_Pos) & (1 << 9) ? true : false);
+
+    // forces a breakpoint causing the debugger to stop
+    // if no debugger is attached this is ignored
+    __asm volatile("BKPT #0\n");
+
+    // If no debugger connected, just reset the board
+    NVIC_SystemReset();
+}
+
+void MemManage_Handler(void) {
+
+    //Copy to local variables (not pointers) to allow GDB "i loc" to directly show the info
+    //Get thread context. Contains main registers including PC and LR
+    struct port_extctx ctx;
+    memcpy(&ctx, (void*)__get_PSP(), sizeof(struct port_extctx));
+    (void)ctx;
+
+    //Interrupt status register: Which interrupt have we encountered, e.g. HardFault?
+    FaultType faultType = (FaultType)__get_IPSR();
+    (void)faultType;
+
+    //For HardFault/BusFault this is the address that was accessed causing the error
+    volatile uint32_t faultAddress = SCB->MMFAR;
+
+    //Flags about hardfault / busfault
+    //See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/Cihdjcfc.html for reference
+    volatile bool isInstructionAccessViolation = ((SCB->CFSR >> SCB_CFSR_MEMFAULTSR_Pos) & (1 << 0) ? true : false);
+    volatile bool isDataAccessViolation = ((SCB->CFSR >> SCB_CFSR_MEMFAULTSR_Pos) & (1 << 1) ? true : false);
+    volatile bool isExceptionUnstackingFault = ((SCB->CFSR >> SCB_CFSR_MEMFAULTSR_Pos) & (1 << 3) ? true : false);
+    volatile bool isExceptionStackingFault = ((SCB->CFSR >> SCB_CFSR_MEMFAULTSR_Pos) & (1 << 4) ? true : false);
+    volatile bool isFaultAddressValid = ((SCB->CFSR >> SCB_CFSR_MEMFAULTSR_Pos) & (1 << 7) ? true : false);
+
+    // forces a breakpoint causing the debugger to stop
+    // if no debugger is attached this is ignored
+    __asm volatile("BKPT #0\n");
+
+    // If no debugger connected, just reset the board
+    NVIC_SystemReset();
+}


### PR DESCRIPTION
## Description
Add handlers for ARM exceptions that replace the default (and empty ones) from ChibiOS.

## Motivation and Context
This aims to be a handy and helpful debugger tool.
Current handlers do not expose any details about the fault/exception that has occurred.
The debugger is not able to backtrack through exceptions because those are executed on a separate stack.
These handlers expose the NVIC registers and context in local vars allowing easy inspection of those.

## How Has This Been Tested?
Causing a hard fault exception and verifying that the handler hits the break point there.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>