### PR TITLE
Revert last batch of improvements on STM32 I2C code

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
@@ -1,8 +1,3 @@
-//
-// Copyright (c) 2017 The nanoFramework project contributors
-// See LICENSE file in the project root for full license information.
-//
-
 #include "win_dev_i2c_native.h"
 
 
@@ -22,25 +17,21 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::DisposeNative___VOID,
-    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1,
+    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___I4__SZARRAY_U1__U4__SZARRAY_U1__U4,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
     NULL,
     NULL,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::GetDeviceSelector___STATIC__STRING,
-    NULL,
-    NULL,
-    NULL,
     NULL,
     NULL,
     NULL,
@@ -52,6 +43,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_I2c =
 {
     "Windows.Devices.I2c", 
-    0xA170B1E0,
+    0xC5ABF45E,
     method_lookup
 };
+

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
@@ -1,7 +1,15 @@
+//-----------------------------------------------------------------------------
 //
-// Copyright (c) 2017 The nanoFramework project contributors
-// See LICENSE file in the project root for full license information.
+//                   ** WARNING! ** 
+//    This file was generated automatically by a tool.
+//    Re-running the tool will overwrite this file.
+//    You should copy this file to a custom location
+//    before adding any customization in the copy to
+//    prevent loss of your changes when the tool is
+//    re-run.
 //
+//-----------------------------------------------------------------------------
+
 
 #ifndef _WIN_DEV_I2C_NATIVE_H_
 #define _WIN_DEV_I2C_NATIVE_H_
@@ -10,6 +18,13 @@
 #include <nanoCLR_Runtime.h>
 #include <nanoCLR_Checks.h>
 #include <hal.h>
