### PR TITLE
Getting the MinSizeRel build working for the ESP32

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -409,7 +409,7 @@
             $splitOption = [System.StringSplitOptions]::RemoveEmptyEntries
             $cmakeOptions = $env:BUILD_OPTIONS.Split($separator, $splitOption)
 
-             &$cmake -G Ninja "-DTOOLCHAIN_PREFIX=$env:ESP32_TOOLCHAIN_PATH" "-DESP32_IDF_PATH=$env:ESP32_IDF_PATH" "-DESP32_LIBS_PATH=$env:ESP32_LIBS_PATH" "-DCMAKE_BUILD_TYPE=Debug" $cmakeOptions "-DBUILD_VERSION=$env:GitVersion_AssemblySemVer" ..
+             &$cmake -G Ninja "-DTOOLCHAIN_PREFIX=$env:ESP32_TOOLCHAIN_PATH" "-DESP32_IDF_PATH=$env:ESP32_IDF_PATH" "-DESP32_LIBS_PATH=$env:ESP32_LIBS_PATH" "-DCMAKE_BUILD_TYPE=$env:CONFIGURATION" $cmakeOptions "-DBUILD_VERSION=$env:GitVersion_AssemblySemVer" ..
           }
           Else
           {
@@ -444,7 +444,7 @@
           If($env:BOARD_NAME -eq "ESP32_DEVKITC")
           {
             $cmake = "cmake"
-            &$cmake --build (Get-Location).path --target all --config "Debug"
+            &$cmake --build (Get-Location).path --target all --config "$env:CONFIGURATION"
 
             if ($lastexitcode -ne 0)
             {


### PR DESCRIPTION
## Description
MinSizeRel build is now working for the ESP32. We can change the appveyor.yml to use the MinSizeRel build

## Motivation and Context
- Closes nanoFramework/Home#353

## How Has This Been Tested?
After compiling the MinSizeRel build for ESP32 I could deploy and run a test program on the ESP32

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>
