### PR TITLE
Fix managed heap initialization

### DIFF
--- a/CMake/Modules/FindNF_CoreCLR.cmake
+++ b/CMake/Modules/FindNF_CoreCLR.cmake
@@ -58,6 +58,7 @@ set(NF_CoreCLR_SRCS
     GarbageCollector.cpp
     GarbageCollector_Compaction.cpp
     GarbageCollector_ComputeReachabilityGraph.cpp
+    GarbageCollector_Info.cpp
     Interpreter.cpp
     Random.cpp
     Streams.cpp

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -414,7 +414,7 @@ void CLR_RT_ExecutionEngine::Relocate()
 
 #if !defined(NANOCLR_APPDOMAINS)
     CLR_RT_GarbageCollector::Heap_Relocate( (void**)&m_globalLock           );
-    CLR_RT_GarbageCollector::Heap_Relocate( (void**)&m_outOfMemoryException );
+    //CLR_RT_GarbageCollector::Heap_Relocate( (void**)&m_outOfMemoryException );
 #endif
 
     CLR_RT_GarbageCollector::Heap_Relocate( (void**)&m_currentUICulture     );

--- a/src/CLR/Core/GarbageCollector_Compaction.cpp
+++ b/src/CLR/Core/GarbageCollector_Compaction.cpp
@@ -17,7 +17,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteCompaction()
 #if defined(NANOCLR_TRACE_MEMORY_STATS)
     if(s_CLR_RT_fTrace_MemoryStats >= c_CLR_RT_Trace_Info)
     {
-        CLR_Debug::Printf( "GC: performing heap compaction...\r\n" );
+        CLR_Debug::Printf( "GC: performing heap compaction\r\n" );
     }
 #endif
 
@@ -34,6 +34,13 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteCompaction()
     ////////////////////////////////////////////////////////////////////////////////////////////////
 #if defined(NANOCLR_PROFILE_NEW_ALLOCATIONS)
     g_CLR_PRF_Profiler.RecordHeapCompactionEnd();
+#endif
+
+#if defined(NANOCLR_TRACE_MEMORY_STATS)
+    if(s_CLR_RT_fTrace_MemoryStats >= c_CLR_RT_Trace_Info)
+    {
+        CLR_Debug::Printf( "GC: heap compaction completed\r\n" );
+    }
 #endif
 
     return 0;

--- a/src/CLR/Core/GarbageCollector_Info.cpp
+++ b/src/CLR/Core/GarbageCollector_Info.cpp
@@ -1,0 +1,316 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+#include "Core.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#if defined(NANOCLR_GC_VERBOSE)
+
+void CLR_RT_GarbageCollector::GC_Stats( int& resNumberObjects, int& resSizeObjects, int& resNumberEvents, int& resSizeEvents )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    resNumberObjects = 0;
+    resSizeObjects   = 0;
+
+    resNumberEvents  = 0;
+    resSizeEvents    = 0;
+
+    NANOCLR_FOREACH_NODE(CLR_RT_HeapCluster,hc,g_CLR_RT_ExecutionEngine.m_heap)
+    {
+        CLR_RT_HeapBlock_Node* ptr = hc->m_payloadStart;
+        CLR_RT_HeapBlock_Node* end = hc->m_payloadEnd;
+
+        while(ptr < end)
+        {
+            CLR_UINT16 size = ptr->DataSize();
+
+            hc->ValidateBlock( ptr );
+
+            if(ptr->DataType() != DATATYPE_FREEBLOCK)
+            {
+                if(ptr->IsEvent())
+                {
+                    resNumberEvents += 1;
+                    resSizeEvents   += size * sizeof(CLR_RT_HeapBlock);
+                }
+                else
+                {
+                    resNumberObjects += 1;
+                    resSizeObjects   += size * sizeof(CLR_RT_HeapBlock);
+                }
+            }
+
+            ptr += size;
+        }
+    }
+    NANOCLR_FOREACH_NODE_END();
+}
+
+
+static void DumpTimeout( CLR_RT_Thread* th, CLR_INT64& t )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    CLR_Debug::Printf( ": %d", th ? th->m_pid : -1 );
+
+    if(t < TIMEOUT_INFINITE)
+    {
+        t -= g_CLR_RT_ExecutionEngine.m_currentMachineTime;
+
+        CLR_Debug::Printf( " %d", (int)t );
+    }
+    else
+    {
+        CLR_Debug::Printf( " INFINITE" );
+    }
+}
+
+void CLR_RT_GarbageCollector::DumpThreads()
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_FOREACH_NODE(CLR_RT_Thread,th,g_CLR_RT_ExecutionEngine.m_threadsReady)
+    {
+        th->DumpStack();
+    }
+    NANOCLR_FOREACH_NODE_END();
+
+    NANOCLR_FOREACH_NODE(CLR_RT_Thread,th,g_CLR_RT_ExecutionEngine.m_threadsWaiting)
+    {
+        th->DumpStack();
+    }
+    NANOCLR_FOREACH_NODE_END();
+
+    CLR_Debug::Printf( "\r\n" );
+}
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#if NANOCLR_VALIDATE_HEAP >= NANOCLR_VALIDATE_HEAP_3_Compaction
+
+void CLR_RT_GarbageCollector::ValidateCluster( CLR_RT_HeapCluster* hc )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    CLR_RT_HeapBlock_Node* ptr = hc->m_payloadStart;
+    CLR_RT_HeapBlock_Node* end = hc->m_payloadEnd;
+
+    while(ptr < end)
+    {
+        hc->ValidateBlock( ptr );
+
+        ptr += ptr->DataSize();
+    }
+}
+
+void CLR_RT_GarbageCollector::ValidateHeap( CLR_RT_DblLinkedList& lst )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_FOREACH_NODE(CLR_RT_HeapCluster,hc,lst)
+    {
+        ValidateCluster( hc );
+    }
+    NANOCLR_FOREACH_NODE_END();
+}
+
+void CLR_RT_GarbageCollector::ValidateBlockNotInFreeList( CLR_RT_DblLinkedList& lst, CLR_RT_HeapBlock_Node* dst )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_FOREACH_NODE(CLR_RT_HeapCluster,hc,lst)
+    {
+        NANOCLR_FOREACH_NODE(CLR_RT_HeapBlock_Node,ptr,hc->m_freeList)
+        {
+            CLR_RT_HeapBlock_Node* ptrEnd = ptr + ptr->DataSize();
+
+            if(ptr <= dst && dst < ptrEnd)
+            {
+                CLR_Debug::Printf( "Pointer into free list!! %08x %08x %08x\r\n", dst, ptr, ptrEnd );
+
+                NANOCLR_DEBUG_STOP();
+            }
+        }
+        NANOCLR_FOREACH_NODE_END();
+    }
+    NANOCLR_FOREACH_NODE_END();
+}
+
+bool CLR_RT_GarbageCollector::IsBlockInFreeList( CLR_RT_DblLinkedList& lst, CLR_RT_HeapBlock_Node* dst, bool fExact )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_FOREACH_NODE(CLR_RT_HeapCluster,hc,lst)
+    {
+        NANOCLR_FOREACH_NODE(CLR_RT_HeapBlock_Node,ptr,hc->m_freeList)
+        {
+            if(fExact)
+            {
+                if(ptr == dst) return true;
+            }
+            else
+            {
+                CLR_RT_HeapBlock_Node* ptrEnd = ptr + ptr->DataSize();
+
+                if(ptr <= dst && dst < ptrEnd) return true;
+            }
+        }
+        NANOCLR_FOREACH_NODE_END();
+    }
+    NANOCLR_FOREACH_NODE_END();
+
+    return false;
+}
+
+bool CLR_RT_GarbageCollector::IsBlockInHeap( CLR_RT_DblLinkedList& lst, CLR_RT_HeapBlock_Node* dst )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_FOREACH_NODE(CLR_RT_HeapCluster,hc,lst)
+    {
+        if(hc->m_payloadStart <= dst && dst < hc->m_payloadEnd) return true;
+    }
+    NANOCLR_FOREACH_NODE_END();
+
+    return false;
+}
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#if NANOCLR_VALIDATE_HEAP >= NANOCLR_VALIDATE_HEAP_4_CompactionPlus
+
+CLR_RT_GarbageCollector::Rel_List CLR_RT_GarbageCollector::s_lstRecords;
+CLR_RT_GarbageCollector::Rel_Map  CLR_RT_GarbageCollector::s_mapOldToRecord;
+CLR_RT_GarbageCollector::Rel_Map  CLR_RT_GarbageCollector::s_mapNewToRecord;
+
+//--//
+
+bool CLR_RT_GarbageCollector::TestPointers_PopulateOld_Worker( void** ref )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    CLR_UINT32* dst = (CLR_UINT32*)*ref;
+
+    if(dst)
+    {
+        RelocationRecord* ptr = new RelocationRecord();
+
+        s_lstRecords.push_back( ptr );
+
+        ptr->oldRef =  ref;
+        ptr->oldPtr =  dst;
+
+        ptr->newRef =  NULL;
+        ptr->newPtr =  NULL;
+
+        ptr->data   = *dst;
+
+        if(s_mapOldToRecord.find( ref ) != s_mapOldToRecord.end())
+        {
+            CLR_Debug::Printf( "Duplicate base OLD: %08x\r\n", ref );
+        }
+
+        s_mapOldToRecord[ ref ] = ptr;
+
+        if(IsBlockInFreeList( g_CLR_RT_ExecutionEngine.m_heap, (CLR_RT_HeapBlock_Node*)dst, false ))
+        {
+            CLR_Debug::Printf( "Some data points into a free list: %08x\r\n", dst );
+
+            NANOCLR_DEBUG_STOP();
+        }
+    }
+
+    return false;
+}
+
+void CLR_RT_GarbageCollector::TestPointers_PopulateOld()
+{
+    NATIVE_PROFILE_CLR_CORE();
+    Rel_List_Iter itLst;
+
+    for(itLst = s_lstRecords.begin(); itLst != s_lstRecords.end(); itLst++)
+    {
+        RelocationRecord* ptr = *itLst;
+
+        delete ptr;
+    }
+
+    s_lstRecords    .clear();
+    s_mapOldToRecord.clear();
+    s_mapNewToRecord.clear();
+
+    //--//
+
+    Heap_Relocate_Pass( TestPointers_PopulateOld_Worker );
+}
+
+//--//
+
+void CLR_RT_GarbageCollector::TestPointers_Remap()
+{
+    NATIVE_PROFILE_CLR_CORE();
+    Rel_Map_Iter it;
+
+    // for(it = s_mapOldToRecord.begin(); it != s_mapOldToRecord.end(); it++)
+    // {
+    //     RelocationRecord* ptr = it->second;
+    //     void**            ref = it->first  ; CLR_RT_GarbageCollector::Relocation_UpdatePointer( (void**)&ref );
+    //     CLR_UINT32*       dst = ptr->oldPtr; CLR_RT_GarbageCollector::Relocation_UpdatePointer( (void**)&dst );
+
+    //     if(s_mapNewToRecord.find( ref ) != s_mapNewToRecord.end())
+    //     {
+    //         CLR_Debug::Printf( "Duplicate base NEW: %08x\r\n", ref );
+    //     }
+
+    //     s_mapNewToRecord[ ref ] = ptr;
+
+    //     ptr->newRef = ref;
+    //     ptr->newPtr = dst;
+    // }
+}
+
+//--//
+
+bool CLR_RT_GarbageCollector::TestPointers_PopulateNew_Worker( void** ref )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    CLR_UINT32* dst = (CLR_UINT32*)*ref;
+
+    if(dst)
+    {
+        Rel_Map_Iter it = s_mapNewToRecord.find( ref );
+
+        if(it != s_mapNewToRecord.end())
+        {
+            RelocationRecord* ptr = it->second;
+
+            if(ptr->newPtr != dst)
+            {
+                CLR_Debug::Printf( "Bad pointer: %08x %08x\r\n", ptr->newPtr, dst );
+            }
+            else if(ptr->data != *dst)
+            {
+                CLR_Debug::Printf( "Bad data: %08x %08x\r\n", ptr->data, *dst );
+            }
+
+            if(IsBlockInFreeList( g_CLR_RT_ExecutionEngine.m_heap, (CLR_RT_HeapBlock_Node*)dst, false ))
+            {
+                CLR_Debug::Printf( "Some data points into a free list: %08x\r\n", dst );
+
+                NANOCLR_DEBUG_STOP();
+            }
+        }
+        else
+        {
+            CLR_Debug::Printf( "Bad base: %08x\r\n", ref );
+        }
+    }
+
+    return false;
+}
+
+void CLR_RT_GarbageCollector::TestPointers_PopulateNew()
+{
+    NATIVE_PROFILE_CLR_CORE();
+    Heap_Relocate_Pass( TestPointers_PopulateNew_Worker );
+}
+
+#endif

