### PR TITLE
Review ESP32 compiler options to enable warnings as errors

### DIFF
--- a/CMake/toolchain.FreeRtos.ESP32.GCC.cmake
+++ b/CMake/toolchain.FreeRtos.ESP32.GCC.cmake
@@ -62,10 +62,8 @@ set(GCC_ESP32_LINKER_LD, " -L ${ESP32_IDF_PATH}/components/esp32/ld  -T esp32_ou
 
 set(CMAKE_CXX_FLAGS "" CACHE INTERNAL "")
 
-set(CMAKE_C_FLAGS_DEBUG "-std=gnu99 -Og -ggdb -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-old-style-declaration -Wno-error=maybe-uninitialized -DWITH_POSIX -DHAVE_CONFIG_H -DESP_PLATFORM -D IDF_VER=\"v3.0-dev-349-g2861f3e-dirty\" -MMD -MP  " CACHE INTERNAL "c compiler flags debug")
-set(CMAKE_CXX_FLAGS_DEBUG " -Og -ggdb -std=gnu++11 -fno-exceptions -fno-rtti  -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wextra -Wno-unused-parameter -Wno-sign-compare -DESP_PLATFORM " CACHE INTERNAL "cxx compiler flags debug")
-# added for CLR
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-invalid-offsetof  -Wno-switch -Wno-unused-variable -Wno-parentheses -Wno-unused-label" CACHE INTERNAL "cxx compiler flags debug")
+set(CMAKE_C_FLAGS_DEBUG "-std=gnu99 -Og -ggdb -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -DWITH_POSIX -DHAVE_CONFIG_H -DESP_PLATFORM -D IDF_VER=\"v3.0-dev-349-g2861f3e-dirty\" -MMD -MP  " CACHE INTERNAL "c compiler flags debug")
+set(CMAKE_CXX_FLAGS_DEBUG " -Og -ggdb -std=gnu++11 -fno-exceptions -fno-rtti  -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -DESP_PLATFORM " CACHE INTERNAL "cxx compiler flags debug")
 
 set(CMAKE_ASM_FLAGS_DEBUG " -g3 -ggdb" CACHE INTERNAL "asm compiler flags debug")
 
@@ -73,9 +71,8 @@ set(CMAKE_ASM_FLAGS_DEBUG " -g3 -ggdb" CACHE INTERNAL "asm compiler flags debug"
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG " -nostdlib -u call_user_start_cpu0  -Wl,--gc-sections -Wl,-static  " CACHE INTERNAL "linker flags debug")
 
 # set release flags
-set(CMAKE_C_FLAGS_RELEASE " -std=gnu99 -Os -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -MMD -MP -Wall -D IDF_VER=\"v3.0-dev-349-g2861f3e-dirty\"  " CACHE INTERNAL "c compiler flags release")
-
-#set(CMAKE_CXX_FLAGS_RELEASE " -Os -std=gnu++11 -g3 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=deprecated-declarations -Wextra -Wno-unused-parameter -Wno-sign-compare -DESP_PLATFORM " CACHE INTERNAL "cxx compiler flags release")
+set(CMAKE_C_FLAGS_RELEASE " -std=gnu99 -Os -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -MMD -MP -Wall -Wextra -Werror -D IDF_VER=\"v3.0-dev-349-g2861f3e-dirty\"  " CACHE INTERNAL "c compiler flags release")
+set(CMAKE_CXX_FLAGS_RELEASE " -Os -std=gnu++11 -g3 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -DESP_PLATFORM " CACHE INTERNAL "cxx compiler flags release")
 
 set(CMAKE_ASM_FLAGS_RELEASE "" CACHE INTERNAL "asm compiler flags release")
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE " ${GCC_ESP32_LINKER_FLAGS} ${GCC_ESP32_LINKER_LIBS} ${GCC_ESP32_LINKER_LD}" CACHE INTERNAL "linker flags release")

--- a/src/CLR/Core/CLR_RT_UnicodeHelper.cpp
+++ b/src/CLR/Core/CLR_RT_UnicodeHelper.cpp
@@ -122,13 +122,6 @@ int CLR_RT_UnicodeHelper::CountNumberOfBytes( int max )
 
 //--//
 
