### PR TITLE
Definitive fix for I2C and SPI on F7 MCU

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/board.h
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/board.h
@@ -335,12 +335,12 @@
                                      PIN_PUPDR_FLOATING(GPIOA_AN4) |         \
                                      PIN_PUPDR_FLOATING(GPIOA_AN1) |     \
                                      PIN_PUPDR_FLOATING(GPIOA_AN3) |      \
-                                     PIN_PUPDR_FLOATING(GPIOA_FLASH_HOLD) |   \
+                                     PIN_PUPDR_PULLDOWN(GPIOA_FLASH_HOLD) |   \
                                      PIN_PUPDR_FLOATING(GPIOA_TX4) |      \
                                      PIN_PUPDR_FLOATING(GPIOA_RX4) |      \
                                      PIN_PUPDR_FLOATING(GPIOA_OTG_FS_DM) |     \
                                      PIN_PUPDR_FLOATING(GPIOA_OTG_FS_DP) |     \
-                                     PIN_PUPDR_PULLDOWN(GPIOA_FLASH_CS) |        \
+                                     PIN_PUPDR_FLOATING(GPIOA_FLASH_CS) |        \
                                      PIN_PUPDR_FLOATING(GPIOA_INT4) |      \
                                      PIN_PUPDR_FLOATING(GPIOA_GPIO1))
 #define VAL_GPIOA_ODR               (PIN_ODR_LOW(GPIOA_PA0) |           \
@@ -351,12 +351,12 @@
                                      PIN_ODR_LOW(GPIOA_AN4) |             \
                                      PIN_ODR_LOW(GPIOA_AN1) |           \
                                      PIN_ODR_LOW(GPIOA_AN3) |          \
-                                     PIN_ODR_HIGH(GPIOA_FLASH_HOLD) |         \
+                                     PIN_ODR_LOW(GPIOA_FLASH_HOLD) |         \
                                      PIN_ODR_LOW(GPIOA_TX4) |          \
                                      PIN_ODR_LOW(GPIOA_RX4) |          \
                                      PIN_ODR_HIGH(GPIOA_OTG_FS_DM) |           \
                                      PIN_ODR_HIGH(GPIOA_OTG_FS_DP) |           \
-                                     PIN_ODR_LOW(GPIOA_FLASH_CS) |            \
+                                     PIN_ODR_HIGH(GPIOA_FLASH_CS) |            \
                                      PIN_ODR_LOW(GPIOA_INT4) |            \
                                      PIN_ODR_LOW(GPIOA_GPIO1))
 #define VAL_GPIOA_AFRL              (PIN_AFIO_AF(GPIOA_PA0, 0U) |        \

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/board.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/board.h
@@ -678,8 +678,8 @@
                                      PIN_MODE_INPUT(GPIOB_ZIO_D22) |        \
                                      PIN_MODE_INPUT(GPIOB_ZIO_D26) |        \
                                      PIN_MODE_OUTPUT(GPIOB_LED2) |          \
-                                     PIN_MODE_INPUT(GPIOB_ARD_D15) |        \
-                                     PIN_MODE_INPUT(GPIOB_ARD_D14) |        \
+                                     PIN_MODE_ALTERNATE(GPIOB_I2C1_SCL) |        \
+                                     PIN_MODE_ALTERNATE(GPIOB_I2C1_SDA) |        \
                                      PIN_MODE_INPUT(GPIOB_ZIO_D36) |        \
                                      PIN_MODE_INPUT(GPIOB_ZIO_D35) |        \
                                      PIN_MODE_INPUT(GPIOB_ZIO_D19) |        \
@@ -694,8 +694,8 @@
                                      PIN_OTYPE_PUSHPULL(GPIOB_ZIO_D22) |    \
                                      PIN_OTYPE_PUSHPULL(GPIOB_ZIO_D26) |    \
                                      PIN_OTYPE_PUSHPULL(GPIOB_LED2) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOB_ARD_D15) |    \
-                                     PIN_OTYPE_PUSHPULL(GPIOB_ARD_D14) |    \
+                                     PIN_OTYPE_OPENDRAIN(GPIOB_I2C1_SCL) |    \
+                                     PIN_OTYPE_OPENDRAIN(GPIOB_I2C1_SDA) |    \
                                      PIN_OTYPE_PUSHPULL(GPIOB_ZIO_D36) |    \
                                      PIN_OTYPE_PUSHPULL(GPIOB_ZIO_D35) |    \
                                      PIN_OTYPE_PUSHPULL(GPIOB_ZIO_D19) |    \
