### PR TITLE
Fix bug with unwanted read or write after I2C operation 

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -302,12 +302,22 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
             // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
             palI2c->WriteSize = writeBuffer->m_numOfElements;
         }
+        else
+        {
+            // nothing to write, have to zero this
+            palI2c->WriteSize = 0;
+        }
 
         readBuffer = stack.Arg2().DereferenceArray();
         if (readBuffer != NULL)
         {
             // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
             palI2c->ReadSize = readBuffer->m_numOfElements;
+        }
+        else
+        {
+            // nothing to read, have to zero this
+            palI2c->ReadSize = 0;
         }
 
         // check if this is a long running operation


### PR DESCRIPTION
## Description
- Properly set ReadSize and WriteSize vars when setting up I2C operation (always have to set these, otherwise they'll be "reusing" the values from the last operation when there was no read or write buffer causing unwanted read or write after the real operation)
- This affects only the STM32 targets.

## Motivation and Context
- Resolves nanoFramework/Home#319

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
