### PR TITLE
Fix CMake Find modules

### DIFF
--- a/CMake/Modules/FindWindows.Devices.Adc.cmake
+++ b/CMake/Modules/FindWindows.Devices.Adc.cmake
@@ -38,4 +38,4 @@ endforeach()
 
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(NF_Debugger DEFAULT_MSG Windows.Devices.Adc_INCLUDE_DIRS Windows.Devices.Adc_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Windows.Devices.Adc DEFAULT_MSG Windows.Devices.Adc_INCLUDE_DIRS Windows.Devices.Adc_SOURCES)

--- a/CMake/Modules/FindWindows.Devices.Gpio.cmake
+++ b/CMake/Modules/FindWindows.Devices.Gpio.cmake
@@ -54,4 +54,4 @@ endforeach()
 
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(NF_Debugger DEFAULT_MSG Windows.Devices.Gpio_INCLUDE_DIRS Windows.Devices.Gpio_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Windows.Devices.Gpio DEFAULT_MSG Windows.Devices.Gpio_INCLUDE_DIRS Windows.Devices.Gpio_SOURCES)

--- a/CMake/Modules/FindWindows.Devices.I2c.cmake
+++ b/CMake/Modules/FindWindows.Devices.I2c.cmake
@@ -38,4 +38,4 @@ endforeach()
 
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(NF_Debugger DEFAULT_MSG Windows.Devices.I2c_INCLUDE_DIRS Windows.Devices.I2c_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Windows.Devices.I2c DEFAULT_MSG Windows.Devices.I2c_INCLUDE_DIRS Windows.Devices.I2c_SOURCES)

--- a/CMake/Modules/FindWindows.Devices.Pwm.cmake
+++ b/CMake/Modules/FindWindows.Devices.Pwm.cmake
@@ -39,4 +39,4 @@ endforeach()
 
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(NF_Debugger DEFAULT_MSG Windows.Devices.Pwm_INCLUDE_DIRS Windows.Devices.Pwm_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Windows.Devices.Pwm DEFAULT_MSG Windows.Devices.Pwm_INCLUDE_DIRS Windows.Devices.Pwm_SOURCES)

--- a/CMake/Modules/FindWindows.Devices.SerialCommunication.cmake
+++ b/CMake/Modules/FindWindows.Devices.SerialCommunication.cmake
@@ -37,4 +37,4 @@ endforeach()
 
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(NF_Debugger DEFAULT_MSG Windows.Devices.SerialCommunication_INCLUDE_DIRS Windows.Devices.SerialCommunication_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Windows.Devices.SerialCommunication DEFAULT_MSG Windows.Devices.SerialCommunication_INCLUDE_DIRS Windows.Devices.SerialCommunication_SOURCES)

--- a/CMake/Modules/FindWindows.Devices.Spi.cmake
+++ b/CMake/Modules/FindWindows.Devices.Spi.cmake
@@ -38,4 +38,4 @@ endforeach()
 
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(NF_Debugger DEFAULT_MSG Windows.Devices.Spi_INCLUDE_DIRS Windows.Devices.Spi_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Windows.Devices.Spi DEFAULT_MSG Windows.Devices.Spi_INCLUDE_DIRS Windows.Devices.Spi_SOURCES)

--- a/CMake/Modules/FindnanoFramework.Runtime.Events.cmake
+++ b/CMake/Modules/FindnanoFramework.Runtime.Events.cmake
@@ -52,4 +52,4 @@ endforeach()
 
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(NF_Debugger DEFAULT_MSG nanoFramework.Runtime.Events_INCLUDE_DIRS nanoFramework.Runtime.Events_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(nanoFramework.Runtime.Events DEFAULT_MSG nanoFramework.Runtime.Events_INCLUDE_DIRS nanoFramework.Runtime.Events_SOURCES)


### PR DESCRIPTION
## Description
- Fix CMake Find modules

## Motivation and Context
- The Find modules were using the wrong module name when setting the module arguments

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


Signed-off-by: José Simões <jose.simoes@eclo.solutions>
