### PR TITLE
SNTP fixes for ESP32

### DIFF
--- a/targets/FreeRTOS/ESP32_DevKitC/Network/targetHAL_Network.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/Network/targetHAL_Network.cpp
@@ -8,6 +8,7 @@
 #include <nanoHAL.h>
 #include "Esp32_os.h"
 #include "LWIP_Sockets.h"
+#include "apps/sntp/sntp.h"
 
 extern "C" void set_signal_sock_function( void (*funcPtr)() );
 
@@ -47,6 +48,13 @@ static void PostScanComplete()
     PostManagedEvent( EVENT_WIFI, WiFiEventType_ScanComplete, 0, 0 );
 }
 
+static void initialize_sntp()
+{
+	sntp_stop();
+    sntp_setoperatingmode(SNTP_OPMODE_POLL);
+    sntp_setservername(0, SNTP_SERVER_DEFAULT_ADDRESS);
+    sntp_init();
+}
 
 //
 // Network event loop handler
@@ -68,6 +76,7 @@ static  esp_err_t event_handler(void *ctx, system_event_t *event)
     case SYSTEM_EVENT_STA_GOT_IP:
 //ets_printf("SYSTEM_EVENT_STA_GOT_IP\n");
 		PostAddressChanged();
+		initialize_sntp();
         //xEventGroupSetBits(wifi_event_group, CONNECTED_BIT);
         break;
 	case SYSTEM_EVENT_STA_LOST_IP:
@@ -119,6 +128,7 @@ static  esp_err_t event_handler(void *ctx, system_event_t *event)
 		break;
 	case SYSTEM_EVENT_ETH_GOT_IP:
 		PostAddressChanged();
+		initialize_sntp();
 		break;
     case SYSTEM_EVENT_ETH_DISCONNECTED:
 		PostAvailabilityOff();

--- a/targets/FreeRTOS/ESP32_DevKitC/target_lwip_sntp_opts.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/target_lwip_sntp_opts.h
@@ -9,9 +9,9 @@
 // (value in milliseconds)
 #define SNTP_UPDATE_DELAY       3600000
 
-// better have a startup delay because we can have DHCP enabled (default 30 seconds)
-// value in milliseconds
-#define SNTP_STARTUP_DELAY      30000
+// better have a startup delay because we can have DHCP enabled, value in milliseconds.
+// As we automatically start SNTP when we get the IP address then only a small delay
+#define SNTP_STARTUP_DELAY      1000
 
 // retry timeout (15 minutes)
 // value in milliseconds


### PR DESCRIPTION
## Description
Added code to automatically start SNTP when we receive an IP address for Wireless or Ethernet connection.
Fix an issue where we were getting the time from the system ticks where it should have been RTC via 
gettimeofday().

## How Has This Been Tested?<!-- (if applicable) -->
DIsplayed the date / time ever second after connecting to wireless network. After 12 secs the date/time was correct from SNTP

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
