### PR TITLE
Improvement on Serial NativeRead

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -867,6 +867,12 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
                 bytesToRead = palUart->RxRingBuffer.Length();
             }
         }
+
+        // we have enough bytes, skip wait for event
+        eventResult = false;
+               
+        // clear event by getting it
+        Events_Get(SYSTEM_EVENT_FLAG_COM_IN);
     }
     else
     {


### PR DESCRIPTION
## Description
- The call now returns without further delay if there are enough bytes in the buffer to satisfy the request

## Motivation and Context
- Fixes issue with read not returning until timeout elapsed, no matter if there were enough bytes available for read

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
