### PR TITLE
Fix issue with CLR_RT_UnicodeHelper::ConvertFromUTF8

### DIFF
--- a/src/CLR/Core/CLR_RT_UnicodeHelper.cpp
+++ b/src/CLR/Core/CLR_RT_UnicodeHelper.cpp
@@ -122,6 +122,13 @@ int CLR_RT_UnicodeHelper::CountNumberOfBytes( int max )
 
 //--//
 
+// dev note: need the pragma bellow because there are a couple of 'smart' hacks in
+// the switch cases to improve the algorithm
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+
 bool CLR_RT_UnicodeHelper::ConvertFromUTF8( int iMaxChars, bool fJustMove, int iMaxBytes )
 {
     NATIVE_PROFILE_CLR_CORE();
@@ -143,14 +150,7 @@ bool CLR_RT_UnicodeHelper::ConvertFromUTF8( int iMaxChars, bool fJustMove, int i
 
         switch(ch & 0xF0)
         {
-            case 0x00: 
-                if(ch == 0)
-                { 
-                    inputUTF8--; 
-                    goto ExitFalse; 
-                }
-                break;
-
+            case 0x00: if(ch == 0) { inputUTF8--; goto ExitFalse; }
             case 0x10:
             case 0x20:
             case 0x30:
@@ -310,16 +310,20 @@ bool CLR_RT_UnicodeHelper::ConvertFromUTF8( int iMaxChars, bool fJustMove, int i
     res = true;
     goto Exit;
 
-ExitFalse:
+  ExitFalse:
     res = false;
 
-Exit:
+  Exit:
     m_inputUTF8        = inputUTF8;
     m_outputUTF16      = outputUTF16;
     m_outputUTF16_size = outputUTF16_size;
 
     return res;
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 bool CLR_RT_UnicodeHelper::ConvertToUTF8( int iMaxChars, bool fJustMove )
 {


### PR DESCRIPTION
## Description
- Remove break statement placed there to keep the compiler happy
- Add pragma push & pop to wrap unconvential switch case fallthrough

## Motivation and Context
- Fixes nanoFramework/Home#343

## How Has This Been Tested?<!-- (if applicable) -->
- Using test code in the issue. After the fix the output matches the one of the .NET 4.6 console app.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


Signed-off-by: José Simões <jose.simoes@eclo.solutions>

