### PR TITLE
Correct UART_INIT macro for F4 and F0 targets

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native.h
@@ -221,7 +221,7 @@ extern uint8_t Uart8_RxBuffer[];
     Uart##num##_PAL.Uart_cfg.cr1 = 0; \
     Uart##num##_PAL.Uart_cfg.cr2 = 0; \
     Uart##num##_PAL.Uart_cfg.cr3 = 0; \
-    Uart##num##_TxBuffer = (uint8_t*)chHeapAlloc(NULL, tx_buffer_size); \
+    Uart##num##_PAL.TxBuffer = Uart##num##_TxBuffer; \
     Uart##num##_PAL.TxRingBuffer.Initialize( Uart##num##_PAL.TxBuffer, tx_buffer_size); \
     Uart##num##_PAL.TxOngoingCount = 0; \
     Uart##num##_PAL.RxBuffer = Uart##num##_RxBuffer; \


### PR DESCRIPTION
## Description
- Correct UART_INIT macro for F4 and F0 targets

## Motivation and Context
- The buffer declaration was wrong

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
