### PR TITLE
Work related with floating point

### DIFF
--- a/CMake/Modules/CHIBIOS_STM32F0xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F0xx_GCC_options.cmake
@@ -7,7 +7,7 @@
 # WHEN ADDING A NEW SERIES add the appropriate GCC options bellow
 #################################################################
 
-set(CMAKE_C_FLAGS "-mthumb -fno-builtin -mcpu=cortex-m0  -Wall -std=c11 -w -ffunction-sections -fshort-wchar -falign-functions=16 -fdata-sections -fsingle-precision-constant -fomit-frame-pointer -mlong-calls -fdollars-in-identifiers -mabi=aapcs -fno-exceptions -fno-unroll-loops -mstructure-size-boundary=8 -ftree-vectorize -specs=nano.specs" CACHE INTERNAL "c compiler flags")
+set(CMAKE_C_FLAGS "-mthumb -fno-builtin -mcpu=cortex-m0 -Wall -std=c11 -w -ffunction-sections -fshort-wchar -falign-functions=16 -fdata-sections -fsingle-precision-constant -fomit-frame-pointer -mlong-calls -fdollars-in-identifiers -mabi=aapcs -fno-exceptions -fno-unroll-loops -mstructure-size-boundary=8 -ftree-vectorize -specs=nano.specs" CACHE INTERNAL "c compiler flags")
 set(CMAKE_CXX_FLAGS "-mthumb -fno-builtin -mcpu=cortex-m0 -Wall -std=c++11 -w -ffunction-sections -fshort-wchar -falign-functions=16 -fdata-sections -fsingle-precision-constant -fomit-frame-pointer -mlong-calls -fdollars-in-identifiers -mabi=aapcs -fno-exceptions -fno-unroll-loops -mstructure-size-boundary=8 -ftree-vectorize -fcheck-new -fno-rtti -fno-use-cxa-atexit -fno-threadsafe-statics -specs=nano.specs" CACHE INTERNAL "cxx compiler flags")
 set(CMAKE_ASM_FLAGS "-c -mthumb -mcpu=cortex-m0 -g -Wa,--no-warn -x assembler-with-cpp " CACHE INTERNAL "asm compiler flags")
 

