### PR TITLE
Work on PAL events and PAL time

### DIFF
--- a/src/PAL/AsyncProcCall/AsyncCompletions.cpp
+++ b/src/PAL/AsyncProcCall/AsyncCompletions.cpp
@@ -169,7 +169,7 @@ void HAL_COMPLETION::Abort()
 
 //--//
 
-void HAL_COMPLETION::WaitForInterrupts(uint64_t expire, uint32_t sleepLevel, uint64_t wakeEvents)
+void HAL_COMPLETION::WaitForInterrupts(uint64_t expireTicks, uint32_t sleepLevel, uint64_t wakeEvents)
 {
     NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
 
@@ -186,7 +186,7 @@ void HAL_COMPLETION::WaitForInterrupts(uint64_t expire, uint32_t sleepLevel, uin
     {
         state = setCompare | nilCompare;
     }
-    else if(ptr->EventTimeTicks > expire)
+    else if(ptr->EventTimeTicks > expireTicks)
     {
         state = setCompare | resetCompare;
     }
@@ -197,7 +197,7 @@ void HAL_COMPLETION::WaitForInterrupts(uint64_t expire, uint32_t sleepLevel, uin
 
     if(state & setCompare)
     {
-        Time_SetCompare(expire);
+        Time_SetCompare(expireTicks);
     }
 
     CPU_Sleep((SLEEP_LEVEL_type)sleepLevel, wakeEvents);

--- a/src/PAL/AsyncProcCall/Async_stubs.cpp
+++ b/src/PAL/AsyncProcCall/Async_stubs.cpp
@@ -84,7 +84,7 @@ __nfweak void HAL_COMPLETION::DequeueAndExec()
     NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
 }
 
-__nfweak void HAL_COMPLETION::WaitForInterrupts( uint64_t Expire, uint32_t sleepLevel, uint64_t wakeEvents )
+__nfweak void HAL_COMPLETION::WaitForInterrupts( uint64_t expireTicks, uint32_t sleepLevel, uint64_t wakeEvents )
 {
     NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
 }

--- a/src/PAL/Include/nanoPAL_AsyncProcCalls_decl.h
+++ b/src/PAL/Include/nanoPAL_AsyncProcCalls_decl.h
@@ -127,7 +127,7 @@ struct HAL_COMPLETION : public HAL_CONTINUATION
 
     static void DequeueAndExec();
 
-    static void WaitForInterrupts( uint64_t expire, uint32_t sleepLevel, uint64_t wakeEvents );
+    static void WaitForInterrupts( uint64_t expireTicks, uint32_t sleepLevel, uint64_t wakeEvents );
 };
 
 //--//

--- a/src/PAL/Include/nanoPAL_Time.h
+++ b/src/PAL/Include/nanoPAL_Time.h
@@ -18,9 +18,9 @@ extern "C" {
 /// Initializes PAL Time drivers, must be called before any of the Time_* PAL
 /// methods could be used.
 /// </summary>
-HRESULT    Time_Initialize    (                     );
-HRESULT    Time_Uninitialize  (                     );
-void       Time_SetCompare    ( uint64_t compareValue );
+HRESULT    Time_Initialize    (                            );
+HRESULT    Time_Uninitialize  (                            );
+void       Time_SetCompare    ( uint64_t compareValueTicks );
 
 #ifdef __cplusplus
 }

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/chconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/chconf.h
@@ -567,8 +567,6 @@
  */
 #define CH_CFG_SYSTEM_TICK_HOOK() {                                         \
   /* System tick event code here.*/                                         \
-  extern void Time_Interrupt_Hook();                                        \
-  Time_Interrupt_Hook();                                                    \
 }
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/chconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/chconf.h
@@ -567,8 +567,7 @@
  */
 #define CH_CFG_SYSTEM_TICK_HOOK() {                                         \
   /* System tick event code here.*/                                         \
-  extern void Time_Interrupt_Hook();                                        \
-  Time_Interrupt_Hook();                                                    \
+
 }
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/chconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/chconf.h
@@ -567,7 +567,6 @@
  */
 #define CH_CFG_SYSTEM_TICK_HOOK() {                                         \
   /* System tick event code here.*/                                         \
