### PR TITLE
Remove wait from Monitor_Reboot

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -815,10 +815,6 @@ bool CLR_DBG_Debugger::Monitor_Reboot( WP_Message* msg)
 
     WP_ReplyToCommand(msg, true, false, NULL, 0);
 
-    // Allow some time for CLR to Reboot
-    // FIXME find a better way to syncronise the reboot with clr 
-    PLATFORM_WAIT( 1000 );
-
     return true;
 }
 


### PR DESCRIPTION
## Description
- Remove wait from Monitor_Reboot

## Motivation and Context
- After the improvement in deploy workflow (VS extension v0.3.8.58) this is not required anymore
- Reverts #2b1f18f
- Fixes nanoFramework/Home#316

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
