### PR TITLE
Fix for string.LastIndexOf(char, int) and string.LastIndexOf(string, int) should search toward the beginning of the string #400

### DIFF
--- a/src/CLR/CorLib/corlib_native.h
+++ b/src/CLR/CorLib/corlib_native.h
@@ -886,6 +886,7 @@ struct Library_corlib_native_System_String
     static const int c_IndexOf__StartIndex    = 0x00000010;
     static const int c_IndexOf__Count         = 0x00000020;
     static const int c_IndexOf__Last          = 0x00000040;
+    static const int c_IndexOf__String_Last   = 0x00000044;
 
     static HRESULT FromCharArray( CLR_RT_StackFrame& stack, int startIndex, int count );
     static HRESULT ToCharArray  ( CLR_RT_StackFrame& stack, int startIndex, int count );

--- a/src/CLR/Core/CLR_RT_UnicodeHelper.cpp
+++ b/src/CLR/Core/CLR_RT_UnicodeHelper.cpp
@@ -328,6 +328,39 @@ bool CLR_RT_UnicodeHelper::ConvertFromUTF8( int iMaxChars, bool fJustMove, int i
 #pragma GCC diagnostic pop
 #endif
 
+// move backward in the UTF8 input
+bool CLR_RT_UnicodeHelper::MoveBackwardInUTF8( const char* utf8StringStart, int iMaxChars )
+{
+    // already at the beginning or iMaxChars < 1?
+    if (m_inputUTF8 <= (const CLR_UINT8*)utf8StringStart || iMaxChars < 1)
+    {
+        return false;
+    }
+    
+    while (true)
+    {
+        // move back one byte and test if it's 0xxxxxxx or 11xxxxxx, because that are start bytes
+        m_inputUTF8--;
+        char current = m_inputUTF8[0];
+        if ((current & 0x10000000) == 0x00000000 || (current & 0x11000000) == 0x11000000)
+        {
+            iMaxChars--;
+        }
+        
+        // moved back enough?
+        if (iMaxChars == 0)
+        {
+            return true;
+        }
+        
+        // reached the beginning?
+        if (m_inputUTF8 == (const CLR_UINT8*)utf8StringStart)
+        {
+            return false;
+        }
+    }
+}
+
 bool CLR_RT_UnicodeHelper::ConvertToUTF8( int iMaxChars, bool fJustMove )
 {
     NATIVE_PROFILE_CLR_CORE();

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -724,6 +724,8 @@ struct CLR_RT_UnicodeHelper
     bool ConvertFromUTF8( int iMaxChars, bool fJustMove, int iMaxBytes = -1 );
     bool ConvertToUTF8  ( int iMaxChars, bool fJustMove                     );
 
+    bool MoveBackwardInUTF8( const char* utf8StringStart, int iMaxChars );
+    
 #if defined(_WIN32)
     static void ConvertToUTF8  ( const std::wstring& src, std:: string& dst );
     static void ConvertFromUTF8( const std:: string& src, std::wstring& dst );


### PR DESCRIPTION
## Description
Found that searching backward in a string was not implemented in ```Library_corlib_native_System_String::IndexOf```. I've added the ability to search also backward in a string. That's needed for the ```string.LastIndexOf``` and ```string.LastIndexOfAny``` methods. To support the backward search in an UTF8 string I've also implemended the ```bool CLR_RT_UnicodeHelper::MoveBackwardInUTF8( const char* utf8StringStart, int iMaxChars )``` function. 

## Motivation and Context
- Fixes/Closes/Resolves nanoFramework/Home#400

## How Has This Been Tested?<!-- (if applicable) -->
```
namespace NFApp1
{
	public class Program
	{
		public static void Main()
		{
			string s1 = "nanoFramework tests are running on nanoCLR!";

			int i01 = s1.LastIndexOf('t');													// 17
			int i02 = s1.LastIndexOf('x');                                                  // -1

			int i03 = s1.LastIndexOf("nano");                                               // 35
			int i04 = s1.LastIndexOf("micro");                                              //-1

			int i05 = s1.LastIndexOf('t', 15);												// 14
			int i06 = s1.LastIndexOf('t', 13);												// -1

			int i07 = s1.LastIndexOf("nano", 10);											// 0
			int i08 = s1.LastIndexOf("nano", 40);											// 35
			int i09 = s1.LastIndexOf("nano", 3);                                            // 0
			int i10 = s1.LastIndexOf("nano", 2);                                            // -1
			int i11 = s1.LastIndexOf("are", 10);                                            // -1

			int i12 = s1.LastIndexOf('n', 20, 20);                                          // 2
			int i13 = s1.LastIndexOf('n', 40, 10);                                          // 37
			int i14 = s1.LastIndexOf('w', 5, 3);                                            // -1

			int i15 = s1.LastIndexOf("nano", 40, 10);										// 35
			int i16 = s1.LastIndexOf("nano", 25, 10);                                       // -1
			int i17 = s1.LastIndexOf("nano", 3, 3);                                         // -1

			int i18 = s1.LastIndexOfAny(new char[] { 'e', 's', 't', 'l' });					// 22
			int i19 = s1.LastIndexOfAny(new char[] { 'b', 'c', 'd', 'f', 'h', 'j' });		// -1

			int i20 = s1.LastIndexOfAny(new char[] { 'e', 'r', 'n', 's', 't', 'l' }, 10);   // 8
			int i21 = s1.LastIndexOfAny(new char[] { 'e', 'r', 'n', 's', 't', 'l' }, 38);	// 37
			int i22 = s1.LastIndexOfAny(new char[] { 'e', 'r', 's', 't', 'l' }, 4);			// -1

			int i23 = s1.LastIndexOfAny(new char[] { 'e', 'n', 's', 't', 'l' }, 20, 10);	// 18
			int i24 = s1.LastIndexOfAny(new char[] { 'e', 'n', 's', 't', 'l' }, 12, 4);		// -1
			int i25 = s1.LastIndexOfAny(new char[] { 'e', 's', 't', 'l' }, 5, 3);			// -1

			string s2 = "nanoFramework tests are running!";

			int i26 = s2.IndexOf('t');														// 14
			int i27 = s2.IndexOf('x');                                                      // -1

			int i28 = s2.IndexOf("est");                                                    // 15
			int i29 = s2.IndexOf("micro");                                                  // -1

			int i30 = s2.IndexOf('t', 15);													// 17
			int i31 = s2.IndexOf('t', 19);													// -1

			string s3 = "nanoFramework tests are running on nanoCLR!";

			int i32 = s3.IndexOf("nano", 10);												// 35
			int i33 = s3.IndexOf("nano", 36);                                               // -1
			int i34 = s3.IndexOf("nano", 42);												// -1

			int i35 = s3.IndexOf('C', 30, 10);												// 39
			int i36 = s3.IndexOf('C', 25, 10);												// -1
			int i37 = s3.IndexOf('C', 40, 3);												// -1
			int i38 = s3.IndexOf("nano", 30, 10);                                           // 35

			int i39 = s3.IndexOf("nano", 25, 10);											// -1
			int i40 = s3.IndexOf("nano", 40, 3);											// -1

			int i41 = s3.IndexOfAny(new char[] { 'e', 's', 't', 'l' });						// 8
			int i42 = s3.IndexOfAny(new char[] { 'b', 'c', 'd', 'f', 'h', 'j' });			// -1

			int i43 = s3.IndexOfAny(new char[] { 'e', 'r', 'n', 's', 't', 'l' }, 10);		// 11
			int i44 = s3.IndexOfAny(new char[] { 'e', 'r', 'n', 's', 't', 'l' }, 38);		// -1
			int i45 = s3.IndexOfAny(new char[] { 'e', 'r', 'n', 's', 't', 'l' }, 42);		// -1

			int i46 = s3.IndexOfAny(new char[] { 'e', 'n', 's', 't', 'l' }, 9, 10);			// 14
			int i47 = s3.IndexOfAny(new char[] { 'e', 'n', 's', 't', 'l' }, 9, 4);			// -1
			int i48 = s3.IndexOfAny(new char[] { 'e', 'n', 's', 't', 'l' }, 40, 3);			// -1
		}
	}
}
```

The values at the end of the lines are the expected values. All calls give now the expected values.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>
