### PR TITLE
Improvements in GenericPort_Write

### DIFF
--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -203,20 +203,8 @@ void CLR_Debug::Emit( const char *text, int len )
                 CLR_EE_DBG_EVENT_BROADCAST( CLR_DBG_Commands::c_Monitor_Message, s_chars, s_buffer, WP_Flags_c_NonCritical | WP_Flags_c_NoCaching );
             }
 
-            if(!CLR_EE_DBG_IS( Enabled ) || HalSystemConfig.DebugTextPort != HalSystemConfig.DebuggerPort)
+            if(HalSystemConfig.DebugTextPort != HalSystemConfig.DebuggerPort)
             {
-//#if !defined(PLATFORM_TOOLS)
-// TODO: Fix the build so that PLATFORM_TOOLS can work here
-// (or eliminate the use of native code from the CLR in the tools by converting them all to managed)
-// This entire function could be moved to info_win32.cpp to help.
-// The problem is that the build doesn't distinguish between building the diagnostics lib for
-// desktop tools, X86, WIN32 or the emulator platforms. And this code was written to assume 
-// an equivalence for all - as the idea of a non-win32 emulator port to an x86 device wasn't
-// considered a reality. However, for testing and development purposes a pure non-emulator x86
-// build is useful, not to mention the potential of Quark and Edison x86 family of chip sets
-// targeting IoT. Thus, this needs some re-thinking as DebuggerPort_Write etc... aren't available
-// when building the desktop tools, but should be available when building a WIN32 based test
-// platform
 #if !defined(_WIN32)
                 DebuggerPort_Write( HalSystemConfig.DebugTextPort, s_buffer, s_chars, 0 ); // skip null terminator and don't bother retrying
                 DebuggerPort_Flush( HalSystemConfig.DebugTextPort );                    // skip null terminator

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_common.c
@@ -15,11 +15,11 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // unsigned int      DebuggerPorts[MAX_DEBUGGERS];
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     {
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     0,//ConvertCOM_DebugHandle(0),

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_common.c
@@ -15,11 +15,11 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // unsigned int      DebuggerPorts[MAX_DEBUGGERS];
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     {
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     0,//ConvertCOM_DebugHandle(0),

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_common.c
@@ -15,11 +15,11 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // unsigned int      DebuggerPorts[MAX_DEBUGGERS];
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     {
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     0,//ConvertCOM_DebugHandle(0),

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/target_common.c
@@ -15,11 +15,11 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // unsigned int      DebuggerPorts[MAX_DEBUGGERS];
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     {
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     0,//ConvertCOM_DebugHandle(0),

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_common.c
@@ -15,11 +15,11 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // unsigned int      DebuggerPorts[MAX_DEBUGGERS];
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     {
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     0,//ConvertCOM_DebugHandle(0),

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_common.c
@@ -15,11 +15,11 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // unsigned int      DebuggerPorts[MAX_DEBUGGERS];
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     {
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     0,//ConvertCOM_DebugHandle(0),

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_common.c
@@ -15,11 +15,11 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
     {                                               // unsigned int      DebuggerPorts[MAX_DEBUGGERS];
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     {
-        0//ConvertCOM_DebugHandle(0),
+        1//ConvertCOM_DebugHandle(1),
     },
 
     0,//ConvertCOM_DebugHandle(0),

--- a/targets/FreeRTOS/ESP32_DevKitC/target_common.c
+++ b/targets/FreeRTOS/ESP32_DevKitC/target_common.c
@@ -15,12 +15,12 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     //--//
 
 //    {                                               // unsigned int      DebuggerPorts[MAX_DEBUGGERS];
-        0//ConvertCOM_DebugHandle(0),           // DebuggerPort COM_HANDLE
+        1//ConvertCOM_DebugHandle(1),           // DebuggerPort COM_HANDLE
 //    }
     ,
 
 //    {
-        0//ConvertCOM_DebugHandle(0),           // MessagingPort COM_HANDLE
+        1//ConvertCOM_DebugHandle(1),           // MessagingPort COM_HANDLE
 //    }
     ,
 


### PR DESCRIPTION
## Description
- Remove check that was preventing SWO output when a debugger is connected (VS usually)
- Rework CMSIS implementation of GenericPort_Write to improve performance
- Update all targets HalSystemConfig to use 1 as index for DebugPort

## Motivation and Context
- Improves the debugging experiencing by making the SMT32 SWO output available independently of a debugger being attached or not

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>