### PR TITLE
Fix tiny printf implementation

### DIFF
--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -71,9 +71,7 @@ bool CLR_SafeSprintfV( char*& szBuffer, size_t& iBuffer, const char* format, va_
 {
     NATIVE_PROFILE_CLR_DIAGNOSTICS();
 
-#if defined(_WIN32)
-
-    int  chars = hal_vsnprintf( szBuffer, iBuffer, format, arg );
+    int  chars = vsnprintf( szBuffer, iBuffer, format, arg );
     bool fRes  = (chars >= 0);
 
     if(fRes == false) chars = (int)iBuffer;
@@ -82,15 +80,6 @@ bool CLR_SafeSprintfV( char*& szBuffer, size_t& iBuffer, const char* format, va_
     iBuffer  -= chars;
 
     return fRes;
-
-#else
-
-    // use out tiny sprintf
-    iBuffer = tiny_vstringfn(szBuffer, iBuffer, format, arg);
-
-    return TRUE;
-
-#endif
 }
 
 bool CLR_SafeSprintf( char*& szBuffer, size_t& iBuffer, const char* format, ... )
@@ -235,23 +224,23 @@ int CLR_Debug::PrintfV( const char *format, va_list arg )
 #if defined(_WIN32)
     char   buffer[512];
 	char*  szBuffer = buffer;
-    size_t iBuffer  = MAXSTRLEN(buffer);
+    int16_t bufferSize = MAXSTRLEN(buffer);
+    size_t iBuffer  = bufferSize;
+#else
+    // this should be more than enough for the existing output needs
+    const int16_t c_BufferSize = 512;
 
+    char*  buffer = (char*)platform_malloc(c_BufferSize);
+	char*  szBuffer = buffer;
+    size_t iBuffer = c_BufferSize;
+    int16_t bufferSize = c_BufferSize;
+#endif
     
     bool fRes = CLR_SafeSprintfV(szBuffer, iBuffer, format, arg );
     
     _ASSERTE(fRes);
 
-    iBuffer = MAXSTRLEN(buffer) - iBuffer;
-
-#else
-    char*  buffer = (char*)platform_malloc(512);
-    size_t iBuffer = 512;
-
-    CLR_SafeSprintfV( buffer, iBuffer, format, arg );
-    iBuffer  = hal_strlen_s(buffer);
-    
-#endif
+    iBuffer = bufferSize - iBuffer;
 
     Emit( buffer, (int)iBuffer );
 
@@ -829,7 +818,7 @@ const char* CLR_RT_DUMP::GETERRORMESSAGE( HRESULT hrError )
 
     static char s_tmp[ 32 ];
 
-    sprintf( s_tmp, "0x%08x", hrError );
+    snprintf( s_tmp, MAXSTRLEN(s_tmp), "0x%08x", hrError );
 
     return s_tmp;
 }

--- a/src/CLR/Helpers/TinyPrintf/printf.c
+++ b/src/CLR/Helpers/TinyPrintf/printf.c
@@ -487,7 +487,7 @@ int tiny_snprintf(char *out, unsigned int max_len, const char *format, ...)
     return count;
 }
 
-int tiny_vstringfn(char *out, unsigned int max_len, const char *format, va_list va)
+int tiny_vsnprintf(char *out, unsigned int max_len, const char *format, va_list va)
 {
     max_output_len = (int) max_len;
     curr_output_len = 0;

--- a/src/CLR/Helpers/TinyPrintf/printf.h
+++ b/src/CLR/Helpers/TinyPrintf/printf.h
@@ -18,7 +18,7 @@ extern "C" {
 
 int tiny_sprintf (char *out, const char *format, ...);
 int tiny_snprintf(char *out, unsigned int max_len, const char *format, ...);
-int tiny_vstringfn(char *out, unsigned int max_len, const char *format, va_list va);
+int tiny_vsnprintf(char *out, unsigned int max_len, const char *format, va_list va);
 
 #ifdef __cplusplus
 }
@@ -26,5 +26,7 @@ int tiny_vstringfn(char *out, unsigned int max_len, const char *format, va_list 
 
 // the defines bellow allow using the regular calls to sprintf
 #define sprintf tiny_sprintf 
+#define snprintf tiny_snprintf
+#define vsnprintf tiny_vsnprintf
 
 #endif

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoCRT.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoCRT.cpp
@@ -114,8 +114,8 @@ extern "C" {
     
         va_start( arg_ptr, format );
     
-        int len = sprintf(buffer, format, arg_ptr );
-   
+        int len = vsnprintf( buffer, sizeof(buffer)-1, format, arg_ptr );
+
         DebuggerPort_Write( HalSystemConfig.stdio, buffer, len, 0 ); // skip null terminator
     
         va_end( arg_ptr );

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoCRT.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoCRT.cpp
@@ -16,7 +16,6 @@
 void hal_fprintf_SetLoggingCallback( LOGGING_CALLBACK fpn )
 {
     (void)fpn;
-    
     NATIVE_PROFILE_PAL_CRT();
 
 }
@@ -116,7 +115,7 @@ extern "C" {
     
         va_start( arg_ptr, format );
     
-        int len = sprintf( buffer, format, arg_ptr );
+        int len = vsnprintf( buffer, sizeof(buffer)-1, format, arg_ptr );
    
         DebuggerPort_Write( HalSystemConfig.stdio, buffer, len, 0 ); // skip null terminator
     


### PR DESCRIPTION
## Description
- Replace with vsnprintf
- Correct old format hal_nnn with correct replacements from standard printf calls

## Motivation and Context
- Fixes issues with bad/wrong output from printf related calls

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
