### PR TITLE
Fix number conversion

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -11,27 +11,6 @@ void nf_GetFormatString(char* formatStr, char formatCh, int precision, bool isLo
     sprintf(formatStr, "%%%s%d%s%s", isFloat ? "." : isSigned ? "-0" : "0", precision, isLong ? "l" : isFloat ? "f" : "", formatCh == 'X' ? "X" :  isFloat ? "" : isSigned ? "d" : "u");
 }
 
-void nf_RemoveTrailingZeros(char* buffer, int32_t length)
-{
-    for(; length > 0; length--)
-    {
-        if( buffer[length] == '0' ||
-            buffer[length] < '0'  || 
-            buffer[length] > '9')
-        {
-            // NULL every position that is not a digit or '0' (zero)
-            // this is OK because we are moving backwards and want to clear everything except the number representation
-            buffer[length] = 0;
-        }
-        else if(buffer[length] >= '0' || buffer[length] <= '9')
-        {
-            // stop on first char NOT a digit
-            // this is OK because we are moving backwards and want to stop on the first occurrence that is a digit other than 0
-            break;
-        }
-    }
-}
-
 HRESULT Library_corlib_native_System_Number::FormatNative___STATIC__STRING__OBJECT__CHAR__I4( CLR_RT_StackFrame& stack )
 {
     NATIVE_PROFILE_CLR_CORE();
@@ -143,7 +122,6 @@ HRESULT Library_corlib_native_System_Number::FormatNative___STATIC__STRING__OBJE
                 nf_GetFormatString(formatStr, formatCh, precision, false, true, false);
 
                 sprintf(result, formatStr, value->NumericByRef().r4);
-                nf_RemoveTrailingZeros(result, ARRAYSIZE(result));
               #else
                 CLR_INT32 f = value->NumericByRef().r4;
                 NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
@@ -175,7 +153,6 @@ HRESULT Library_corlib_native_System_Number::FormatNative___STATIC__STRING__OBJE
                 nf_GetFormatString(formatStr, formatCh, precision, false, true, false);
                 
                 sprintf(result, formatStr, (CLR_DOUBLE_TEMP_CAST)value->NumericByRef().r8);
-                nf_RemoveTrailingZeros(result, ARRAYSIZE(result));
               #else
                 CLR_INT64 d = (CLR_DOUBLE_TEMP_CAST)value->NumericByRef().r8;
                 NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);


### PR DESCRIPTION
## Description
- Remove unnecessary call to function removing trailing zeros

## Motivation and Context
- Fixes nanoFramework/Home#381

## How Has This Been Tested?<!-- (if applicable) -->
- ToString sample app from samples repo

### output from desktop console app
```
*************************
* plain ToString() test *
*************************
integer '0': 0
integer '12345': 12345
integer '-12345': -12345
double '123.45': 123.45
float '456.78F': 456.78
long '85': 85
long '1234567': 1234567
ulong '200': 200

**********************
* ToString("X") test *
**********************
integer '0': 0
integer '12345': 3039
integer '-12345': FFFFCFC7
long '85': 55
long '1234567': 12D687
ulong '200': C8

**********************
* ToString("X2") test *
**********************
integer '0': 00
integer '12345': 3039
integer '-12345': FFFFCFC7
long '85': 55
long '1234567': 12D687
ulong '200': C8

**********************
* ToString("X0") test *
**********************
integer '0': 0
integer '12345': 3039
integer '-12345': FFFFCFC7
long '85': 55
long '1234567': 12D687
ulong '200': C8

**********************
* ToString("N0") test *
**********************
integer '0': 0
integer '12345': 12,345
integer '-12345': -12,345
long '85': 85
long '1234567': 1,234,567
ulong '200': 200
double '123.45': 123
double '-1898300.1987': -1,898,300
float '456.78F': 457

**********************
* ToString("N") test *
**********************
integer '0': 0.00
integer '12345': 12,345.00
integer '-12345': -12,345.00
long '85': 85.00
long '1234567': 1,234,567.00
ulong '200': 200.00
double '123.45': 123.45
double '-1898300.1987': -1,898,300.20
float '456.78F': 456.78

**********************
* ToString("N3") test *
**********************
integer '0': 0.000
integer '12345': 12,345.000
integer '-12345': -12,345.000
long '85': 85.000
long '1234567': 1,234,567.000
ulong '200': 200.000
double '123.45': 123.450
double '-1898300.1987': -1,898,300.199
float '456.78F': 456.780
```

### output from nanoFramework device
```
*************************
* plain ToString() test *
*************************
integer '0': 0
integer '12345': 12345
integer '-12345': -12345
double '123.45': 123.450000000000002
float '456.78F': 456.779998779
long '85': 85
long '1234567': 1234567
ulong '200': 200

**********************
* ToString("X") test *
**********************
integer '0': 00
integer '12345': 3039
integer '-12345': FFFFCFC7
long '85': 55
long '1234567': 12D687
ulong '200': C8

**********************
* ToString("X2") test *
**********************
integer '0': 00
integer '12345': 3039
integer '-12345': FFFFCFC7
long '85': 55
long '1234567': 12D687
ulong '200': C8

**********************
* ToString("X0") test *
**********************
integer '0': 0
integer '12345': 3039
integer '-12345': FFFFCFC7
long '85': 55
long '1234567': 12D687
ulong '200': C8

**********************
* ToString("N0") test *
**********************
integer '0': 0
integer '12345': 12,345
integer '-12345': -12,345
long '85': 85
long '1234567': 1,234,567
ulong '200': 200
double '123.45': 123
double '-1898300.1987': -1,898,300
float '456.78F': 457

**********************
* ToString("N") test *
**********************
integer '0': 00.00
integer '12345': 12,345.00
integer '-12345': -12,345.00
long '85': 85.00
long '1234567': 1,234,567.00
ulong '200': 200.00
double '123.45': 123.45
double '-1898300.1987': -1,898,300.20
float '456.78F': 456.78

**********************
* ToString("N3") test *
**********************
integer '0': 000.000
integer '12345': 12,345.000
integer '-12345': -12,345.000
long '85': 850.000
long '1234567': 1,234,567.000
ulong '200': 200.000
double '123.45': 123.450
double '-1898300.1987': -1,898,300.199
float '456.78F': 456.780
```

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>