### PR TITLE
Add debugger minimal for RTM

### DIFF
--- a/CMake/Modules/FindNF_Debugger.cmake
+++ b/CMake/Modules/FindNF_Debugger.cmake
@@ -13,7 +13,6 @@ list(APPEND NF_Debugger_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/src/CLR/Include)
 set(NF_Debugger_SRCS
 
     Debugger.cpp
-    Debugger_full.cpp
 
     Messaging.cpp
     
@@ -24,6 +23,14 @@ set(NF_Debugger_SRCS
 
     nanoSupport_CRC32.c
 )
+
+# add the debugger source file according to the build flavor
+if(NF_BUILD_RTM)
+    set(NF_Debugger_SRCS ${NF_Debugger_SRCS} Debugger_minimal.cpp)
+else()
+    set(NF_Debugger_SRCS ${NF_Debugger_SRCS} Debugger_full.cpp)
+endif()
+
 
 foreach(SRC_FILE ${NF_Debugger_SRCS})
     set(NF_Debugger_SRC_FILE SRC_FILE-NOTFOUND)

--- a/src/CLR/Debugger/Debugger_minimal.cpp
+++ b/src/CLR/Debugger/Debugger_minimal.cpp
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+#include <nanoCLR_Runtime.h>
+#include <nanoCLR_Debugging.h>
+
+#define DEFINE_CMD(cmd)  { CLR_DBG_Debugger::Debugging_##cmd, CLR_DBG_Commands::c_Debugging_##cmd }
+#define DEFINE_CMD2(cmd) { CLR_DBG_Debugger::Monitor_##cmd  , CLR_DBG_Commands::c_Monitor_##cmd   }
+
+const CLR_Messaging_CommandHandlerLookup c_Debugger_Lookup_Request[] =
+{
+    DEFINE_CMD2(Ping       ),
+    DEFINE_CMD2(Reboot     ),
+    DEFINE_CMD(Execution_QueryCLRCapabilities),
+
+    DEFINE_CMD2(ReadMemory ),
+    DEFINE_CMD2(WriteMemory),
+    DEFINE_CMD2(EraseMemory),
+    //
+    DEFINE_CMD2(Execute    ),
+    DEFINE_CMD2(MemoryMap  ),
+    DEFINE_CMD2(FlashSectorMap),
+
+    DEFINE_CMD(UpgradeToSsl),
+
+
+
+
+
+
+
+};
+
+const CLR_Messaging_CommandHandlerLookup c_Debugger_Lookup_Reply[] =
+{
+    DEFINE_CMD2(Ping),
+};
+
+#undef DEFINE_CMD
+#undef DEFINE_CMD2
+
+const CLR_UINT32 c_Debugger_Lookup_Request_count = ARRAYSIZE(c_Debugger_Lookup_Request);
+const CLR_UINT32 c_Debugger_Lookup_Reply_count   = ARRAYSIZE(c_Debugger_Lookup_Reply);


### PR DESCRIPTION
## Description
- Add debugger minimal for RTM

## Motivation and Context
- Fixes/Closes/Resolves nanoFramework/Home#134

## How Has This Been Tested?<!-- (if applicable) -->
nanoCLR image size for STM32F769I DISCO
Full debug: 212280kB
RTM: 194048kB

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>