+
+struct nfI2CConfig
+{
+    I2CConfig Configuration;
+    I2CDriver * Driver;
+    uint16_t SlaveAddress;
+};
 
 struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cConnectionSettings
 {
@@ -24,8 +39,7 @@ struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cConnectionSettings
 
 struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController
 {
-    static const int FIELD_STATIC__s_instance = 0;
-    static const int FIELD_STATIC__s_deviceCollection = 1;
+    static const int FIELD_STATIC__DeviceCollection = 0;
 
 
     //--//
@@ -37,60 +51,28 @@ struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice
     static const int FIELD___syncLock = 1;
     static const int FIELD___deviceId = 2;
     static const int FIELD___connectionSettings = 3;
-    static const int FIELD___disposed = 4;
+    static const int FIELD___i2cBus = 4;
+    static const int FIELD___disposedValue = 5;
 
     NANOCLR_NATIVE_DECLARE(NativeInit___VOID);
     NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
-    NANOCLR_NATIVE_DECLARE(NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1);
+    NANOCLR_NATIVE_DECLARE(NativeTransmit___I4__SZARRAY_U1__U4__SZARRAY_U1__U4);
     NANOCLR_NATIVE_DECLARE(GetDeviceSelector___STATIC__STRING);
 
     //--//
-    static void GetI2cConfig(CLR_RT_HeapBlock* managedConfig, I2CConfig* llConfig);
-    static bool IsLongRunningOperation(int writeSize, int readSize, float byteTime, int& estimatedDurationMiliseconds);
+    static nfI2CConfig GetConfig(int bus, CLR_RT_HeapBlock* config);
 };
 
 struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult
 {
-    static const int FIELD___bytesTransferred = 1;
-    static const int FIELD___status = 2;
+    static const int FIELD__BytesTransferred = 1;
+    static const int FIELD__Status = 2;
 
 
     //--//
 
 };
 
-extern const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_I2c;
-
-// struct representing the I2C 
-struct NF_PAL_I2C
-{
-    I2CDriver*  Driver;
-    I2CConfig   Configuration;
-    thread_t*   WorkingThread;
-    i2caddr_t   Address;
-    float ByteTime;
-
-    uint8_t* WriteBuffer;
-    uint8_t  WriteSize;
-
-    uint8_t* ReadBuffer;
-    uint8_t  ReadSize;
-};
-
-///////////////////////////////////////////
-// declaration of the the I2C PAL strucs //
-///////////////////////////////////////////
-#if STM32_I2C_USE_I2C1
-    extern NF_PAL_I2C I2C1_PAL;
-#endif
-#if STM32_I2C_USE_I2C2
-    extern NF_PAL_I2C I2C2_PAL;
-#endif
-#if STM32_I2C_USE_I2C3
-    extern NF_PAL_I2C I2C3_PAL;
-#endif
-#if STM32_I2C_USE_I2C4
-    extern NF_PAL_I2C I2C4_PAL;
-#endif
+    extern const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_I2c;
 
 #endif  //_WIN_DEV_I2C_NATIVE_H_

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -5,486 +5,196 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <cmsis_os.h>
 #include <string.h>
 #include <targetPAL.h>
-#include <nanoHAL.h>
+
 #include "win_dev_i2c_native.h"
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // !!! KEEP IN SYNC WITH Windows.Devices.I2c.I2cSharingMode (in managed code) !!!    //
 ///////////////////////////////////////////////////////////////////////////////////////
 enum I2cSharingMode
-{
-    Exclusive = 0,
-    Shared
-};
+    {
+        Exclusive = 0,
+        Shared
+    };
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // !!! KEEP IN SYNC WITH Windows.Devices.I2c.I2cTransferStatus (in managed code) !!! //
 ///////////////////////////////////////////////////////////////////////////////////////
  enum I2cTransferStatus
-{
-    I2cTransferStatus_FullTransfer = 0,
-    I2cTransferStatus_ClockStretchTimeout,
-    I2cTransferStatus_PartialTransfer,
-    I2cTransferStatus_SlaveAddressNotAcknowledged,
-    I2cTransferStatus_UnknownError
-};
+    {
+        I2cTransferStatus_FullTransfer = 0,
+        I2cTransferStatus_ClockStretchTimeout,
+        I2cTransferStatus_PartialTransfer,
+        I2cTransferStatus_SlaveAddressNotAcknowledged,
+        I2cTransferStatus_UnknownError
+    };
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // !!! KEEP IN SYNC WITH Windows.Devices.I2c.I2cBusSpeed (in managed code) !!!       //
 ///////////////////////////////////////////////////////////////////////////////////////
 enum I2cBusSpeed
-{
-    I2cBusSpeed_StandardMode = 0,
-    I2cBusSpeed_FastMode
-};
+    {
+        I2cBusSpeed_StandardMode = 0,
+        I2cBusSpeed_FastMode
+	};
 
 typedef Library_win_dev_i2c_native_Windows_Devices_I2c_I2cConnectionSettings I2cConnectionSettings;
 
+nfI2CConfig Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::GetConfig(int bus, CLR_RT_HeapBlock* config)
+{
+    I2CDriver * _drv;
+    
+    int slaveAddress = config[ I2cConnectionSettings::FIELD___slaveAddress ].NumericByRef().s4;
+    int busSpeed = config[ I2cConnectionSettings::FIELD___busSpeed ].NumericByRef().s4;
 
-/////////////////////////////////////////////////////
-// I2C PAL strucs declared in win_dev_i2c_native.h //
-/////////////////////////////////////////////////////
+    // Choose the driver that is mapped to the chosen bus
+    switch (bus)
+    {
 #if STM32_I2C_USE_I2C1
-    NF_PAL_I2C I2C1_PAL;
+        case 1 :   _drv = &I2CD1;
+                    break;
 #endif
 #if STM32_I2C_USE_I2C2
-    NF_PAL_I2C I2C2_PAL;
+        case 2 :    _drv = &I2CD2;
+                    break;
 #endif
 #if STM32_I2C_USE_I2C3
-    NF_PAL_I2C I2C3_PAL;
+        case 3 :    _drv = &I2CD3;
+                    break;
 #endif
 #if STM32_I2C_USE_I2C4
-    NF_PAL_I2C I2C4_PAL;
+        case 4 :    _drv = &I2CD4;
+                    break;
 #endif
-
-
-// ChibiOS I2C working thread
-static THD_FUNCTION(I2CWorkingThread, arg)
-{
-    NF_PAL_I2C* palI2c = (NF_PAL_I2C*)arg;
-    msg_t result;
-    int estimatedDurationMiliseconds = palI2c->ByteTime * (palI2c->WriteSize + palI2c->ReadSize + 1);
-
-    if (palI2c->ReadSize != 0 && palI2c->WriteSize != 0)
-    {
-        // this is a Write/Read transaction
-       result = i2cMasterTransmitTimeout(palI2c->Driver, palI2c->Address, palI2c->WriteBuffer, palI2c->WriteSize, palI2c->ReadBuffer, palI2c->ReadSize, TIME_MS2I(estimatedDurationMiliseconds));
     }
-    else
+
+    // Create the final configuration
+    nfI2CConfig cfg =
     {
-        if (palI2c->ReadSize == 0)
         {
-            // this is Write only transaction
+#ifdef STM32F4xx_MCUCONF
+            OPMODE_I2C,
+            busSpeed == I2cBusSpeed_StandardMode ? 100000U : 400000U,
+            busSpeed == I2cBusSpeed_StandardMode ? STD_DUTY_CYCLE : FAST_DUTY_CYCLE_2
+#endif
+#ifdef STM32F7xx_MCUCONF
+            // Standard mode : 100 KHz, Rise time 120 ns, Fall time 25 ns, 54MHz clock source
+            // Fast mode : 400 KHz, Rise time 120 ns, Fall time 25 ns, 54MHz clock source
+            // Timing register value calculated by STM32 CubeMx
+            busSpeed == I2cBusSpeed_StandardMode ? 0x80201721 : 0x00B01B59,
+            0,
+            0
+#endif
+        },
+        _drv,
+        (uint16_t)slaveAddress
+    };
 
-            estimatedDurationMiliseconds = palI2c->ByteTime * (palI2c->WriteSize + 1);
-
-            result = i2cMasterTransmitTimeout(palI2c->Driver, palI2c->Address, palI2c->WriteBuffer, palI2c->WriteSize, NULL, 0, TIME_MS2I(estimatedDurationMiliseconds));
-        }
-        else
-        {
-            // this is a Read only transaction
-
-            estimatedDurationMiliseconds = palI2c->ByteTime * (palI2c->ReadSize + 1);
-
-            result = i2cMasterReceiveTimeout (palI2c->Driver, palI2c->Address, palI2c->ReadBuffer, palI2c->ReadSize, TIME_MS2I(estimatedDurationMiliseconds));
-        }
-    }
-
-    i2cReleaseBus(palI2c->Driver);
-
-    // fire event for I2C transaction complete
-    Events_Set(SYSTEM_EVENT_FLAG_I2C_MASTER);
-
-    chThdExit(result);
-}
-
-void Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::GetI2cConfig(CLR_RT_HeapBlock* managedConfig, I2CConfig* llConfig)
-{
-    I2cBusSpeed busSpeed = (I2cBusSpeed)managedConfig[ I2cConnectionSettings::FIELD___busSpeed ].NumericByRef().s4;
-
-    // set the LL I2C configuration (according to I2C driver version)
-    #if defined(STM32F1xx_MCUCONF) || defined(STM32F4xx_MCUCONF) || defined(STM32L1xx_MCUCONF)
-
-    llConfig->op_mode = OPMODE_I2C;
-    llConfig->clock_speed = busSpeed == I2cBusSpeed_StandardMode ? 100000U : 400000U;
-    llConfig->duty_cycle = busSpeed == I2cBusSpeed_StandardMode ? STD_DUTY_CYCLE : FAST_DUTY_CYCLE_2;
-
-    #endif
-
-    #if defined(STM32F7xx_MCUCONF) || defined(STM32F3xx_MCUCONF) || defined(STM32F0xx_MCUCONF) || \
-            defined(STM32L0xx_MCUCONF) ||  defined(STM32L4xx_MCUCONF) || \
-            defined(STM32H7xx_MCUCONF) 
-
-    // Standard mode : 100 KHz, Rise time 120 ns, Fall time 25 ns, 54MHz clock source
-    // Fast mode : 400 KHz, Rise time 120 ns, Fall time 25 ns, 54MHz clock source
-    // Timing register value calculated by STM32 CubeMx
-    llConfig->timingr = busSpeed == I2cBusSpeed_StandardMode ? 0x80201721 : 0x00B01B59;
-    llConfig->cr1 = 0;
-    llConfig->cr2 = 0;
-
-    #endif
-
-}
-
-// estimate the time required to perform the I2C transaction
-bool Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::IsLongRunningOperation(int writeSize, int readSize, float byteTime, int& estimatedDurationMiliseconds)
-{
-    // add an extra byte to account for the address
-    estimatedDurationMiliseconds = byteTime * (writeSize + readSize + 1);
-
-    if(estimatedDurationMiliseconds > CLR_RT_Thread::c_TimeQuantum_Milliseconds)
-    {
-        // total operation time will exceed thread quantum, so this is a long running operation
-        return true;
-    }
-    else
-    {
-        return false;        
-    }
+    return cfg;
 }
 
 HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
-    {
-        NF_PAL_I2C* palI2c;
-
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
-       
-        // get a pointer to the managed I2C connectionSettings object instance
-        CLR_RT_HeapBlock* pConfig = pThis[ FIELD___connectionSettings ].Dereference();
-
-        // get bus index
-        // this is coded with a multiplication, need to perform and int division to get the number
-        // see the comments in the I2cDevice() constructor in managed code for details
-        uint8_t busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
-
-        // init the PAL struct for this I2C bus and assign the respective driver
-        // all this occurs if not already done
-        // why do we need this? because several I2cDevice objects can be created associated to the same bus just using different addresses
-        switch (busIndex)
-        {
-    #if STM32_I2C_USE_I2C1
-            case 1:
-                if(I2C1_PAL.Driver == NULL)
-                {
-                    I2C1_PAL.Driver = &I2CD1;
-                    palI2c = &I2C1_PAL;
-                }
-                break;
-    #endif
-    #if STM32_I2C_USE_I2C2
-            case 2:
-                if(I2C2_PAL.Driver == NULL)
-                {
-                    I2C2_PAL.Driver = &I2CD2;
-                    palI2c = &I2C2_PAL;
-                }
-                break;
-    #endif
-    #if STM32_I2C_USE_I2C3
-            case 3:
-                if(I2C3_PAL.Driver == NULL)
-                {
-                    I2C3_PAL.Driver = &I2CD3;
-                    palI2c = &I2C3_PAL;
-                }
-                break;
-    #endif
-    #if STM32_I2C_USE_I2C4
-            case 4:
-                if(I2C4_PAL.Driver == NULL)
-                {
-                    I2C4_PAL.Driver = &I2CD4;
-                    palI2c = &I2C4_PAL;
-                }
-                break;
-    #endif
-
-            default:
-                // this I2C bus is not valid
-                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-                break;
-        }
-
-        // Get a general low-level I2C configuration, depending on user's managed parameters
-        GetI2cConfig(pConfig, &palI2c->Configuration);
-
-        // compute rough estimate on the time to tx/rx a byte (in milliseconds)
-        if((I2cBusSpeed)pConfig[ I2cConnectionSettings::FIELD___busSpeed ].NumericByRef().s4 == I2cBusSpeed_StandardMode)
-        {
-            // 100kbit/s: this is roughly 0.10ms per byte, give or take
-            palI2c->ByteTime = 0.1;
-        }
-        else
-        {
-            // 400kbit/s: this is roughly 0.02ms per byte, give or take
-            palI2c->ByteTime = 0.02;
-        }
-
-    }
     NANOCLR_NOCLEANUP();
 }
 
 HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::DisposeNative___VOID( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
-    {
-    }
+
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1( CLR_RT_StackFrame& stack )
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___I4__SZARRAY_U1__U4__SZARRAY_U1__U4( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
     {
-        uint8_t busIndex;
-        NF_PAL_I2C* palI2c;
-        bool isLongRunningOperation = false;
-        msg_t transactionResult = MSG_OK;
-
-        CLR_RT_HeapBlock    hbTimeout;
-        CLR_INT64*          timeout;
-        bool                eventResult = true;
-        int                 estimatedDurationMiliseconds;
-
-        CLR_RT_HeapBlock_Array* writeBuffer;
-        CLR_RT_HeapBlock_Array* readBuffer;
-        CLR_RT_HeapBlock*       result;
+        
+        unsigned char * writeData = NULL;
+        unsigned char * readData = NULL;
+        int writeSize = 0;
+        int readSize = 0;
+        msg_t i2cStatus;
+        int returnStatus = I2cTransferStatus_FullTransfer;
 
         // get a pointer to the managed object instance and check that it's not NULL
         CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
-
-        // get pointer to connection settings field
-        CLR_RT_HeapBlock* connectionSettings = pThis[ FIELD___connectionSettings ].Dereference();
+        
+        // get a pointer to the managed spi connectionSettings object instance
+        CLR_RT_HeapBlock* pConfig = pThis[ FIELD___connectionSettings ].Dereference();
 
         // get bus index
         // this is coded with a multiplication, need to perform and int division to get the number
-        // see the comments in the I2cDevice() constructor in managed code for details
-        busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
+        // see the comments in the SpiDevice() constructor in managed code for details
+        uint8_t bus = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
 
-        // get the driver for the I2C bus
-        switch (busIndex)
-        {
-    #if STM32_I2C_USE_I2C1
-            case 1 :
-                palI2c = &I2C1_PAL;
-                break;
-    #endif
-    #if STM32_I2C_USE_I2C2
-            case 2 :
-                palI2c = &I2C2_PAL;
-                break;
-    #endif
-    #if STM32_I2C_USE_I2C3
-            case 3 :
-                palI2c = &I2C3_PAL;
-                break;
-    #endif
-    #if STM32_I2C_USE_I2C4
-            case 4 :
-                palI2c = &I2C4_PAL;
-                break;
-    #endif
-            default:
-                // the requested I2C bus is not valid
-                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-                break;
-        }
+        // Get a complete low-level SPI configuration, depending on user's managed parameters
+        nfI2CConfig cfg = GetConfig(bus, pThis[ FIELD___connectionSettings ].Dereference());
 
         // dereference the write and read buffers from the arguments
-        writeBuffer = stack.Arg1().DereferenceArray();
+        CLR_RT_HeapBlock_Array* writeBuffer = stack.Arg1().DereferenceArray();
         if (writeBuffer != NULL)
         {
-            // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
-            palI2c->WriteSize = writeBuffer->m_numOfElements;
+            // grab the pointer to the array by getting the first element of the array
+            writeData = writeBuffer->GetFirstElement();
+
+            // get the size of the buffer by reading the number of elements in the HeapBlock array
+            writeSize = writeBuffer->m_numOfElements;
         }
 
-        readBuffer = stack.Arg2().DereferenceArray();
+        CLR_RT_HeapBlock_Array* readBuffer = stack.Arg3().DereferenceArray();
         if (readBuffer != NULL)
         {
-            // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
-            palI2c->ReadSize = readBuffer->m_numOfElements;
+            // grab the pointer to the array by getting the first element of the array
+            readData = readBuffer->GetFirstElement();
+
+            // get the size of the buffer by reading the number of elements in the HeapBlock array
+            readSize = readBuffer->m_numOfElements;
         }
 
-        // check if this is a long running operation
-        isLongRunningOperation = IsLongRunningOperation(palI2c->WriteSize, palI2c->ReadSize, palI2c->ByteTime, (int&)estimatedDurationMiliseconds);
-
-        if(isLongRunningOperation)
+        // because the bus access is shared, acquire the appropriate bus
+        i2cStart(cfg.Driver, &cfg.Configuration);
+        i2cAcquireBus(cfg.Driver);
+#ifdef STM32F7xx_MCUCONF
+        SCB_CleanInvalidateDCache();
+#endif
+        if (readSize != 0 && writeSize != 0)  // WriteRead
         {
-            // if this is a long running operation, set a timeout equal to the estimated transaction duration in milliseconds
-            // this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() bellow
-            hbTimeout.SetInteger((CLR_INT64)estimatedDurationMiliseconds * TIME_CONVERSION__TO_MILLISECONDS);
-
-            NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks( hbTimeout, timeout ));
-            
-            // protect the buffers from GC so DMA can find them where they are supposed to be
-            CLR_RT_ProtectFromGC gcWriteBuffer( *writeBuffer );
-            CLR_RT_ProtectFromGC gcReadBuffer( *readBuffer );
-        }
-
-        // this is going to be used to check for the right event in case of simultaneous I2C transaction
-        if(!isLongRunningOperation || stack.m_customState == 1)
-        {
-            // get slave address from connection settings field
-            palI2c->Address = (i2caddr_t)connectionSettings[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cConnectionSettings::FIELD___slaveAddress].NumericByRef().s4;
-
-            // when using I2Cv1 driver the address needs to be loaded in the I2C driver struct
-    #if defined(STM32F1xx_MCUCONF) || defined(STM32F4xx_MCUCONF) || defined(STM32L1xx_MCUCONF)
-            palI2c->Driver->addr = palI2c->Address;
-    #endif
-
-            if (writeBuffer != NULL)
-            {
-                palI2c->WriteBuffer = (uint8_t*)writeBuffer->GetFirstElement();
-
-                // flush DMA buffer to ensure cache coherency
-                // (only required for Cortex-M7)
-                cacheBufferFlush(palI2c->WriteBuffer, palI2c->WriteSize);
-            }
-
-            if (readBuffer != NULL)
-            {
-                palI2c->ReadBuffer = (uint8_t*)readBuffer->GetFirstElement();
-            }
-            
-            // because the bus access is shared, acquire the appropriate bus
-            i2cStart(palI2c->Driver, &palI2c->Configuration);
-            i2cAcquireBus(palI2c->Driver);
-        }
-
-        if(isLongRunningOperation)
-        {
-            // this is a long running operation and hasn't started yet
-            // perform I2C transaction using driver's ASYNC API which is launching a thread to perform it
-            if(stack.m_customState == 1)
-            {
-                // spawn working thread to perform the I2C transaction
-                palI2c->WorkingThread = chThdCreateFromHeap(NULL, THD_WORKING_AREA_SIZE(256),
-                                            "I2CWT", NORMALPRIO, I2CWorkingThread, palI2c);
-
-                if(palI2c->WorkingThread == NULL)
-                {
-                    NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
-                }
-                
-                // bump custom state
-                stack.m_customState = 2;                      
-            }
+            i2cStatus = i2cMasterTransmitTimeout(cfg.Driver, cfg.SlaveAddress, &writeData[0], writeSize, &readData[0], readSize, 2000);
         }
         else
         {
-            // this is NOT a long running operation
-            // perform I2C transaction using driver's SYNC API
-
-            if (palI2c->ReadSize != 0 && palI2c->WriteSize != 0)
+            if (readSize == 0)      //Write
             {
-                // this is a Write/Read transaction
-                transactionResult = i2cMasterTransmitTimeout(palI2c->Driver, palI2c->Address, palI2c->WriteBuffer, palI2c->WriteSize, palI2c->ReadBuffer, palI2c->ReadSize, TIME_MS2I(20));
+                i2cStatus = i2cMasterTransmitTimeout(cfg.Driver, cfg.SlaveAddress, &writeData[0], writeSize, NULL, 0, 2000);
             }
-            else
+            else                    // Read
             {
-                if (palI2c->ReadSize == 0)
-                {
-                    // this is Write only transaction
-                    transactionResult = i2cMasterTransmitTimeout(palI2c->Driver, palI2c->Address, palI2c->WriteBuffer, palI2c->WriteSize, NULL, 0, TIME_MS2I(20));
-                }
-                else
-                {
-                    // this is a Read only transaction
-                    transactionResult = i2cMasterReceiveTimeout (palI2c->Driver, palI2c->Address, palI2c->ReadBuffer, palI2c->ReadSize, TIME_MS2I(20));
-                }
-            }
-
-            i2cReleaseBus(palI2c->Driver);
-        }    
-
-        while(eventResult)
-        {
-            if(!isLongRunningOperation)
-            {
-                // this is not a long running operation so nothing to do here
-                break;
-            }
-
-            if(palI2c->WorkingThread->state == CH_STATE_FINAL)
-            {
-                // I2C working thread is now complete
-                break;
-            }
-
-            // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
-            NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents( stack.m_owningThread, *timeout, CLR_RT_ExecutionEngine::c_Event_I2cMaster, eventResult ));
-        }
-
-        if(isLongRunningOperation)
-        {
-            // pop timeout heap block from stack
-            stack.PopValue();
-        }
-
-        if(eventResult || !isLongRunningOperation)
-        {
-            // event occurred
-            // OR this is NOT a long running operation
-
-            // create the return object (I2cTransferResult)
-            // only at this point we are sure that there will be a return from this thread so it's OK to use the managed stack
-            CLR_RT_HeapBlock& top = stack.PushValueAndClear();
-            NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
-            result = top.Dereference(); FAULT_ON_NULL(result);
-
-            if(isLongRunningOperation)
-            {
-                // ChibiOS requirement: need to call chThdWait for I2C working thread in order to have it's memory released to the heap, otherwise it won't be returned
-                transactionResult = chThdWait(palI2c->WorkingThread);
-            }
-
-            // get the result from the working thread execution
-            if (transactionResult != MSG_OK)
-            {
-                // error in transaction
-                int errors = i2cGetErrors(palI2c->Driver);
-                
-                // figure out what was the error and set the status field
-                switch(errors)
-                {
-                    case I2C_ACK_FAILURE:
-                        result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status ].SetInteger((CLR_UINT32)I2cTransferStatus_SlaveAddressNotAcknowledged);
-                        break;
-
-                    case I2C_TIMEOUT:
-                        result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status ].SetInteger((CLR_UINT32)I2cTransferStatus_ClockStretchTimeout);
-                        break;
-
-                    default:
-                        result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status ].SetInteger((CLR_UINT32)I2cTransferStatus_UnknownError);
-                }
-
-                // set the bytes transferred count to 0 because we don't have a way to know how many bytes were actually sent/received
-                result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___bytesTransferred ].SetInteger(0);
-            }
-            else
-            {
-                // successfull transaction
-                // set the result field
-                result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status ].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
-
-                // set the bytes transferred field
-                result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___bytesTransferred ].SetInteger((CLR_UINT32)(palI2c->WriteSize + palI2c->ReadSize));
-            }
-        
-            if(palI2c->ReadSize > 0)
-            {
-                // invalidate cache over read buffer to ensure that content from DMA is read
-                // (only required for Cortex-M7)
-                cacheBufferInvalidate(palI2c->ReadBuffer, palI2c->ReadSize);
+                i2cStatus = i2cMasterReceiveTimeout (cfg.Driver, cfg.SlaveAddress, &readData[0], readSize, 2000);
             }
         }