-
 }
 
 /**

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Events.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Events.cpp
@@ -152,7 +152,7 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
         }
 
         // no events, pass control to the OS
-        taskYIELD(0);
+        taskYIELD();
     }
 
     return 0;

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Events.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Events.cpp
@@ -10,17 +10,13 @@
 
 uint64_t CPU_MiliSecondsToSysTicks(uint64_t miliSeconds);
 
-// events timer
-static TimerHandle_t eventsBoolTimer;
+// timer for bool events
+static TimerHandle_t boolEventsTimer;
 static bool*  saveTimerCompleteFlag = 0;
 
 volatile uint32_t systemEvents;
 
-
 static void local_Events_SetBoolTimer_Callback(  TimerHandle_t xTimer  );
-
-#define chSysLock() 
-#define chSysUnlock() 
 
 set_Event_Callback g_Event_Callback     = NULL;
 void*              g_Event_Callback_Arg = NULL;
@@ -30,11 +26,9 @@ bool Events_Initialize()
     NATIVE_PROFILE_PAL_EVENTS();
 
     // init events
- //   chSysLock();
     systemEvents = 0;
- //   chSysUnlock();
 
-    eventsBoolTimer = xTimerCreate( "eventsTimer", 10, pdFALSE, (void *)0, local_Events_SetBoolTimer_Callback);
+    boolEventsTimer = xTimerCreate( "boolEventsTimer", 10, pdFALSE, (void *)0, local_Events_SetBoolTimer_Callback);
  
     return true;
 }
@@ -43,7 +37,7 @@ bool Events_Uninitialize()
 {
     NATIVE_PROFILE_PAL_EVENTS();
 
-    xTimerDelete(eventsBoolTimer,0);
+    xTimerDelete(boolEventsTimer,0);
  
     return true;
 }
@@ -53,9 +47,7 @@ void Events_Set( uint32_t events )
     NATIVE_PROFILE_PAL_EVENTS();
 
     // set events
-    chSysLock();
     systemEvents |= events;
-    chSysUnlock();
 
     if( g_Event_Callback != NULL )
     {
@@ -71,9 +63,7 @@ uint32_t Events_Get( uint32_t eventsOfInterest )
     uint32_t returnEvents = (systemEvents & eventsOfInterest);
 
     // ... clear the requested flags atomically
-    chSysLock();
     systemEvents &= ~eventsOfInterest;
-    chSysUnlock();
     
     // give the caller notice of just the events they asked for ( and were cleared already )
     return returnEvents;
@@ -88,9 +78,6 @@ uint32_t Events_MaskedRead( uint32_t eventsOfInterest )
 static void local_Events_SetBoolTimer_Callback(  TimerHandle_t xTimer  )
 {
     NATIVE_PROFILE_PAL_EVENTS();
-
-//   bool* timerCompleteFlag = (bool*)pvTimerGetTimerID( xTimer );
-// *timerCompleteFlag = true;
 
     *saveTimerCompleteFlag = true;
 }
@@ -108,18 +95,18 @@ void Events_SetBoolTimer( bool* timerCompleteFlag, uint32_t millisecondsFromNow 
     NATIVE_PROFILE_PAL_EVENTS();
 
     // we assume only 1 can be active, abort previous just in case
-    xTimerStop( eventsBoolTimer, 0 );
+    xTimerStop( boolEventsTimer, 0 );
 
     if(timerCompleteFlag != NULL)
     {
 
-        xTimerChangePeriod( eventsBoolTimer, millisecondsFromNow / portTICK_PERIOD_MS,  0 );
+        xTimerChangePeriod( boolEventsTimer, millisecondsFromNow / portTICK_PERIOD_MS,  0 );
 
-// Was going to just change existing timer but vTimerSetTimerID() does not exist in this version of FreeRtos
+// Was going to just change existing timer but vTimerSetTimerID() does not exist in this version of FreeRTOS
 // As only one timer running at a time we will just save it in global memory
         saveTimerCompleteFlag = timerCompleteFlag;
-        //        vTimerSetTimerID( eventsBoolTimer, (void *)timerCompleteFlag );
-        xTimerStart(eventsBoolTimer, 0);
+        //        vTimerSetTimerID( boolEventsTimer, (void *)timerCompleteFlag );
+        xTimerStart(boolEventsTimer, 0);
     }
 }
 
@@ -133,7 +120,7 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
     Events_WaitForEvents_Calls++;
 #endif
 
-    uint64_t expire          = HAL_Time_CurrentSysTicks() + countsRemaining;
+    uint64_t expireTicks  = HAL_Time_CurrentTime() + countsRemaining;
     bool runContinuations = true;
 
     while(true)
@@ -144,7 +131,7 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
             return events;
         }
 
-        if(expire <= HAL_Time_CurrentSysTicks())
+        if(expireTicks <= HAL_Time_CurrentTime())
         {
             break;
         }
@@ -161,11 +148,11 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
             // try stalled continuations again after sleeping
             runContinuations = true;
 
-            HAL_COMPLETION::WaitForInterrupts(expire, powerLevel, wakeupSystemEvents );          
+            HAL_COMPLETION::WaitForInterrupts(expireTicks, powerLevel, wakeupSystemEvents );          
         }
 
-        // no events, release time to OS
-        vTaskDelay(0);
+        // no events, pass control to the OS
+        taskYIELD(0);
     }
 
     return 0;

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Events.cpp.groups.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Events.cpp.groups.cpp
@@ -13,7 +13,7 @@
 static void local_Events_SetBoolTimer_Callback(  TimerHandle_t xTimer  );
 
 // events timer
-static TimerHandle_t eventsBoolTimer;
+static TimerHandle_t boolEventsTimer;
 static bool*  saveTimerCompleteFlag = 0;
 
 EventGroupHandle_t systemEventsHigh;
@@ -32,7 +32,7 @@ bool Events_Initialize()
     systemEventsHigh = xEventGroupCreate();
     systemEventsLow  = xEventGroupCreate();
     
-    eventsBoolTimer = xTimerCreate( "eventsTimer", 10, pdFALSE, (void *)0, local_Events_SetBoolTimer_Callback);
+    boolEventsTimer = xTimerCreate( "boolEventsTimer", 10, pdFALSE, (void *)0, local_Events_SetBoolTimer_Callback);
 
     return true;
 }
@@ -93,9 +93,6 @@ static void local_Events_SetBoolTimer_Callback(  TimerHandle_t xTimer  )
 {
     NATIVE_PROFILE_PAL_EVENTS();
 
-//   bool* timerCompleteFlag = (bool*)pvTimerGetTimerID( xTimer );
-// *timerCompleteFlag = true;
-
     *saveTimerCompleteFlag = true;
 }
 
@@ -112,18 +109,18 @@ void Events_SetBoolTimer( bool* timerCompleteFlag, uint32_t millisecondsFromNow 
     NATIVE_PROFILE_PAL_EVENTS();
 
     // we assume only 1 can be active, abort previous just in case
-    xTimerStop( eventsBoolTimer, 0 );
+    xTimerStop( boolEventsTimer, 0 );
 
     if(timerCompleteFlag != NULL)
     {
 
-        xTimerChangePeriod( eventsBoolTimer, millisecondsFromNow / portTICK_PERIOD_MS,  0 );
+        xTimerChangePeriod( boolEventsTimer, millisecondsFromNow / portTICK_PERIOD_MS,  0 );
 
-// Was going to just change existing timer but vTimerSetTimerID() does not exist in this version of FreeRtos
+// Was going to just change existing timer but vTimerSetTimerID() does not exist in this version of FreeRTOS
 // As only one timer running at a time we will just save it in global memory
         saveTimerCompleteFlag = timerCompleteFlag;
-        //        vTimerSetTimerID( eventsBoolTimer, (void *)timerCompleteFlag );
-        xTimerStart(eventsBoolTimer, 0);
+        //        vTimerSetTimerID( boolEventsTimer, (void *)timerCompleteFlag );
+        xTimerStart(boolEventsTimer, 0);
     }
 }
 
@@ -135,7 +132,7 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
 #endif
 
     EventBits_t events = (xEventGroupGetBits(systemEventsHigh) << 16) & xEventGroupGetBits(systemEventsLow)
-   if( events == 0) {
+    if( events == 0) {
         // no events, wait for timeout_Milliseconds
         vTaskDelay( timeout_Milliseconds / portTICK_PERIOD_MS );
     }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Time.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Time.cpp
@@ -41,6 +41,6 @@ void Time_SetCompare ( uint64_t compareValueTicks )
     else
     {
         // need to convert from ticks to milliseconds
-        xTimerChangePeriod( boolEventsTimer, (compareValueTicks * TIME_CONVERSION__TO_MILLISECONDS) / portTICK_PERIOD_MS,  0 );
+        xTimerChangePeriod( nextEventTimer, (compareValueTicks * TIME_CONVERSION__TO_MILLISECONDS) / portTICK_PERIOD_MS,  0 );
     }
 }


### PR DESCRIPTION
## Description
- Rename PAL events timer to improve clarity
- Correct bug in Events_WaitForEvents: wrong call to HAL_Time_CurrentSysTicks instead of HAL_Time_CurrentTime because nF ticks are required for HAL_COMPLETION
- Events_WaitForEvents is now using OS Yield instead of OS Wait for a smoother execution
- Rework PAL time by using a timer with callback to schedule HAL_COMPLETION events instead of checking for that on every sysTick
- Remove Time_Interrupt_Hook() from CH_CFG_SYSTEM_TICK_HOOK (not required anymore)
- Rename some argumens to improve clarity
- Clean up code in PAL events for ESP32

## Motivation and Context
- Fixes/Closes/Resolves nanoFramework/Home#NNNN

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>