--- a/CMake/Modules/FindNF_CoreCLR.cmake
+++ b/CMake/Modules/FindNF_CoreCLR.cmake
@@ -145,6 +145,7 @@ set(NF_CoreCLR_SRCS
 
     # PAL
     nanoPAL_BlockStorage.c
+    nanoPAL_NativeDouble.cpp
 
     # PAL stubs
     Async_stubs.cpp
@@ -184,6 +185,7 @@ foreach(SRC_FILE ${NF_CoreCLR_SRCS})
             # PAL
             ${PROJECT_SOURCE_DIR}/src/PAL
             ${PROJECT_SOURCE_DIR}/src/PAL/BlockStorage
+            ${PROJECT_SOURCE_DIR}/src/PAL/Double
 
             # PAL stubs
             ${PROJECT_SOURCE_DIR}/src/PAL/AsyncProcCall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,6 @@ set(USE_FPU_IS_TRUE FALSE)
 
 if(USE_FPU)
     if(NOT "${USE_FPU}" STREQUAL "")
-
         if("${USE_FPU}" STREQUAL "TRUE")
             set(USE_FPU_IS_TRUE TRUE CACHE INTERNAL "FPU preference")
         elseif("${USE_FPU}" STREQUAL "FALSE")
@@ -121,7 +120,6 @@ if(USE_FPU)
             # something other that TRUE or FALSE...
             message(FATAL_ERROR "\n\n'${USE_FPU}' is an invalid option for USE_FPU. Acceptable values are TRUE or FALSE.\n\n")
         endif()    
-
     endif()
 endif()
 
@@ -193,6 +191,15 @@ message(STATUS "Build  directory is '${PROJECT_BINARY_DIR}'.")
 message(STATUS "Toolchain is '${TOOLCHAIN}'.")
 message(STATUS "")
 #######################
+
+
+#################################################################
+# output FPU option
+if("${USE_FPU}" STREQUAL "TRUE")
+    message(STATUS "Hardware Floating Point enabled")
+elseif("${USE_FPU}" STREQUAL "FALSE")
+    message(STATUS "Emulated Floating Point enabled")
+endif()
 
 
 #################################################################

--- a/src/CLR/CorLib/corlib_native_System_Double.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Double.cpp
@@ -4,7 +4,7 @@
 // See LICENSE file in the project root for full license information.
 //
 #include "CorLib.h"
-#include "nanoPAL_double_decl.h"
+#include "nanoPAL_NativeDouble.h"
 
 #if !defined(NANOCLR_EMULATED_FLOATINGPOINT)
 HRESULT Library_corlib_native_System_Double::CompareTo___STATIC__I4__R8__R8( CLR_RT_StackFrame& stack )

--- a/src/CLR/CorLib/corlib_native_System_Math.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Math.cpp
@@ -6,7 +6,7 @@
 #include "CorLib.h"
 
 #if !defined(NANOCLR_EMULATED_FLOATINGPOINT)
-#include "nanoPAL_double_decl.h"
+#include "nanoPAL_NativeDouble.h"
 
 HRESULT Library_corlib_native_System_Math::Acos___STATIC__R8__R8( CLR_RT_StackFrame& stack )
 {
@@ -211,7 +211,7 @@ HRESULT Library_corlib_native_System_Math::Sign___STATIC__I4__R8( CLR_RT_StackFr
     NANOCLR_HEADER();
 
     double d = stack.Arg0().NumericByRefConst().r8;
-    INT32 res;
+    int32_t res;
     if (d < 0) res =  -1;
     else if (d > 0) res =  +1;
     else res = 0;

--- a/src/CLR/Include/nanoCLR_PlatformDef.h
+++ b/src/CLR/Include/nanoCLR_PlatformDef.h
@@ -23,7 +23,7 @@
 
 
 #if defined(PLATFORM_EMULATED_FLOATINGPOINT)
-#define NANOCLR_EMULATED_FLOATINGPOINT    // use the fixed point floating point notation in the clr ocdes 
+#define NANOCLR_EMULATED_FLOATINGPOINT    // use the fixed point floating point notation in the clr codes
 #endif
 
 #if defined(NANOCLR_USE_APPDOMAINS)

--- a/src/HAL/Include/nanoHAL.h
+++ b/src/HAL/Include/nanoHAL.h
@@ -13,22 +13,20 @@
 #include <nanoWeak.h>
 #include <nanoHAL_v2.h>
 
+#if defined(PLATFORM_EMULATED_FLOATINGPOINT)
+/***************************************************/
+// Keep in sync with the nanoCLR_Runtime__HeapBlock.h
 
+#define HAL_FLOAT_SHIFT         10
+#define HAL_FLOAT_PRECISION     1000
 
+#define HAL_DOUBLE_SHIFT        16
+#define HAL_DOUBLE_PRECISION    10000
 
-
-
-
-
-
-
-
-
-
-
-
-
-
+/************************************************/
+#else
+#include <math.h>
+#endif
 
 
 

--- a/src/PAL/Double/nanoPAL_NativeDouble.cpp
+++ b/src/PAL/Double/nanoPAL_NativeDouble.cpp
@@ -5,7 +5,7 @@
 //
 
 #include "stdafx.h"
-#include "nanoPAL_double_decl.h"
+#include "nanoPAL_NativeDouble.h"
 
 #include <math.h>
 
@@ -87,7 +87,7 @@ using namespace System;
 //     Greater than zero 
 //         This instance is greater than value. -or- 
 //         This instance is a number and value is not a number (System.Double.NaN).
-INT32 Double::CompareTo( double d, double val )
+int32_t Double::CompareTo( double d, double val )
 {
 
     if (__isnand(d))
@@ -179,11 +179,11 @@ bool Double::IsNegativeInfinity( double d )
 
     /* Return signbit of __x */
     /* Used by signbit macro */
-    INT8 signBit = __signbitd(d);
+    int8_t signBit = __signbitd(d);
     
     /* Return 1 if __x is infinite, 0 otherwise */
     /* Used by isinf macro */
-    INT8 infiniteBit = __isinfd(d) != 0;
+    int8_t infiniteBit = __isinfd(d) != 0;
     
     bool retVal = (signBit != 0) && (infiniteBit != 0); 
     return retVal;
@@ -206,11 +206,11 @@ bool Double::IsPositiveInfinity( double d )
 
     /* Return signbit of __x */
     /* Used by signbit macro */
-    INT8 signBit = __signbitd(d);
+    int8_t signBit = __signbitd(d);
     
     /* Return 1 if __x is infinite, 0 otherwise */
     /* Used by isinf macro */
-    INT8 infiniteBit = __isinfd(d);
+    int8_t infiniteBit = __isinfd(d);
     
     bool retVal = (signBit == 0) && (infiniteBit != 0);  
     return retVal;
@@ -308,7 +308,7 @@ double Math::Round( double d )
     return retVal;
 }
 
-INT32 Math::Sign( double d )
+int32_t Math::Sign( double d )
 {
     if (d < 0) return -1;
     if (d > 0) return +1;

--- a/src/PAL/Include/nanoCRT.h
+++ b/src/PAL/Include/nanoCRT.h
@@ -7,12 +7,12 @@
 #ifndef _NANOCRT_DECL_H_
 #define _NANOCRT_DECL_H_ 1
 
-#if !defined(PLATFORM_EMULATED_FLOATINGPOINT)
+#if defined(PLATFORM_EMULATED_FLOATINGPOINT)
+int hal_snprintf_float( char* buffer, size_t len, const char* format, int32_t f );
+int hal_snprintf_double( char* buffer, size_t len, const char* format, int64_t& d );
+#else
 int hal_snprintf_float( char* buffer, size_t len, const char* format, float f );
 int hal_snprintf_double( char* buffer, size_t len, const char* format, double d );
-#else
-int hal_snprintf_float( char* buffer, size_t len, const char* format, signed int f );
-int hal_snprintf_double( char* buffer, size_t len, const char* format, signed __int64& d );
 #endif
 
 // Compares 2 ASCII strings case insensitive. Always defined in our code ( nanoCRT.cpp )

--- a/src/PAL/Include/nanoPAL_NativeDouble.h
+++ b/src/PAL/Include/nanoPAL_NativeDouble.h
@@ -6,13 +6,13 @@
 #ifndef _NANOPAL_DOUBLE_DECL_H_
 #define _NANOPAL_DOUBLE_DECL_H_
 
-//#include <tinyhal.h>
+#include <nanoHAL.h>
 
 namespace System
 {
     struct Double
     {
-        static signed int   CompareTo( double d, double val );
+        static int32_t      CompareTo( double d, double val );
         static bool         IsInfinity( double d );
         static bool         IsNaN( double d );
         static bool         IsNegativeInfinity( double d );
@@ -36,7 +36,7 @@ namespace System
         static double       Log10(double d);
         static double       Pow(double x, double y);
         static double       Round(double d);
-        static signed int   Sign(double d);
+        static int32_t      Sign(double d);
         static double       Sin(double d);
         static double       Sinh(double d);
         static double       Sqrt(double d);

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -160,12 +160,23 @@ CHIBIOS_PRINT_SIZE_OF_TARGETS(${NANOCLR_PROJECT_NAME}.elf)
 
 # set extra compiler flags, some are related with the build type
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    # build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+# build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
 else()
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+endif()
+
+# set compiler definition for platform emulated floating point according to FPU
+# no FPU requires FP emulation from the platform
+target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+
+# using FPU requires enabling printf with FP support for newlib nano, but just for nanoCLR target, don't need that for nanoBooter
+if(USE_FPU_IS_TRUE)
+set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES C_STANDARD "-u _printf_float" )
+set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES CXX_STANDARD "-u _printf_float" )
 endif()
 
 # set compiler definition for FPU

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
@@ -160,12 +160,23 @@ CHIBIOS_PRINT_SIZE_OF_TARGETS(${NANOCLR_PROJECT_NAME}.elf)
 
 # set extra compiler flags, some are related with the build type
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    # build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+# build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
 else()
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+endif()
+
+# set compiler definition for platform emulated floating point according to FPU
+# no FPU requires FP emulation from the platform
+target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+
+# using FPU requires enabling printf with FP support for newlib nano, but just for nanoCLR target, don't need that for nanoBooter
+if(USE_FPU_IS_TRUE)
+    set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES C_STANDARD "-u _printf_float" )
+    set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES CXX_STANDARD "-u _printf_float" )
 endif()
 
 # set compiler definition for FPU

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
@@ -159,12 +159,23 @@ CHIBIOS_PRINT_SIZE_OF_TARGETS(${NANOCLR_PROJECT_NAME}.elf)
 
 # set extra compiler flags, some are related with the build type
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    # build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+# build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
 else()
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+endif()
+
+# set compiler definition for platform emulated floating point according to FPU
+# no FPU requires FP emulation from the platform
+target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+
+# using FPU requires enabling printf with FP support for newlib nano, but just for nanoCLR target, don't need that for nanoBooter
+if(USE_FPU_IS_TRUE)
+    set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES C_STANDARD "-u _printf_float" )
+    set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES CXX_STANDARD "-u _printf_float" )
 endif()
 
 # set compiler definition for using Application Domains feature

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/common/Device_BlockStorage.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/common/Device_BlockStorage.c
@@ -13,12 +13,12 @@ const BlockRange BlockRange1[] =
 
 const BlockRange BlockRange2[] = 
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 34   }           // 08004000 nanoCLR    
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 38   }          // 08004000 nanoCLR    
 };
 
 const BlockRange BlockRange3[] =
 {      
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 23 }           // 08027000 deployment  
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 19 }            // 0802B000 deployment  
 };
 
 const BlockRegionInfo BlockRegions[] = 
