### PR TITLE
Fix format specifier for double printf

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -132,7 +132,7 @@ HRESULT Library_corlib_native_System_Number::FormatNative___STATIC__STRING__OBJE
 
                 if (formatCh == 'G') 
                 {
-                    hal_snprintf( formatStr, ARRAYSIZE(formatStr), "%%.%dg", (dt == DATATYPE_R4) ? 9 : 17 ); // "%.9g" for float, "%.17g" for double
+                    hal_snprintf( formatStr, ARRAYSIZE(formatStr), "%%.%dg", (dt == DATATYPE_R4) ? 9 : 15 ); // "%.9g" for float, "%.15g" for double
                 }
                 else
                 {


### PR DESCRIPTION
## Description
- The format specifier when calling the printf wasn't correct.

## Motivation and Context
- This fix makes the double tostring ouput to match the standard .NET

## How Has This Been Tested?<!-- (if applicable) -->

### Test code
```
 double hiTemp = 62.1;
Console.WriteLine("hiTemp: " + hiTemp.ToString());
```

### Current output
` hiTemp: 62.100000000000001` 

### Output after this fix (matching the output from the standard .NET)
` hiTemp: 62.1` 


## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
