### PR TITLE
Move command to list native interop assemblies to QueryCLRCapabilities

### DIFF
--- a/src/CLR/Debugger/Debugger.h
+++ b/src/CLR/Debugger/Debugger.h
@@ -53,7 +53,6 @@ typedef enum CLR_DBG_Commands_Debugging
                                                                  
     CLR_DBG_Commands_c_Debugging_TypeSys_Assemblies                 = 0x00020040, // Lists all the assemblies in the system.
     CLR_DBG_Commands_c_Debugging_TypeSys_AppDomains                 = 0x00020044, // Lists all the AppDomans loaded.
-    CLR_DBG_Commands_c_Debugging_TypeSys_InteropNativeAssemblies    = 0x00020045, // Lists all the Interop Native Assemblies.
                                                                 
     CLR_DBG_Commands_c_Debugging_Resolve_Assembly               = 0x00020050, // Resolves an assembly.
     CLR_DBG_Commands_c_Debugging_Resolve_Type                   = 0x00020051, // Resolves a type to a string.

--- a/src/CLR/Debugger/Debugger_full.cpp
+++ b/src/CLR/Debugger/Debugger_full.cpp
@@ -71,9 +71,8 @@ const CLR_Messaging_CommandHandlerLookup c_Debugger_Lookup_Request[] =
     DEFINE_CMD(Value_AllocateArray       ),
     DEFINE_CMD(Value_Assign              ),
     //
-    DEFINE_CMD(TypeSys_Assemblies               ),
-    DEFINE_CMD(TypeSys_AppDomains               ),
-    DEFINE_CMD(TypeSys_InteropNativeAssemblies  ),
+    DEFINE_CMD(TypeSys_Assemblies        ),
+    DEFINE_CMD(TypeSys_AppDomains        ),
     //
     DEFINE_CMD(Resolve_AppDomain         ),
     DEFINE_CMD(Resolve_Assembly          ),

--- a/src/CLR/Include/WireProtocol_MonitorCommands.h
+++ b/src/CLR/Include/WireProtocol_MonitorCommands.h
@@ -140,14 +140,6 @@ typedef struct CLR_DBG_Commands_Monitor_MemoryMap
 
 }CLR_DBG_Commands_Monitor_MemoryMap;
 
-typedef struct NativeAssembly_Details
-{
-    uint32_t CheckSum;
-    // version Version  // TODO add 'version info' in a future version
-    uint8_t AssemblyName[128];
-
-}NativeAssembly_Details;
-
 //////////////////////////////////////////
 // function declarations (commands)
 

--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -224,7 +224,6 @@ struct CLR_DBG_Commands
                                                                  
     static const unsigned int c_Debugging_TypeSys_Assemblies                = 0x00020040; // Lists all the assemblies in the system.
     static const unsigned int c_Debugging_TypeSys_AppDomains                = 0x00020044; // Lists all the AppDomans loaded.
-    static const unsigned int c_Debugging_TypeSys_InteropNativeAssemblies   = 0x00020045; // Lists all the Interop Native Assemblies.
                                                                  
     static const unsigned int c_Debugging_Resolve_Assembly               = 0x00020050; // Resolves an assembly.
     static const unsigned int c_Debugging_Resolve_Type                   = 0x00020051; // Resolves a type to a string.
@@ -270,6 +269,7 @@ struct CLR_DBG_Commands
         static const CLR_UINT32 c_HalSystemInfo               = 5;
         static const CLR_UINT32 c_ClrInfo                     = 6;
         static const CLR_UINT32 c_TargetReleaseInfo           = 7;
+        static const CLR_UINT32 c_InteropNativeAssemblies     = 8;
 
         static const CLR_UINT32 c_CapabilityFlags_FloatingPoint             = 0x00000001;
         static const CLR_UINT32 c_CapabilityFlags_SourceLevelDebugging      = 0x00000002;
@@ -298,6 +298,14 @@ struct CLR_DBG_Commands
             NFVersion     m_TargetFrameworkVersion;
         };
         
+        struct __nfpack NativeAssemblyDetails
+        {
+            uint32_t CheckSum;
+            NFVersion Version;
+            uint8_t AssemblyName[128];
+
+        };
+
         union ReplyUnion
         {
             CLR_UINT32          u_capsFlags;
@@ -1105,9 +1113,8 @@ public:
     static bool Debugging_Value_AllocateArray           ( WP_Message* msg );
     static bool Debugging_Value_Assign                  ( WP_Message* msg );
                                              
-    static bool Debugging_TypeSys_Assemblies                ( WP_Message* msg );
-    static bool Debugging_TypeSys_AppDomains                ( WP_Message* msg );
-    static bool Debugging_TypeSys_InteropNativeAssemblies   ( WP_Message* msg );
+    static bool Debugging_TypeSys_Assemblies            ( WP_Message* msg );
+    static bool Debugging_TypeSys_AppDomains            ( WP_Message* msg );
                                              
     static bool Debugging_Resolve_AppDomain             ( WP_Message* msg );
     static bool Debugging_Resolve_Assembly              ( WP_Message* msg );


### PR DESCRIPTION
## Description
- Move command to list native interop assemblies to QueryCLRCapabilities

## Motivation and Context
- The native assemblies collection is static, is baked in the fw image and part of it. Therefore it seems logical that it should belong to the CLR devices capabilities and be requested with those.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
