### PR TITLE
Added header for ESP32 to define uint8_t etc

### DIFF
--- a/src/CLR/Include/nanoCLR_PlatformDef.h
+++ b/src/CLR/Include/nanoCLR_PlatformDef.h
@@ -205,6 +205,7 @@
 
 #include <stdarg.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/src/HAL/Include/nanoHAL.h
+++ b/src/HAL/Include/nanoHAL.h
@@ -8,6 +8,7 @@
 #define _NANOHAL_H_ 1
 
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdarg.h>
 #include <nanoWeak.h>

--- a/src/HAL/Include/nanoHAL_Network.h
+++ b/src/HAL/Include/nanoHAL_Network.h
@@ -31,40 +31,40 @@ typedef enum AddressMode
 typedef struct __nfpack Configuration_Network {
 
     // this is the marker placeholder for this configuration block
-    unsigned char Marker[4];
+    uint8_t Marker[4];
 
     // Pointer to MAC address as an array of 6 unsigned bytes.
-    unsigned char MacAddress[6];
+    uint8_t MacAddress[6];
 
     // Network IPv4 address as 32-bit unsigned integer
-    unsigned int  IPv4Address;
+    uint32_t  IPv4Address;
 
     // Network IPv4 subnet mask as 32-bit unsigned integer
-    unsigned int  IPv4NetMask;
+    uint32_t  IPv4NetMask;
 
     // Network gateway IPv4 address as 32-bit unsigned integer
-    unsigned int  IPv4GatewayAddress;
+    uint32_t  IPv4GatewayAddress;
 
     // DNS server 1 IPv4 address as 32-bit unsigned integer
-    unsigned int  IPv4DNS1Address;
+    uint32_t  IPv4DNS1Address;
 
     // DNS server 2 IPv4 address as 32-bit unsigned integer
-    unsigned int  IPv4DNS2Address;
+    uint32_t  IPv4DNS2Address;
 
     // Network IPv6 address as an array of 4 32-bit unsigned integers
-    unsigned int  IPv6Address[4];
+    uint32_t  IPv6Address[4];
 
     // Network IPv6 subnet mask as an array of 4 32-bit unsigned integers
-    unsigned int  IPv6NetMask[4];
+    uint32_t  IPv6NetMask[4];
 
     // Network gateway IPv6 address as an array of 4 32-bit unsigned integers
-    unsigned int  IPv6GatewayAddress[4];
+    uint32_t  IPv6GatewayAddress[4];
 
     // DNS server 1 IPv6 address as an array of 4 32-bit unsigned integers
-    unsigned int  IPv6DNS1Address[4];
+    uint32_t  IPv6DNS1Address[4];
 
     // DNS server 2 IPv6 address as an array of 4 32-bit unsigned integers
-    unsigned int  IPv6DNS2Address[4];
+    uint32_t  IPv6DNS2Address[4];
 
     // Startup network addressing mode - static, DHCP, auto
     AddressMode StartupAddressMode;

--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -8,6 +8,7 @@
 #define _NANOHAL_V2_H_ 1
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdbool.h>
 
 #include <nanoHAL_Network.h>


### PR DESCRIPTION
## Description
For ESP32 it needs the stdint.h header included for the uint8_t  etc types.
Reverted Configuration_Network back to using these types.

Doesn't seem to be a problem for the STM32 builds with header included.

## How Has This Been Tested?<!-- (if applicable) -->

Built ESP32 and F746ZG builds without error

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
