### PR TITLE
Work on SPI and I2C

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -158,7 +158,17 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
         // because the bus access is shared, acquire the appropriate bus
         i2cStart(cfg.Driver, &cfg.Configuration);
         i2cAcquireBus(cfg.Driver);
-        if (readSize != 0 && writeSize != 0)  // WriteRead
+
+#if defined(STM32F756xx) || defined(STM32F746xx) || defined(STM32F745xx) || defined(STM32F767xx) || \
+defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) || defined(STM32F722xx) || \
+defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
+
+        // Data synchronous Barrier, forcing the CPU to respect the sequence of instruction without optimization
+        __DSB();
+#endif
+
+        // WriteRead
+        if (readSize != 0 && writeSize != 0)
         {
             i2cStatus = i2cMasterTransmitTimeout(cfg.Driver, cfg.SlaveAddress, &writeData[0], writeSize, &readData[0], readSize, TIME_INFINITE);
         }
@@ -173,6 +183,8 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
                 i2cStatus = i2cMasterReceiveTimeout (cfg.Driver, cfg.SlaveAddress, &readData[0], readSize, TIME_INFINITE);
             }
         }
+
+        // release the I2C now
         i2cReleaseBus(cfg.Driver);
 
         if (i2cStatus != MSG_OK)

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -326,6 +326,14 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer
 
         // Are we using SPI full-duplex for transfer ?
         bool fullDuplex = (bool)stack.Arg3().NumericByRef().u1;
+        
+#if defined(STM32F756xx) || defined(STM32F746xx) || defined(STM32F745xx) || defined(STM32F767xx) || \
+defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) || defined(STM32F722xx) || \
+defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
+
+        // Data synchronous Barrier, forcing the CPU to respect the sequence of instruction without optimization
+        __DSB();
+#endif
 
         if (writeSize != 0 && readSize != 0)
         {


### PR DESCRIPTION
## Description
Add data sync barrier for F7's (see ARM manual [here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka14041.html).


## Motivation and Context
Fix issues in SPI and I2C data transfer in F7 targets.

## How Has This Been Tested?
Requires testing.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
Signed-off-by: José Simões <jose.simoes@eclo.solutions>

