### PR TITLE
Update win_dev_gpio_native_Windows_Devices_Gpio_GpioPin.cpp

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native_Windows_Devices_Gpio_GpioPin.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native_Windows_Devices_Gpio_GpioPin.cpp
@@ -195,13 +195,8 @@ HRESULT Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::Toggle___VOID(
             NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
         }
 
-        // get IoLine from pin number
-        ioline_t ioLine = GetIoLine(pThis[ FIELD___pinNumber ].NumericByRefConst().s4);
-
         GpioPinDriveMode driveMode = (GpioPinDriveMode)pThis[ FIELD___driveMode ].NumericByRefConst().s4;
-
-        GpioPinValue state = (GpioPinValue)stack.Arg1().NumericByRef().s4;
-
+	    
         // sanity check for drive mode set to output so we don't mess up writing to an input pin
         if ((driveMode == GpioPinDriveMode_Output) ||
             (driveMode == GpioPinDriveMode_OutputOpenDrain) ||
@@ -209,6 +204,8 @@ HRESULT Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::Toggle___VOID(
             (driveMode == GpioPinDriveMode_OutputOpenSource) ||
             (driveMode == GpioPinDriveMode_OutputOpenSourcePullDown))
         {
+	    // get IoLine from pin number
+	    ioline_t ioLine = GetIoLine(pThis[ FIELD___pinNumber ].NumericByRefConst().s4);
             palToggleLine(ioLine);
         }
 


### PR DESCRIPTION
## Description
"state" variable was not used.
No need to get the "ioLine" variable if we don't use it. So moved it to the location where it is really needed.

Those two changes cost less CPU time and memory.
A few more bytes could probably be saved by not declaring the "ioLine" variable : `palToggleLine (GetIoLine(pThis[ FIELD___pinNumber ].NumericByRefConst().s4));`


## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