+        i2cReleaseBus(cfg.Driver);
 
+        if (i2cStatus != MSG_OK)
+        {
+            int errorMask = i2cGetErrors(cfg.Driver);
+
+            //TODO: return correct error status regarding UWP API
+            returnStatus = I2cTransferStatus_UnknownError;
+        }
+
+        // null pointers and vars
+        writeData = NULL;
+        readData = NULL;
+        writeBuffer = NULL;
+        readBuffer = NULL;
+        pThis = NULL;
+
+        stack.SetResult_I4(returnStatus);
     }
     NANOCLR_NOCLEANUP();
 }
@@ -492,28 +202,28 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
 HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::GetDeviceSelector___STATIC__STRING( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
-    {
+   {
        // declare the device selector string whose max size is "I2C1,I2C2,I2C3,I2C4," + terminator and init with the terminator
-       char deviceSelectorString[20 + 1] = { 0 };
+       char deviceSelectorString[ 20 + 1] = { 0 };
 
-    #if STM32_I2C_USE_I2C1
-        strcat(deviceSelectorString, "I2C1,");
-    #endif
-    #if STM32_I2C_USE_I2C2
-        strcat(deviceSelectorString, "I2C2,");
-    #endif
-    #if STM32_I2C_USE_I2C3
-        strcat(deviceSelectorString, "I2C3,");
-    #endif
-    #if STM32_I2C_USE_I2C4
-        strcat(deviceSelectorString, "I2C4,");
-    #endif
-        // replace the last comma with a terminator
+   #if STM32_I2C_USE_I2C1
+       strcat(deviceSelectorString, "I2C1,");
+   #endif
+   #if STM32_I2C_USE_I2C2
+       strcat(deviceSelectorString, "I2C2,");
+   #endif
+   #if STM32_I2C_USE_I2C3
+       strcat(deviceSelectorString, "I2C3,");
+   #endif
+   #if STM32_I2C_USE_I2C4
+       strcat(deviceSelectorString, "I2C4,");
+   #endif
+       // replace the last comma with a terminator
        deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
 
        // because the caller is expecting a result to be returned
        // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
        stack.SetResult_String(deviceSelectorString);
-    }
-    NANOCLR_NOCLEANUP();
+   }
+   NANOCLR_NOCLEANUP();
 }

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -162,7 +162,9 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
         i2cStart(cfg.Driver, &cfg.Configuration);
         i2cAcquireBus(cfg.Driver);
         // Handle potential cache issues on MCUs that have it (e.g. F7xx, H7xx)
+#if defined(STM32F7xx_MCUCONF) || defined(STM32H7xx_MCUCONF)
         SCB_CleanInvalidateDCache();
+#endif
 
         if (readSize != 0 && writeSize != 0)  // WriteRead
         {


### PR DESCRIPTION
## Description
- Revert I2C code @ 99ad98a5102ea7e5b472e41a5292c7f63466aefa

## Motivation and Context
- Seems that the last batch of changes have introduced unwanted behaviour of the I2C module. This reverts the code to point of a very well tested implementation. 


**Mind to reference I2C Nuget 1.0.0-preview171**
