### PR TITLE
Fix issues that stopped ESP32 build after change to events

### DIFF
--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -164,7 +164,7 @@ extern "C" {
 #endif
 
 void CPU_Reset();
-void CPU_Sleep(SLEEP_LEVEL_type level, uint64_t wakeEvents);
+//void CPU_Sleep(SLEEP_LEVEL_type level, uint64_t wakeEvents);
 
 #ifdef __cplusplus
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL.h
@@ -19,7 +19,7 @@
 // these macros are to be used at entry/exit of native interrupt handlers
 #define NATIVE_INTERRUPT_START  SystemState_SetNoLock( SYSTEM_STATE_ISR              );   \
                                 SystemState_SetNoLock( SYSTEM_STATE_NO_CONTINUATIONS );
-#define NATIVEINTERRUPT_END     SystemState_ClearNoLock( SYSTEM_STATE_NO_CONTINUATIONS ); \
+#define NATIVE_INTERRUPT_END    SystemState_ClearNoLock( SYSTEM_STATE_NO_CONTINUATIONS ); \
                                 SystemState_ClearNoLock( SYSTEM_STATE_ISR              );
 
 


### PR DESCRIPTION
## Description
Commented out CPU_Sleep from nanoHALV2.h for now as compile giving error that uint64_t is not defined. Can't find out why for moment.  But doesn't seem to need it as also defined in TargetHal_power.h.  Both arm and esp32 builds ok without it.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy<adriansoundy@gmail.com>
