### PR TITLE
Fix serial com Store() delay

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -665,6 +665,9 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
             {
                 // OK to Tx
                 txOk = true;
+
+                // don't bother going into the event loop
+                eventResult = false;
             }
             else
             {
@@ -692,13 +695,6 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
             {
                 // wait for event
                 NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents( stack.m_owningThread, *timeoutTicks, CLR_RT_ExecutionEngine::c_Event_SerialPortOut, eventResult ));
-
-                if(eventResult)
-                {
-                    // event occurred
-                    // OK to Tx
-                    txOk = true;
-                }
             }
         }
 


### PR DESCRIPTION
## Description
- Correct code for events handling that was causing a delay equal to the timeout when storing data in the Tx stream


## Motivation and Context
- Fixes nanoframework/Home#282

## How Has This Been Tested?<!-- (if applicable) -->
- SerialComm app from samples repo

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