@@ -710,8 +710,8 @@
                                      PIN_OSPEED_HIGH(GPIOB_ZIO_D22) |       \
                                      PIN_OSPEED_HIGH(GPIOB_ZIO_D26) |       \
                                      PIN_OSPEED_HIGH(GPIOB_LED2) |          \
-                                     PIN_OSPEED_HIGH(GPIOB_ARD_D15) |       \
-                                     PIN_OSPEED_HIGH(GPIOB_ARD_D14) |       \
+                                     PIN_OSPEED_HIGH(GPIOB_I2C1_SCL) |       \
+                                     PIN_OSPEED_HIGH(GPIOB_I2C1_SDA) |       \
                                      PIN_OSPEED_HIGH(GPIOB_ZIO_D36) |       \
                                      PIN_OSPEED_HIGH(GPIOB_ZIO_D35) |       \
                                      PIN_OSPEED_HIGH(GPIOB_ZIO_D19) |       \
@@ -726,8 +726,8 @@
                                      PIN_PUPDR_PULLUP(GPIOB_ZIO_D22) |      \
                                      PIN_PUPDR_PULLUP(GPIOB_ZIO_D26) |      \
                                      PIN_PUPDR_FLOATING(GPIOB_LED2) |       \
-                                     PIN_PUPDR_PULLUP(GPIOB_ARD_D15) |      \
-                                     PIN_PUPDR_PULLUP(GPIOB_ARD_D14) |      \
+                                     PIN_PUPDR_FLOATING(GPIOB_I2C1_SCL) |      \
+                                     PIN_PUPDR_FLOATING(GPIOB_I2C1_SDA) |      \
                                      PIN_PUPDR_PULLUP(GPIOB_ZIO_D36) |      \
                                      PIN_PUPDR_PULLUP(GPIOB_ZIO_D35) |      \
                                      PIN_PUPDR_PULLUP(GPIOB_ZIO_D19) |      \
@@ -742,8 +742,8 @@
                                      PIN_ODR_HIGH(GPIOB_ZIO_D22) |          \
                                      PIN_ODR_HIGH(GPIOB_ZIO_D26) |          \
                                      PIN_ODR_LOW(GPIOB_LED2) |              \
-                                     PIN_ODR_HIGH(GPIOB_ARD_D15) |          \
-                                     PIN_ODR_HIGH(GPIOB_ARD_D14) |          \
+                                     PIN_ODR_LOW(GPIOB_I2C1_SCL) |          \
+                                     PIN_ODR_LOW(GPIOB_I2C1_SDA) |          \
                                      PIN_ODR_HIGH(GPIOB_ZIO_D36) |          \
                                      PIN_ODR_HIGH(GPIOB_ZIO_D35) |          \
                                      PIN_ODR_HIGH(GPIOB_ZIO_D19) |          \
@@ -758,8 +758,8 @@
                                      PIN_AFIO_AF(GPIOB_ZIO_D22, 0U) |       \
                                      PIN_AFIO_AF(GPIOB_ZIO_D26, 0U) |       \
                                      PIN_AFIO_AF(GPIOB_LED2, 0U))
-#define VAL_GPIOB_AFRH              (PIN_AFIO_AF(GPIOB_ARD_D15, 0U) |       \
-                                     PIN_AFIO_AF(GPIOB_ARD_D14, 0U) |       \
+#define VAL_GPIOB_AFRH              (PIN_AFIO_AF(GPIOB_I2C1_SCL, 4U) |       \
+                                     PIN_AFIO_AF(GPIOB_I2C1_SDA, 4U) |       \
                                      PIN_AFIO_AF(GPIOB_ZIO_D36, 0U) |       \
                                      PIN_AFIO_AF(GPIOB_ZIO_D35, 0U) |       \
                                      PIN_AFIO_AF(GPIOB_ZIO_D19, 0U) |       \

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/board.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/board.h
@@ -1255,7 +1255,7 @@
  * PG14 - ARD_D1 USART6_TX          (input pullup).
  * PG15 - PIN15                     (input pullup).
  */