-// dev note: need the pragma bellow because there are a couple of 'smart' hacks in
-// the switch cases to improve the algorithm
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-
 bool CLR_RT_UnicodeHelper::ConvertFromUTF8( int iMaxChars, bool fJustMove, int iMaxBytes )
 {
     NATIVE_PROFILE_CLR_CORE();

--- a/src/CLR/Core/CLR_RT_UnicodeHelper.cpp
+++ b/src/CLR/Core/CLR_RT_UnicodeHelper.cpp
@@ -122,6 +122,16 @@ int CLR_RT_UnicodeHelper::CountNumberOfBytes( int max )
 
 //--//
 
+// dev note: need the pragma bellow because there are a couple of 'smart' hacks in	
+// the switch cases to improve the algorithm	
+#ifdef __GNUC__	
+#pragma GCC diagnostic push
+// the GCC compiler for ESP32 doesn't know the -Wimplicit-fallthrough option
+#ifndef PLATFORM_ESP32
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+#endif
+
 bool CLR_RT_UnicodeHelper::ConvertFromUTF8( int iMaxChars, bool fJustMove, int iMaxBytes )
 {
     NATIVE_PROFILE_CLR_CORE();

--- a/src/CLR/Core/GarbageCollector_ComputeReachabilityGraph.cpp
+++ b/src/CLR/Core/GarbageCollector_ComputeReachabilityGraph.cpp
@@ -248,7 +248,6 @@ bool CLR_RT_GarbageCollector::ComputeReachabilityGraphForMultipleBlocks( CLR_RT_
                     case DATATYPE_BINARY_BLOB_HEAD:
                         {
                             CLR_RT_HeapBlock_BinaryBlob* blob = (CLR_RT_HeapBlock_BinaryBlob*)ptr;
-                            (void)blob;
                             
                             _ASSERTE(blob->BinaryBlobMarkingHandler() == NULL);
                         }

--- a/src/CLR/Core/GarbageCollector_ComputeReachabilityGraph.cpp
+++ b/src/CLR/Core/GarbageCollector_ComputeReachabilityGraph.cpp
@@ -248,7 +248,8 @@ bool CLR_RT_GarbageCollector::ComputeReachabilityGraphForMultipleBlocks( CLR_RT_
                     case DATATYPE_BINARY_BLOB_HEAD:
                         {
                             CLR_RT_HeapBlock_BinaryBlob* blob = (CLR_RT_HeapBlock_BinaryBlob*)ptr;
-
+                            (void)blob;
+                            
                             _ASSERTE(blob->BinaryBlobMarkingHandler() == NULL);
                         }
                         break;

--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -226,6 +226,7 @@ int CLR_Debug::PrintfV( const char *format, va_list arg )
     size_t iBuffer  = MAXSTRLEN(buffer);
 
     bool fRes = CLR_SafeSprintfV( szBuffer, iBuffer, format, arg );
+    (void)fRes;
 
     _ASSERTE(fRes);
 

--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -226,8 +226,7 @@ int CLR_Debug::PrintfV( const char *format, va_list arg )
     size_t iBuffer  = MAXSTRLEN(buffer);
 
     bool fRes = CLR_SafeSprintfV( szBuffer, iBuffer, format, arg );
-    (void)fRes;
-
+    
     _ASSERTE(fRes);
 
     iBuffer = MAXSTRLEN(buffer) - iBuffer;

--- a/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL.h
@@ -33,8 +33,6 @@ extern portMUX_TYPE globalLockMutex;
 #define INT32 int32_t
 #define TRUE  true
 #define FALSE false
-#define fmod(x,y) (1)
-
 
 #if !defined(BUILD_RTM)
 

--- a/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL_Power.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/Include/targetHAL_Power.h
@@ -12,7 +12,7 @@
 inline void CPU_Reset(){ esp_restart(); };
 
 // CPU sleep is not currently implemented in this target
-inline void CPU_Sleep(SLEEP_LEVEL_type level, uint64_t wakeEvents){ };
+inline void CPU_Sleep(SLEEP_LEVEL_type level, uint64_t wakeEvents){ (void)level; (void)wakeEvents; };
 
 inline bool CPU_IsSoftRebootSupported() { return true; };
 

--- a/targets/FreeRTOS/ESP32_DevKitC/common/Esp32_DeviceMapping.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/common/Esp32_DeviceMapping.cpp
@@ -77,9 +77,6 @@ int  Esp32_GetMappedDevicePins( Esp32_MapDeviceType deviceType, int DevNumber, i
     {
         switch( deviceType )
         {
-            case  DEV_TYPE_GPIO:
-                break;           
-
             case DEV_TYPE_SPI:
                 DevNumber--;        // 0 index not used
                 return (int)Esp32_SPI_DevicePinMap[DevNumber][PinIndex];
@@ -92,6 +89,9 @@ int  Esp32_GetMappedDevicePins( Esp32_MapDeviceType deviceType, int DevNumber, i
 
             case DEV_TYPE_SERIAL:
                 return (int)Esp32_SERIAL_DevicePinMap[DevNumber][PinIndex];
+
+            default:
+                break;
         };
     }
     return -1;

--- a/targets/FreeRTOS/ESP32_DevKitC/common/LaunchCLR.c
+++ b/targets/FreeRTOS/ESP32_DevKitC/common/LaunchCLR.c
@@ -12,6 +12,8 @@
 
 void LaunchCLR(uint32_t address)
 {
+    (void)address;
+
     //// function pointer to load nanoCLR ResetHandler address
     //irq_vector_t JumpToNanoCLR;
 
@@ -36,6 +38,8 @@ void LaunchCLR(uint32_t address)
 
 bool CheckValidCLRImage(uint32_t address)
 {
+    (void)address;
+    
     //// load nanoCLR vector table
     //const vectors_t* nanoCLRVectorTable = (vectors_t*) address;
 

--- a/targets/FreeRTOS/ESP32_DevKitC/common/Target_BlockStorage.c
+++ b/targets/FreeRTOS/ESP32_DevKitC/common/Target_BlockStorage.c
@@ -65,21 +65,21 @@ IBlockStorageDevice ESP32Flash_BlockStorageInterface =
 
 void BlockStorage_AddDevices()
 {
-    BlockStorageList_AddDevice( &Device_BlockStorage, &ESP32Flash_BlockStorageInterface, &Device_BlockStorageConfig, false);
+    BlockStorageList_AddDevice( (BlockStorageDevice*)&Device_BlockStorage, &ESP32Flash_BlockStorageInterface, &Device_BlockStorageConfig, false);
 }
 
 bool BlockStorageList_FindDeviceForPhysicalAddress(BlockStorageDevice** pBSD, unsigned int physicalAddress, ByteAddress* blockAddress)
 {
     *pBSD = NULL;
        
-    BlockStorageDevice* block = BlockStorageList_GetFirstDevice;
+    BlockStorageDevice* block = (BlockStorageDevice*)BlockStorageList_GetFirstDevice;
 
     // this has to add to make metadataprocessor happy
     if(!block) return true;
 
-    DeviceBlockInfo* pDeviceInfo = BlockStorageDevice_GetDeviceInfo(&block);
+    DeviceBlockInfo* pDeviceInfo = BlockStorageDevice_GetDeviceInfo((BlockStorageDevice*)&block);
         
-    for(int i=0; i < pDeviceInfo->NumRegions; i++)
+    for(unsigned int i=0; i < pDeviceInfo->NumRegions; i++)
     {
         BlockRegionInfo* pRegion = &pDeviceInfo->Regions[i];
         
@@ -101,6 +101,8 @@ bool BlockStorageList_FindDeviceForPhysicalAddress(BlockStorageDevice** pBSD, un
 
 bool BlockStorageList_AddDevice(BlockStorageDevice* pBSD, IBlockStorageDevice* vtable, void* config, bool init)
 {
+    (void)init;
+
     pBSD->m_BSD     = vtable;
     pBSD->m_context = config;
 

--- a/targets/FreeRTOS/ESP32_DevKitC/common/WireProtocol_HAL_Interface.c
+++ b/targets/FreeRTOS/ESP32_DevKitC/common/WireProtocol_HAL_Interface.c
@@ -40,6 +40,8 @@ static const char g_ESP32_Uart_TxD_Pins[] = ESP32_UART_TXD_PINS;
 
 bool WP_Initialise(COM_HANDLE port)
 {
+    (void)port;
+
     if ( WP_Port > UART_NUM_2 ) return false;
  
     uart_config_t uart_config = {
@@ -128,7 +130,7 @@ int WP_TransmitMessage(WP_Message* message)
         ///////////////////////////////////////////////////////////
         // see description above
         //////////////////////////////////////////////////////////
-        if (uart_write_bytes(WP_Port, (const char*)message->m_payload, message->m_header.m_size ) != message->m_header.m_size ) return false;
+        if (uart_write_bytes(WP_Port, (const char*)message->m_payload, message->m_header.m_size ) != (int)message->m_header.m_size ) return false;
     }
 
     return true;    

--- a/targets/FreeRTOS/ESP32_DevKitC/common/swo.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/common/swo.cpp
@@ -14,6 +14,7 @@ extern "C" void SwoInit()
 
 extern "C" void SwoPrintChar(char c)
 {
+    (void)c;
 }
 
 extern "C" void SwoPrintString(const char *s)
@@ -27,8 +28,10 @@ extern "C" void SwoPrintString(const char *s)
 
 uint32_t GenericPort_Write( int portNum, const char* data, size_t size )
 {
-    char* p = (char*)data;
-    int counter = 0;
+    (void)portNum;
+    (void)data;
+    //char* p = (char*)data;
+    //int counter = 0;
 
     /// send characters directly to the trace port
     // while(*p != '\0' || counter < size)

--- a/targets/FreeRTOS/ESP32_DevKitC/common/wifi_smart_config.c
+++ b/targets/FreeRTOS/ESP32_DevKitC/common/wifi_smart_config.c
@@ -68,6 +68,8 @@ static  void sc_callback(smartconfig_status_t status, void *pdata)
 
 void  smartconfig_task(void * parm)
 {
+    (void)parm;
+
     EventBits_t uxBits;
     ESP_ERROR_CHECK( esp_smartconfig_set_type(SC_TYPE_ESPTOUCH) );
     ESP_ERROR_CHECK( esp_smartconfig_start(sc_callback) );
@@ -86,6 +88,8 @@ void  smartconfig_task(void * parm)
 
 static  esp_err_t event_handler(void *ctx, system_event_t *event)
 {
+    (void)ctx;
+    
     switch(event->event_id) {
     case SYSTEM_EVENT_STA_START:
        // Smart config commented out as giving exception when running

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/CLRStartup.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/CLRStartup.cpp
@@ -165,7 +165,7 @@ struct Settings
 
         const CLR_RECORD_ASSEMBLY* header;
         unsigned char * assembliesBuffer ;
-        signed int  headerInBytes = sizeof(CLR_RECORD_ASSEMBLY);
+        unsigned int  headerInBytes = sizeof(CLR_RECORD_ASSEMBLY);
         unsigned char * headerBuffer  = NULL;
 
         while(stream.CurrentIndex < stream.Length)

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcChannel.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcChannel.cpp
@@ -24,7 +24,7 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcChannel::NativeReadVal
 
         // need to get the deviceId for the ADC controller of this channel
         // get pointer to AdcController field
-        CLR_RT_HeapBlock* adcController = pThis[FIELD___adcController].Dereference();
+        //CLR_RT_HeapBlock* adcController = pThis[FIELD___adcController].Dereference();
 
         // get pointer to _deviceId field
 //       int adcNumber = adcController[Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::FIELD___deviceId].NumericByRef().s4;
@@ -59,9 +59,11 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcChannel::NativeReadVal
 
 HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcChannel::NativeDisposeChannel___VOID( CLR_RT_StackFrame& stack )
 {
+    (void)stack;
+    
     NANOCLR_HEADER();
 
     // left empty on purpose, nothing to do here
 
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcController.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcController.cpp
@@ -96,7 +96,7 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeGetC
         // Return value to the managed application
         stack.SetResult_I4(channelCount);
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeGetMaxValue___I4( CLR_RT_StackFrame& stack )
@@ -106,7 +106,7 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeGetM
         // Currently fixed 12 bit so return 4095
         stack.SetResult_I4(4095);
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeGetMinValue___I4( CLR_RT_StackFrame& stack )
@@ -116,7 +116,7 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeGetM
     // Return 0 for now, is this signed ?
     stack.SetResult_I4(0);
 
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeIsChannelModeSupported___BOOLEAN__I4( CLR_RT_StackFrame& stack )
@@ -129,7 +129,7 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeIsCh
         stack.SetResult_Boolean( (mode == (int)AdcChannelMode::SingleEnded) ) ;
     }
 
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeGetResolutionInBits___I4( CLR_RT_StackFrame& stack )
@@ -139,7 +139,7 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeGetR
         // Fixed at 12 bit for now
         stack.SetResult_I4(12);
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeInit___VOID( CLR_RT_StackFrame& stack )
@@ -182,5 +182,5 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::GetDeviceS
        // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
        stack.SetResult_String(deviceSelectorString);
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native_Windows_Devices_Gpio_GpioPin.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native_Windows_Devices_Gpio_GpioPin.cpp
@@ -211,7 +211,7 @@ HRESULT Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::NativeIsDriveM
         // Return value to the managed application
         stack.SetResult_Boolean( driveModeSupported ) ;
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::NativeSetDriveMode___VOID__WindowsDevicesGpioGpioPinDriveMode( CLR_RT_StackFrame& stack )
@@ -324,11 +324,13 @@ HRESULT Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::NativeInit___B
 
 HRESULT Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::NativeSetDebounceTimeout___VOID( CLR_RT_StackFrame& stack )
 {
+    (void)stack;
+    
     NANOCLR_HEADER();
 
     // nothing to do here as the debounce timeout is grabbed from the managed object when required
 
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_gpio_native_Windows_Devices_Gpio_GpioPin::WriteNative___VOID__WindowsDevicesGpioGpioPinValue( CLR_RT_StackFrame& stack )

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -254,5 +254,5 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::GetDeviceSelec
        // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
        stack.SetResult_String(deviceSelectorString);
    }
-   NANOCLR_NOCLEANUP();
+   NANOCLR_NOCLEANUP_NOLABEL();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmController.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmController.cpp
@@ -17,7 +17,7 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmController::get_MaxFre
 
         stack.SetResult_R8(maxFrequency);
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmController::get_MinFrequency___R8( CLR_RT_StackFrame& stack )
@@ -27,7 +27,7 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmController::get_MinFre
         // FIXME : how can this value be determined ?
         stack.SetResult_R8(1.0);
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmController::get_PinCount___I4( CLR_RT_StackFrame& stack )
@@ -39,7 +39,7 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmController::get_PinCou
 
         stack.SetResult_I4(pinCount);
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmController::NativeSetDesiredFrequency___U4__U4( CLR_RT_StackFrame& stack )
@@ -109,5 +109,5 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmController::GetDeviceS
        // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
        stack.SetResult_String(deviceSelectorString);
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmPin.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmPin.cpp
@@ -70,8 +70,7 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::ConfigureAndStart
 int  Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::GetChannel (int pin, int timerId, bool create)
 {
     int channel = -1;  // Return if not found
-    int index;
-
+    
     // Selct map depending if high or low speed timers
     char * pMap =  (timerId > 3)? LowSpeedPinMap: HighSpeedPinMap;
     char * pMap2 = pMap;
@@ -117,8 +116,8 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::NativeInit___VOID
        // get a pointer to the managed object instance and check that it's not NULL
         CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
 
-        int timerId   = (int)(pThis[ FIELD___pwmTimer ].NumericByRef().u4);
-        PwmPulsePolarity polarity  = (PwmPulsePolarity)(pThis[ FIELD___polarity ].NumericByRef().u4);
+        //int timerId   = (int)(pThis[ FIELD___pwmTimer ].NumericByRef().u4);
+        //PwmPulsePolarity polarity  = (PwmPulsePolarity)(pThis[ FIELD___polarity ].NumericByRef().u4);
 
         // Check pin number is a valid for output
         int pinNumber = (int)(pThis[ FIELD___pinNumber ].NumericByRef().u4);
@@ -131,7 +130,7 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::NativeInit___VOID
         NANOCLR_CHECK_HRESULT( ConfigureAndStart(pThis, true, true) );
 
         // Get speed mode based on Timer used
-        ledc_mode_t speed_mode = GetSpeedMode(timerId);
+        //ledc_mode_t speed_mode = GetSpeedMode(timerId);
     }
     NANOCLR_NOCLEANUP();
 }
@@ -174,11 +173,13 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::NativeSetActiveDu
 
 HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::NativeSetPolarity___VOID__U1( CLR_RT_StackFrame& stack )
 {
+    (void)stack;
+    
     NANOCLR_HEADER();
     {
         // Nothing to do here, we handle it other places
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmPin.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmPin.cpp
@@ -116,9 +116,6 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::NativeInit___VOID
        // get a pointer to the managed object instance and check that it's not NULL
         CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
 
-        //int timerId   = (int)(pThis[ FIELD___pwmTimer ].NumericByRef().u4);
-        //PwmPulsePolarity polarity  = (PwmPulsePolarity)(pThis[ FIELD___polarity ].NumericByRef().u4);
-
         // Check pin number is a valid for output
         int pinNumber = (int)(pThis[ FIELD___pinNumber ].NumericByRef().u4);
         if ( !GPIO_IS_VALID_OUTPUT_GPIO(pinNumber) )
@@ -128,9 +125,6 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::NativeInit___VOID
 
         // Create a new entry in channel table and configure channel which will also start channel
         NANOCLR_CHECK_HRESULT( ConfigureAndStart(pThis, true, true) );
-
-        // Get speed mode based on Timer used
-        //ledc_mode_t speed_mode = GetSpeedMode(timerId);
     }
     NANOCLR_NOCLEANUP();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -115,9 +115,13 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         }
 
 
-        // call the configure
+        // call the configure and abort if not OK
         HRESULT res = NativeConfig___VOID(stack);
-        
+        if (res != S_OK)
+        {
+            NANOCLR_SET_AND_LEAVE(res);
+        }
+
         // Install driver
         esp_err_t esp_err = uart_driver_install(uart_num, 
                                                 UART_RX_BUFER_SIZE, // rx_buffer_size, 
@@ -256,6 +260,9 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
                 rtsPin = UART_NUM_2_CTS_DIRECT_GPIO_NUM; // 8
                 ctsPin = UART_NUM_2_RTS_DIRECT_GPIO_NUM; // 7
                 break;
+
+            default:
+                break;
        }
 
        // Don't use RTS/CTS if no hardware handshake enabled
@@ -348,7 +355,7 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         uart_port_t uart_num = (uart_port_t)(pThis[ FIELD___portIndex ].NumericByRef().s4 - 1);
 
         // Wait for 1 sec for data to be sent
-        esp_err_t esp_err = uart_wait_tx_done( uart_num,  (TickType_t) 1000 / portTICK_PERIOD_MS);
+        /*esp_err_t esp_err =*/ uart_wait_tx_done( uart_num,  (TickType_t) 1000 / portTICK_PERIOD_MS);
 
 
         // return how many bytes were send to the UART
@@ -462,5 +469,5 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
        // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
        stack.SetResult_String(deviceSelectorString);
    }
-   NANOCLR_NOCLEANUP();
+   NANOCLR_NOCLEANUP_NOLABEL();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -355,8 +355,15 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         uart_port_t uart_num = (uart_port_t)(pThis[ FIELD___portIndex ].NumericByRef().s4 - 1);
 
         // Wait for 1 sec for data to be sent
-        /*esp_err_t esp_err =*/ uart_wait_tx_done( uart_num,  (TickType_t) 1000 / portTICK_PERIOD_MS);
-
+        esp_err_t esp_err = uart_wait_tx_done( uart_num,  (TickType_t) 1000 / portTICK_PERIOD_MS);
+        if (esp_err == ESP_ERR_TIMEOUT)
+        {
+            NANOCLR_SET_AND_LEAVE(CLR_E_TIMEOUT);
+        }
+        else if (esp_err != ESP_OK)
+        {
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        }
 
         // return how many bytes were send to the UART
         stack.SetResult_U4(length);

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo.cpp
@@ -11,30 +11,30 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo::get_MaxClockF
 {
     NANOCLR_HEADER();
     {
-        CLR_RT_HeapBlock* pArg = &(stack.Arg1());
+        //CLR_RT_HeapBlock* pArg = &(stack.Arg1());
 
         // spiBus is an ASCII string with the bus name in format 'SPIn'
         // need to grab 'n' from the string and convert to the integer value from the ASCII code
-        uint8_t bus = (uint8_t)pArg[0].RecoverString()[3] - 48;
+        //uint8_t bus = (uint8_t)pArg[0].RecoverString()[3] - 48;
 
         stack.SetResult_I4 ( MAX_CLOCK_FREQUENCY );
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo::get_MinClockFrequency___I4( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
     {
-        CLR_RT_HeapBlock* pArg = &(stack.Arg1());
+        //CLR_RT_HeapBlock* pArg = &(stack.Arg1());
 
         // spiBus is an ASCII string with the bus name in format 'SPIn'
         // need to grab 'n' from the string and convert to the integer value from the ASCII code
-        uint8_t bus = (uint8_t)pArg[0].RecoverString()[3] - 48;
+        //uint8_t bus = (uint8_t)pArg[0].RecoverString()[3] - 48;
 
         // Max prescaler value = 256
         // SPI2 or SPI3 are on APB1, so divide max frequency by four.
         stack.SetResult_I4 (  1000000 );
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo.cpp
@@ -11,12 +11,6 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo::get_MaxClockF
 {
     NANOCLR_HEADER();
     {
-        //CLR_RT_HeapBlock* pArg = &(stack.Arg1());
-
-        // spiBus is an ASCII string with the bus name in format 'SPIn'
-        // need to grab 'n' from the string and convert to the integer value from the ASCII code
-        //uint8_t bus = (uint8_t)pArg[0].RecoverString()[3] - 48;
-
         stack.SetResult_I4 ( MAX_CLOCK_FREQUENCY );
     }
     NANOCLR_NOCLEANUP_NOLABEL();
@@ -26,14 +20,6 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo::get_MinClockF
 {
     NANOCLR_HEADER();
     {
-        //CLR_RT_HeapBlock* pArg = &(stack.Arg1());
-
-        // spiBus is an ASCII string with the bus name in format 'SPIn'
-        // need to grab 'n' from the string and convert to the integer value from the ASCII code
-        //uint8_t bus = (uint8_t)pArg[0].RecoverString()[3] - 48;
-
-        // Max prescaler value = 256
-        // SPI2 or SPI3 are on APB1, so divide max frequency by four.
         stack.SetResult_I4 (  1000000 );
     }
     NANOCLR_NOCLEANUP_NOLABEL();

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -337,8 +337,6 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___V
 {
     NANOCLR_HEADER();
 
-    //spi_device_interface_config_t dev_config;
- 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock* pThis = stack.This();  //FAULT_ON_NULL(pThis);
 
@@ -349,9 +347,6 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___V
 
     spi_host_device_t bus = (spi_host_device_t)( deviceId / 1000 );
     
-    // Chip Select
-    //int chipSelect  = deviceId % 1000;
-
     // Check valid bus
     if ( bus < HSPI_HOST || bus > VSPI_HOST )
     {

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -152,7 +152,7 @@ bool Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::GetDevice( CLR_RT
     // Find device in spiconfig
     for( int index=0; index < MAX_SPI_DEVICES; index++)
     {
-        if ( spiconfig[*pBus].deviceId[index] = deviceId )
+        if ( spiconfig[*pBus].deviceId[index] == deviceId )
         {
             // Device found with same deviceId
             *pDeviceIndex = index;
@@ -164,6 +164,8 @@ bool Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::GetDevice( CLR_RT
 // Give a complete low-level SPI configuration from user's managed connectionSettings
 spi_device_interface_config_t Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::GetConfig( int bus, CLR_RT_HeapBlock* config)
 {
+    (void)bus;
+
     int csPin    = config[ SpiConnectionSettings::FIELD___csLine ].NumericByRef().s4;
     uint8_t spiMode  = (uint8_t)config[ SpiConnectionSettings::FIELD___spiMode ].NumericByRef().s4;
     int bitOrder = config[ SpiConnectionSettings::FIELD___bitOrder ].NumericByRef().s4;
@@ -335,7 +337,7 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___V
 {
     NANOCLR_HEADER();
 
-    spi_device_interface_config_t dev_config;
+    //spi_device_interface_config_t dev_config;
  
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock* pThis = stack.This();  //FAULT_ON_NULL(pThis);
@@ -348,7 +350,7 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___V
     spi_host_device_t bus = (spi_host_device_t)( deviceId / 1000 );
     
     // Chip Select
-    int chipSelect  = deviceId % 1000;
+    //int chipSelect  = deviceId % 1000;
 
     // Check valid bus
     if ( bus < HSPI_HOST || bus > VSPI_HOST )
@@ -433,6 +435,6 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::GetDeviceSelec
        // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
        stack.SetResult_String(deviceSelectorString);
    }
-   NANOCLR_NOCLEANUP();
+   NANOCLR_NOCLEANUP_NOLABEL();
 }
 

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/WireProtocol_App_Interface.c
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/WireProtocol_App_Interface.c
@@ -13,7 +13,7 @@ extern bool CLR_Messaging_ProcessPayload(WP_Message* msg);
 
 
 // Initialize to a packet sequence number impossible to encounter
-static uint32_t lastPacketSequence = 0x00FEFFFF;
+//static uint32_t lastPacketSequence = 0x00FEFFFF;
 
 // defining this array here makes is local helping reduce the image size because of compiler opmitizations
 static const CommandHandlerLookup c_Lookup_Request[] =

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/app_main.c
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/app_main.c
@@ -30,6 +30,8 @@ extern bool Esp32FlashDriver_InitializeDevice(void* context);
 
 void receiver_task(void *pvParameter)
 {
+  (void)pvParameter;
+
   ReceiverThread( 0);
    
   vTaskDelete(NULL);
@@ -38,6 +40,8 @@ void receiver_task(void *pvParameter)
 // Main task start point
 void main_task(void *pvParameter)
 {
+  (void)pvParameter;
+  
   CLRStartupThread( 0);
  
   vTaskDelete(NULL);

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoCRT.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoCRT.cpp
@@ -14,6 +14,8 @@
 
 void hal_fprintf_SetLoggingCallback( LOGGING_CALLBACK fpn )
 {
+    (void)fpn;
+    
     NATIVE_PROFILE_PAL_CRT();
 
 }
@@ -141,18 +143,23 @@ extern "C" {
 
 int hal_printf( const char* format, ... )
 {
+    (void)format;
     NATIVE_PROFILE_PAL_CRT();
     return 0;
 }
 
 int hal_vprintf( const char* format, va_list arg )
 {
+    (void)format;
+    (void)arg;
     NATIVE_PROFILE_PAL_CRT();
     return 0;
 }
 
 int hal_fprintf( COM_HANDLE stream, const char* format, ... )
 {
+    (void)stream;
+    (void)format;
     NATIVE_PROFILE_PAL_CRT();
     return 0;
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_Logging.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_Logging.cpp
@@ -15,6 +15,6 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
  
         esp_log_level_set(szTag, logLevel);
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_Sleep.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_Sleep.cpp
@@ -21,7 +21,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
         stack.SetResult_I4( (int)err ) ;
 
     }    
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakeupByPin___STATIC__nanoFrameworkHardwareEsp32EspNativeError__nanoFrameworkHardwareEsp32SleepWakeupGpioPin__I4( CLR_RT_StackFrame& stack )
@@ -36,7 +36,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
         // Return err to the managed application
         stack.SetResult_I4( (int)err ) ;
  }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakeupByMultiPins___STATIC__nanoFrameworkHardwareEsp32EspNativeError__nanoFrameworkHardwareEsp32SleepWakeupGpioPin__nanoFrameworkHardwareEsp32SleepWakeupMode( CLR_RT_StackFrame& stack )
@@ -51,7 +51,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
         // Return err to the managed application
         stack.SetResult_I4( (int)err ) ;
   }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeEnableWakeupByTouchPad___STATIC__nanoFrameworkHardwareEsp32EspNativeError( CLR_RT_StackFrame& stack )
@@ -64,7 +64,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
         stack.SetResult_I4( (int)err ) ;
 
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeStartLightSleep___STATIC__nanoFrameworkHardwareEsp32EspNativeError( CLR_RT_StackFrame& stack )
@@ -76,16 +76,18 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
         // Return err to the managed application
         stack.SetResult_I4( (int)err ) ;
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeStartDeepSleep___STATIC__nanoFrameworkHardwareEsp32EspNativeError( CLR_RT_StackFrame& stack )
 {
+    (void)stack;
+    
     NANOCLR_HEADER();
     {
         esp_deep_sleep_start();
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeGetWakeupCause___STATIC__nanoFrameworkHardwareEsp32SleepWakeupCause( CLR_RT_StackFrame& stack )
@@ -97,7 +99,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
         // Return value to the managed application
         stack.SetResult_I4( (int32_t)cause ) ;
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeGetWakeupGpioPin___STATIC__nanoFrameworkHardwareEsp32SleepWakeupGpioPin( CLR_RT_StackFrame& stack )
@@ -109,7 +111,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
         // Return value to the managed application
         stack.SetResult_I8( pin ) ;
     }    
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeGetWakeupTouchpad___STATIC__nanoFrameworkHardwareEsp32SleepTouchPad( CLR_RT_StackFrame& stack )
@@ -121,5 +123,5 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
         // Return value to the managed application
         stack.SetResult_I4( (int)touch_pad ) ;
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoFramework.Runtime.Native/nf_rt_native_nanoFramework_Runtime_Native_RTC.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoFramework.Runtime.Native/nf_rt_native_nanoFramework_Runtime_Native_RTC.cpp
@@ -34,7 +34,7 @@ HRESULT Library_nf_rt_native_nanoFramework_Runtime_Native_RTC::Native_RTC_SetSys
         // Return value to the managed application
         stack.SetResult_Boolean(true);
     }
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_nf_rt_native_nanoFramework_Runtime_Native_RTC::Native_RTC_SetAlarm___STATIC__BOOLEAN__I4__U1__U1__U1__U1__U1__U1( CLR_RT_StackFrame& stack )

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL.cpp
@@ -18,7 +18,7 @@ static ON_SOFT_REBOOT_HANDLER s_rebootHandlers[16] = {NULL, NULL, NULL, NULL, NU
 
 void HAL_AddSoftRebootHandler(ON_SOFT_REBOOT_HANDLER handler)
 {
-    for(int i=0; i<ARRAYSIZE(s_rebootHandlers); i++)
+    for(unsigned int i=0; i<ARRAYSIZE(s_rebootHandlers); i++)
     {
         if(s_rebootHandlers[i] == NULL)
         {
@@ -71,7 +71,7 @@ void nanoHAL_Initialize()
 void nanoHAL_Uninitialize()
 {
     // check for s_rebootHandlers
-    for(int i = 0; i< ARRAYSIZE(s_rebootHandlers); i++)
+    for(unsigned int i = 0; i< ARRAYSIZE(s_rebootHandlers); i++)
     {
         if(s_rebootHandlers[i] != NULL)
         {

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL_Time.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL_Time.cpp
@@ -13,6 +13,8 @@
 // Converts Tickcount to .NET ticks (100 nanoseconds)
 uint64_t HAL_Time_SysTicksToTime(unsigned int sysTicks) {
     
+    (void)sysTicks;
+    
     // convert to microseconds from FreeRTOS Tickcount
     int64_t microsecondsFromSysTicks = ((( xTaskGetTickCount() ) * 1000000ULL + (int64_t)configTICK_RATE_HZ - 1ULL) / (int64_t)configTICK_RATE_HZ);
 

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Events.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Events.cpp
@@ -77,6 +77,8 @@ uint32_t Events_MaskedRead( uint32_t eventsOfInterest )
 
 static void local_Events_SetBoolTimer_Callback(  TimerHandle_t xTimer  )
 {
+    (void)xTimer;
+
     NATIVE_PROFILE_PAL_EVENTS();
 
     *saveTimerCompleteFlag = true;
@@ -160,5 +162,10 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
 
 void FreeManagedEvent(uint8_t category, uint8_t subCategory, uint16_t data1, uint32_t data2)
 {
+    (void)category;
+    (void)subCategory;
+    (void)data1;
+    (void)data2;
+    
     NATIVE_PROFILE_PAL_EVENTS();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Time.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Time.cpp
@@ -11,6 +11,8 @@ static TimerHandle_t nextEventTimer;
 
 static void NextEventTimer_Callback( TimerHandle_t xTimer )
 {
+    (void)xTimer;
+    
     // this call also schedules the next one, if there is one
     HAL_COMPLETION::DequeueAndExec();
 }


### PR DESCRIPTION
## Description
Added the compiler options -Wall -Wextra -Werror and removed all the -Wno-error... options for the ESP32 target.

## Motivation and Context
- Resolves nanoFramework/Home#341

## How Has This Been Tested?
With the changes the ESP32 target compiles without errors

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>
