### PR TITLE
Improved code to remove compiler warning

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
@@ -67,11 +67,10 @@ int Monitor_Ping(WP_Message* message)
     {
         Monitor_Ping_Reply cmdReply;
         cmdReply.m_source = Monitor_Ping_c_Ping_Source_NanoBooter;
+        cmdReply.m_dbg_flags = 0;
 
     #if defined(WP_IMPLEMENTS_CRC32)
-        cmdReply.m_dbg_flags |= Monitor_Ping_c_Ping_WPFlag_SupportsCRC32;
-    #else
-        cmdReply.m_dbg_flags = 0;
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_Ping_WPFlag_SupportsCRC32;    
     #endif
 
         WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added initialization for Monitor_Ping_Reply and fine tuned conditional statement in method Monitor_Ping. If a build is done with NF_WP_IMPLEMENTS_CRC32 = ON, the compilation was failing (if you set treat warnings as errors) because of incorrect initialization of Monitor_Ping_Reply.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes compiler warning/error (if treat warning as error is set) due to incorrect initialization

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested build on a 64-bit Windows 10 OS. 
## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: sharmavishnu
