### PR TITLE
Change Spi Full-duplex buffer size

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -233,12 +233,12 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer
             if (fullDuplex)
             {
                 // Full duplex
-                spiExchange(cfg.Driver, writeSize, &writeData[0], &readData[0]);    
+                spiExchange(cfg.Driver, writeSize > readSize ? writeSize : readSize, writeData, readData);
             }
             else
             {
-                spiSend(cfg.Driver, writeSize, &writeData[0]);
-                spiReceive(cfg.Driver, readSize, &readData[0]);
+                spiSend(cfg.Driver, writeSize, writeData);
+                spiReceive(cfg.Driver, readSize, readData);
             }
         }
         else
@@ -246,11 +246,11 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer
             // Transmit only or Receive only
             if (readSize != 0) 
             {
-                spiReceive(cfg.Driver, readSize, &readData[0]);
+                spiReceive(cfg.Driver, readSize, readData);
             }
             else
             {
-                spiSend(cfg.Driver, writeSize, &writeData[0]);
+                spiSend(cfg.Driver, writeSize, writeData);
             }
         }
         // Release the bus
@@ -344,12 +344,13 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer
             if (fullDuplex)
             {
                 // Full duplex
-                spiExchange(cfg.Driver, writeSize, &writeData[0], &readData[0]);    
+                // Uses the largest buffer size as transfer size
+                spiExchange(cfg.Driver, writeSize > readSize ? writeSize : readSize, writeData, readData);
             }
             else
             {
-                spiSend(cfg.Driver, writeSize, &writeData[0]);
-                spiReceive(cfg.Driver, readSize, &readData[0]);
+                spiSend(cfg.Driver, writeSize, writeData);
+                spiReceive(cfg.Driver, readSize, readData);
             }
         }
         else
@@ -357,11 +358,11 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer
             // Transmit only or Receive only
             if (readSize != 0) 
             {
-                spiReceive(cfg.Driver, readSize, &readData[0]);
+                spiReceive(cfg.Driver, readSize, readData);
             }
             else
             {
-                spiSend(cfg.Driver, writeSize, &writeData[0]);
+                spiSend(cfg.Driver, writeSize, writeData);
             }
         }
 


### PR DESCRIPTION
## Description
Fix the size of the buffer used for full-duplex transfers. It is now using the largest buffer between writeData and readData.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes a potential bug when receive buffer is larger than send buffer in full-duplex transfers.

## How Has This Been Tested?
It now correctly reads JEDEC SFDP information on Quail's onboard Flash chip in both full-duplex and sequential transfers.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

