### PR TITLE
Improvements with timers from ChibiOS API

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL_Events.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL_Events.cpp
@@ -95,11 +95,9 @@ void Events_SetBoolTimer( bool* timerCompleteFlag, uint32_t millisecondsFromNow 
 {
     NATIVE_PROFILE_PAL_EVENTS();
 
-    // we assume only 1 can be active, abort previous just in case
-    chVTResetI(&boolEventsTimer);
-
     if(timerCompleteFlag != NULL)
     {
+        // no need to stop the timer even if it's running because the API does it anyway
         chVTSetI(&boolEventsTimer, TIME_MS2I(millisecondsFromNow), local_Events_SetBoolTimer_Callback, timerCompleteFlag);
     }
 }


### PR DESCRIPTION
## Description
- Remove call to stop a timer before setting it (no need as the API already does that)
- Add dummy var to timer callback argument, instead of NULL, to make sure that the API and compiler are absolutly happy with it
- Add ChibiOS Syslock and unlock to time event callback


## Motivation and Context
- Improves usage of ChibiOS timers and removes unnecessary calls

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
