### PR TITLE
Correct issue with define related with debugging

### DIFF
--- a/CMake/toolchain.ChibiOS.GCC.cmake
+++ b/CMake/toolchain.ChibiOS.GCC.cmake
@@ -128,9 +128,8 @@ function(NF_SET_COMPILER_DEFINITIONS TARGET)
     # definition for platform (always ARM here)
     target_compile_definitions(${TARGET} PUBLIC "-DPLATFORM_ARM ")
 
-    # set compiler definitions related with the build type
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-        # build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
+    # build types that have debugging capabilities AND are NOT RTM have to have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
+    if((NOT NF_BUILD_RTM) OR NF_FEATURE_DEBUGGER)
         target_compile_definitions(${TARGET} PUBLIC "-DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
     endif()
 

--- a/targets/FreeRTOS/ESP32_DevKitC/CMakeLists.txt
+++ b/targets/FreeRTOS/ESP32_DevKitC/CMakeLists.txt
@@ -193,15 +193,14 @@ target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
     "${TARGET_NANO_APIS_INCLUDES}"
 )
 
+# set platform
+target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ESP32 " )
 
 # set extra compiler flags, some are related with the build type
-if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    ## build types that include debug have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
-#    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ESP32  -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC    "-DPLATFORM_ESP32 -DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
-else()
-#    target_compile_definitions(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ESP32 ")
-    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC    "-DPLATFORM_ESP32 " )
+
+# build types that have debugging capabilities AND are NOT RTM have to have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
+if((NOT NF_BUILD_RTM) OR NF_FEATURE_DEBUGGER)
+    target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DNANOCLR_ENABLE_SOURCELEVELDEBUGGING ")
 endif()
 
 # set compiler definition for using Application Domains feature


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- This define wasn't being properly set and was preventing the deployment and debug from VS when build flavour wasn't set to include debug information

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
