### PR TITLE
Fix inclusion of target source file for serial API

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -46,8 +46,16 @@ if(USE_FILESYSTEM_OPTION)
     find_package(CHIBIOS_FATFS REQUIRED)
 endif()
 
-#######################################
+####################################################
+# sources for target specifc stuff related with APIs
+list(APPEND API_RELATED_TARGET_SOURCES "")
 
+# Windows.Devices.SerialCommunication
+if(API_Windows.Devices.SerialCommunication)
+    list(APPEND API_RELATED_TARGET_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/target_windows_devices_serialcommunication_config.cpp")    
+endif()
+
+#######################################
 
 add_subdirectory("common")
 add_subdirectory("nanoBooter")
@@ -105,9 +113,9 @@ add_executable(
 
     # sources for nanoFramework APIs
     "${TARGET_NANO_APIS_SOURCES}"
-    # sources for target specifc stuff related with APIs
-    # Windows.Devices.SerialCommunication
-    "target_windows_devices_serialcommunication_config.cpp"
+
+    # sources for API which are target specific
+    "${API_RELATED_TARGET_SOURCES}"
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
@@ -46,8 +46,16 @@ if(USE_FILESYSTEM_OPTION)
     find_package(CHIBIOS_FATFS REQUIRED)
 endif()
 
-#######################################
+####################################################
+# sources for target specifc stuff related with APIs
+list(APPEND API_RELATED_TARGET_SOURCES "")
 
+# Windows.Devices.SerialCommunication
+if(API_Windows.Devices.SerialCommunication)
+    list(APPEND API_RELATED_TARGET_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/target_windows_devices_serialcommunication_config.cpp")    
+endif()
+
+#######################################
 
 add_subdirectory("common")
 add_subdirectory("nanoBooter")
@@ -105,9 +113,9 @@ add_executable(
 
     # sources for nanoFramework APIs
     "${TARGET_NANO_APIS_SOURCES}"
-	# sources for target specifc stuff related with APIs
-    # Windows.Devices.SerialCommunication
-    "target_windows_devices_serialcommunication_config.cpp"
+
+    # sources for API which are target specific
+    "${API_RELATED_TARGET_SOURCES}"
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
@@ -46,8 +46,16 @@ if(USE_FILESYSTEM_OPTION)
     find_package(CHIBIOS_FATFS REQUIRED)
 endif()
 
-#######################################
+####################################################
+# sources for target specifc stuff related with APIs
+list(APPEND API_RELATED_TARGET_SOURCES "")
 
+# Windows.Devices.SerialCommunication
+if(API_Windows.Devices.SerialCommunication)
+    list(APPEND API_RELATED_TARGET_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/target_windows_devices_serialcommunication_config.cpp")    
+endif()
+
+#######################################
 
 add_subdirectory("common")
 add_subdirectory("nanoBooter")
@@ -105,10 +113,9 @@ add_executable(
 
     # sources for nanoFramework APIs
     "${TARGET_NANO_APIS_SOURCES}"
-	
-	# sources for target specifc stuff related with APIs
-    # Windows.Devices.SerialCommunication
-    "target_windows_devices_serialcommunication_config.cpp"
+
+    # sources for API which are target specific
+    "${API_RELATED_TARGET_SOURCES}"
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -46,8 +46,16 @@ if(USE_FILESYSTEM_OPTION)
     find_package(CHIBIOS_FATFS REQUIRED)
 endif()
 
-#######################################
+####################################################
+# sources for target specifc stuff related with APIs
+list(APPEND API_RELATED_TARGET_SOURCES "")
 
+# Windows.Devices.SerialCommunication
+if(API_Windows.Devices.SerialCommunication)
+    list(APPEND API_RELATED_TARGET_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/target_windows_devices_serialcommunication_config.cpp")    
+endif()
+
+#######################################
 
 add_subdirectory("common")
 add_subdirectory("nanoBooter")
@@ -106,9 +114,8 @@ add_executable(
     # sources for nanoFramework APIs
     "${TARGET_NANO_APIS_SOURCES}"
 	
-	# sources for target specifc stuff related with APIs
-    # Windows.Devices.SerialCommunication
-    "target_windows_devices_serialcommunication_config.cpp"
+    # sources for API which are target specific
+    "${API_RELATED_TARGET_SOURCES}"
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
@@ -46,8 +46,16 @@ if(USE_FILESYSTEM_OPTION)
     find_package(CHIBIOS_FATFS REQUIRED)
 endif()
 
-#######################################
+####################################################
+# sources for target specifc stuff related with APIs
+list(APPEND API_RELATED_TARGET_SOURCES "")
 
+# Windows.Devices.SerialCommunication
+if(API_Windows.Devices.SerialCommunication)
+    list(APPEND API_RELATED_TARGET_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/target_windows_devices_serialcommunication_config.cpp")    
+endif()
+
+#######################################
 
 add_subdirectory("common")
 add_subdirectory("nanoBooter")
@@ -106,9 +114,8 @@ add_executable(
     # sources for nanoFramework APIs
     "${TARGET_NANO_APIS_SOURCES}"
 
-    # sources for target specifc stuff related with APIs
-    # Windows.Devices.SerialCommunication
-    "target_windows_devices_serialcommunication_config.cpp"
+    # sources for API which are target specific
+    "${API_RELATED_TARGET_SOURCES}"
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)


### PR DESCRIPTION
## Description
- Fix inclusion of target source file for serial API

## Motivation and Context
- The build was failing for targets that have the serial stuff setup and the CMake option is OFF. The cpp file was always in the build but the header couldn't be found because the include directory was only there when the option was ON.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
