### PR TITLE
Initial ESP32 native hardware support

### DIFF
--- a/CMake/Modules/FindHardware.Esp32.cmake
+++ b/CMake/Modules/FindHardware.Esp32.cmake
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2017 The nanoFramework project contributors
+# See LICENSE file in the project root for full license information.
+#
+
+# native code directory
+set(BASE_PATH_FOR_THIS_MODULE "${BASE_PATH_FOR_CLASS_LIBRARIES_MODULES}/Hardware.Esp32")
+
+
+# set include directories
+list(APPEND Hardware.Esp32_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/CLR/Core")
+list(APPEND Hardware.Esp32_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/CLR/Include")
+list(APPEND Hardware.Esp32_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/HAL/Include")
+list(APPEND Hardware.Esp32_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/PAL/Include")
+list(APPEND Hardware.Esp32_INCLUDE_DIRS "${BASE_PATH_FOR_THIS_MODULE}")
+
+# source files
+set(Hardware.Esp32_SRCS
+    hardware_esp32_native.cpp
+    hardware_esp32_native.h
+    hardware_esp32_native_Hardware_Esp32_sleep.cpp
+    hardware_esp32_native_Hardware_Esp32_Logging.cpp
+)
+
+foreach(SRC_FILE ${Hardware.Esp32_SRCS})
+    set(Hardware.Esp32_SRC_FILE SRC_FILE-NOTFOUND)
+    find_file(Hardware.Esp32_SRC_FILE ${SRC_FILE}
+        PATHS 
+            "${BASE_PATH_FOR_THIS_MODULE}"
+
+        CMAKE_FIND_ROOT_PATH_BOTH
+    )
+    message("${SRC_FILE} >> ${Hardware.Esp32_SRC_FILE}") # debug helper
+    list(APPEND Hardware.Esp32_SOURCES ${Hardware.Esp32_SRC_FILE})
+endforeach()
+
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Hardware.Esp32 DEFAULT_MSG Hardware.Esp32_INCLUDE_DIRS Hardware.Esp32_SOURCES)

--- a/CMake/Modules/NF_API_Namespaces.cmake
+++ b/CMake/Modules/NF_API_Namespaces.cmake
@@ -21,6 +21,9 @@ option(API_Windows.Devices.Spi                  "option for Windows.Devices.Spi 
 option(API_Windows.Networking.Sockets           "option for Windows.Networking.Sockets")
 
 
+# Esp32 only
+option(API_Hardware.Esp32                       "option for Hardware.Esp32")
+
 #################################################################
 # macro to perform individual settings to add an API to the build
 macro(PerformSettingsForApiEntry apiNamespace)
@@ -123,7 +126,12 @@ macro(ParseApiOptions)
         PerformSettingsForApiEntry("Windows.Networking.Sockets")
     endif()
     
-    
+    # Hardware.Esp32
+    if(API_Hardware.Esp32)
+        ##### API name here (doted name)
+        PerformSettingsForApiEntry("Hardware.Esp32")
+    endif()
+
     # parse the declarations to have new lines and ';'
     string(REPLACE ";;" ";\n" CLR_RT_NativeAssemblyDataDeclarations "${CLR_RT_NativeAssemblyDataList}")
     # parse the list to have new lines, ',' and identation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -356,7 +356,7 @@
     matrix:
       - BOARD_NAME: 'STM32'
       - BOARD_NAME: 'ESP32_DEVKITC'
-        BUILD_OPTIONS: '-DTARGET_SERIES=ESP32 -DRTOS=FREERTOS -DNF_FEATURE_DEBUGGER=TRUE -DNF_FEATURE_RTC=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=OFF'
+        BUILD_OPTIONS: '-DTARGET_SERIES=ESP32 -DRTOS=FREERTOS -DNF_FEATURE_DEBUGGER=TRUE -DNF_FEATURE_RTC=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=OFF -DAPI_Hardware.Esp32=ON'
       - BOARD_NAME: 'NANOCLR_WINDOWS'
 
   matrix:

--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -56,7 +56,8 @@
             "API_Windows.Devices.Pwm" : "OFF-default-ON-to-add-this-API",
             "API_Windows.Devices.SerialCommunication" : "OFF-default-ON-to-add-this-API",
             "API_Windows.Devices.Spi" : "OFF-default-ON-to-add-this-API",
-            "API_Windows.Networking.Sockets" : "OFF-default-ON-to-add-this-API"
+            "API_Windows.Networking.Sockets" : "OFF-default-ON-to-add-this-API",
+            "API_Hardware.Esp32" : "OFF-default-ON-to-add-this-API"
           }
       },
       "OPTION2_NAME_HERE": {
@@ -93,7 +94,8 @@
             "API_Windows.Devices.Pwm" : "OFF-default-ON-to-add-this-API",
             "API_Windows.Devices.SerialCommunication" : "OFF-default-ON-to-add-this-API",
             "API_Windows.Devices.Spi" : "OFF-default-ON-to-add-this-API",
-            "API_Windows.Networking.Sockets" : "OFF-default-ON-to-add-this-API"
+            "API_Windows.Networking.Sockets" : "OFF-default-ON-to-add-this-API",
+            "API_Hardware.Esp32" : "OFF-default-ON-to-add-this-API"
         }
       },
       "default$": "",

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Hardware.ESP32/hardware_esp32_native.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Hardware.ESP32/hardware_esp32_native.cpp
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+#include "hardware_esp32_native.h"
+
+static const CLR_RT_MethodHandler method_lookup[] =
+{
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Logging::NativeSetLogLevel___STATIC__VOID__STRING__I4,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakupByTimer___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp__U8,
+    Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakupByPin___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp__nanoFrameworkHardwareEsp32SleepWakeupGpioPin__I4,
+    Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakeupByMultiPins___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp__nanoFrameworkHardwareEsp32SleepWakeupGpioPin__nanoFrameworkHardwareEsp32SleepWakupMode,
+    Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakeupByTouchPad___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp,
+    Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeStartLightSleep___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp,
+    Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeStartDeepSleep___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp,
+    Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeGetWakeupCause___STATIC__nanoFrameworkHardwareEsp32SleepWakeupCause,
+    Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeGetWakeupGpioPin___STATIC__nanoFrameworkHardwareEsp32SleepWakeupGpioPin,
+    Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeGetWakeupTouchpad___STATIC__nanoFrameworkHardwareEsp32SleepTouchPad,
+    NULL,
+    NULL,
+};
+
+const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Hardware_Esp32 =
+{
+    "Hardware.Esp32", 
+    0xF04C828C,
+    method_lookup
+};
+
+
+

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Hardware.ESP32/hardware_esp32_native.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Hardware.ESP32/hardware_esp32_native.h
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+#ifndef _HARDWARE_ESP32_NATIVE_H_
+#define _HARDWARE_ESP32_NATIVE_H_
+
+#include <nanoCLR_Interop.h>
+#include <nanoCLR_Runtime.h>
+#include <nanoCLR_Checks.h>
+#include <corlib_native.h>
+
+struct Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Logging
+{
+    NANOCLR_NATIVE_DECLARE(NativeSetLogLevel___STATIC__VOID__STRING__I4);
+
+    //--//
+
+};
+
+struct Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep
+{
+    NANOCLR_NATIVE_DECLARE(NativeEnableWakupByTimer___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp__U8);
+    NANOCLR_NATIVE_DECLARE(NativeEnableWakupByPin___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp__nanoFrameworkHardwareEsp32SleepWakeupGpioPin__I4);
+    NANOCLR_NATIVE_DECLARE(NativeEnableWakeupByMultiPins___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp__nanoFrameworkHardwareEsp32SleepWakeupGpioPin__nanoFrameworkHardwareEsp32SleepWakupMode);
+    NANOCLR_NATIVE_DECLARE(NativeEnableWakeupByTouchPad___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp);
+    NANOCLR_NATIVE_DECLARE(NativeStartLightSleep___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp);
+    NANOCLR_NATIVE_DECLARE(NativeStartDeepSleep___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp);
+    NANOCLR_NATIVE_DECLARE(NativeGetWakeupCause___STATIC__nanoFrameworkHardwareEsp32SleepWakeupCause);
+    NANOCLR_NATIVE_DECLARE(NativeGetWakeupGpioPin___STATIC__nanoFrameworkHardwareEsp32SleepWakeupGpioPin);
+    NANOCLR_NATIVE_DECLARE(NativeGetWakeupTouchpad___STATIC__nanoFrameworkHardwareEsp32SleepTouchPad);
+
+    //--//
+
+};
+
+extern const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Hardware_Esp32;
+
+#endif  //_HARDWARE_ESP32_NATIVE_H_

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Hardware.ESP32/hardware_esp32_native_Hardware_Esp32_Logging.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Hardware.ESP32/hardware_esp32_native_Hardware_Esp32_Logging.cpp
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+#include "hardware_esp32_native.h"
+
+HRESULT Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Logging::NativeSetLogLevel___STATIC__VOID__STRING__I4( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+        const char * szTag = stack.Arg0().RecoverString();
+        esp_log_level_t logLevel = (esp_log_level_t)stack.Arg1().NumericByRef().s4;
+ 
+        esp_log_level_set(szTag, logLevel);
+    }
+    NANOCLR_NOCLEANUP();
+}
+

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Hardware.ESP32/hardware_esp32_native_Hardware_Esp32_Sleep.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Hardware.ESP32/hardware_esp32_native_Hardware_Esp32_Sleep.cpp
@@ -1,0 +1,125 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+#include <string.h>
+#include <targetPAL.h>
+
+#include "hardware_esp32_native.h"
+
+HRESULT Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakupByTimer___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp__U8( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+        uint64_t time_us = (uint64_t)stack.Arg0().NumericByRef().s8;
+
+        esp_err_t err = esp_sleep_enable_timer_wakeup(time_us);
+
+        // Return err to the managed application
+        stack.SetResult_I4( (int)err ) ;
+
+    }    
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakupByPin___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp__nanoFrameworkHardwareEsp32SleepWakeupGpioPin__I4( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+        gpio_num_t gpio_num = (gpio_num_t)stack.Arg0().NumericByRef().s4;
+        int  level = stack.Arg1().NumericByRef().s4;
+        
+        esp_err_t err = esp_sleep_enable_ext0_wakeup( gpio_num, level);
+
+        // Return err to the managed application
+        stack.SetResult_I4( (int)err ) ;
+ }
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakeupByMultiPins___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp__nanoFrameworkHardwareEsp32SleepWakeupGpioPin__nanoFrameworkHardwareEsp32SleepWakupMode( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+        uint64_t mask = (uint64_t)stack.Arg0().NumericByRef().s8;
+        esp_sleep_ext1_wakeup_mode_t  mode = (esp_sleep_ext1_wakeup_mode_t)stack.Arg1().NumericByRef().s4;
+        
+        esp_err_t err = esp_sleep_enable_ext1_wakeup(mask, mode);
+
+        // Return err to the managed application
+        stack.SetResult_I4( (int)err ) ;
+  }
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakeupByTouchPad___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+        esp_err_t err = esp_sleep_enable_touchpad_wakeup();
+
+        // Return err to the managed application
+        stack.SetResult_I4( (int)err ) ;
+
+    }
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeStartLightSleep___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+        esp_err_t err = esp_light_sleep_start();
+
+        // Return err to the managed application
+        stack.SetResult_I4( (int)err ) ;
+    }
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeStartDeepSleep___STATIC__nanoFrameworkHardwareEsp32ErrorsEsp( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+        esp_deep_sleep_start();
+    }
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeGetWakeupCause___STATIC__nanoFrameworkHardwareEsp32SleepWakeupCause( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+        esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
+
+        // Return value to the managed application
+        stack.SetResult_I4( (int32_t)cause ) ;
+    }
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeGetWakeupGpioPin___STATIC__nanoFrameworkHardwareEsp32SleepWakeupGpioPin( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+        int64_t pin = (int64_t)esp_sleep_get_ext1_wakeup_status();
+        
+        // Return value to the managed application
+        stack.SetResult_I8( pin ) ;
+    }    
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeGetWakeupTouchpad___STATIC__nanoFrameworkHardwareEsp32SleepTouchPad( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+        touch_pad_t touch_pad = esp_sleep_get_touchpad_wakeup_status();
+
+        // Return value to the managed application
+        stack.SetResult_I4( (int)touch_pad ) ;
+    }
+    NANOCLR_NOCLEANUP();
+}


### PR DESCRIPTION
## Description
This adds an interface so native ESP32 functions that are not included in normal UWP assemblies can be called from managed code.

- Call the ESP32 Sleep functions.
- Change the IDF logging options.

## Motivation and Context
Required as no functions in UWP assemblies to call these functions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
