### PR TITLE
Fix Debugging_Execution_BreakpointDef

### DIFF
--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -505,7 +505,7 @@ struct CLR_DBG_Commands
 
         static const CLR_UINT16 c_STEP               = c_STEP_IN | c_STEP_OVER | c_STEP_OUT;
 
-        static const CLR_UINT32 c_PID_ANY            = 0xFFFFFFFF;
+        static const CLR_INT32 c_PID_ANY             = 0x7FFFFFFF;
 
         static const CLR_UINT32 c_DEPTH_EXCEPTION_FIRST_CHANCE    = 0x00000000;
         static const CLR_UINT32 c_DEPTH_EXCEPTION_USERS_CHANCE    = 0x00000001;
@@ -525,7 +525,7 @@ struct CLR_DBG_Commands
         CLR_UINT16             m_id;
         CLR_UINT16             m_flags;
 
-        CLR_UINT32             m_pid;
+        CLR_INT32              m_pid;
         CLR_UINT32             m_depth;
 
         //


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- Need to change type and constant declaration because of comparisons with thread process ID
- Required to support nanoframework/nf-debugger#144 ⚠️ 

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
