### PR TITLE
Add WP command to list interop native assemblies

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -2760,6 +2760,43 @@ bool CLR_DBG_Debugger::Debugging_Value_Assign( WP_Message* msg)
 
 //--//
 
+bool CLR_DBG_Debugger::Debugging_TypeSys_InteropNativeAssemblies( WP_Message* msg)
+{
+    NATIVE_PROFILE_CLR_DEBUGGER();
+
+    extern const CLR_RT_NativeAssemblyData *g_CLR_InteropAssembliesNativeData[];
+
+    int nativeAssembliesCount = 0;
+    NativeAssembly_Details* interopNativeAssemblies;
+
+    // because the Interop assemblies list is assembled during the build we have to count how many are there before allocating memory for the array
+    for ( int i = 0; g_CLR_InteropAssembliesNativeData[i]; i++ )
+    {
+        if (g_CLR_InteropAssembliesNativeData[i] != NULL)
+        {
+            nativeAssembliesCount++;
+        }
+    }
+
+    interopNativeAssemblies = (NativeAssembly_Details*)platform_malloc(sizeof(NativeAssembly_Details) * nativeAssembliesCount);
+
+    // fill the array
+    for ( int i = 0; i < nativeAssembliesCount; i++ )
+    {
+        if (g_CLR_InteropAssembliesNativeData[i] != NULL)
+        {
+            interopNativeAssemblies[i].CheckSum = g_CLR_InteropAssembliesNativeData[i]->m_checkSum;
+            hal_strcpy_s((char*)interopNativeAssemblies[i].AssemblyName, ARRAYSIZE(interopNativeAssemblies[i].AssemblyName), g_CLR_InteropAssembliesNativeData[i]->m_szAssemblyName);
+        }
+    }
+
+    WP_ReplyToCommand( msg, true, false, interopNativeAssemblies, (sizeof(NativeAssembly_Details) * nativeAssembliesCount));
+
+    platform_free(interopNativeAssemblies);
+
+    return true;
+}
+
 bool CLR_DBG_Debugger::Debugging_TypeSys_Assemblies( WP_Message* msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();

--- a/src/CLR/Debugger/Debugger.h
+++ b/src/CLR/Debugger/Debugger.h
@@ -51,9 +51,10 @@ typedef enum CLR_DBG_Commands_Debugging
     CLR_DBG_Commands_c_Debugging_Value_AllocateArray            = 0x0002003A, // Creates a new instance of an array.
     CLR_DBG_Commands_c_Debugging_Value_Assign                   = 0x0002003B, // Assigns a value to another value.
                                                                  
-    CLR_DBG_Commands_c_Debugging_TypeSys_Assemblies             = 0x00020040, // Lists all the assemblies in the system.
-    CLR_DBG_Commands_c_Debugging_TypeSys_AppDomains             = 0x00020044, // Lists all the AppDomans loaded.
-                                                                 
+    CLR_DBG_Commands_c_Debugging_TypeSys_Assemblies                 = 0x00020040, // Lists all the assemblies in the system.
+    CLR_DBG_Commands_c_Debugging_TypeSys_AppDomains                 = 0x00020044, // Lists all the AppDomans loaded.
+    CLR_DBG_Commands_c_Debugging_TypeSys_InteropNativeAssemblies    = 0x00020045, // Lists all the Interop Native Assemblies.
+                                                                
     CLR_DBG_Commands_c_Debugging_Resolve_Assembly               = 0x00020050, // Resolves an assembly.
     CLR_DBG_Commands_c_Debugging_Resolve_Type                   = 0x00020051, // Resolves a type to a string.
     CLR_DBG_Commands_c_Debugging_Resolve_Field                  = 0x00020052, // Resolves a field to a string.

--- a/src/CLR/Debugger/Debugger_full.cpp
+++ b/src/CLR/Debugger/Debugger_full.cpp
@@ -71,8 +71,9 @@ const CLR_Messaging_CommandHandlerLookup c_Debugger_Lookup_Request[] =
     DEFINE_CMD(Value_AllocateArray       ),
     DEFINE_CMD(Value_Assign              ),
     //
-    DEFINE_CMD(TypeSys_Assemblies        ),
-    DEFINE_CMD(TypeSys_AppDomains        ),
+    DEFINE_CMD(TypeSys_Assemblies               ),
+    DEFINE_CMD(TypeSys_AppDomains               ),
+    DEFINE_CMD(TypeSys_InteropNativeAssemblies  ),
     //
     DEFINE_CMD(Resolve_AppDomain         ),
     DEFINE_CMD(Resolve_Assembly          ),

--- a/src/CLR/Include/WireProtocol_MonitorCommands.h
+++ b/src/CLR/Include/WireProtocol_MonitorCommands.h
@@ -140,6 +140,13 @@ typedef struct CLR_DBG_Commands_Monitor_MemoryMap
 
 }CLR_DBG_Commands_Monitor_MemoryMap;
 
+typedef struct NativeAssembly_Details
+{
+    uint32_t CheckSum;
+    // version Version  // TODO add 'version info' in a future version
+    uint8_t AssemblyName[128];
+
+}NativeAssembly_Details;
 
 //////////////////////////////////////////
 // function declarations (commands)

--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -222,8 +222,9 @@ struct CLR_DBG_Commands
     static const unsigned int c_Debugging_Value_AllocateArray            = 0x0002003A; // Creates a new instance of an array.
     static const unsigned int c_Debugging_Value_Assign                   = 0x0002003B; // Assigns a value to another value.
                                                                  
-    static const unsigned int c_Debugging_TypeSys_Assemblies             = 0x00020040; // Lists all the assemblies in the system.
-    static const unsigned int c_Debugging_TypeSys_AppDomains             = 0x00020044; // Lists all the AppDomans loaded.
+    static const unsigned int c_Debugging_TypeSys_Assemblies                = 0x00020040; // Lists all the assemblies in the system.
+    static const unsigned int c_Debugging_TypeSys_AppDomains                = 0x00020044; // Lists all the AppDomans loaded.
+    static const unsigned int c_Debugging_TypeSys_InteropNativeAssemblies   = 0x00020045; // Lists all the Interop Native Assemblies.
                                                                  
     static const unsigned int c_Debugging_Resolve_Assembly               = 0x00020050; // Resolves an assembly.
     static const unsigned int c_Debugging_Resolve_Type                   = 0x00020051; // Resolves a type to a string.
@@ -1104,8 +1105,9 @@ public:
     static bool Debugging_Value_AllocateArray           ( WP_Message* msg );
     static bool Debugging_Value_Assign                  ( WP_Message* msg );
                                              
-    static bool Debugging_TypeSys_Assemblies            ( WP_Message* msg );
-    static bool Debugging_TypeSys_AppDomains            ( WP_Message* msg );
+    static bool Debugging_TypeSys_Assemblies                ( WP_Message* msg );
+    static bool Debugging_TypeSys_AppDomains                ( WP_Message* msg );
+    static bool Debugging_TypeSys_InteropNativeAssemblies   ( WP_Message* msg );
                                              
     static bool Debugging_Resolve_AppDomain             ( WP_Message* msg );
     static bool Debugging_Resolve_Assembly              ( WP_Message* msg );


### PR DESCRIPTION
## Description
- Add WP command to list interop native assemblies

## Motivation and Context
- This is to be used by a debugger connected to the target in order to determine what native methods are available
- Addresses nanoFramework/Home#329

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
