### PR TITLE
Update win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -147,7 +147,9 @@ nfSPIConfig Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::GetConfig(
     nfSPIConfig cfg =
     {
         {
-            TRUE,
+#if (SPI_SUPPORTS_CIRCULAR == TRUE)
+            SPI_USE_CIRCULAR,
+#endif
             NULL,
             GPIO_PORT(csPin),
             csPin % 16,


### PR DESCRIPTION
## Description
Make correct use of the circular buffer parameter of SPIConfig in the 18.2 version of ChibiOS.

## Motivation and Context
Circular buffer may not be supported on some hardware and, even if it is supported, it can be activated or not.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

