### PR TITLE
Rework bool functions and args

### DIFF
--- a/src/CLR/Include/WireProtocol_App_Interface.h
+++ b/src/CLR/Include/WireProtocol_App_Interface.h
@@ -10,11 +10,11 @@
 
 //////////////////////////////////////////
 extern uint8_t receptionBuffer[2048];
-extern void ReplyToCommand(WP_Message* message, bool fSuccess, bool fCritical, void* ptr, int size);
+extern void ReplyToCommand(WP_Message* message, int fSuccess, int fCritical, void* ptr, int size);
 
 //////////////////////////////////////////
-bool WP_App_ProcessHeader(WP_Message* message);
-bool WP_App_ProcessPayload(WP_Message* message);
+int WP_App_ProcessHeader(WP_Message* message);
+int WP_App_ProcessPayload(WP_Message* message);
 
 #endif // _WIREPROTOCOL_APP_INTERFACE_H_
 

--- a/src/CLR/Include/WireProtocol_HAL_Interface.h
+++ b/src/CLR/Include/WireProtocol_HAL_Interface.h
@@ -9,8 +9,8 @@
 #include "WireProtocol.h"
 
 //////////////////////////////////////////
-bool WP_ReceiveBytes(uint8_t* ptr, unsigned short* size);
-bool WP_TransmitMessage(WP_Message* message);
+int WP_ReceiveBytes(uint8_t* ptr, unsigned short* size);
+int WP_TransmitMessage(WP_Message* message);
 void WP_CheckAvailableIncomingData();
 
 #endif // _WIREPROTOCOL_HAL_INTERFACE_H_

--- a/src/CLR/Include/WireProtocol_Message.h
+++ b/src/CLR/Include/WireProtocol_Message.h
@@ -38,10 +38,10 @@ void WP_Message_PrepareRequest(WP_Message* message, uint32_t cmd, uint32_t flags
 void WP_Message_PrepareReply(WP_Message* message, const WP_Packet* req, uint32_t flags, uint32_t payloadSize,  uint8_t* payload);
 void WP_Message_SetPayload(WP_Message* message, uint8_t* payload);
 void WP_Message_Release(WP_Message* message);
-bool WP_Message_VerifyHeader(WP_Message* message);
-bool WP_Message_VerifyPayload(WP_Message* message);
+int  WP_Message_VerifyHeader(WP_Message* message);
+int  WP_Message_VerifyPayload(WP_Message* message);
 void WP_Message_ReplyBadPacket(uint32_t flags);
-bool WP_Message_Process(WP_Message* message);
+int  WP_Message_Process(WP_Message* message);
 
 #ifdef __cplusplus
 }
@@ -54,7 +54,7 @@ bool WP_Message_Process(WP_Message* message);
 extern "C" {
 #endif
 
-void WP_ReplyToCommand(WP_Message* message, bool fSuccess, bool fCritical, void* ptr, int size);
+void WP_ReplyToCommand(WP_Message* message, int fSuccess, int fCritical, void* ptr, int size);
 void WP_SendProtocolMessage(WP_Message *message);
 void WP_PrepareAndSendProtocolMessage(uint32_t cmd, uint32_t payloadSize, uint8_t* payload, uint32_t flags);
 

--- a/src/CLR/Include/WireProtocol_MonitorCommands.h
+++ b/src/CLR/Include/WireProtocol_MonitorCommands.h
@@ -148,14 +148,14 @@ typedef struct CLR_DBG_Commands_Monitor_MemoryMap
 extern "C" {
 #endif
 
-bool Monitor_Ping(WP_Message* message);
-bool Monitor_OemInfo(WP_Message* message);
-bool Monitor_WriteMemory(WP_Message* message);
-bool Monitor_Reboot(WP_Message* message);
-bool Monitor_EraseMemory(WP_Message* message);
-bool Monitor_CheckMemory(WP_Message* message);
-bool Monitor_MemoryMap(WP_Message* message);
-bool Monitor_FlashSectorMap(WP_Message* message);
+int Monitor_Ping(WP_Message* message);
+int Monitor_OemInfo(WP_Message* message);
+int Monitor_WriteMemory(WP_Message* message);
+int Monitor_Reboot(WP_Message* message);
+int Monitor_EraseMemory(WP_Message* message);
+int Monitor_CheckMemory(WP_Message* message);
+int Monitor_MemoryMap(WP_Message* message);
+int Monitor_FlashSectorMap(WP_Message* message);
 
 #ifdef __cplusplus
 }

--- a/src/CLR/Messaging/Messaging.cpp
+++ b/src/CLR/Messaging/Messaging.cpp
@@ -479,7 +479,7 @@ bool CLR_Messaging::ProcessPayload( WP_Message* msg )
 }
 
 // wrapper function for CLR_Messaging::ProcessPayload(
