### PR TITLE
Fix WiFi version

### DIFF
--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Wifi/win_dev_wifi_native.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Wifi/win_dev_wifi_native.cpp
@@ -59,5 +59,5 @@ const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_Wifi =
     "Windows.Devices.Wifi", 
     0x5AC050C9,
     method_lookup,
-    { 1, 0, 0, 1 }
+    { 1, 0, 0, 0 }
 };


### PR DESCRIPTION
## Description
Having problems with the nuget package not being excepted by VS-extension. Can't find native assembly. Although checksum is correct. Looks liek its looking for version 1,0,0,0 although it is version 1,0,0,1

So changed version back to 1,0,0,0 to see if that fixes problem.
Local assembly is ok

## How Has This Been Tested?<!-- (if applicable) -->
to be tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy<adriansoundy@gmail.com>
