### PR TITLE
Fixes exception in ToString()

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoCRT.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoCRT.cpp
@@ -81,7 +81,17 @@ int hal_vfprintf( COM_HANDLE stream, const char* format, va_list arg )
 int hal_snprintf( char* buffer, size_t len, const char* format, ... )
 {
     NATIVE_PROFILE_PAL_CRT();
-    return 0;
+    
+    va_list arg_ptr;
+    int     chars;
+
+    va_start( arg_ptr, format );
+
+    chars = hal_vsnprintf( buffer, len, format, arg_ptr );
+
+    va_end( arg_ptr );
+
+    return chars;
 }
 
 


### PR DESCRIPTION
## Description
Implements `hal_snprintf` for ChibiOS nanoCRT allowing printf .

## Motivation and Context
- Fixes/Closes/Resolves nanoFramework/Home#215
- Fixes/Closes/Resolves nanoFramework/Home#118

## How Has This Been Tested? (if applicable)
- C# test app with a call to `Int32.ToString()` and `Int32.ToString("N0")` without throwing any exception.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
