### PR TITLE
GLOBAL_LOCK / GLOBAL_UNLOCK implemented

### DIFF
--- a/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL.h
@@ -8,13 +8,13 @@
 
 #include <target_board.h>
 #include <nanoWeak.h>
+#include <esp32_os.h>
 
-//TODO: implement
-//#define GLOBAL_LOCK(x)              chSysLock();
-//#define GLOBAL_UNLOCK(x);           chSysUnlock();
-#define GLOBAL_LOCK(x)             
-#define GLOBAL_UNLOCK(x);          
+extern portMUX_TYPE globalLockMutex;
+#define GLOBAL_LOCK(x)              taskENTER_CRITICAL(&globalLockMutex);
+#define GLOBAL_UNLOCK(x)            taskEXIT_CRITICAL(&globalLockMutex);
 #define ASSERT_IRQ_MUST_BE_OFF()   // TODO need to determine if this needs implementation
+
 
 #define PLATFORM_WAIT(milliSecs)    vTaskDelay(milliSecs/portTICK_PERIOD_MS);
 

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/app_main.c
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/app_main.c
@@ -14,6 +14,8 @@
 
 extern void CLRStartupThread(void const * argument);
 
+// Mutex for GLOBAL_LOCK / GLOBAL_UNLOCK
+portMUX_TYPE globalLockMutex = portMUX_INITIALIZER_UNLOCKED;
 
 // These are offsets in the Deployment partition
 uint32_t  __deployment_start__ = 0;


### PR DESCRIPTION
## Description
GLOBAL_LOCK / GLOBAL_UNLOCK was not implemented for the ESP32 target until now. I found a solution here: https://esp32.com/viewtopic.php?t=1703#p7918
We can use taskENTER_CRITICAL / taskEXIT_CRITICAL

## Motivation and Context
After talking with @AdrianSoundy he mentioned that the GLOBAL_LOCK / GLOBAL_UNLOCK was not implemented for the ESP32 target. So I found a solution for it and implemented it via taskENTER_CRITICAL / taskEXIT_CRITICAL. With these calls the interrupts are disabled/enabled for critical regions that should not be interrupted by others.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>