### PR TITLE
Work on GPIO events

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native.h
@@ -33,7 +33,8 @@ struct Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin
     static const int FIELD___debounceTimeout = 4;
     static const int FIELD___callbacks = 5;
     static const int FIELD___lastOutputValue = 6;
-    static const int FIELD___disposedValue = 7;
+    static const int FIELD___lastInputValue = 7;
+    static const int FIELD___disposedValue = 8;
 
     NANOCLR_NATIVE_DECLARE(Read___WindowsDevicesGpioGpioPinValue);
     NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native_Windows_Devices_Gpio_GpioPin.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native_Windows_Devices_Gpio_GpioPin.cpp
@@ -83,6 +83,9 @@ static void debounceTimer_Callback( void* arg )
     // read line
     uint16_t currentValue = palReadLine(GetIoLine(pinNumber));
 
+    // read pad
+    uint16_t lastPadValue = pThis[ Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::FIELD___lastInputValue ].NumericByRef().s4;
+
     if(lastPadValue == currentValue)
     {
         // value hasn't change for debounce interval so this is a valid change
@@ -127,7 +130,7 @@ static void GpioEventCallback(void *arg)
 
     // check if there is a debounce time set
     int64_t debounceTimeoutMilsec = (CLR_INT64_TEMP_CAST) pThis[ Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::FIELD___debounceTimeout ].NumericByRefConst().s8 / TIME_CONVERSION__TO_MILLISECONDS;
-                
+
     if(debounceTimeoutMilsec > 0)
     {
         // debounce set, need to handle it
@@ -143,13 +146,16 @@ static void GpioEventCallback(void *arg)
         }
 
         // read pad
-        lastPadValue = palReadLine(ioLine);
+        pThis[ Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::FIELD___lastInputValue ].NumericByRef().s4 = palReadLine(ioLine);
 
         // setup timer
         chVTSetI(&debounceTimer, TIME_MS2I(debounceTimeoutMilsec), debounceTimer_Callback, pThis);
     }
     else
     {
+        // read pad
+        pThis[ Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::FIELD___lastInputValue ].NumericByRef().s4 = palReadLine(ioLine);
+
         // post a managed event with the current pin reading
         PostManagedEvent( EVENT_GPIO, 0, pinNumber, palReadLine(ioLine) );
     }

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native_nanoFramework_Runtime_Events_EventSink.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native_nanoFramework_Runtime_Events_EventSink.cpp
@@ -12,7 +12,7 @@ void PostManagedEvent(uint8_t category, uint8_t subCategory, uint16_t data1, uin
 {
     if(g_Context != NULL)
     {
-        uint16_t d = ((uint16_t)data1 << 16) | (category << 8) | subCategory;
+        uint32_t d = ((uint32_t)data1 << 16) | (category << 8) | subCategory;
 
         SaveNativeEventToHALQueue( g_Context, d, data2 );
     }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native.h
@@ -33,7 +33,8 @@ struct Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin
     static const int FIELD___debounceTimeout = 4;
     static const int FIELD___callbacks = 5;
     static const int FIELD___lastOutputValue = 6;
-    static const int FIELD___disposedValue = 7;
+    static const int FIELD___lastInputValue = 7;
+    static const int FIELD___disposedValue = 8;
 
     NANOCLR_NATIVE_DECLARE(Read___WindowsDevicesGpioGpioPinValue);
     NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native_Windows_Devices_Gpio_GpioPin.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native_Windows_Devices_Gpio_GpioPin.cpp
@@ -353,7 +353,3 @@ HRESULT Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::NativeSetAlter
     }
     NANOCLR_NOCLEANUP();
 }
-
-
-
-

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native_nanoFramework_Runtime_Events_EventSink.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoFramework.Runtime.Events/nf_rt_events_native_nanoFramework_Runtime_Events_EventSink.cpp
@@ -12,7 +12,7 @@ void PostManagedEvent(uint8_t category, uint8_t subCategory, uint16_t data1, uin
 {
     if(g_Context != NULL)
     {
-        uint16_t d = ((uint16_t)data1 << 16) | (category << 8) | subCategory;
+        uint32_t d = ((uint32_t)data1 << 16) | (category << 8) | subCategory;
 
         SaveNativeEventToHALQueue( g_Context, d, data2 );
     }


### PR DESCRIPTION
## Description
- Fix wrong type in native events preventing GPIO events from firing except on pin 0
- Fix debounce not working for GPIO events

## Motivation and Context
- Fixes nanoFramework/Home#300

## How Has This Been Tested?<!-- (if applicable) -->
- GPIO+events app from sample repo

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>

