### PR TITLE
Improve Esp32 debug session start

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -815,10 +815,9 @@ bool CLR_DBG_Debugger::Monitor_Reboot( WP_Message* msg)
 
     WP_ReplyToCommand(msg, true, false, NULL, 0);
 
-#if defined(PLATFORM_ESP32)
-    // Wait for CLR to Reboot
-    vTaskDelay( 1000 / portTICK_PERIOD_MS);
-#endif
+    // Allow some time for CLR to Reboot
+    // FIXME find a better way to syncronise the reboot with clr 
+    PLATFORM_WAIT( 1000 );
 
     return true;
 }

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -815,6 +815,11 @@ bool CLR_DBG_Debugger::Monitor_Reboot( WP_Message* msg)
 
     WP_ReplyToCommand(msg, true, false, NULL, 0);
 
+#if defined(PLATFORM_ESP32)
+    // Wait for CLR to Reboot
+    vTaskDelay( 1000 / portTICK_PERIOD_MS);
+#endif
+
     return true;
 }
 

--- a/src/HAL/Include/nanoHAL.h
+++ b/src/HAL/Include/nanoHAL.h
@@ -1832,6 +1832,7 @@ bool              Watchdog_GetSetEnabled ( bool enabled, bool fSet );
 //#define GLOBAL_LOCK_SOCKETS(x)     // UNDONE: FIXME: SmartPtr_IRQ x
 #define GLOBAL_UNLOCK(x)
 
+#define PLATFORM_WAIT(milliSecs)
 
 #if defined(_DEBUG)
 #define ASSERT_IRQ_MUST_BE_OFF()   ASSERT( HAL_Windows_HasGlobalLock())

--- a/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
@@ -13,6 +13,8 @@
 #define GLOBAL_UNLOCK(x);           chSysUnlock();
 #define ASSERT_IRQ_MUST_BE_OFF()    // TODO need to determine if this needs implementation
 
+#define PLATFORM_WAIT(milliSecs)    osDelay(milliSecs);
+
 // Defininitions for Sockets/Network
 #define GLOBAL_LOCK_SOCKETS(x)       
 #define SOCKETS_MAX_COUNT 16

--- a/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL.h
@@ -16,6 +16,8 @@
 #define GLOBAL_UNLOCK(x);          
 #define ASSERT_IRQ_MUST_BE_OFF()   // TODO need to determine if this needs implementation
 
+#define PLATFORM_WAIT(milliSecs)    vTaskDelay(milliSecs/portTICK_PERIOD_MS);
+
 // Defininitions for Sockets/Network
 #define GLOBAL_LOCK_SOCKETS(x)       
 #define SOCKETS_MAX_COUNT 16


### PR DESCRIPTION
## Description
This change adds a delay to allow the ESP32 to reboot before the debugger starts to request details about current assemblies.  This is specific to ESP32 as using serial link.

There may be a better way to do this by monitoring the state of the CLR. Didn't seem to be possible with current flags. But this is a good stop gap change. 

## How Has This Been Tested?<!-- (if applicable) -->
Tested multiples times starting a debug session without error

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy<adriansoundy@gmail.com>