### PR TITLE
The format for 64bit values is "ll" not "l"

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -8,7 +8,7 @@
 // compose sprintf format string according to requested parameters
 void nf_GetFormatString(char* formatStr, char formatCh, int precision, bool isLong, bool isFloat, bool isSigned)
 {
-    sprintf(formatStr, "%%%s%d%s%s", isFloat ? "." : isSigned ? "-0" : "0", precision, isLong ? "l" : isFloat ? "f" : "", formatCh == 'X' ? "X" :  isFloat ? "" : isSigned ? "d" : "u");
+    sprintf(formatStr, "%%%s%d%s%s", isFloat ? "." : isSigned ? "-0" : "0", precision, isLong ? "ll" : isFloat ? "f" : "", formatCh == 'X' ? "X" :  isFloat ? "" : isSigned ? "d" : "u");
 }
 
 // remove the prepended zeros and (if possible) the decimal point in a float that's formated as string. e.g. "47.1100815000000" => "47.1100815" or "8.0000E-12" => "8E-12"


### PR DESCRIPTION
## Description
That fixes issue #399: ToString methods of ulong/UInt64 and long/Int64 are not returning the correct values

## Motivation and Context
- Fixes nanoFramework/Home#399

## How Has This Been Tested?<!-- (if applicable) -->
I've tested that with the C# program from the issue. Now it returns the correct values.

## Screenshots
From console output:
```
12345678998765432101
AB54A9A3A069ED25
-1234567899876543210
EEDDEF093CC23516
```

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>