### PR TITLE
Add new Guid and random for Esp32

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Guid.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Guid.cpp
@@ -5,12 +5,29 @@
 //
 #include "CorLib.h"
 
+//
+//  Generate a new GUID
+//
+//  Based on the version 4 GUID (random)
+//  http://guid.one/guid/make
+
 
 HRESULT Library_corlib_native_System_Guid::GenerateNewGuid___STATIC__SZARRAY_U1( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
 
-    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
+    CLR_RT_Random       rand;
+    CLR_UINT8*          buf;
+    CLR_RT_HeapBlock&   top = stack.PushValueAndClear();
+ 
+    // Create a array of 16 bytes on top of stack to return
+    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance( top, 16, g_CLR_RT_WellKnownTypes.m_UInt8 ));
+    buf = top.DereferenceArray()->GetFirstElement();
 
+    rand.NextBytes(buf, 16);           // fill with random numbers
+
+    buf[7] =  (buf[7] & 0x0f) | 0x40;  // Set verion
+    buf[9] =  (buf[7] & 0x3f) | 0x80;  // Set variant
+    
     NANOCLR_NOCLEANUP();
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/CMakeLists.txt
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/CMakeLists.txt
@@ -38,6 +38,8 @@ list(APPEND TARGET_ESP32_NANOCLR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/targetHAL.
 # append files from Runtime.Native
 list(APPEND TARGET_ESP32_NANOCLR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/nanoFramework.Runtime.Native/nf_rt_native_nanoFramework_Runtime_Native_Rtc.cpp")
 
+# append nanoHAL
+list(APPEND TARGET_ESP32_NANOCLR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/targetRandom.cpp")
 
 # add native assemblies
 ParseNativeAssemblies()

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetRandom.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetRandom.cpp
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+#include "Core.h"
+
+void CLR_RT_Random::Initialize()
+{
+}
+
+void CLR_RT_Random::Initialize( int seed )
+{
+    (void)seed;
+}
+
+uint32_t CLR_RT_Random::Next()
+{
+    return esp_random();
+}
+
+double CLR_RT_Random::NextDouble()
+{
+    // the hardware generator returns a value between 0 - 0xFFFFFFFF
+    return ((double)esp_random()) / ((double)0xFFFFFFFF);
+}
+
+void CLR_RT_Random::NextBytes(unsigned char* buffer, unsigned int count)
+{
+    unsigned int i;
+
+    for(i = 0; i < count; i++)
+    {
+        buffer[i] = (unsigned char)esp_random();
+    }
+}


### PR DESCRIPTION
## Description
Add the new guid implementation based on the version 4 guid ( random )
See : http://guid.one/guid/make
Added the targetRandom.cpp for Esp32 so random numbers use the true random numbers
Well random seed if no wireless and True random numbers if Wireless initialised.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Closes nanoframework/Home#129

## How Has This Been Tested?<!-- (if applicable) -->
Print out 20 x GUIDs and all different
Restart board
Print out 20 x GUIDs and all different again from first lot

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: adriansoundy <adriansoundy@gmail.com>
