### PR TITLE
Fix Random.Next returns negative numbers #405

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Random.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Random.cpp
@@ -14,7 +14,7 @@ HRESULT Library_corlib_native_System_Random::Next___I4( CLR_RT_StackFrame& stack
 
     NANOCLR_CHECK_HRESULT(GetRandom( stack, rand ));
 
-    stack.SetResult_I4( rand->Next() );
+    stack.SetResult_I4( rand->Next() & 0x7FFFFFFF );
 
     NANOCLR_NOCLEANUP();
 }


### PR DESCRIPTION
## Description
We need to clear the first bit because rand->Next returns uint32 and the method needs to return int32.

## Motivation and Context
- Fixes nanoFramework/Home#405

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch info@matthias-jentsch.de