@@ -26,23 +26,23 @@ const BlockRegionInfo BlockRegions[] =
     {
         0x08000000,                         // start address for block region
         4,                                  // total number of blocks in this region
-        0x1000,                              // total number of bytes per block
+        0x1000,                             // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange1),
         BlockRange1,
     },
 
     {
         0x08004000,                         // start address for block region
-        35,                                 // total number of blocks in this region
-        0x1000,                              // total number of bytes per block
+        39,                                 // total number of blocks in this region
+        0x1000,                             // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange2),
         BlockRange2,
     },
 
     {
-        0x08027000,                         // start address for block region
-        24,                                 // total number of blocks in this region
-        0x1000,                              // total number of bytes per block
+        0x0802B000,                         // start address for block region
+        20,                                 // total number of blocks in this region
+        0x1000,                             // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange3),
         BlockRange3,
     }

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/STM32F091xC_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/STM32F091xC_CLR.ld
@@ -12,8 +12,8 @@
  */
 MEMORY
 {
-    flash       : org = 0x08004000, len = 256k - 16k - 96k   /* flash size less the space reserved for nanoBooter and application deployment*/
-    deployment  : org = 0x08027000, len = 96k                /* space reserved for application deployment */
+    flash       : org = 0x08004000, len = 256k - 16k - 82k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    deployment  : org = 0x0802B000, len = 82k                /* space reserved for application deployment */
     ramvt       : org = 0x20000000, len = 0xC0               /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x200000C0, len = 32k - 0xC0         /* remaining RAM is free for use */
     ram1        : org = 0x00000000, len = 0

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -160,12 +160,23 @@ CHIBIOS_PRINT_SIZE_OF_TARGETS(${NANOCLR_PROJECT_NAME}.elf)
 
 # set extra compiler flags, some are related with the build type
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    # build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+# build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
 else()
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+endif()
+
+# set compiler definition for platform emulated floating point according to FPU
+# no FPU requires FP emulation from the platform
+target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+
+# using FPU requires enabling printf with FP support for newlib nano, but just for nanoCLR target, don't need that for nanoBooter
+if(USE_FPU_IS_TRUE)
+    set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES C_STANDARD "-u _printf_float" )
+    set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES CXX_STANDARD "-u _printf_float" )
 endif()
 
 # set compiler definition for FPU

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
@@ -160,12 +160,23 @@ CHIBIOS_PRINT_SIZE_OF_TARGETS(${NANOCLR_PROJECT_NAME}.elf)
 
 # set extra compiler flags, some are related with the build type
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    # build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+# build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
 else()
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+endif()
+
+# set compiler definition for platform emulated floating point according to FPU
+# no FPU requires FP emulation from the platform
+target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+
+# using FPU requires enabling printf with FP support for newlib nano, but just for nanoCLR target, don't need that for nanoBooter
+if(USE_FPU_IS_TRUE)
+    set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES C_STANDARD "-u _printf_float" )
+    set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES CXX_STANDARD "-u _printf_float" )
 endif()
 
 # set compiler definition for FPU

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
@@ -161,11 +161,22 @@ CHIBIOS_PRINT_SIZE_OF_TARGETS(${NANOCLR_PROJECT_NAME}.elf)
 # set extra compiler flags, some are related with the build type
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     # build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
 else()
