### PR TITLE
Add suport for ConfigBlockRequiresErase flag in Capabilities

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -979,6 +979,11 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg
                 reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_SoftReboot;
             }
 
+            if (::Target_ConfigUpdateRequiresErase())
+            {
+                reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_ConfigBlockRequiresErase;
+            }
+
             data = (CLR_UINT8*)&reply.u_capsFlags;
             size = sizeof(reply.u_capsFlags);
             break;

--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -270,16 +270,17 @@ struct CLR_DBG_Commands
         static const CLR_UINT32 c_ClrInfo                     = 6;
         static const CLR_UINT32 c_TargetReleaseInfo           = 7;
 
-        static const CLR_UINT32 c_CapabilityFlags_FloatingPoint         = 0x00000001;
-        static const CLR_UINT32 c_CapabilityFlags_SourceLevelDebugging  = 0x00000002;
-        static const CLR_UINT32 c_CapabilityFlags_AppDomains            = 0x00000004;
-        static const CLR_UINT32 c_CapabilityFlags_ExceptionFilters      = 0x00000008;
-        static const CLR_UINT32 c_CapabilityFlags_IncrementalDeployment = 0x00000010;
-        static const CLR_UINT32 c_CapabilityFlags_SoftReboot            = 0x00000020;
-        static const CLR_UINT32 c_CapabilityFlags_Profiling             = 0x00000040;
-        static const CLR_UINT32 c_CapabilityFlags_Profiling_Allocations = 0x00000080;
-        static const CLR_UINT32 c_CapabilityFlags_Profiling_Calls       = 0x00000100;
-        static const CLR_UINT32 c_CapabilityFlags_ThreadCreateEx        = 0x00000400;
+        static const CLR_UINT32 c_CapabilityFlags_FloatingPoint             = 0x00000001;
+        static const CLR_UINT32 c_CapabilityFlags_SourceLevelDebugging      = 0x00000002;
+        static const CLR_UINT32 c_CapabilityFlags_AppDomains                = 0x00000004;
+        static const CLR_UINT32 c_CapabilityFlags_ExceptionFilters          = 0x00000008;
+        static const CLR_UINT32 c_CapabilityFlags_IncrementalDeployment     = 0x00000010;
+        static const CLR_UINT32 c_CapabilityFlags_SoftReboot                = 0x00000020;
+        static const CLR_UINT32 c_CapabilityFlags_Profiling                 = 0x00000040;
+        static const CLR_UINT32 c_CapabilityFlags_Profiling_Allocations     = 0x00000080;
+        static const CLR_UINT32 c_CapabilityFlags_Profiling_Calls           = 0x00000100;
+        static const CLR_UINT32 c_CapabilityFlags_ThreadCreateEx            = 0x00000400;
+        static const CLR_UINT32 c_CapabilityFlags_ConfigBlockRequiresErase  = 0x00000800;
 
         CLR_UINT32 m_cmd;
 

--- a/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
@@ -7,6 +7,7 @@
 #define _TARGET_HAL_H_
 
 #include <target_board.h>
+#include <nanoWeak.h>
 
 #define GLOBAL_LOCK(x)              chSysLock();
 #define GLOBAL_UNLOCK(x);           chSysUnlock();
@@ -50,6 +51,11 @@ inline void HAL_AssertEx()
     __BKPT(0);
     while(true) { /*nop*/ }
 }
+
+// Provides information whether the configuration block storage requires erase command before sending the update command
+// The 'weak' implementation for ChibiOS targets is true
+// If a target implements the store differently it has to provide a 'strong' implementation of this.
+__nfweak bool Target_ConfigUpdateRequiresErase() { return true; };
 
 extern int HeapBegin;
 extern int HeapEnd;

--- a/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL.h
@@ -7,6 +7,7 @@
 #define _TARGET_HAL_H_
 
 #include <target_board.h>
+#include <nanoWeak.h>
 
 //TODO: implement
 //#define GLOBAL_LOCK(x)              chSysLock();
@@ -62,6 +63,10 @@ inline void HAL_AssertEx()
  //   __BKPT(0);
     while(true) { /*nop*/ }
 }
+
+// Provides information whether the configuration block storage requires erase command before sending the update command
+// ESP32 is storing this using its non-volatile storage therefore no erase is required.
+__nfweak bool Target_ConfigUpdateRequiresErase() { return false; };
 
 extern int HeapBegin;
 extern int HeapEnd;

--- a/targets/os/win32/Include/targetHAL.h
+++ b/targets/os/win32/Include/targetHAL.h
@@ -26,6 +26,11 @@ inline void __cdecl HARD_Breakpoint()
 
 #define HARD_BREAKPOINT()     HARD_Breakpoint()
 
+inline bool Target_ConfigUpdateRequiresErase()
+{ 
+	return true;
+}
+
 // #if defined(_DEBUG)
 // #define DEBUG_HARD_BREAKPOINT()     HARD_Breakpoint()
 // #else


### PR DESCRIPTION
## Description
- Add Capability flag to signal if an erase is required before uploading the configuration block

## Motivation and Context
- This required to accommodate targets with different flavours of configuration block storage/management. Looking into this flag the engine knows if a flash erase is required before uploading the configuration block.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
