### PR TITLE
Correct calls to cache helpers for STM32 targets

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -333,7 +333,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
 
             // flush DMA buffer to ensure cache coherency
             // (only required for Cortex-M7)
-            cacheBufferInvalidate(palI2c->WriteBuffer, palI2c->WriteSize);
+            cacheBufferFlush(palI2c->WriteBuffer, palI2c->WriteSize);
             
             // spawn working thread to perform the I2C transaction
             palI2c->WorkingThread = chThdCreateFromHeap(NULL, THD_WORKING_AREA_SIZE(128),
@@ -415,7 +415,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
                     // need to dereference readBuffer argument to be able to write back on it
                     readBuffer = stack.Arg2().DereferenceArray();
 
-                    // flush DMA buffer to ensure cache coherency
+                    // invalidate cache over read buffer to ensure that content from DMA is read
                     // (only required for Cortex-M7)
                     cacheBufferInvalidate(palI2c->ReadBuffer, palI2c->ReadSize);
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -704,7 +704,7 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         
         // flush DMA buffer to ensure cache coherency
         // (only required for Cortex-M7)
-        cacheBufferInvalidate(palUart->TxRingBuffer.Reader(), length);
+        cacheBufferFlush(palUart->TxRingBuffer.Reader(), length);
 
         // set TX ongoing count
         palUart->TxOngoingCount = length;


### PR DESCRIPTION
## Description
- The wrong cache helper function were being called on some locations
- Correct comments

## Motivation and Context
- Fix potential issues with cache enabled targets (STM32F7 & H7)

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