-#define VAL_GPIOG_MODER             (PIN_MODE_INPUT(GPIOG_ZIO_D65) |        \
+#define VAL_GPIOG_MODER             (PIN_MODE_OUTPUT(GPIOG_ZIO_D65) |        \
                                      PIN_MODE_OUTPUT(GPIOG_ZIO_D64) |        \
                                      PIN_MODE_INPUT(GPIOG_ZIO_D49) |        \
                                      PIN_MODE_INPUT(GPIOG_ZIO_D50) |        \
@@ -1287,7 +1287,7 @@
                                      PIN_OTYPE_PUSHPULL(GPIOG_RMII_TXD0) |  \
                                      PIN_OTYPE_PUSHPULL(GPIOG_ARD_D1) |     \
                                      PIN_OTYPE_PUSHPULL(GPIOG_PIN15))
-#define VAL_GPIOG_OSPEEDR           (PIN_OSPEED_VERYLOW(GPIOG_ZIO_D65) |    \
+#define VAL_GPIOG_OSPEEDR           (PIN_OSPEED_HIGH(GPIOG_ZIO_D65) |    \
                                      PIN_OSPEED_HIGH(GPIOG_ZIO_D64) |    \
                                      PIN_OSPEED_VERYLOW(GPIOG_ZIO_D49) |    \
                                      PIN_OSPEED_VERYLOW(GPIOG_ZIO_D50) |    \

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/mcuconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/mcuconf.h
@@ -81,7 +81,7 @@
  #define STM32_CK48MSEL                      STM32_CK48MSEL_PLL
  #define STM32_SDMMCSEL                      STM32_SDMMCSEL_SYSCLK
  #define STM32_SRAM2_NOCACHE                 FALSE
- 
+
 /*
  * ADC driver system settings.
  */
@@ -172,8 +172,8 @@
 /*
  * I2C driver system settings.
  */
-#define STM32_I2C_USE_I2C1                  FALSE
-#define STM32_I2C_USE_I2C2                  FALSE
+#define STM32_I2C_USE_I2C1                  TRUE
+#define STM32_I2C_USE_I2C2                  TRUE
 #define STM32_I2C_USE_I2C3                  FALSE
 #define STM32_I2C_USE_I2C4                  FALSE
 #define STM32_I2C_BUSY_TIMEOUT              50

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -113,6 +113,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
 {
     NANOCLR_HEADER();
     {
+        
         unsigned char * writeData = NULL;
         unsigned char * readData = NULL;
         int writeSize = 0;
@@ -158,6 +159,9 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
         // because the bus access is shared, acquire the appropriate bus
         i2cStart(cfg.Driver, &cfg.Configuration);
         i2cAcquireBus(cfg.Driver);
+#ifdef STM32F7xx_MCUCONF
+        SCB_CleanInvalidateDCache();
+#endif
         if (readSize != 0 && writeSize != 0)  // WriteRead
         {
             i2cStatus = i2cMasterTransmitTimeout(cfg.Driver, cfg.SlaveAddress, &writeData[0], writeSize, &readData[0], readSize, TIME_INFINITE);

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -219,6 +219,9 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer
         // Are we using SPI full-duplex for transfer ?
         bool fullDuplex = (bool)stack.Arg3().NumericByRef().u1;
 
+#ifdef STM32F7xx_MCUCONF
+        SCB_CleanInvalidateDCache();
+#endif
         if (writeSize != 0 && readSize != 0)
         {
             // Transmit+Receive
@@ -327,6 +330,9 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer
         // Are we using SPI full-duplex for transfer ?
         bool fullDuplex = (bool)stack.Arg3().NumericByRef().u1;
 
+#ifdef STM32F7xx_MCUCONF
+        SCB_CleanInvalidateDCache();
+#endif
         if (writeSize != 0 && readSize != 0)
         {
             // Transmit+Receive


### PR DESCRIPTION
## Description
This fixes the "garbage" issue on F7 MCUs with I2C and SPI.

## How Has This Been Tested?<!-- (if applicable) -->
Tested on Nucleo-F746ZG with Devantech LCD03 (I2C @100KHz) and MikroElektronika Led8x8 board (SPI)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

