### PR TITLE
Add suport for hex2dfu utility

### DIFF
--- a/CMake/Modules/FindBuildUtils.cmake
+++ b/CMake/Modules/FindBuildUtils.cmake
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2017 The nanoFramework project contributors
+# See LICENSE file in the project root for full license information.
+#
+
+function(NF_GENERATE_DFU_PACKAGE FILE1 ADDRESS1 FILE2 ADDRESS2 OUTPUTFILENAME)
+
+    add_custom_command(
+        TARGET ${NANOCLR_PROJECT_NAME}.elf POST_BUILD
+        COMMAND ${TOOL_HEX2DFU_PREFIX}/hex2dfu 
+        
+        -b="${FILE1}" -a="${ADDRESS1}"
+        -b="${FILE2}" -a="${ADDRESS2}"
+        -o="${OUTPUTFILENAME}"
+        
+        WORKING_DIRECTORY ${TOOL_HEX2DFU_PREFIX} 
+        
+        COMMENT "exporting bin files to DFU image" 
+    )
+
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,25 @@ endif()
 
 #########################################
 
+########################################################
+# check availability of hex2dfu tool if specified
+# only relevant if this is running on a Windows machine
+if(WIN32)
+    if(NOT "${TOOL_HEX2DFU_PREFIX}" STREQUAL "")
+        if(NOT EXISTS ${TOOL_HEX2DFU_PREFIX}/hex2dfu.exe)
+            message(STATUS "")
+            message(STATUS "Couldn't find the hex2dfu tool at the specified path: ${TOOL_HEX2DFU_PREFIX}/hex2dfu.exe")
+            message(STATUS "Make sure that the CMake option TOOL_HEX2DFU_PREFIX has the correct path.")
+            message(STATUS "If you don't have this tool download it from https://github.com/nanoframework/nf-tools/releases")
+            message(STATUS "")
+            message(FATAL_ERROR "hex2dfu tool not found")
+        else()
+            set(HEX2DFU_TOOL_AVAILABLE TRUE CACHE INTERNAL "hex2dfu tool available")
+        endif()
+    endif()
+endif()
+
+
 
 project(nanoFramework VERSION 0.0.0.0)
 

--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -29,6 +29,7 @@
         "description$": "<description-here>",
         "settings": {
             "TOOLCHAIN_PREFIX" : "<path-to-gcc-toolchain-mind-the-forward-slash>",
+            "TOOL_HEX2DFU_PREFIX" : "<path-to-hex2dfu-utility-mind-the-forward-slash>",
             "TARGET_SERIES" : "<series-name-of-the-target-chip-STM32F0xx-STM32F4xx-STM32F7xx>",
             "USE_FPU" : "<TRUE-for-using-hardware-floating-point-unit>",
             "CHIBIOS_VERSION" : "<N.N.N>",
@@ -51,6 +52,7 @@
         "description$": "<description-here>",
         "settings": {
             "TOOLCHAIN_PREFIX" : "<path-to-gcc-toolchain-mind-the-forward-slash>",
+            "TOOL_HEX2DFU_PREFIX" : "<path-to-hex2dfu-utility-mind-the-forward-slash>",
             "TARGET_SERIES" : "<series-name-of-the-target-chip-STM32F0xx-STM32F4xx-STM32F7xx>",
             "USE_FPU" : "<TRUE-for-using-hardware-floating-point-unit>",
             "CHIBIOS_VERSION" : "<N.N.N>",

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -17,6 +17,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/target_common.h.in"
 set(NANOBOOTER_PROJECT_NAME "nanoBooter")
 set(NANOCLR_PROJECT_NAME "nanoCLR")
 
+find_package(BuildUtils REQUIRED)
 find_package(CHIBIOS REQUIRED)
 find_package(ChibiOSnfOverlay REQUIRED)
 find_package(WireProtocol REQUIRED)
@@ -277,7 +278,23 @@ else()
 
             # dump target image as source code listing
             COMMAND ${CMAKE_OBJDUMP} -d -EL -S $<TARGET_FILE:${NANOCLR_PROJECT_NAME}.elf> > ${NANOCLR_DUMP_FILE}
-
+           
             COMMENT "Generate nanoCLR HEX and BIN files for deployment, LST file for debug")
+
+endif()
+
+
+# if HEX2DFU tool is available pack the binaries into a DFU package
+if(HEX2DFU_TOOL_AVAILABLE)
+
+    ####################################################################################################
+    ## when changing the linker file make sure to update the new addresses for the image files bellow ##
+    ## DO NOT use the leading 0x notation, just the address in plain hexadecimal formating            ##
+    ####################################################################################################
+    NF_GENERATE_DFU_PACKAGE(
+        ${NANOBOOTER_BIN_FILE} 08000000 
+        ${NANOCLR_BIN_FILE} 08008000 
+        ${PROJECT_SOURCE_DIR}/build/nanobooter-nanoclr.dfu
+    )
 
 endif()

--- a/targets/CMSIS-OS/ChibiOS/common/rules_code.ld
+++ b/targets/CMSIS-OS/ChibiOS/common/rules_code.ld
@@ -27,7 +27,7 @@ SECTIONS
         __fini_array_end = .;
     } > XTORS_FLASH AT > XTORS_FLASH_LMA
 
-    .text ALIGN(16) : ALIGN(16)
+    .text : ALIGN(16)
     {
         *(.text)
         *(.text.*)


### PR DESCRIPTION
## Description
- add CMake function with command to to generate DFU package from build binaries
- add support for new CMake option to specify location of hex2dfu utility
- update cmake-variants template
- update CMake of QUAIL to make use of the new function

## Motivation and Context
When developing for a target board that requires a DFU package to flash the image it's a pain having to go and use DFU manager to manually generate the DFU package.
This improvement takes advantage of the new hex2dfu command line utility and generates the DFU package right after the successful build of the nanoBooter and nanoCLR binary images. 


## How Has This Been Tested?<!-- (if applicable) -->
Successfully generated a DFU package and upload it to a target board.

## Screenshots<!-- (if appropriate): -->

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>