### PR TITLE
Improve heap definition

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -171,8 +171,8 @@ nf_set_linker_options(${NANOCLR_PROJECT_NAME}.elf TRUE)
 ###################################################
 # the size of the CLR managed heap is defined here
 ###################################################
-set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x0")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x9000")
+set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x400")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x1800")
 
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
@@ -171,8 +171,8 @@ nf_set_linker_options(${NANOCLR_PROJECT_NAME}.elf TRUE)
 ###################################################
 # the size of the CLR managed heap is defined here
 ###################################################
-set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x0")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x9000")
+set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x400")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x1800")
 
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
@@ -171,8 +171,8 @@ nf_set_linker_options(${NANOCLR_PROJECT_NAME}.elf TRUE)
 ###################################################
 # the size of the CLR managed heap is defined here
 ###################################################
-set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x0")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x2B000")
+set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x400")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x1800")
 
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/STM32F746xG_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/STM32F746xG_CLR.ld
@@ -119,17 +119,8 @@ SECTIONS
 /* Code rules inclusion.*/
 INCLUDE rules_code.ld
 
-/*  
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// 
-// rules_clr.ld have to be included **BEFORE** the rules_data.ld 
-// this is because the CRT heap (processed in rules_data.ld) takes up all the remaining free space of the memory region where it's assigned 
-// the size of the managed heap (processed in rules_clr.ld) is set in each target configuration 
-// in case it shares the same region as the CRT heap it won't have any room left if the CRT heap is assigned first 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// 
-/*  
+/* Data rules inclusion.*/
+INCLUDE rules_data.ld
 
 /* nanoCLR rules inclusion.*/
 INCLUDE rules_clr.ld
-
-/* Data rules inclusion.*/
-INCLUDE rules_data.ld

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
@@ -171,8 +171,8 @@ nf_set_linker_options(${NANOCLR_PROJECT_NAME}.elf TRUE)
 ###################################################
 # the size of the CLR managed heap is defined here
 ###################################################
-set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x0")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x2000")
+set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x400")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x1800")
 
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -171,8 +171,8 @@ nf_set_linker_options(${NANOCLR_PROJECT_NAME}.elf TRUE)
 ###################################################
 # the size of the CLR managed heap is defined here
 ###################################################
-set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x0")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x29600")
+set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x400")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x1800")
 
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
@@ -171,8 +171,8 @@ nf_set_linker_options(${NANOCLR_PROJECT_NAME}.elf TRUE)
 ###################################################
 # the size of the CLR managed heap is defined here
 ###################################################
-set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x0")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x196C0")
+set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x400")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x1800")
 
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
@@ -171,8 +171,8 @@ nf_set_linker_options(${NANOCLR_PROJECT_NAME}.elf TRUE)
 ###################################################
 # the size of the CLR managed heap is defined here
 ###################################################
-set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x0")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__clr_managed_heap_size__=0x4B000")
+set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x400")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x1800")
 
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/STM32F76xx_CLR.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/STM32F76xx_CLR.ld
@@ -119,17 +119,8 @@ SECTIONS
 /* Code rules inclusion.*/
 INCLUDE rules_code.ld
 
-/*  
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// 
-// rules_clr.ld have to be included **BEFORE** the rules_data.ld 
-// this is because the CRT heap (processed in rules_data.ld) takes up all the remaining free space of the memory region where it's assigned 
-// the size of the managed heap (processed in rules_clr.ld) is set in each target configuration 
-// in case it shares the same region as the CRT heap it won't have any room left if the CRT heap is assigned first 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// 
-/*  
+/* Data rules inclusion.*/
+INCLUDE rules_data.ld
 
 /* nanoCLR rules inclusion.*/
 INCLUDE rules_clr.ld
-
-/* Data rules inclusion.*/
-INCLUDE rules_data.ld

--- a/targets/CMSIS-OS/ChibiOS/common/rules.ld
+++ b/targets/CMSIS-OS/ChibiOS/common/rules.ld
@@ -12,18 +12,8 @@ INCLUDE rules_stacks.ld
 /* Code rules inclusion.*/
 INCLUDE rules_code.ld
 
-
-/* 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// rules_clr.ld have to be included **BEFORE** the rules_data.ld
-// this is because the CRT heap (processed in rules_data.ld) takes up all the remaining free space of the memory region where it's assigned
-// the size of the managed heap (processed in rules_clr.ld) is set in each target configuration
-// in case it shares the same region as the CRT heap it won't have any room left if the CRT heap is assigned first
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-/* 
+/* Data rules inclusion.*/
+INCLUDE rules_data.ld
 
 /* nanoCLR rules inclusion.*/
 INCLUDE rules_clr.ld
-
-/* Data rules inclusion.*/
-INCLUDE rules_data.ld

--- a/targets/CMSIS-OS/ChibiOS/common/rules_clr.ld
+++ b/targets/CMSIS-OS/ChibiOS/common/rules_clr.ld
@@ -1,19 +1,19 @@
  SECTIONS
 {
  
- /* nanoFramework CLR managed heap section at the specified RAM section.*/
+    /* nanoFramework CLR managed heap section at the specified RAM section.*/
     .clr_managed_heap (NOLOAD) :
     {
         . = ALIGN(8);
-        PROVIDE(HeapBegin = LOADADDR(.clr_managed_heap));
         __clr_managed_heap_base__ = .;
-        . += __clr_managed_heap_size__;
+        PROVIDE(HeapBegin = LOADADDR(.clr_managed_heap));
+        . = ORIGIN(CLR_MANAGED_HEAP_RAM) + LENGTH(CLR_MANAGED_HEAP_RAM) - LENGTH(ramvt);
         . = ALIGN(8);
         __clr_managed_heap_end__ = .;
         PROVIDE(HeapEnd = .);
     } > CLR_MANAGED_HEAP_RAM
 
-        /* RAM space reserved for the vector table */
+    /* RAM space reserved for the vector table */
     .RAMVectorTable (NOLOAD) : ALIGN(4)
     {
         *(.RAMVectorTable)

--- a/targets/CMSIS-OS/ChibiOS/common/rules_data.ld
+++ b/targets/CMSIS-OS/ChibiOS/common/rules_data.ld
@@ -266,7 +266,8 @@ SECTIONS
     {
         . = ALIGN(8);
         __heap_base__ = .;
-        . = ORIGIN(HEAP_RAM) + LENGTH(HEAP_RAM);
+        . += __crt_heap_size__;
+        . = ALIGN(8);
         __heap_end__ = .;
     } > HEAP_RAM
 }


### PR DESCRIPTION
## Description
- CRT heap now has defined size (was managed Heap).
- Update linker and rules files accordingly.

## Motivation and Context
- The previous approach had a defined size for the managed Heap (defined as a linker symbol). The CRT heap was taking the available RAM left from all the other region assignments. 
This approach required an adjustment (increase) of the managed Heap as more features where added to the image. The need for this manual adjustment prevented the automated resize of the available RAM for the managed heap, which is a poor solution.
Moreover there was an issue with the managed heap definition that was wrongly setting the region start to the RAM start.

## How Has This Been Tested?<!-- (if applicable) -->
Image compiled and tested with Blinky on several reference boards.

## Screenshots<!-- (if appropriate): -->

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
