### PR TITLE
Fix ADC declaration on all targets 🚧 

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_windows_devices_adc_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_windows_devices_adc_config.cpp
@@ -21,9 +21,9 @@ const NF_PAL_ADC_PORT_PIN_CHANNEL AdcPortPinConfig[] = {
     {3, GPIOC, 5, ADC_CHANNEL_IN13},
 
     // these are the internal sources, available only at ADC1
-    {1, NULL, NULL, ADC_CHANNEL_SENSOR},
-    {1, NULL, NULL, ADC_CHANNEL_VREFINT},
-    {1, NULL, NULL, ADC_CHANNEL_VBAT},
+    {1, NULL, 0, ADC_CHANNEL_SENSOR},
+    {1, NULL, 0, ADC_CHANNEL_VREFINT},
+    {1, NULL, 0, ADC_CHANNEL_VBAT},
 };
 
 const int AdcChannelCount = ARRAYSIZE(AdcPortPinConfig);

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_windows_devices_adc_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_windows_devices_adc_config.cpp
@@ -24,9 +24,9 @@ const NF_PAL_ADC_PORT_PIN_CHANNEL AdcPortPinConfig[] = {
     {3, GPIOF, 4, ADC_CHANNEL_IN14},
     
     // these are the internal sources, available only at ADC1
-    {1, NULL, NULL, ADC_CHANNEL_SENSOR},
-    {1, NULL, NULL, ADC_CHANNEL_VREFINT},
-    {1, NULL, NULL, ADC_CHANNEL_VBAT},
+    {1, NULL, 0, ADC_CHANNEL_SENSOR},
+    {1, NULL, 0, ADC_CHANNEL_VREFINT},
+    {1, NULL, 0, ADC_CHANNEL_VBAT},
 };
 
 const int AdcChannelCount = ARRAYSIZE(AdcPortPinConfig);

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_adc_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_adc_config.cpp
@@ -18,9 +18,9 @@ const NF_PAL_ADC_PORT_PIN_CHANNEL AdcPortPinConfig[] = {
     {3, GPIOF, 6, ADC_CHANNEL_IN4},
 
     // these are the internal sources, available only at ADC1
-    {1, NULL, NULL, ADC_CHANNEL_SENSOR},
-    {1, NULL, NULL, ADC_CHANNEL_VREFINT},
-    {1, NULL, NULL, ADC_CHANNEL_VBAT},
+    {1, NULL, 0, ADC_CHANNEL_SENSOR},
+    {1, NULL, 0, ADC_CHANNEL_VREFINT},
+    {1, NULL, 0, ADC_CHANNEL_VBAT},
 };
 
 const int AdcChannelCount = ARRAYSIZE(AdcPortPinConfig);

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_windows_devices_adc_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_windows_devices_adc_config.cpp
@@ -18,9 +18,9 @@ const NF_PAL_ADC_PORT_PIN_CHANNEL AdcPortPinConfig[] = {
     {2, GPIOB, 0, ADC_CHANNEL_IN8},
 
     // these are the internal sources, available only at ADC1
-    {1, NULL, NULL, ADC_CHANNEL_SENSOR},
-    {1, NULL, NULL, ADC_CHANNEL_VREFINT},
-    {1, NULL, NULL, ADC_CHANNEL_VBAT},
+    {1, NULL, 0, ADC_CHANNEL_SENSOR},
+    {1, NULL, 0, ADC_CHANNEL_VREFINT},
+    {1, NULL, 0, ADC_CHANNEL_VBAT},
 };
 
 const int AdcChannelCount = ARRAYSIZE(AdcPortPinConfig);

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_adc_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_adc_config.cpp
@@ -18,9 +18,9 @@ const NF_PAL_ADC_PORT_PIN_CHANNEL AdcPortPinConfig[] = {
     {3, GPIOB, 8, ADC_CHANNEL_IN7},
 
     // these are the internal sources, available only at ADC1
-    {1, NULL, NULL, ADC_CHANNEL_SENSOR},
-    {1, NULL, NULL, ADC_CHANNEL_VREFINT},
-    {1, NULL, NULL, ADC_CHANNEL_VBAT},
+    {1, NULL, 0, ADC_CHANNEL_SENSOR},
+    {1, NULL, 0, ADC_CHANNEL_VREFINT},
+    {1, NULL, 0, ADC_CHANNEL_VBAT},
 };
 
 const int AdcChannelCount = ARRAYSIZE(AdcPortPinConfig);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- Can't use NULL for uint8_t (pin field)

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