--- a/src/CLR/Include/nanoCLR_PlatformDef.h
+++ b/src/CLR/Include/nanoCLR_PlatformDef.h
@@ -64,6 +64,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // WINDOWS
 #if defined(_WIN32)
+
 #define NANOCLR_GC_VERBOSE
 #define NANOCLR_TRACE_MEMORY_STATS
 #define NANOCLR_PROFILE_NEW
@@ -78,7 +79,7 @@
 //#define NANOCLR_VALIDATE_APPDOMAIN_ISOLATION
 #define NANOCLR_TRACE_HRESULT        // enable tracing of HRESULTS from interop libraries 
 #else //RELEASE
-#define NANOCLR_VALIDATE_HEAP NANOCLR_VALIDATE_HEAP_0_None
+#define NANOCLR_VALIDATE_HEAP                   NANOCLR_VALIDATE_HEAP_0_None
 #endif
 #define NANOCLR_ENABLE_SOURCELEVELDEBUGGING
 #endif
@@ -86,7 +87,9 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // ARM
 #if defined(PLATFORM_ARM)
+//#define NANOCLR_GC_VERBOSE
 #define NANOCLR_TRACE_MEMORY_STATS
+//#define NANOCLR_VALIDATE_HEAP                   NANOCLR_VALIDATE_HEAP_3_Compaction
 #endif
 
 //-o-//-o-//-o-//-o-//-o-//-o-//

