### PR TITLE
Work on STM32 SPI

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.h
@@ -64,9 +64,8 @@ struct Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice
 
     //--//
 
-    static uint16_t ComputePrescaler (uint8_t bus, int32_t requestedFrequency);
-    static void GetSPIConfig(int busIndex, CLR_RT_HeapBlock* config, SPIConfig* llConfig);
-    static void GetOperationConfig(int busIndex, CLR_RT_HeapBlock* config, SPIConfig* llConfig, bool bufferIs16bits);
+    static uint16_t ComputeBaudRate(uint8_t bus, int32_t requestedFrequency, int32_t& actualFrequency);
+    static void GetSPIConfig(int busIndex, CLR_RT_HeapBlock* config, SPIConfig* llConfig, bool bufferIs16bits);
     static bool IsLongRunningOperation(int writeSize, int readSize, bool bufferIs16bits, float byteTime, int& estimatedDurationMiliseconds);
     static HRESULT NativeTransfer(CLR_RT_StackFrame& stack, bool bufferIs16bits);
 };


### PR DESCRIPTION
## Description
- SPI LL config is now performed on each transaction because SpiConnectionSettings can be changed between calls
- Improve SPI config function by removing unneeded settings and optimizing others
- Correct bug with timeout calculation for CLR events
- Correct bug with byte time estimation on NativeInit
- Remove unnecessary code in NativeTransfer
- Total rework of SPI baud rate calculator (and rename, for clarity)


## Motivation and Context
- General improvements in SPI for STM32 targets
- Fixes nanoframework/Home#324


## How Has This Been Tested?<!-- (if applicable) -->
- SPI sample app
- Demo app for Ili9341 driver

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
