### PR TITLE
Correct missing call to wait debugger commands

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/CLRStartup.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/CLRStartup.cpp
@@ -318,7 +318,7 @@ void ClrStartup(CLR_SETTINGS params)
 
             if(params.EnterDebuggerLoopAfterExit)
             {
-                // UNDONE: FIXME: CLR_DBG_Debugger::Debugger_WaitForCommands();
+                CLR_DBG_Debugger::Debugger_WaitForCommands();
             }
         }
 


### PR DESCRIPTION
## Description
- Remove commented call.

## Motivation and Context
- This call has left commented after initial import preventing the CLR startup to remain in a loop waiting for debugger commands. It was wrongly exiting if there was no assembly to execute leaving the device dead in the water and requiring a reboot.
- Fixes nanoFramework/Home#250

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions
