### PR TITLE
Add support for configurable Wire Protocol packet size

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -314,6 +314,17 @@ bool CLR_DBG_Debugger::Monitor_Ping( WP_Message* msg)
         #if defined(WP_IMPLEMENTS_CRC32)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_Ping_WPFlag_SupportsCRC32;
         #endif
+     
+        // Wire Protocol packet size 
+      #if (WP_PACKET_SIZE == 512)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0512;
+      #elif (WP_PACKET_SIZE == 256)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0256;
+      #elif (WP_PACKET_SIZE == 128)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0128;
+      #elif (WP_PACKET_SIZE == 1024)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_1024;
+      #endif
 
         WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
     }

--- a/src/CLR/Include/WireProtocol.h
+++ b/src/CLR/Include/WireProtocol.h
@@ -13,6 +13,10 @@
 #include <string.h>
 #include <nanoSupport.h>
 
+#if !defined(_WIN32)
+#include <target_common.h>
+#endif
+
 #ifndef min
 #define min(a,b)  (((a) < (b)) ? (a) : (b))
 #endif
@@ -23,6 +27,11 @@
 
 #define MARKER_DEBUGGER_V1 "NFDBGV1" // Used to identify the debugger at boot time.
 #define MARKER_PACKET_V1   "NFPKTV1" // Used to identify the start of a packet.
+
+#ifndef WP_PACKET_SIZE
+// no Wire Protocol defined at target_common, set to default as 1024
+#define WP_PACKET_SIZE      1024U
+#endif
 
 // enum with Wire Protocol flags
 // backwards compatible with .NETMF
@@ -133,8 +142,9 @@ typedef struct WP_Message
 
 
 // enum with flags for Monitor ping source and debugger flags
-// backwards compatible with .NETMF in debugger flags only
-// adds NEW flags for nanoBooter and nanoCLR
+///////////////////////////////////////////////////////////////////////
+// !!! KEEP IN SYNC WITH Monitor_Ping (in debugger library code) !!! //
+///////////////////////////////////////////////////////////////////////
 typedef enum Monitor_Ping_Source_Flags
 {
     Monitor_Ping_c_Ping_Source_NanoCLR          = 0x00010000,
@@ -145,6 +155,13 @@ typedef enum Monitor_Ping_Source_Flags
     
     // flags specific to Wire Protocol capabilities
     Monitor_Ping_c_Ping_WPFlag_SupportsCRC32    = 0x00000010,
+    
+    // Wire Protocol packet size (3rd position)
+    Monitor_Ping_c_PacketSize_1024              = 0x00000100,
+    Monitor_Ping_c_PacketSize_0512              = 0x00000200,
+    Monitor_Ping_c_PacketSize_0256              = 0x00000300,
+    Monitor_Ping_c_PacketSize_0128              = 0x00000400,
+
 }Monitor_Ping_Source_Flags;
 
 

--- a/src/CLR/Include/WireProtocol_App_Interface.h
+++ b/src/CLR/Include/WireProtocol_App_Interface.h
@@ -9,7 +9,7 @@
 #include "WireProtocol.h"
 
 //////////////////////////////////////////
-extern uint8_t receptionBuffer[2048];
+extern uint8_t receptionBuffer[sizeof(WP_Packet) + WP_PACKET_SIZE];
 extern void ReplyToCommand(WP_Message* message, int fSuccess, int fCritical, void* ptr, int size);
 
 //////////////////////////////////////////

--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -8,7 +8,7 @@
 #include <nanoSupport.h>
 #include "WireProtocol_Message.h"
 
-uint8_t receptionBuffer[2048];
+uint8_t receptionBuffer[sizeof(WP_Packet) + WP_PACKET_SIZE];
 static uint16_t lastOutboundMessage;
 // FIXME #146 uint32_t m_payloadTicks;
 static uint8_t* marker;

--- a/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
@@ -73,6 +73,18 @@ int Monitor_Ping(WP_Message* message)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_Ping_WPFlag_SupportsCRC32;    
     #endif
 
+    // Wire Protocol packet size 
+    #if (WP_PACKET_SIZE == 512)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0512;
+    #elif (WP_PACKET_SIZE == 256)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0256;
+    #elif (WP_PACKET_SIZE == 128)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0128;
+    #elif (WP_PACKET_SIZE == 1024)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_1024;
+    #endif
+
+
         WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
     }
 


### PR DESCRIPTION
## Description
- Add enum for various packet sizes
- Update code for booter and debugger to check for WP packet size definition from target_common.h, if not found default to the historic 1024 size
- Improve declaration of buffer to maximum possible size instead of using twice the payload size (which was a waste of RAM)

## Motivation and Context
- Closes nanoFramework/Home#362

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
