### PR TITLE
Add check for series definition in ChibiOS targetPAL

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/Include/targetPAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetPAL.h
@@ -3,11 +3,13 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#ifndef _GPIO_PORT
-#define _GPIO_PORT
+#ifndef _TARGETPAL_H_
+#define _TARGETPAL_H_
 
 #include <hal.h>
 
+
+#if defined(STM32F0XX) || defined(STM32F4XX) || defined(STM32F7XX) || defined(STM32H7XX)
 
 // Contains available GPIO ports for the current board
 extern stm32_gpio_t* gpioPort[];
@@ -15,4 +17,6 @@ extern stm32_gpio_t* gpioPort[];
 //Gets the GPIO according to a pin number
 #define GPIO_PORT(pin) (gpioPort[pin/16])
 
-#endif
+#endif // defined(STM32F0xx) || defined(STM32F4xx) || defined(STM32F7xx) || defined(STM32H7xx)
+
+#endif // _TARGETPAL_H_

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL.c
@@ -5,6 +5,8 @@
 
 #include <hal.h>
 
+#if defined(STM32F0XX) || defined(STM32F4XX) || defined(STM32F7XX) || defined(STM32H7XX)
+
 stm32_gpio_t* gpioPort[] = { GPIOA, GPIOB
 #if STM32_HAS_GPIOC
 , GPIOC
@@ -34,3 +36,5 @@ stm32_gpio_t* gpioPort[] = { GPIOA, GPIOB
 , GPIOK
 #endif
 };
+
+#endif // defined(STM32F0xx) || defined(STM32F4xx) || defined(STM32F7xx) || defined(STM32H7xx)

--- a/targets/FreeRTOS/ESP32_DevKitC/Include/targetPAL.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/Include/targetPAL.h
@@ -3,9 +3,9 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#ifndef _GPIO_PORT
-#define _GPIO_PORT
+#ifndef _TARGETPAL_H_
+#define _TARGETPAL_H_
 
 
 
-#endif
+#endif // _TARGETPAL_H_


### PR DESCRIPTION
## Description
- Add check for series definition in ChibiOS targetPAL
- Correct wrong guard define in targetPAL header

## Motivation and Context
- This check allows separating definition from series other than STM32 ones

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
