### PR TITLE
Improve serial operations

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native.h
@@ -106,6 +106,7 @@ struct NF_PAL_UART
 
     HAL_RingBuffer<uint8_t> RxRingBuffer;
     uint8_t* RxBuffer;
+    uint16_t RxBytesToRead;
 };
 
 


### PR DESCRIPTION
## Description
- Rework Store and Read to use CLR events for timeout

## Motivation and Context
- The previous implementation using the RTOS waiting functions was blocking the execution engine, thus preventing all other managed threads to run.

## How Has This Been Tested?<!-- (if applicable) -->
- Serial Comm app from samples repo


## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