-extern "C" bool CLR_Messaging_ProcessPayload(WP_Message* msg)
+extern "C" int CLR_Messaging_ProcessPayload(WP_Message* msg)
 {
     //CLR_Messaging* instance = (CLR_Messaging*)&g_scratchDebuggerMessaging[0];
 

--- a/src/CLR/WireProtocol/WireProtocol_App_Interface.c
+++ b/src/CLR/WireProtocol/WireProtocol_App_Interface.c
@@ -15,14 +15,14 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 // provided as weak to be replaced by actual implementation in the client application
-__nfweak bool WP_App_ProcessHeader(WP_Message* message)
+__nfweak int WP_App_ProcessHeader(WP_Message* message)
 {
     // default to false
     return false;
 }
 
 // provided as weak to be replaced by actual implementation in the client application
-__nfweak bool WP_App_ProcessPayload(WP_Message* message)
+__nfweak int WP_App_ProcessPayload(WP_Message* message)
 {
     // default to false
     return false; 

--- a/src/CLR/WireProtocol/WireProtocol_HAL_Interface.c
+++ b/src/CLR/WireProtocol/WireProtocol_HAL_Interface.c
@@ -16,14 +16,14 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 // provided as weak to be replaced by actual implementation by HAL interface
-__nfweak bool WP_ReceiveBytes(uint8_t* ptr, unsigned short* size)
+__nfweak int WP_ReceiveBytes(uint8_t* ptr, unsigned short* size)
 {
     // default to false
     return false;
 }
 
 // provided as weak to be replaced by actual implementation by HAL interface
-__nfweak bool WP_TransmitMessage(WP_Message* message)
+__nfweak int WP_TransmitMessage(WP_Message* message)
 {
     // default to false
     return false;

--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -18,7 +18,7 @@ extern void debug_printf( const char* format, ... );
 //////////////////////////////////////////
 // helper functions
 
-void WP_ReplyToCommand(WP_Message* message, bool fSuccess, bool fCritical, void* ptr, int size)
+void WP_ReplyToCommand(WP_Message* message, int fSuccess, int fCritical, void* ptr, int size)
 {
     WP_Message msgReply;
     uint32_t     flags = 0;
@@ -117,7 +117,7 @@ void WP_Message_Release(WP_Message* message)
     }
 }
 
-bool WP_Message_VerifyHeader(WP_Message* message)
+int WP_Message_VerifyHeader(WP_Message* message)
 {
     uint32_t crc = message->m_header.m_crcHeader;
     message->m_header.m_crcHeader = 0;
@@ -132,7 +132,7 @@ bool WP_Message_VerifyHeader(WP_Message* message)
     return true;
 }
 
-bool WP_Message_VerifyPayload(WP_Message* message)
+int WP_Message_VerifyPayload(WP_Message* message)
 {
     if(message->m_payload == NULL && message->m_header.m_size)
     {
@@ -157,7 +157,7 @@ void WP_Message_ReplyBadPacket(uint32_t flags)
     WP_TransmitMessage(&message);
 }
 
-bool WP_Message_Process(WP_Message* message)
+int WP_Message_Process(WP_Message* message)
 {
     uint8_t* buf = (uint8_t*)&message->m_header;
     int len;

--- a/src/CLR/WireProtocol/WireProtocol_MonitorCommands.c
+++ b/src/CLR/WireProtocol/WireProtocol_MonitorCommands.c
@@ -9,56 +9,56 @@
 ////////////////////////////////////////////////////
 
 // provided as weak to be replaced by actual implementation by application
-__nfweak bool Monitor_Ping(WP_Message* message)
+__nfweak int Monitor_Ping(WP_Message* message)
 {
    // default to false
    return false;
 }
 
 // provided as weak to be replaced by actual implementation by application
-__nfweak bool Monitor_OemInfo(WP_Message* message)
+__nfweak int Monitor_OemInfo(WP_Message* message)
 {
    // default to false
    return false;
 }
 
 // provided as weak to be replaced by actual implementation by application
-__nfweak bool Monitor_WriteMemory(WP_Message* message)
+__nfweak int Monitor_WriteMemory(WP_Message* message)
 {
    // default to false
    return false;
 }
 
 // provided as weak to be replaced by actual implementation by application
-__nfweak bool Monitor_Reboot(WP_Message* message)
+__nfweak int Monitor_Reboot(WP_Message* message)
 {
    // default to false
    return false;
 }
 
 // provided as weak to be replaced by actual implementation by application
-__nfweak bool Monitor_EraseMemory(WP_Message* message)
+__nfweak int Monitor_EraseMemory(WP_Message* message)
 {
    // default to false
    return false;
 }
 
 // provided as weak to be replaced by actual implementation by application
-__nfweak bool Monitor_CheckMemory(WP_Message* message)
+__nfweak int Monitor_CheckMemory(WP_Message* message)
 {
    // default to false
    return false;
 }
 
 // provided as weak to be replaced by actual implementation by application
-__nfweak bool Monitor_MemoryMap(WP_Message* message)
+__nfweak int Monitor_MemoryMap(WP_Message* message)
 {
    // default to false
    return false;
 }
 
 // provided as weak to be replaced by actual implementation by application
-__nfweak bool Monitor_FlashSectorMap(WP_Message* message)
+__nfweak int Monitor_FlashSectorMap(WP_Message* message)
 {
    // default to false
    return false;

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/CMakeLists.txt
@@ -175,7 +175,7 @@ nf_set_linker_options(${NANOCLR_PROJECT_NAME}.elf TRUE)
 # the size of the CLR managed heap is defined here
 ###################################################
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x400")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x1800")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x800,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x1800")
 
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
@@ -51,14 +51,14 @@ int main(void) {
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
-  osDelay(20);    // Let init stabilize
+  //osDelay(100);    // Let init stabilize
 
   // the following IF is not mandatory, it's just providing a way for a user to 'force'
   // the board to remain in nanoBooter and not launching nanoCLR
 
   // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
   // the user button in this board has a pull-up resistor so the check has to be inverted
-  if (palReadPad(GPIOA, GPIOA_BUTTON))
+  if (!palReadPad(GPIOA, GPIOA_BUTTON))
   {
     // check for valid CLR image 
     if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/main.c
@@ -59,7 +59,7 @@ int main(void) {
   // EXT driver needs to be started from main   
   #if (HAL_USE_EXT == TRUE)
   extStart(&EXTD1, &extInterruptsConfiguration);
-  #endif
+  #endif 
 
   // start kernel, after this main() will behave like a thread with priority osPriorityNormal
   osKernelStart();

--- a/targets/CMSIS-OS/ChibiOS/common/WireProtocol_HAL_Interface.c
+++ b/targets/CMSIS-OS/ChibiOS/common/WireProtocol_HAL_Interface.c
@@ -29,7 +29,7 @@ binary_semaphore_t wpChannelSemaphore;
 
 #if (HAL_USE_SERIAL_USB == TRUE)
 
-bool WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
+int WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
 {
     // save for latter comparison
     uint16_t requestedSize = *size;
@@ -72,7 +72,7 @@ bool WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
 }
 #elif (HAL_USE_SERIAL == TRUE)
 
-bool WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
+int WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
 {
     // save for latter comparison
     uint16_t requestedSize = *size;
@@ -121,7 +121,7 @@ bool WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
 
 #if (HAL_USE_SERIAL_USB == TRUE)
 
-bool WP_TransmitMessage(WP_Message* message)
+int WP_TransmitMessage(WP_Message* message)
 {
     int writeResult;
     bool operationResult = false;
@@ -181,7 +181,7 @@ bool WP_TransmitMessage(WP_Message* message)
 }
 #elif (HAL_USE_SERIAL == TRUE)
 
-bool WP_TransmitMessage(WP_Message* message)
+int WP_TransmitMessage(WP_Message* message)
 {
     int writeResult;
     bool operationResult = false;

--- a/targets/CMSIS-OS/ChibiOS/common/WireProtocol_ReceiverThread.c
+++ b/targets/CMSIS-OS/ChibiOS/common/WireProtocol_ReceiverThread.c
@@ -5,7 +5,6 @@
 
 #include <ch.h>
 #include <cmsis_os.h>
-
 #include "WireProtocol_HAL_Interface.h"
 
 extern WP_Message inboundMessage;

--- a/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_App_Interface.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_App_Interface.c
@@ -50,7 +50,7 @@ static const CommandHandlerLookup c_Lookup_Reply[] =
     /*******************************************************************************************************************************************************************/
 };
 
-bool WP_App_ProcessHeader(WP_Message* message)
+int WP_App_ProcessHeader(WP_Message* message)
 {
     // check for reception buffer overflow 
     if(message->m_header.m_size > sizeof(receptionBuffer))
@@ -62,7 +62,7 @@ bool WP_App_ProcessHeader(WP_Message* message)
     return true;
 }
 
-bool WP_App_ProcessPayload(WP_Message* message)
+int WP_App_ProcessPayload(WP_Message* message)
 {
     // Prevent processing duplicate packets
     if(message->m_header.m_seq == lastPacketSequence)
@@ -100,7 +100,7 @@ bool WP_App_ProcessPayload(WP_Message* message)
         if(cmd->command == message->m_header.m_cmd)
         {
             // execute command handler and save the result
-            bool commandHandlerExecuteResult = ((bool* (*)(WP_Message*))cmd->handler)(message);
+            int commandHandlerExecuteResult = ((int* (*)(WP_Message*))cmd->handler)(message);
 
             WP_ReplyToCommand(message, commandHandlerExecuteResult, false, NULL, 0);
             return true;

--- a/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
@@ -15,7 +15,7 @@
 //////////////////////////////////////////////////////////////////////
 // helper functions
 
-bool NanoBooter_GetReleaseInfo(ReleaseInfo* releaseInfo)
+int NanoBooter_GetReleaseInfo(ReleaseInfo* releaseInfo)
 {
     releaseInfo->version.usMajor = VERSION_MAJOR;
     releaseInfo->version.usMinor = VERSION_MINOR;
@@ -27,7 +27,7 @@ bool NanoBooter_GetReleaseInfo(ReleaseInfo* releaseInfo)
     return true;
 }
 
-static bool AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t* buffer, int mode, unsigned int* errorCode)
+static int AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t* buffer, int mode, unsigned int* errorCode)
 {
     // reset error code
     *errorCode = AccessMemoryErrorCode_NoError;
@@ -60,7 +60,7 @@ static bool AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t* buf
 
 ////////////////////////////////////////////////////
 
-bool Monitor_Ping(WP_Message* message)
+int Monitor_Ping(WP_Message* message)
 {
     if((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
@@ -73,7 +73,7 @@ bool Monitor_Ping(WP_Message* message)
     return true;
 }
 
-bool Monitor_OemInfo(WP_Message* message)
+int Monitor_OemInfo(WP_Message* message)
 {
     if((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
@@ -87,7 +87,7 @@ bool Monitor_OemInfo(WP_Message* message)
     return true;
 }
 
-bool Monitor_WriteMemory(WP_Message* message)
+int Monitor_WriteMemory(WP_Message* message)
 {
     CLR_DBG_Commands_Monitor_WriteMemory* cmd = (CLR_DBG_Commands_Monitor_WriteMemory*)message->m_payload;
     CLR_DBG_Commands_Monitor_WriteMemory_Reply cmdReply;
@@ -112,7 +112,7 @@ bool Monitor_WriteMemory(WP_Message* message)
     return true;
 }
 
-bool Monitor_Reboot(WP_Message* message)
+int Monitor_Reboot(WP_Message* message)
 {
     Monitor_Reboot_Command* cmd = (Monitor_Reboot_Command*)message->m_payload;
 
@@ -134,7 +134,7 @@ bool Monitor_Reboot(WP_Message* message)
     return true;
 }
 
-bool Monitor_EraseMemory(WP_Message* message)
+int Monitor_EraseMemory(WP_Message* message)
 {
     CLR_DBG_Commands_Monitor_EraseMemory* cmd = (CLR_DBG_Commands_Monitor_EraseMemory*)message->m_payload;
     CLR_DBG_Commands_Monitor_EraseMemory_Reply cmdReply;
@@ -149,7 +149,7 @@ bool Monitor_EraseMemory(WP_Message* message)
     return true;
 }
 
-bool Monitor_CheckMemory(WP_Message* message)
+int Monitor_CheckMemory(WP_Message* message)
 {
     bool ret = false;
 
@@ -164,7 +164,7 @@ bool Monitor_CheckMemory(WP_Message* message)
     return ret;
 }
 
-bool Monitor_MemoryMap(WP_Message* message)
+int Monitor_MemoryMap(WP_Message* message)
 {
     MemoryMap_Range map[2];
 
@@ -188,7 +188,7 @@ bool Monitor_MemoryMap(WP_Message* message)
     return true;
 }
 
-bool Monitor_FlashSectorMap(WP_Message* message)
+int Monitor_FlashSectorMap(WP_Message* message)
 {
     struct Flash_Sector
     {

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/WireProtocol_App_Interface.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/WireProtocol_App_Interface.c
@@ -9,7 +9,7 @@
 
 
 // declaration for wrapper function
-extern bool CLR_Messaging_ProcessPayload(WP_Message* msg);
+extern int CLR_Messaging_ProcessPayload(WP_Message* msg);
 
 
 // Initialize to a packet sequence number impossible to encounter
@@ -54,7 +54,7 @@ static const CommandHandlerLookup c_Lookup_Reply[] =
     /*******************************************************************************************************************************************************************/
 };
 
-bool WP_App_ProcessHeader(WP_Message* message)
+int WP_App_ProcessHeader(WP_Message* message)
 {
     // check for reception buffer overflow 
     if(message->m_header.m_size > sizeof(receptionBuffer))
@@ -66,7 +66,7 @@ bool WP_App_ProcessHeader(WP_Message* message)
     return true;
 }
 
-bool WP_App_ProcessPayload(WP_Message* message)
+int WP_App_ProcessPayload(WP_Message* message)
 {
     return CLR_Messaging_ProcessPayload(message);
 }

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/stm32_flash/hal_stm32_flash.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/stm32_flash/hal_stm32_flash.h
@@ -42,9 +42,9 @@ extern "C" {
   void stm32FlashInit(void);
   void stm32FlashObjectInit(SMT32FlashDriver* flash);
   void stm32FlashReadBytes(uint32_t startAddress, uint32_t length, uint8_t* buffer);
-  bool stm32FlashWrite(uint32_t startAddress, uint32_t length, const uint8_t* buffer);
-  bool stm32FlashIsErased(uint32_t startAddress, uint32_t length);
-  bool stm32FlashErase(uint32_t address);
+  int  stm32FlashWrite(uint32_t startAddress, uint32_t length, const uint8_t* buffer);
+  int  stm32FlashIsErased(uint32_t startAddress, uint32_t length);
+  int  stm32FlashErase(uint32_t address);
 
 #ifdef __cplusplus
 }

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.c
@@ -75,7 +75,7 @@ void flash_lld_readBytes(uint32_t startAddress, uint32_t length, uint8_t* buffer
     }
 }
 
-bool flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer) {
+int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer) {
 
     __IO uint8_t* cursor = (__IO uint8_t*)startAddress;
     __IO uint8_t* endAddress = (__IO uint8_t*)(startAddress + length);
@@ -123,7 +123,7 @@ bool flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buff
     return false;
 }
 
-bool flash_lld_isErased(uint32_t startAddress, uint32_t length) {
+int flash_lld_isErased(uint32_t startAddress, uint32_t length) {
 
     __IO uint32_t* cursor = (__IO uint32_t*)startAddress;
     __IO uint32_t* endAddress = (__IO uint32_t*)(startAddress + length);
@@ -148,7 +148,7 @@ uint8_t flash_lld_getSector(uint32_t address)
   return (address - FLASH_BASE) / F0_SERIES_SECTOR_SIZE;
 }
 
-bool flash_lld_erase(uint32_t address) {
+int flash_lld_erase(uint32_t address) {
 
     // unlock the FLASH
     if(HAL_FLASH_Unlock())

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.h
@@ -80,9 +80,9 @@ extern "C" {
   
   void flash_lld_init();
   void flash_lld_readBytes(uint32_t startAddress, uint32_t length, uint8_t* buffer);
-  bool flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer);
-  bool flash_lld_isErased(uint32_t startAddress, uint32_t length);
-  bool flash_lld_erase(uint32_t address);
+  int  flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer);
+  int  flash_lld_isErased(uint32_t startAddress, uint32_t length);
+  int  flash_lld_erase(uint32_t address);
   uint8_t flash_lld_getSector(uint32_t address);
 
 #ifdef __cplusplus

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
@@ -123,7 +123,7 @@ void flash_lld_readBytes(uint32_t startAddress, uint32_t length, uint8_t* buffer
     }
 }
 
-bool flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer) {
+int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer) {
 
     __IO uint8_t* cursor = (__IO uint8_t*)startAddress;
     __IO uint8_t* endAddress = (__IO uint8_t*)(startAddress + length);
@@ -212,7 +212,7 @@ bool flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buff
     return false;
 }
 
-bool flash_lld_isErased(uint32_t startAddress, uint32_t length) {
+int flash_lld_isErased(uint32_t startAddress, uint32_t length) {
 
     __IO uint32_t* cursor = (__IO uint32_t*)startAddress;
     __IO uint32_t* endAddress = (__IO uint32_t*)(startAddress + length);
@@ -312,7 +312,7 @@ uint8_t flash_lld_getSector(uint32_t address)
   return sector;
 }
 
-bool flash_lld_erase(uint32_t address) {
+int flash_lld_erase(uint32_t address) {
 
     // unlock the FLASH
     if(HAL_FLASH_Unlock())

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.h
@@ -420,9 +420,9 @@ extern "C" {
   
   void flash_lld_init();
   void flash_lld_readBytes(uint32_t startAddress, uint32_t length, uint8_t* buffer);
-  bool flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer);
-  bool flash_lld_isErased(uint32_t startAddress, uint32_t length);
-  bool flash_lld_erase(uint32_t address);
+  int  flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer);
+  int  flash_lld_isErased(uint32_t startAddress, uint32_t length);
+  int  flash_lld_erase(uint32_t address);
   uint8_t flash_lld_getSector(uint32_t address);
 
 #ifdef __cplusplus

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_flash/hal_stm32_flash.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_flash/hal_stm32_flash.c
@@ -42,19 +42,19 @@ void stm32FlashReadBytes(uint32_t startAddress, uint32_t length, uint8_t* buffer
   flash_lld_readBytes(startAddress, length, buffer);
 }
 
-bool stm32FlashWrite(uint32_t startAddress, uint32_t length, const uint8_t* buffer) {
+int stm32FlashWrite(uint32_t startAddress, uint32_t length, const uint8_t* buffer) {
   osalDbgCheck((startAddress > FLASH_BASE) && (length > 0U) && (buffer != NULL));
 
   return flash_lld_write(startAddress, length, buffer);
 }
 
-bool stm32FlashIsErased(uint32_t startAddress, uint32_t length) {
+int stm32FlashIsErased(uint32_t startAddress, uint32_t length) {
   osalDbgCheck((startAddress > FLASH_BASE) && (length > 0U));
 
   return flash_lld_isErased(startAddress, length);
 }
 
-bool stm32FlashErase(uint32_t address) {
+int stm32FlashErase(uint32_t address) {
   osalDbgCheck(address > FLASH_BASE);
 
   return flash_lld_erase(address);

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/stm32-internal-flash-driver.md
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/stm32-internal-flash-driver.md
@@ -16,16 +16,16 @@ The functions provided by driver are:
   - length: how many bytes to be read from the flash
   - buffer: pointer to the buffer where to read the flash data
 
-- ```bool stm32FlashWrite(uint32_t startAddress, uint32_t length, const uint8_t* buffer)```
+- ```int stm32FlashWrite(uint32_t startAddress, uint32_t length, const uint8_t* buffer)```
   - startAddress: the flash start address where to write data to
   - length: how many bytes to be written to the flash
   - buffer: pointer to the buffer whit the data to be written to the flash
 
-- ```bool stm32FlashIsErased(uint32_t startAddress, uint32_t length)```
+- ```int stm32FlashIsErased(uint32_t startAddress, uint32_t length)```
   - startAddress: the flash start address to check if it's erased
   - length: length of the flash segment to check if it's erased
 
-- ```bool stm32FlashErase(uint32_t address)```
+- ```int stm32FlashErase(uint32_t address)```
   - address: the flash address belonging to the segment to be erased (this can be a block or a page depending on the flash organization of the target series)
 
 The driver performs basic and trivial checks on the arguments passed.

--- a/targets/os/mbed-os/nanoBooter/WireProtocol.cpp
+++ b/targets/os/mbed-os/nanoBooter/WireProtocol.cpp
@@ -87,7 +87,7 @@ void WP_Message::Release()
     }
 }
 
-bool WP_Message::VerifyHeader()
+int WP_Message::VerifyHeader()
 {
     unsigned int crc = m_header.m_crcHeader;
     m_header.m_crcHeader = 0;
@@ -102,7 +102,7 @@ bool WP_Message::VerifyHeader()
     return true;
 }
 
-bool WP_Message::VerifyPayload()
+int WP_Message::VerifyPayload()
 {
     if(m_payload == NULL && m_header.m_size)
     {
@@ -127,7 +127,7 @@ void WP_Message::ReplyBadPacket(unsigned int flags)
     m_parent->SendProtocolMessage(msg);
 }
 
-bool WP_Message::Process()
+int WP_Message::Process()
 {
     unsigned char* buf = (unsigned char*)&m_header;
     int len;
@@ -324,18 +324,18 @@ void WP_Controller::Initialize(const char* szMarker, const WP_PhysicalLayer* phy
     m_inboundMessage.PrepareReception();
 }
 
-bool WP_Controller::AdvanceState()
+int WP_Controller::AdvanceState()
 {
     return m_inboundMessage.Process();
 }
 
-bool WP_Controller::SendProtocolMessage(const WP_Message& msg)
+int WP_Controller::SendProtocolMessage(const WP_Message& msg)
 {
     TRACE(TRACE_HEADERS, "TXMSG: 0x%08X, 0x%08X, 0x%08X\n", msg.m_header.m_cmd, msg.m_header.m_flags, msg.m_header.m_size);
     return m_phy->TransmitMessage(m_state, &msg);
 }
 
-bool WP_Controller::SendProtocolMessage(unsigned int cmd, unsigned int flags, unsigned int payloadSize, unsigned char* payload)
+int WP_Controller::SendProtocolMessage(unsigned int cmd, unsigned int flags, unsigned int payloadSize, unsigned char* payload)
 {
     WP_Message msg;
     msg.Initialize(this);

--- a/targets/os/mbed-os/nanoBooter/WireProtocol.h
+++ b/targets/os/mbed-os/nanoBooter/WireProtocol.h
@@ -94,15 +94,15 @@ struct WP_PhysicalLayer
     // TransmitMessage has to be fully buffered, in the sense it should accept all the input and return.
     // Blocking behavior has to be hidden in the driver.
     //
-    bool (*ReceiveBytes)(void* state, unsigned char*& ptr, unsigned int & size);
-    bool (*TransmitMessage)(void* state, const WP_Message* msg);
+    int (*ReceiveBytes)(void* state, unsigned char*& ptr, unsigned int & size);
+    int (*TransmitMessage)(void* state, const WP_Message* msg);
 };
 
 struct WP_ApplicationLayer
 {
-    bool (*ProcessHeader)(void* state, WP_Message* msg);
-    bool (*ProcessPayload)(void* state, WP_Message* msg);
-    bool (*Release)(void* state, WP_Message* msg);
+    int (*ProcessHeader)(void* state, WP_Message* msg);
+    int (*ProcessPayload)(void* state, WP_Message* msg);
+    int (*Release)(void* state, WP_Message* msg);
 };
 
 //--//
@@ -139,11 +139,11 @@ public:
     void PrepareReply(const WP_Packet& req, unsigned int flags, unsigned int payloadSize, unsigned char* payload);
     void SetPayload(unsigned char* payload);
     void Release();
-    bool Process();
+    int  Process();
 
 private:
-    bool VerifyHeader ();
-    bool VerifyPayload();
+    int  VerifyHeader ();
+    int  VerifyPayload();
     void ReplyBadPacket(unsigned int flags);
 };
 
@@ -159,9 +159,9 @@ struct WP_Controller
 
 
     void Initialize(const char* szMarker, const WP_PhysicalLayer* phy, const WP_ApplicationLayer* app, void* state);
-    bool AdvanceState();
-    bool SendProtocolMessage(const WP_Message& msg);
-    bool SendProtocolMessage(unsigned int cmd, unsigned int flags = 0, unsigned int payloadSize = 0, unsigned char* payload = NULL);
+    int  AdvanceState();
+    int  SendProtocolMessage(const WP_Message& msg);
+    int  SendProtocolMessage(unsigned int cmd, unsigned int flags = 0, unsigned int payloadSize = 0, unsigned char* payload = NULL);
 };
 
 //--//


### PR DESCRIPTION
## Description
- Replace return types and arguments from bool by int on functions used in C and C++

## Motivation and Context
- This was causing compiler warnings becuase of C code being called by C++ code

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
