### PR TITLE
Update corlib_native_System_Number.cpp

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -81,22 +81,22 @@ HRESULT Library_corlib_native_System_Number::FormatNative___STATIC__STRING__OBJE
         switch(dt)
         {
         case DATATYPE_I1: 
-            hal_snprintf( result, ARRAYSIZE(result), "%.*d", precision, value->NumericByRef().s1 ); 
+            hal_snprintf( result, ARRAYSIZE(result), formatCh == 'N' ? "%d" : "%.*d", formatCh == 'N' ? value->NumericByRef().s1 : precision, value->NumericByRef().s1 );
             break;
         case DATATYPE_U1: 
-            hal_snprintf( result, ARRAYSIZE(result), "%.*u", precision, value->NumericByRef().u1 ); 
+            hal_snprintf( result, ARRAYSIZE(result), formatCh == 'N' ? "%u" : "%.*u", formatCh == 'N' ? value->NumericByRef().u1 : precision, value->NumericByRef().u1 );
             break;
         case DATATYPE_I2: 
-            hal_snprintf( result, ARRAYSIZE(result), "%.*d", precision, value->NumericByRef().s2 ); 
+            hal_snprintf( result, ARRAYSIZE(result), formatCh == 'N' ? "%d" : "%.*d", formatCh == 'N' ? value->NumericByRef().s2 : precision, value->NumericByRef().s2 );
             break;
         case DATATYPE_U2: 
-            hal_snprintf( result, ARRAYSIZE(result), "%.*u", precision, value->NumericByRef().u2 ); 
+            hal_snprintf( result, ARRAYSIZE(result), formatCh == 'N' ? "%u" : "%.*u", formatCh == 'N' ? value->NumericByRef().u2 : precision, value->NumericByRef().u2 );
             break;
         case DATATYPE_I4: 
-            hal_snprintf( result, ARRAYSIZE(result), "%.*d", precision, value->NumericByRef().s4 ); 
+            hal_snprintf( result, ARRAYSIZE(result), formatCh == 'N' ? "%d" : "%.*d", formatCh == 'N' ? value->NumericByRef().s4 : precision, value->NumericByRef().s4 );
             break;
         case DATATYPE_U4: 
-            hal_snprintf( result, ARRAYSIZE(result), "%.*u", precision, value->NumericByRef().u4 ); 
+            hal_snprintf( result, ARRAYSIZE(result), formatCh == 'N' ? "%u" : "%.*u", formatCh == 'N' ? value->NumericByRef().u4 : precision, value->NumericByRef().u4 );
             break;
 #if defined(_WIN32)
         case DATATYPE_I8: 


### PR DESCRIPTION
## Description
Make ouput conform to .Net Desktop regarding formatting of integers and precision.

## Motivation and Context
Output from .ToString(format) was not compliant with .Net desktop.

## How Has This Been Tested?
```
private static uint myVar = 2;
private static uint myVar0 = 0;

Console.WriteLine("myVar0 = " + myVar0.ToString("N0"));
Console.WriteLine("myVar0 = " + myVar0.ToString("N1"));
Console.WriteLine("myVar0 = " + myVar0.ToString("N2"));

Console.WriteLine("myVar = " + myVar.ToString("N0"));
Console.WriteLine("myVar = " + myVar.ToString("N1"));
Console.WriteLine("myVar = " + myVar.ToString("N2"));
Console.WriteLine("myVar = " + myVar.ToString("N3"));
Console.WriteLine("myVar = " + myVar.ToString("N4"));
Console.WriteLine("myVar = " + myVar.ToString("D4"));
```
nanoFramework now returns :

> myVar0 = 0
> myVar0 = 0.0
> myVar0 = 0.00
> myVar = 2
> myVar = 2.0
> myVar = 2.00
> myVar = 2.000
> myVar = 2.0000
> myVar = 0002

.Net Desktop returns :

> myVar0 = 0
> myVar0 = 0,0
> myVar0 = 0,00
> myVar = 2
> myVar = 2,0
> myVar = 2,00
> myVar = 2,000
> myVar = 2,0000
> myVar = 0002

The only difference is the CultureInfo that is US in nanoFramework.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
