### PR TITLE
Adding Missing ifdefs to allow stm32F469/479 to be target Mcu

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmPin.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmPin.cpp
@@ -17,7 +17,7 @@ int Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::GetChannel (int pin, 
     (void)timerId;
 
     int channel = 0;
-#if defined(STM32F427xx) || defined(STM32F429xx)
+#if defined(STM32F427xx) || defined(STM32F429xx)  || defined(STM32F469xx)  || defined(STM32F479xx)
     switch (timerId)
     {
         case 1 :

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/stm32_fsmc/hal_stm32_fsmc.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/stm32_fsmc/hal_stm32_fsmc.h
@@ -16,6 +16,7 @@
 // (Re)define if needed base address constants supplied in ST's CMSIS
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+	 defined(STM32F469xx) || defined(STM32F479xx) || \
      defined(STM32F745xx) || defined(STM32F746xx) || \
      defined(STM32F756xx) || defined(STM32F767xx) || \
      defined(STM32F769xx) || defined(STM32F777xx) || \
@@ -65,6 +66,7 @@
 #define FSMC_Bank4_MAP_BASE               ((uint32_t) 0x90000000)
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+	 defined(STM32F469xx) || defined(STM32F479xx) || \
      defined(STM32F7))
   #define FSMC_Bank5_MAP_BASE             ((uint32_t) 0xC0000000)
   #define FSMC_Bank6_MAP_BASE             ((uint32_t) 0xD0000000)
@@ -143,6 +145,7 @@ typedef struct {
 
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+	 defined(STM32F469xx) || defined(STM32F479xx) || \
      defined(STM32F7))
 
 typedef struct {
@@ -197,6 +200,7 @@ typedef struct {
 #define  FSMC_BCR_MWID_16         ((uint32_t)1 << 4)
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+	 defined(STM32F469xx) || defined(STM32F479xx) || \
      defined(STM32F7))
 #define  FSMC_BCR_MWID_32         ((uint32_t)2 << 4)
 #else
@@ -215,6 +219,7 @@ typedef struct {
 #define  FSMC_BCR_CBURSTRW        ((uint32_t)1 << 19)
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+	 defined(STM32F469xx) || defined(STM32F479xx) || \
      defined(STM32F7))
 #define  FSMC_BCR_CCLKEN          ((uint32_t)1 << 20)
 #endif
@@ -295,6 +300,7 @@ struct FSMCDriver {
 #endif
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+	 defined(STM32F469xx) || defined(STM32F479xx) || \
      defined(STM32F7))
   #if STM32_USE_FSMC_SDRAM
     FSMC_SDRAM_TypeDef       *sdram;

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sdram_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sdram_lld.c
@@ -8,6 +8,7 @@
 
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+	 defined(STM32F469xx) || defined(STM32F479xx) || \
      defined(STM32F745xx) || defined(STM32F746xx) || \
      defined(STM32F756xx) || defined(STM32F767xx) || \
      defined(STM32F769xx) || defined(STM32F777xx) || \
@@ -162,5 +163,5 @@ void fsmcSdramStop(SDRAMDriver *sdramp) {
 
 #endif // STM32_USE_FSMC_SDRAM 
 
-#endif //STM32F427xx / STM32F429xx / STM32F437xx / STM32F439xx / STM32F745xx / STM32F746xx 
+#endif //STM32F427xx / STM32F429xx / STM32F437xx / STM32F439xx / STM32F469xx / STM32F479xx / STM32F745xx / STM32F746xx 
        // STM32F756xx / STM32F767xx / STM32F769xx / STM32F777xx / STM32F779xx

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sdram_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sdram_lld.h
@@ -9,6 +9,7 @@
 
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+	 defined(STM32F469xx) || defined(STM32F479xx) || \
      defined(STM32F745xx) || defined(STM32F746xx) || \
      defined(STM32F756xx) || defined(STM32F767xx) || \
      defined(STM32F769xx) || defined(STM32F777xx) || \
@@ -124,7 +125,7 @@ extern "C" {
 
 #endif // STM32_USE_FSMC_SDRAM 
 
-#endif //STM32F427xx / STM32F429xx / STM32F437xx / STM32F439xx / STM32F745xx / STM32F746xx 
+#endif //STM32F427xx / STM32F429xx / STM32F437xx / STM32F439xx / STM32F469xx / STM32F479xx / STM32F745xx / STM32F746xx 
        // STM32F756xx / STM32F767xx / STM32F769xx / STM32F777xx / STM32F779xx
 
 #endif // HAL_FMC_SDRAM_H_

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sram_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sram_lld.c
@@ -106,6 +106,7 @@ void fsmcSramStop(SRAMDriver *sramp) {
 
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+	 defined(STM32F469xx) || defined(STM32F479xx) || \
      defined(STM32F745xx) || defined(STM32F746xx) || \
      defined(STM32F756xx) || defined(STM32F767xx) || \
      defined(STM32F769xx) || defined(STM32F777xx) || \

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_fsmc/hal_stm32_fsmc.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_fsmc/hal_stm32_fsmc.c
@@ -67,6 +67,7 @@ void stm32FsmcInit(void) {
 
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
+	 defined(STM32F469xx) || defined(STM32F479xx) || \
      defined(STM32F745xx) || defined(STM32F746xx) || \
      defined(STM32F756xx) || defined(STM32F767xx) || \
      defined(STM32F769xx) || defined(STM32F777xx) || \


### PR DESCRIPTION
Updated all the memory and PWM driver files to allow building the image for the target of stm32f469 and stm32f479 MCUs.

## Description
The changes only involve adding the defines, and there was no code change at all.

## Motivation and Context
It allows a custom image to be build and a board to be specified with the stm32F469xx or stm32F469 MCU on it to be the target.
- resolves nanoframework/Home#352

## How Has This Been Tested?
I have built an image for a board that is based on Disco 429, but uses the 469 Mcu and it works, but is work in progress of course.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: @gligorov
