### PR TITLE
Fix Math.Round

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Math.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Math.cpp
@@ -695,8 +695,18 @@
         NANOCLR_HEADER();
 
         double d = stack.Arg0().NumericByRefConst().r8;
+        double hi = d + 0.5;
+        double res = floor( hi );
 
-        double res = round(d);
+        //If the number was in the middle of two integers, we need to round to the even one.
+        if(res==hi)
+        {
+            if(fmod( res, 2.0 ) != 0)
+            {
+                //Rounding up made the number odd so we should round down.
+                res -= 1.0;
+            }
+        }
 
         stack.SetResult_R8( res );
 
@@ -717,9 +727,18 @@
         NANOCLR_HEADER();
 
         float d = stack.Arg0().NumericByRefConst().r4;
+        float hi = d + 0.5;
+        float res = floorf( hi );
 
-        float res = roundf(d);
-
+        //If the number was in the middle of two integers, we need to round to the even one.
+        if(res==hi)
+        {
+            if(fmodf( res, 2.0 ) != 0)
+            {
+                //Rounding up made the number odd so we should round down.
+                res -= 1.0;
+            }
+        }
         stack.SetResult_R4( res );
 
         NANOCLR_NOCLEANUP_NOLABEL();


### PR DESCRIPTION
## Description
- Revert changes in Math.Round code.

## Motivation and Context
- The .NET implementation is slightly different from the C standard.
- Fixes nanoFramework/Home#391

## How Has This Been Tested?<!-- (if applicable) -->
- Test app following reported issue

```
var x = Math.Round(-8.5f);
Console.WriteLine("Math.Round(-8.5f): " + x.ToString());

x = Math.Round(50.5f);
Console.WriteLine("Math.Round(50.5f): " + x.ToString());
```

## Screenshots<!-- (if appropriate): -->
Console output from VS
```
Math.Round(-8.5f): -8.000000000
Math.Round(50.5f): 50.000000000
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
