### PR TITLE
Add missing ifdefs for ESP32 platform

### DIFF
--- a/src/CLR/Diagnostics/Profile.cpp
+++ b/src/CLR/Diagnostics/Profile.cpp
@@ -190,7 +190,7 @@ static void TestCalibrate( CLR_PROF_CounterCallChain& cnt )
 void CLR_PROF_Handler::Calibrate()
 {
     NATIVE_PROFILE_CLR_DIAGNOSTICS();
-#if defined(PLATFORM_ARM)
+#if defined(PLATFORM_ARM) || defined(PLATFORM_ESP32)
     const int c_training = 10;
 #else
     const int c_training = 1024;
@@ -203,7 +203,7 @@ void CLR_PROF_Handler::Calibrate()
     s_time_freeze   = 0;
     s_time_adjusted = 0;
 
-#if defined(PLATFORM_ARM)
+#if defined(PLATFORM_ARM) || defined(PLATFORM_ESP32)
     ::PAL_PerformanceCounter_Initialize();
 #endif
 

--- a/src/CLR/Include/nanoCLR_PlatformDef.h
+++ b/src/CLR/Include/nanoCLR_PlatformDef.h
@@ -85,8 +85,8 @@
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// ARM
-#if defined(PLATFORM_ARM)
+// ARM & ESP32
+#if defined(PLATFORM_ARM) || defined(PLATFORM_ESP32)
 // #define NANOCLR_STRESS_GC
 // #define NANOCLR_GC_VERBOSE
 // #define NANOCLR_PROFILE_NEW

--- a/src/HAL/Include/nanoHAL.h
+++ b/src/HAL/Include/nanoHAL.h
@@ -574,7 +574,7 @@ void HAL_Assert  ( const char* Func, int Line, const char* File );
 // HAL_AssertEx is defined in the processor or platform selector files.
 extern void HAL_AssertEx();
 
-#if defined(PLATFORM_ARM)
+#if defined(PLATFORM_ARM) || defined(PLATFORM_ESP32)
     #if !defined(BUILD_RTM)
         #define       ASSERT(i)  { if(!(i)) HAL_AssertEx(); }
         #define _SIDE_ASSERTE(i) { if(!(i)) HAL_AssertEx(); }

--- a/src/PAL/Include/nanoPAL.h
+++ b/src/PAL/Include/nanoPAL.h
@@ -208,24 +208,24 @@ enum POWER_LEVEL
 
 //#include <nanocrt_decl.h>
 
-#if defined(PLATFORM_ARM)
+#if defined(PLATFORM_ARM) || defined(PLATFORM_ESP32)
 extern int  hal_vprintf (const char* format, va_list arg) __attribute__ ((format (printf, 1, 0)));
 #endif
 int hal_vprintf( const char* format, va_list arg );
 
-#if defined(PLATFORM_ARM)
+#if defined(PLATFORM_ARM) || defined(PLATFORM_ESP32)
 extern int  hal_vfprintf ( COM_HANDLE stream, const char* format, va_list arg ) __attribute__ ((format (printf, 2, 0)));
 #endif
 int hal_vfprintf( COM_HANDLE stream, const char* format, va_list arg );
 
-#if defined(PLATFORM_ARM)
+#if defined(PLATFORM_ARM) || defined(PLATFORM_ESP32)
 extern int  hal_snprintf ( char* buffer, size_t len, const char* format, ... ) __attribute__ ((format (printf, 3, 0)));
 #endif
 int hal_snprintf( char* buffer, size_t len, const char* format, ... );
 
 int hal_vsnprintf( char* buffer, size_t len, const char* format, va_list arg );
 
-#if defined(PLATFORM_ARM)  | defined(PLATFORM_ESP32)
+#if defined(PLATFORM_ARM) || defined(PLATFORM_ESP32)
 #define printf     DoNotUse_*printf []
 //#define sprintf    DoNotUse_*printf []
 #define fprintf    DoNotUse_*printf []


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- Several platform compiler ifdefs with PLATFORM_ARM where missing the companion PLATFORM_ESP32 check (because for most situation both apply)

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>