-    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_EMULATED_FLOATINGPOINT -DPLATFORM_ARM ")
+    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ARM ")
+endif()
+
+# set compiler definition for platform emulated floating point according to FPU
+# no FPU requires FP emulation from the platform
+target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC $<$<NOT:$<BOOL:USE_FPU_IS_TRUE>>:-DPLATFORM_EMULATED_FLOATINGPOINT>)
+
+# using FPU requires enabling printf with FP support for newlib nano, but just for nanoCLR target, don't need that for nanoBooter
+if(USE_FPU_IS_TRUE)
+    set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES C_STANDARD "-u _printf_float" )
+    set_target_properties( ${NANOCLR_PROJECT_NAME}.elf PROPERTIES CXX_STANDARD "-u _printf_float" )
 endif()
 
 # set compiler definition for FPU

--- a/targets/os/win32/nanoCLR/nanoCLR.vcxproj
+++ b/targets/os/win32/nanoCLR/nanoCLR.vcxproj
@@ -160,7 +160,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\CLR\Core\NativeEventDispatcher\NativeEventDispatcher.cpp" />
-    <ClCompile Include="..\..\..\..\src\PAL\Double\nanoPAL_native_double.cpp" />
+    <ClCompile Include="..\..\..\..\src\PAL\Double\nanoPAL_NativeDouble.cpp" />
     <ClCompile Include="CLRStartup.cpp" />
     <ClCompile Include="Events.cpp" />
     <ClCompile Include="FileStore_Win32.cpp" />

--- a/targets/os/win32/nanoCLR/nanoCLR.vcxproj.filters
+++ b/targets/os/win32/nanoCLR/nanoCLR.vcxproj.filters
@@ -98,7 +98,7 @@
     <ClCompile Include="platform_heap.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\src\PAL\Double\nanoPAL_native_double.cpp">
+    <ClCompile Include="..\..\..\..\src\PAL\Double\nanoPAL_NativeDouble.cpp">
       <Filter>Source Files\PAL</Filter>
     </ClCompile>
     <ClCompile Include="targetHAL_Time.cpp">


### PR DESCRIPTION
## Description
- add message to general CMake to ouput FP option (hardware or emulated)
- add NativeDouble source file to CoreCLR
- correct several type declarations relative with NativeDouble
- correct compiler definitions for PLATFORM_EMULATED_FLOATINGPOINT inclusion in CMake of all ref targets
- rename Native Double source file and header
- add code to implement double and float printf for ChibiOS nanoCRT


## Motivation and Context
- Implements correctly the handling of FP (hardware or emulated)
- Fixes nanoFramework/Home#224


## How Has This Been Tested?<!-- (if applicable) -->
C# test app using ToString() with int, float and double (see test code in nanoFramework/Home#224)


## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
