### PR TITLE
Improve HAL EXT initialization

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/main.c
@@ -16,32 +16,9 @@
 #include <nanoCLR_Application.h>
 #include <nanoPAL_BlockStorage.h>
 
-// need this definition here because it depends on the specifics of the target (how many INT lines exist)
+// need this definition here because it depends on the specifics of the target (how many INT lines exist on that series/device)
 #if (HAL_USE_EXT == TRUE)
-EXTConfig extInterruptsConfiguration = {
-    {{EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL}}};
+EXTConfig extInterruptsConfiguration = { .channels = { {EXT_CH_MODE_DISABLED, NULL} }};
 #endif
 
 // need to declare the Receiver thread here

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/main.c
@@ -14,33 +14,9 @@
 #include <nanoCLR_Application.h>
 #include <nanoPAL_BlockStorage.h>
 
-// need this definition here because it depends on the specifics of the target (how many INT lines exist)
+// need this definition here because it depends on the specifics of the target (how many INT lines exist on that series/device)
 #if (HAL_USE_EXT == TRUE)
-EXTConfig extInterruptsConfiguration = {
-    {{EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL}}};
+EXTConfig extInterruptsConfiguration = { .channels = { {EXT_CH_MODE_DISABLED, NULL} }};
 #endif
 
 // need to declare the Receiver thread here
@@ -79,6 +55,11 @@ int main(void) {
   osThreadCreate(osThread(ReceiverThread), NULL);
   // create the CLR Startup thread 
   osThreadCreate(osThread(CLRStartupThread), NULL); 
+
+  // EXT driver needs to be started from main   
+  #if (HAL_USE_EXT == TRUE)
+  extStart(&EXTD1, &extInterruptsConfiguration);
+  #endif
 
   // start kernel, after this main() will behave like a thread with priority osPriorityNormal
   osKernelStart();

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/main.c
@@ -14,41 +14,9 @@
 #include <nanoCLR_Application.h>
 #include <nanoPAL_BlockStorage.h>
 
-// need this definition here because it depends on the specifics of the target (how many INT lines exist)
+// need this definition here because it depends on the specifics of the target (how many INT lines exist on that series/device)
 #if (HAL_USE_EXT == TRUE)
-EXTConfig extInterruptsConfiguration = {
-    {{EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL}}};
+EXTConfig extInterruptsConfiguration = { .channels = { {EXT_CH_MODE_DISABLED, NULL} }};
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/main.c
@@ -14,32 +14,9 @@
 #include <nanoCLR_Application.h>
 #include <nanoPAL_BlockStorage.h>
 
-// need this definition here because it depends on the specifics of the target (how many INT lines exist)
+// need this definition here because it depends on the specifics of the target (how many INT lines exist on that series/device)
 #if (HAL_USE_EXT == TRUE)
-EXTConfig extInterruptsConfiguration = {
-    {{EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL}}};
+EXTConfig extInterruptsConfiguration = { .channels = { {EXT_CH_MODE_DISABLED, NULL} }};
 #endif
 
 // need to declare the Receiver thread here

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/main.c
@@ -14,32 +14,9 @@
 #include <nanoCLR_Application.h>
 #include <nanoPAL_BlockStorage.h>
 
-// need this definition here because it depends on the specifics of the target (how many INT lines exist)
+// need this definition here because it depends on the specifics of the target (how many INT lines exist on that series/device)
 #if (HAL_USE_EXT == TRUE)
-EXTConfig extInterruptsConfiguration = {
-    {{EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL}}};
+EXTConfig extInterruptsConfiguration = { .channels = { {EXT_CH_MODE_DISABLED, NULL} }};
 #endif
 
 // need to declare the Receiver thread here

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/main.c
@@ -14,33 +14,9 @@
 #include <nanoCLR_Application.h>
 #include <nanoPAL_BlockStorage.h>
 
-// need this definition here because it depends on the specifics of the target (how many INT lines exist)
+// need this definition here because it depends on the specifics of the target (how many INT lines exist on that series/device)
 #if (HAL_USE_EXT == TRUE)
-EXTConfig extInterruptsConfiguration = {
-    {{EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL},
-     {EXT_CH_MODE_DISABLED, NULL}}};
+EXTConfig extInterruptsConfiguration = { .channels = { {EXT_CH_MODE_DISABLED, NULL} }};
 #endif
 
 // need to declare the Receiver thread here


### PR DESCRIPTION
## Description
Improve the HAL EXT driver initialization: now it's more compact and takes the number of the available INT lines directly from the respective #define.
- add missing EXT driver start call for NUCLEO144_F746ZG

## Motivation and Context
Improvements are always in order.

## How Has This Been Tested? (if applicable)
Run C# Gpio test app.

## Types of changes
- [x] Improvement

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
