### PR TITLE
Fix compilation error for F091 with SPI

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -47,10 +47,12 @@ uint16_t Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::ComputePresca
 {
     uint16_t pre = 0;
 #if defined(STM32F4xx_MCUCONF) || defined(STM32F7xx_MCUCONF)
-    int32_t clock = STM32_SPII2S_MAX >> 1;		// SP1, SPI4, SPI5 and SPI6 on APB2
+	int32_t clock = STM32_SPII2S_MAX >> 1;		// SP1, SPI4, SPI5 and SPI6 on APB2
     if (bus == 2 || bus == 3) clock >>= 1;		// SPI2 and SPI3 on APB1
-#else
+#elif defined(STM32F0xx_MCUCONF)
     int32_t clock = 12000000 >> 1;
+#else
+    #error "Please check max SPI frequency"
 #endif
 	if (clock > requestedFrequency << 3)
     {

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -46,9 +46,12 @@ typedef Library_win_dev_spi_native_Windows_Devices_Spi_SpiConnectionSettings Spi
 uint16_t Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::ComputePrescaler (uint8_t bus, int32_t requestedFrequency)
 {
     uint16_t pre = 0;
-	int32_t clock = STM32_SPII2S_MAX >> 1;		// SP1, SPI4, SPI5 and SPI6 on APB2
-	if (bus == 2 || bus == 3) clock >>= 1;		// SPI2 and SPI3 on APB1
-
+#if defined(STM32F4xx_MCUCONF) || defined(STM32F7xx_MCUCONF)
+    int32_t clock = STM32_SPII2S_MAX >> 1;		// SP1, SPI4, SPI5 and SPI6 on APB2
+    if (bus == 2 || bus == 3) clock >>= 1;		// SPI2 and SPI3 on APB1
+#else
+    int32_t clock = 12000000 >> 1;
+#endif
 	if (clock > requestedFrequency << 3)
     {
 		clock >>= 4;


### PR DESCRIPTION
## Description
This board does not have a _STM32_SPII2S_MAX_ #define and its frequency is limited to 12MHz.

This 12MHz frequency becomes the default value for boards other than STM32F4xx and STM32F7xx for now.

## How Has This Been Tested?
No error at compile time with SPI option ON for the STM32F091 board.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

