### PR TITLE
Fix wrong button check in booter (STM32F4 disco)

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
@@ -58,7 +58,7 @@ int main(void) {
 
   // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
   // the user button in this board has a pull-up resistor so the check has to be inverted
-  if (palReadPad(GPIOA, GPIOA_BUTTON))
+  if (!palReadPad(GPIOA, GPIOA_BUTTON))
   {
     // check for valid CLR image 
     if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))


### PR DESCRIPTION
## Description
- Fix wrong button check in booter (STM32F4 disco)

## Motivation and Context
- The check for the button to remain in booter was wrongly changed

## How Has This Been Tested?<!-- (if applicable) -->
- Loading the nanoBooter and CLR images in a STM32F4 disco and testing the loading (or not) of CLR using the user blue button.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
