### PR TITLE
Amend comparison size of assembly marker

### DIFF
--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -52,7 +52,7 @@ int s_CLR_RT_fTrace_SimulateSpeed              = NANOCLR_TRACE_DEFAULT(c_CLR_RT_
 #endif
 
 #if !defined(BUILD_RTM)
-int s_CLR_RT_fTrace_AssemblyOverhead           = NANOCLR_TRACE_DEFAULT(c_CLR_RT_Trace_Info,c_CLR_RT_Trace_None);
+int s_CLR_RT_fTrace_AssemblyOverhead           = NANOCLR_TRACE_DEFAULT(c_CLR_RT_Trace_Info,c_CLR_RT_Trace_Info);
 #endif
 
 #if defined(WIN32)
@@ -1324,7 +1324,7 @@ HRESULT CLR_RT_TypeDescriptor::ExtractTypeIndexFromObject( const CLR_RT_HeapBloc
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 //
-// Keep these strings less than 8-character long!! They are stuffed into an 8-byte structure.
+// Keep this string less than 8-character long (including terminator) because it's stuffed into an 8-byte structure.
 //
 static const char c_MARKER_ASSEMBLY_V1[] = "NFMRK1";
 
@@ -1337,7 +1337,7 @@ bool CLR_RECORD_ASSEMBLY::GoodHeader() const
 
     if(this->stringTableVersion != c_CLR_StringTable_Version) return false;
 
-    return memcmp( marker, c_MARKER_ASSEMBLY_V1, sizeof(marker) ) == 0;
+    return memcmp( marker, c_MARKER_ASSEMBLY_V1, sizeof(c_MARKER_ASSEMBLY_V1) ) == 0;
 }
 
 bool CLR_RECORD_ASSEMBLY::GoodAssembly() const


### PR DESCRIPTION
## Description
- The comparison was being made on the max possible lenght of the struct field. This fails when the actual string constant is shorter than that (as it is) and the memory space ahead is not cleaned.


## Motivation and Context
- Fixes nanoframework/Home#251 and nanoframework/Home#252


## How Has This Been Tested?<!-- (if applicable) -->
- Build image in MinRelSize, flash device and start debugging of managed app 

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