--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -139,18 +139,18 @@ private:
 
             struct U8
             {
-                CLR_UINT32 _L;
-                CLR_UINT32 _H;
+                CLR_UINT32 LL;
+                CLR_UINT32 HH;
 
                 operator CLR_UINT64() const
                 {
-                    return ((CLR_UINT64)_H << 32 | (CLR_UINT64)_L );
+                    return ((CLR_UINT64)HH << 32 | (CLR_UINT64)LL );
                 }
 
                 U8& operator=( const CLR_UINT64 num )
                 {
-                    _L = (CLR_UINT32)((ULONGLONGCONSTANT(0x00000000FFFFFFFF) & num)      );
-                    _H = (CLR_UINT32)((ULONGLONGCONSTANT(0xFFFFFFFF00000000) & num) >> 32);
+                    LL = (CLR_UINT32)((ULONGLONGCONSTANT(0x00000000FFFFFFFF) & num)      );
+                    HH = (CLR_UINT32)((ULONGLONGCONSTANT(0xFFFFFFFF00000000) & num) >> 32);
                     return *this;
                 }
                 U8& operator+=( const U8& num )
@@ -191,8 +191,8 @@ private:
                 U8 operator~( )
                 {
                     U8 ret_value;
-                    ret_value._L = ~_L;                        
-                    ret_value._H = ~_H;
+                    ret_value.LL = ~LL;                        
+                    ret_value.HH = ~HH;
                     return ret_value;
                 }
 
@@ -207,22 +207,22 @@ private:
 
                 U8& operator&=( const U8& num )
                 {
-                    _L &= num._L;
-                    _H &= num._H;
+                    LL &= num.LL;
+                    HH &= num.HH;
                     return *this;
                 }
 
                 U8& operator|=( const U8& num )
                 {
-                    _L |= num._L;
-                    _H |= num._H;
+                    LL |= num.LL;
+                    HH |= num.HH;
                     return *this;
                 }
 
                 U8& operator^=( const U8& num )
                 {
-                    _L ^= num._L;
-                    _H ^= num._H;
+                    LL ^= num.LL;
+                    HH ^= num.HH;
                     return *this;
                 }
 
@@ -275,18 +275,18 @@ private:
 
             struct S8
             {
-                CLR_UINT32 _L;
-                CLR_UINT32 _H;
+                CLR_UINT32 LL;
+                CLR_UINT32 HH;
 
                 operator CLR_INT64() const
                 {
-                     return (((CLR_UINT64)_H) << 32 | (CLR_UINT64)_L);
+                     return (((CLR_UINT64)HH) << 32 | (CLR_UINT64)LL);
                 }
 
                 S8& operator=( const CLR_INT64 num )
                 {
-                    _L = (CLR_UINT32) (( ULONGLONGCONSTANT(0x00000000FFFFFFFF) & num)       );
-                    _H = (CLR_UINT32) (( ULONGLONGCONSTANT(0xFFFFFFFF00000000) & num) >> 32 );
+                    LL = (CLR_UINT32) (( ULONGLONGCONSTANT(0x00000000FFFFFFFF) & num)       );
+                    HH = (CLR_UINT32) (( ULONGLONGCONSTANT(0xFFFFFFFF00000000) & num) >> 32 );
                     return *this;
                 }
 
@@ -327,8 +327,8 @@ private:
                 S8 operator~()
                 {
                     S8 ret_value;
-                    ret_value._L = ~_L;
-                    ret_value._H = ~_H;    
+                    ret_value.LL = ~LL;
+                    ret_value.HH = ~HH;    
                     return ret_value;
                 }
 
@@ -344,22 +344,22 @@ private:
 
                 S8& operator&=( const S8& num )
                 {
-                    _L &= num._L;
-                    _H &= num._H;
+                    LL &= num.LL;
+                    HH &= num.HH;
                     return *this;
                 }
 
                 S8& operator|=( const S8& num )
                 {
-                    _L |= num._L;
-                    _H |= num._H;
+                    LL |= num.LL;
+                    HH |= num.HH;
                     return *this;
                 }
 
                 S8& operator^=( const S8& num )
                 {
-                    _L ^= num._L;
-                    _H ^= num._H;
+                    LL ^= num.LL;
+                    HH ^= num.HH;
                     return *this;
                 }
 
@@ -413,8 +413,8 @@ private:
 
             struct R8
             {
-                CLR_UINT32 _L;
-                CLR_UINT32 _H;
+                CLR_UINT32 LL;
+                CLR_UINT32 HH;
 
                 operator double() const
                 {
@@ -428,7 +428,7 @@ private:
 /// to copy byte by byte.
 ///
                     CLR_UINT8* tmp = (CLR_UINT8*)&ret_val;
-                    CLR_UINT8* src = (CLR_UINT8*)&_L;
+                    CLR_UINT8* src = (CLR_UINT8*)&LL;
                     int i;
                     
                     for(i=0; i<sizeof(CLR_UINT32); i++)
@@ -436,15 +436,15 @@ private:
                         *tmp++ = *src++;
                     }
 
-                    src = (CLR_UINT8*)&_H;
+                    src = (CLR_UINT8*)&HH;
                     for(i=0; i<sizeof(CLR_UINT32); i++)
                     {
                         *tmp++ = *src++;
                     }
 #else
                     CLR_UINT32 *tmp = (CLR_UINT32*)&ret_val;
-                    tmp[0]=_L;
-                    tmp[1]=_H;
+                    tmp[0]=LL;
+                    tmp[1]=HH;
 #endif // defined(__GNUC__)
 
                     return ret_val;
@@ -460,7 +460,7 @@ private:
 /// to copy byte by byte.
 ///
                     CLR_UINT8* src = (CLR_UINT8*)&num;
-                    CLR_UINT8* dst = (CLR_UINT8*)&_L;
+                    CLR_UINT8* dst = (CLR_UINT8*)&LL;
                     int i;
                     
                     for(i=0; i<sizeof(CLR_UINT32); i++)
@@ -468,15 +468,15 @@ private:
                         *dst++ = *src++;
                     }
 
-                    dst = (CLR_UINT8*)&_H;
+                    dst = (CLR_UINT8*)&HH;
                     for(i=0; i<sizeof(CLR_UINT32); i++)
                     {
                         *dst++ = *src++;
                     }
 #else
                     CLR_UINT32* tmp= (CLR_UINT32 *) &num;
-                    _L = (CLR_UINT32)tmp[0];
-                    _H = (CLR_UINT32)tmp[1];
+                    LL = (CLR_UINT32)tmp[0];
+                    HH = (CLR_UINT32)tmp[1];
 #endif
 
                     return *this;
@@ -549,34 +549,34 @@ private:
 
             struct R4 {
                
-                CLR_INT32  _L;
+                CLR_INT32  LL;
 
                 operator CLR_INT32 () const
                 {
-                    return _L;
+                    return LL;
                 }
 
                 R4& operator=( const CLR_INT32 num )
                 {
-                    _L = num;
+                    LL = num;
                     return *this;
                 }
                 R4& operator+=( const R4& num )
                 {
-                    _L += num._L;
+                    LL += num.LL;
                     return *this;
                 }
 
                 R4& operator-=( const R4& num )
                 {
-                    _L -= num._L;
+                    LL -= num.LL;
                    return *this;
                 }
 
 
                 R4& operator%=( const R4& num )
                 {
-                    _L %= num._L;
+                    LL %= num.LL;
                     return *this;
                 }
 
@@ -584,14 +584,14 @@ private:
                 R4 operator*( const R4& num )
                 {
                     R4  ret_value;
-                    ret_value._L = (CLR_INT32)(((CLR_INT64)_L * (CLR_INT64)num._L) >> HB_FloatShift );
+                    ret_value.LL = (CLR_INT32)(((CLR_INT64)LL * (CLR_INT64)num.LL) >> HB_FloatShift );
                     return ret_value;
                 }
 
                 R4 operator/( const R4& num )
                 {
                     R4 ret_value;
-                    ret_value._L = (CLR_INT32)((((CLR_INT64)_L) << HB_FloatShift)  / (CLR_INT64)num._L); 
+                    ret_value.LL = (CLR_INT32)((((CLR_INT64)LL) << HB_FloatShift)  / (CLR_INT64)num.LL); 
                     return ret_value;
                 }
 
@@ -599,18 +599,18 @@ private:
 
             struct R8
             {
-                CLR_UINT32 _L;
-                CLR_UINT32 _H;
+                CLR_UINT32 LL;
+                CLR_UINT32 HH;
 
                 operator CLR_INT64() const
                 {
-                    return ((CLR_INT64)_H << 32 | (CLR_INT64)_L );
+                    return ((CLR_INT64)HH << 32 | (CLR_INT64)LL );
                 }
 
                 R8& operator=( const CLR_INT64 num )
                 {
-                    _L = (CLR_UINT32) (( ULONGLONGCONSTANT(0x00000000FFFFFFFF) & num)       );
-                    _H = (CLR_UINT32) (( ULONGLONGCONSTANT(0xFFFFFFFF00000000) & num) >> 32 );
+                    LL = (CLR_UINT32) (( ULONGLONGCONSTANT(0x00000000FFFFFFFF) & num)       );
+                    HH = (CLR_UINT32) (( ULONGLONGCONSTANT(0xFFFFFFFF00000000) & num) >> 32 );
                     return *this;
                 }
 

--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -89,4 +89,15 @@ extern HAL_SYSTEM_CONFIG  HalSystemConfig;
 // this has to be provided at target level
 void NANOCLR_RELINQUISHEXECUTIONCONTROL();
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void nanoHAL_Initialize_C();
+void HeapLocation_C(unsigned char** baseAddress, unsigned int* sizeInBytes);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif // _NANOHAL_V2_H_

--- a/targets/CMSIS-OS/ChibiOS/common/WireProtocol_ReceiverThread.c
+++ b/targets/CMSIS-OS/ChibiOS/common/WireProtocol_ReceiverThread.c
@@ -18,6 +18,8 @@ void ReceiverThread(void const * argument)
 {
   (void)argument;
 
+  osDelay(500);
+
   // initialize Wire Protocol semaphore in the "not taken" state
   chBSemObjectInit(&wpChannelSemaphore, false);
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/CLRStartup.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/CLRStartup.cpp
@@ -282,7 +282,7 @@ void ClrStartup(CLR_SETTINGS params)
 #if !defined(BUILD_RTM)
         CLR_Debug::Printf( "\r\nnanoCLR (Build %d.%d.%d.%d)\r\n\r\n", VERSION_MAJOR, VERSION_MINOR, VERSION_BUILD, VERSION_REVISION );
         CLR_Debug::Printf( "\r\n%s\r\n\r\n", OEMSYSTEMINFOSTRING );
-        #endif
+#endif
 
         CLR_RT_Memory::Reset();
         

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/CLR_Startup_Thread.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/CLR_Startup_Thread.c
@@ -8,11 +8,8 @@
 
 #include <nanoCLR_Application.h>
 #include <nanoPAL_BlockStorage.h>
+#include <nanoHAL_v2.h>
 
-
-// need to declare this here because this is implemented as a C++ function
-// and the declaration is in nanoHAL.h which is including C++ declarations
-void nanoHAL_Initialize_C();
 
 // This thread needs to be implemented at ChibiOS level because it has to include a call to chThdShouldTerminateX()
 // in case the thread is requested to terminate by the CMSIS call osThreadTerminate()
@@ -23,6 +20,13 @@ void CLRStartupThread(void const * argument)
 
   // initialize block storage devices
   BlockStorage_AddDevices();
+
+  // clear managed heap region
+  uint8_t* baseAddress;
+  uint32_t sizeInBytes;
+
+  HeapLocation_C(&baseAddress, &sizeInBytes);
+  memset(baseAddress, 0, sizeInBytes);
 
   // initialize nanoHAL
   nanoHAL_Initialize_C();

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Memory.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Memory.cpp
@@ -6,10 +6,18 @@
 
 #include <nanoHAL.h>
 
+extern "C" {
+    void HeapLocation_C(unsigned char** baseAddress, unsigned int* sizeInBytes)
+    {
+        *baseAddress = (unsigned char*)(unsigned char*) &HeapBegin;
+        *sizeInBytes = (unsigned int)((size_t)&HeapEnd - (size_t)&HeapBegin);
+    }
+}
+
 void HeapLocation(unsigned char*& baseAddress, unsigned int& sizeInBytes)
 {
     NATIVE_PROFILE_PAL_HEAP();
 
     baseAddress = (unsigned char*)                            &HeapBegin;
-    sizeInBytes = (unsigned int)((size_t)&HeapEnd - (size_t)&HeapBegin + sizeof(HeapEnd));
+    sizeInBytes = (unsigned int)((size_t)&HeapEnd - (size_t)&HeapBegin);
 }

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Time.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Time.cpp
@@ -107,6 +107,31 @@ bool HAL_Time_TimeSpanToStringEx( const int64_t& ticks, char*& buf, size_t& len 
     return len != 0;
 }
 
+bool DateTimeToString(const int64_t& time, char*& buf, size_t& len )
+{
+    SYSTEMTIME st;
+
+    HAL_Time_ToSystemTime( time, &st );
+
+    return CLR_SafeSprintf(buf, len, "%4d/%02d/%02d %02d:%02d:%02d.%03d", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond, st.wMilliseconds );
+}
+
+char* DateTimeToString(const int64_t& time)
+{
+    static char rgBuffer[128];
+    char*  szBuffer =           rgBuffer;
+    size_t iBuffer  = ARRAYSIZE(rgBuffer);
+
+    DateTimeToString( time, szBuffer, iBuffer );
+
+    return rgBuffer;
+}
+
+const char* HAL_Time_CurrentDateTimeToString()
+{
+    return DateTimeToString(HAL_Time_CurrentDateTime(false));
+}
+
 unsigned __int64 CPU_MiliSecondsToSysTicks(unsigned __int64 miliSeconds)
 {
     return MS2ST(miliSeconds);


### PR DESCRIPTION

## Description
- Managed heap size was wrongly being set with the ending address overflowing to the next memory address.
- Managed heap region is now properly reset in start-up.
- Improved output messages on heap compactation.
- Moved declarations to nanoHAL_v2 header.


## Motivation and Context
- Fixes issue with execution of Heap_Compact() throwing hard fault.
- Managed heap should be reset at start-up (was not).

## How Has This Been Tested?<!-- (if applicable) -->
- Managed app can now safely call Debug.GC(true) without resetting board.
- Managed app running for a long time without crashing the board.


## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
