### PR TITLE
Work on GenericPort

### DIFF
--- a/CMake/Modules/FindNF_CoreCLR.cmake
+++ b/CMake/Modules/FindNF_CoreCLR.cmake
@@ -156,6 +156,7 @@ set(NF_CoreCLR_SRCS
     # PAL stubs
     Async_stubs.cpp
     COM_stubs.c
+    GenericPort_stubs.c
 )
 
 foreach(SRC_FILE ${NF_CoreCLR_SRCS})

--- a/src/PAL/COM/COM_stubs.c
+++ b/src/PAL/COM/COM_stubs.c
@@ -22,7 +22,7 @@ __nfweak int DebuggerPort_Write(COM_HANDLE comPortNum, const char* data, size_t 
 {
     NATIVE_PROFILE_PAL_COM();
 
-    // minimum implementation is calling generic port
+    // minimum implementation is calling generic port to be able to use SWO (if available)
     GenericPort_Write( comPortNum, data, size );
 
     return 0;

--- a/src/PAL/COM/GenericPort_stubs.c
+++ b/src/PAL/COM/GenericPort_stubs.c
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+#include <nanoPAL_COM.h>
+
+__nfweak bool GenericPort_Initialize(int comPortNum)
+{
+    NATIVE_PROFILE_PAL_COM();
+    return true;
+}
+
+__nfweak bool GenericPort_Uninitialize(int comPortNum)
+{
+    NATIVE_PROFILE_PAL_COM();
+    return true;
+}
+
+__nfweak int GenericPort_Write(int comPortNum, const char* data, size_t size)
+{
+    NATIVE_PROFILE_PAL_COM();
+    return 0;
+}
+
+__nfweak int GenericPort_Read(int comPortNum, char* data, size_t size)
+{
+    NATIVE_PROFILE_PAL_COM();
+    return 0;
+}
+
+__nfweak bool GenericPort_Flush(int comPortNum)
+{
+    NATIVE_PROFILE_PAL_COM();
+    return true;
+}
+
+__nfweak bool GenericPort_IsSslSupported(int comPortNum)
+{
+    NATIVE_PROFILE_PAL_COM();
+    return false;
+}
+
+__nfweak bool GenericPort_UpgradeToSsl(int comPortNum, unsigned int flags) 
+{ 
+    NATIVE_PROFILE_PAL_COM();
+    return false; 
+}
+
+__nfweak bool GenericPort_IsUsingSsl(int comPortNum)
+{
+    NATIVE_PROFILE_PAL_COM();
+    return false;
+}

--- a/src/PAL/Include/nanoPAL_COM.h
+++ b/src/PAL/Include/nanoPAL_COM.h
@@ -18,7 +18,14 @@
 extern "C" {
 #endif
 
-__nfweak int GenericPort_Write( int portNum, const char* data, size_t size );
+bool GenericPort_Initialize( COM_HANDLE comPortNum );
+bool GenericPort_Uninitialize( COM_HANDLE comPortNum );
+int GenericPort_Write( int portNum, const char* data, size_t size );
+int GenericPort_Read( COM_HANDLE comPortNum, char* data, size_t size );
+bool GenericPort_Flush( COM_HANDLE comPortNum );
+bool GenericPort_IsSslSupported( COM_HANDLE comPortNum );
+bool GenericPort_UpgradeToSsl( COM_HANDLE comPortNum, unsigned int flags );
+bool GenericPort_IsUsingSsl( COM_HANDLE comPortNum );
 
 #ifdef __cplusplus
 }
@@ -33,14 +40,14 @@ int DebuggerPort_Write( COM_HANDLE comPortNum, const char* data, size_t size );
 extern "C" {
 #endif
 
- bool DebuggerPort_Initialize( COM_HANDLE comPortNum );
- bool DebuggerPort_Uninitialize( COM_HANDLE comPortNum );
- int DebuggerPort_Write( COM_HANDLE comPortNum, const char* data, size_t size, int maxRetries );
- int DebuggerPort_Read( COM_HANDLE comPortNum, char* data, size_t size );
- bool DebuggerPort_Flush( COM_HANDLE comPortNum );
- bool DebuggerPort_IsSslSupported( COM_HANDLE comPortNum );
- bool DebuggerPort_UpgradeToSsl( COM_HANDLE comPortNum, unsigned int flags );
- bool DebuggerPort_IsUsingSsl( COM_HANDLE comPortNum );
+bool DebuggerPort_Initialize( COM_HANDLE comPortNum );
+bool DebuggerPort_Uninitialize( COM_HANDLE comPortNum );
+int DebuggerPort_Write( COM_HANDLE comPortNum, const char* data, size_t size, int maxRetries );
+int DebuggerPort_Read( COM_HANDLE comPortNum, char* data, size_t size );
+bool DebuggerPort_Flush( COM_HANDLE comPortNum );
+bool DebuggerPort_IsSslSupported( COM_HANDLE comPortNum );
+bool DebuggerPort_UpgradeToSsl( COM_HANDLE comPortNum, unsigned int flags );
+bool DebuggerPort_IsUsingSsl( COM_HANDLE comPortNum );
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description
- add stubs for GenericPort
- add declaration for GenericPort API
- update CMake accordingly


## Motivation and Context
- The current declaration of Debugger::Print calls the GenericPort output which was declared with the weak attribute. No actual implementation was being provided which caused issues on builds that had the SWO option OFF.
- Resolves nanoFramework/Home#229

## How Has This Been Tested?<!-- (if applicable) -->
- Build and upload QUAIL image with SWO option OFF

## Screenshots<!-- (if appropriate): -->

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>