### PR TITLE
Add missing path in call to hex2dfu

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -186,8 +186,8 @@ if(HEX2DFU_TOOL_AVAILABLE)
     ## DO NOT use the leading 0x notation, just the address in plain hexadecimal formating            ##
     ####################################################################################################
     NF_GENERATE_DFU_PACKAGE(
-        ${NANOBOOTER_PROJECT_NAME}.bin 08000000 
-        ${NANOCLR_PROJECT_NAME}.bin 08008000 
+        ${PROJECT_SOURCE_DIR}/build/${NANOBOOTER_PROJECT_NAME}.bin 08000000 
+        ${PROJECT_SOURCE_DIR}/build/${NANOCLR_PROJECT_NAME}.bin 08008000 
         ${PROJECT_SOURCE_DIR}/build/nanobooter-nanoclr.dfu
     )
 

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
@@ -186,8 +186,8 @@ if(HEX2DFU_TOOL_AVAILABLE)
     ## DO NOT use the leading 0x notation, just the address in plain hexadecimal formating            ##
     ####################################################################################################
     NF_GENERATE_DFU_PACKAGE(
-        ${NANOBOOTER_PROJECT_NAME}.bin 08000000 
-        ${NANOCLR_PROJECT_NAME}.bin 08008000 
+        ${PROJECT_SOURCE_DIR}/build/${NANOBOOTER_PROJECT_NAME}.bin 08000000 
+        ${PROJECT_SOURCE_DIR}/build/${NANOCLR_PROJECT_NAME}.bin 08008000 
         ${PROJECT_SOURCE_DIR}/build/nanobooter-nanoclr.dfu
     )
 


### PR DESCRIPTION
## Description
- add missing path in the call to the tool 

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build QUAIL and loaded DFU in target board.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

