### PR TITLE
Change build configuration of develop branch to MinSizeRel

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -316,7 +316,7 @@
     - git config --global user.name "%GitHubUserName%"
 
   configuration:
-    - Debug
+    - MinSizeRel
 
   environment:
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
@@ -409,7 +409,7 @@
             $splitOption = [System.StringSplitOptions]::RemoveEmptyEntries
             $cmakeOptions = $env:BUILD_OPTIONS.Split($separator, $splitOption)
 
-             &$cmake -G Ninja "-DTOOLCHAIN_PREFIX=$env:ESP32_TOOLCHAIN_PATH" "-DESP32_IDF_PATH=$env:ESP32_IDF_PATH" "-DESP32_LIBS_PATH=$env:ESP32_LIBS_PATH" "-DCMAKE_BUILD_TYPE=$env:CONFIGURATION" $cmakeOptions "-DBUILD_VERSION=$env:GitVersion_AssemblySemVer" ..
+             &$cmake -G Ninja "-DTOOLCHAIN_PREFIX=$env:ESP32_TOOLCHAIN_PATH" "-DESP32_IDF_PATH=$env:ESP32_IDF_PATH" "-DESP32_LIBS_PATH=$env:ESP32_LIBS_PATH" "-DCMAKE_BUILD_TYPE=Debug" $cmakeOptions "-DBUILD_VERSION=$env:GitVersion_AssemblySemVer" ..
           }
           Else
           {
@@ -444,7 +444,7 @@
           If($env:BOARD_NAME -eq "ESP32_DEVKITC")
           {
             $cmake = "cmake"
-            &$cmake --build (Get-Location).path --target all --config "$env:CONFIGURATION"
+            &$cmake --build (Get-Location).path --target all --config "Debug"
 
             if ($lastexitcode -ne 0)
             {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- Need to override the configuration for ESP32 in develop branch to get a successful build.

## 🚧  **ESP32** needs to be fixed to take default configuration for this branch 🚧 

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

