### PR TITLE
Uncommented the CLR_RT_TypeSystem::FindTypeDef functionality

### DIFF
--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -3341,84 +3341,84 @@ bool CLR_RT_TypeSystem::FindTypeDef( const char* szClass, CLR_RT_Assembly* assm,
     (void)res;
 
     NATIVE_PROFILE_CLR_CORE();
-    // UNDONE: FIXME
-    // char rgName     [ MAXTYPENAMELEN ];
-    // char rgNamespace[ MAXTYPENAMELEN ];
+    
+    char rgName     [ MAXTYPENAMELEN ];
+    char rgNamespace[ MAXTYPENAMELEN ];
 
-    // if(hal_strlen_s(szClass) < ARRAYSIZE(rgNamespace))
-    // {
-    //     const char* szPtr              = szClass;
-    //     const char* szPtr_LastDot      = NULL;
-    //     const char* szPtr_FirstSubType = NULL;
-    //     char   c;
-    //     size_t len;
+    if(hal_strlen_s(szClass) < ARRAYSIZE(rgNamespace))
+    {
+        const char* szPtr              = szClass;
+        const char* szPtr_LastDot      = NULL;
+        const char* szPtr_FirstSubType = NULL;
+        char   c;
+        size_t len;
 
-    //     while(true)
-    //     {
-    //         c = szPtr[ 0 ]; if(!c) break;
+        while(true)
+        {
+            c = szPtr[ 0 ]; if(!c) break;
 
-    //         if(c == '.')
-    //         {
-    //             szPtr_LastDot = szPtr;
-    //         }
-    //         else if(c == '+')
-    //         {
-    //             szPtr_FirstSubType = szPtr;
-    //             break;
-    //         }
+            if(c == '.')
+            {
+                szPtr_LastDot = szPtr;
+            }
+            else if(c == '+')
+            {
+                szPtr_FirstSubType = szPtr;
+                break;
+            }
 
-    //         szPtr++;
-    //     }
+            szPtr++;
+        }
 
-    //     if(szPtr_LastDot)
-    //     {
-    //         len = szPtr_LastDot++ - szClass      ; hal_strncpy_s( rgNamespace, ARRAYSIZE(rgNamespace), szClass      , len );
-    //         len = szPtr           - szPtr_LastDot; hal_strncpy_s( rgName     , ARRAYSIZE(rgName     ), szPtr_LastDot, len );
-    //     }
-    //     else
-    //     {
-    //         rgNamespace[ 0 ] = 0;
-    //         hal_strcpy_s( rgName, ARRAYSIZE(rgName), szClass );
-    //     }
+        if(szPtr_LastDot)
+        {
+            len = szPtr_LastDot++ - szClass      ; hal_strncpy_s( rgNamespace, ARRAYSIZE(rgNamespace), szClass      , len );
+            len = szPtr           - szPtr_LastDot; hal_strncpy_s( rgName     , ARRAYSIZE(rgName     ), szPtr_LastDot, len );
+        }
+        else
+        {
+            rgNamespace[ 0 ] = 0;
+            hal_strcpy_s( rgName, ARRAYSIZE(rgName), szClass );
+        }
 
         
-    //     if(FindTypeDef( rgName, rgNamespace, assm, res ))
-    //     {
-    //         //
-    //         // Found the containing type, let's look for the nested type.
-    //         //
-    //         if(szPtr_FirstSubType)
-    //         {
-    //             CLR_RT_TypeDef_Instance inst;
+        if(FindTypeDef( rgName, rgNamespace, assm, res ))
+        {
+            //
+            // Found the containing type, let's look for the nested type.
+            //
+            if(szPtr_FirstSubType)
+            {
+                CLR_RT_TypeDef_Instance inst;
 
-    //             do
-    //             {
-    //                 szPtr = ++szPtr_FirstSubType;
+                do
+                {
+                    szPtr = ++szPtr_FirstSubType;
 
-    //                 while(true)
-    //                 {
-    //                     c = szPtr_FirstSubType[ 0 ]; if(!c) break;
+                    while(true)
+                    {
+                        c = szPtr_FirstSubType[ 0 ]; if(!c) break;
 
-    //                     if(c == '+') break;
+                        if(c == '+') break;
 
-    //                     szPtr_FirstSubType++;
-    //                 }
+                        szPtr_FirstSubType++;
+                    }
 
-    //                 len = szPtr_FirstSubType - szPtr; hal_strncpy_s( rgName, ARRAYSIZE(rgName), szPtr, len );
+                    len = szPtr_FirstSubType - szPtr; hal_strncpy_s( rgName, ARRAYSIZE(rgName), szPtr, len );
 
-    //                 inst.InitializeFromIndex( res );
+                    inst.InitializeFromIndex( res );
 
-    //                 if(inst.m_assm->FindTypeDef( rgName, res.Type(), res ) == false)
-    //                 {
-    //                     return false;
-    //                 }
+                    if(inst.m_assm->FindTypeDef( rgName, res.Type(), res ) == false)
+                    {
+                        return false;
+                    }
 
-    //             } while(c == '+');
-    //         }
+                } while(c == '+');
+            }
 
-    //         return true;
-    //     }
-    // }
+            return true;
+        }
+    }
 
     res.Clear();
 


### PR DESCRIPTION
## Description
Uncommented the CLR_RT_TypeSystem::FindTypeDef functionality
That fixes issue #397
Why was that commented out?

## Motivation and Context
- Fixes nanoFramework/Home#397
- Fixes nanoFramework/Home#404



## How Has This Been Tested?<!-- (if applicable) -->
```
using System;
using System.Reflection;

namespace NFApp1
{
	public class Program
	{
		public static void Main()
		{
			Assembly a = Assembly.GetAssembly(typeof(Program));
			string fn = typeof(Program).FullName;
			Type t = a.GetType(fn);
		}
	}
}
```
In the last line is t now not null. It's set to the correct type.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>