### PR TITLE
Fix single precision Truncate___STATIC__R4__R4

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Math.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Math.cpp
@@ -989,9 +989,9 @@
 
         float d = stack.Arg0().NumericByRefConst().r4;
         float res = 0.0;
-        float retVal = modff(d, &res); 
+        modff(d, &res); 
 
-        stack.SetResult_R4( retVal );
+        stack.SetResult_R4( res );
 
         NANOCLR_NOCLEANUP_NOLABEL();
 


### PR DESCRIPTION
## Description
Fix SP Truncate in native corlib math

## Motivation and Context
The single precision Truncate function in corlib math incorrectly returned the fractional part instead of the integral part.

- Fixes nanoFramework/Home#392

## How Has This Been Tested?
Reproduced bug using STM32F429I-Discovery board.
Updated the CLR and tested with same test code, this time getting the expected result

## Screenshots

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: NemesisXB <485436+NemesisXB@users.noreply.github.com>
