### PR TITLE
Fix DateTime.DaysInMonth

### DIFF
--- a/src/HAL/nanoHAL_Time.cpp
+++ b/src/HAL/nanoHAL_Time.cpp
@@ -7,6 +7,7 @@
 #include <nanoHAL_Time.h>
 
 const int CummulativeDaysForMonth[13] = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
+const int DaysInMonth[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
 #define IS_LEAP_YEAR(y)             (((y % 4 == 0) && (y % 100 != 0)) || (y % 400 == 0))
 #define NUMBER_OF_LEAP_YEARS(y)     ((((y - 1) / 4) - ((y - 1) / 100) + ((y - 1) / 400)) - BASE_YEAR_LEAPYEAR_ADJUST) /// Number of leap years until base year, not including the target year itself.
@@ -14,6 +15,7 @@ const int CummulativeDaysForMonth[13] = {0, 31, 59, 90, 120, 151, 181, 212, 243,
 
 #define YEARS_TO_DAYS(y)            ((NUMBER_OF_YEARS(y) * DAYS_IN_NORMAL_YEAR) + NUMBER_OF_LEAP_YEARS(y))
 #define MONTH_TO_DAYS(y, m)         (CummulativeDaysForMonth[m - 1] + ((IS_LEAP_YEAR(y) && (m > 2)) ? 1 : 0))
+#define DAYS_IN_MONTH(y, m)         (DaysInMonth[m - 1] + ((IS_LEAP_YEAR(y) && (m == 2)) ? 1 : 0))
 
 #define TIMEUNIT_TO_MINUTES         600000000
 #define TIMEUNIT_TO_MILLISECONDS    10000
@@ -88,7 +90,7 @@ HRESULT HAL_Time_AccDaysInMonth(signed int year, signed int month, signed int* d
 
 HRESULT HAL_Time_DaysInMonth(signed int year, signed int month, signed int* days)
 {
-    *days = MONTH_TO_DAYS(year, month);
+    *days = DAYS_IN_MONTH(year, month);
 
     return S_OK;
 }


### PR DESCRIPTION
## Description
Update HAL_Time_DaysInMonth in nanoHAL_Time.cpp fixing the incorrectly returned accumulated days in month.

## Motivation and Context
The nanoHAL_Time implementation of HAL_Time_DaysInMonth incorrectly returned the accumulated days in month instead of the days in the month in question. This is a bug and was fixed.
- Fixes nanoFramework/Home#393

## How Has This Been Tested?
Reproduced the faulty result with the current build.
Fixed the code and tested to get the correct result as show below in screenshots

## Screenshots
### Error
![error](https://user-images.githubusercontent.com/485436/44999179-a82bfb80-afbb-11e8-8b39-16eca302732e.JPG)
### Fixed (Non-leap year)
![fix](https://user-images.githubusercontent.com/485436/44999181-a82bfb80-afbb-11e8-914b-494bf6909f34.JPG)
### Fixed (Leap Year)
![leap](https://user-images.githubusercontent.com/485436/44999182-a8c49200-afbb-11e8-99b0-575923b539e2.JPG)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: NemesisXB <485436+NemesisXB@users.noreply.github.com>
