### PR TITLE
Fix: Unable to start debug session on ESP32 when using SerialCommunication

### DIFF
--- a/targets/FreeRTOS/ESP32_DevKitC/common/GenericPort.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/common/GenericPort.cpp
@@ -6,31 +6,32 @@
 #include <esp32_os.h>
 
 #include "nanoCLR_Types.h"
+#include "nanoCLR_Runtime.h"
 
 uint32_t GenericPort_Write( int portNum, const char* data, size_t size )
 {
-   (void)portNum;
-   (void)data;
-    (void)data;
+    // FIXME
+    // It's only enabled if the C# programm is in running mode and no source level debugger (C# debugger)
+    // is attached. In all other conditions it's better to be quiet.
+    // If the debugger is attached we don't output the data because the debugger use the same serial link.
+    // Maybe later it can also redirect output to the ESP32 app trace 
+    // which is redirected to JTAG/openocd interface
+    (void)portNum;
+    if (g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions == CLR_RT_ExecutionEngine::c_fDebugger_StateProgramRunning)
+    {
+        char* p = (char*)data;
+        int counter = 0;
 
-// FIXME
-// This is commented out as it upsets the debugger through the same serial link
-// Can be enabled if required
-// Maybeb later it can automatically switch on if debugger/vs extension not in use or
-// redirect output to the ESP32 app trace which is redirected to JTAG/openocd interface
-// Add ComDirector
-// TODO fix this when working https://github.com/nanoframework/Home/issues/389
-
-    //char* p = (char*)data;
-    //int counter = 0;
-
-    //// send characters directly to the trace port
-    //while(*p != '\0' || counter < (int)size)
-    //{
-    //    ets_printf( "%c", *p++); 
-    //    counter++;
-    //}
-    //return counter;
-    
-    return (uint32_t)size;
+        // send characters directly to the trace port
+        while(*p != '\0' || counter < (int)size)
+        {
+            ets_printf( "%c", *p++); 
+            counter++;
+        }
+        return counter;
+    }
+    else
+    {
+        return (uint32_t)size;
+    }
 }


### PR DESCRIPTION
## Description
To not confuse the source level debugger (C# debugger) it's safer to output the data in GenericPort_Write
only if the program is in running state without any other flags (without the debugger).

## Motivation and Context
- Fixes nanoFramework/Home#389

## How Has This Been Tested?<!-- (if applicable) -->
Tested with SerialCommunication example and simple Hello World C# program. Both are working.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>
