### PR TITLE
SPI: Use the max clock frequency if unset (#327)

### DIFF
--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.h
@@ -17,6 +17,9 @@
 #define NUM_SPI_BUSES   3
 #define MAX_SPI_DEVICES 3
 
+// Max clock frequency is 20 MHz
+#define MAX_CLOCK_FREQUENCY 20000000
+
 struct nfSpiBusConfig
 {
     bool                spiBusInited;

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo.cpp
@@ -17,7 +17,7 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo::get_MaxClockF
         // need to grab 'n' from the string and convert to the integer value from the ASCII code
         uint8_t bus = (uint8_t)pArg[0].RecoverString()[3] - 48;
 
-        stack.SetResult_I4 ( 20000000 );
+        stack.SetResult_I4 ( MAX_CLOCK_FREQUENCY );
     }
     NANOCLR_NOCLEANUP();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -169,6 +169,12 @@ spi_device_interface_config_t Library_win_dev_spi_native_Windows_Devices_Spi_Spi
     int bitOrder = config[ SpiConnectionSettings::FIELD___bitOrder ].NumericByRef().s4;
     int clockHz  = config[ SpiConnectionSettings::FIELD___clockFrequency ].NumericByRef().s4;
     
+    // if clock frequency is unset use the maximum frequency
+    if (clockHz == 0)
+    {
+        clockHz = MAX_CLOCK_FREQUENCY;
+    }
+
 //ets_printf( "Spi config cspin:%d spiMode:%d bitorder:%d clockHz:%d\n", csPin, spiMode, bitOrder, clockHz);
     uint32_t flags = (bitOrder == 1) ? (SPI_DEVICE_TXBIT_LSBFIRST | SPI_DEVICE_RXBIT_LSBFIRST) : 0;
  


### PR DESCRIPTION
## Description
Fixing "Getting 'System.ArgumentException' Error while calling 'SpiDevice.FromId'". The cause of this exception is the unset SPI clock frequency. Now if the frequency is unset we use the max frequency.

## Motivation and Context
This solves nanoFramework/Home#327

## How Has This Been Tested?
Tested on ESP32 with the following C# code:
`SpiDevice.FromId("SPI1", new SpiConnectionSettings(22));`

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>
