### PR TITLE
Fix for issue #390: object.GetHashCode not working

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -967,9 +967,16 @@ CLR_UINT32 CLR_RT_HeapBlock::GetHashCode( CLR_RT_HeapBlock* ptr, bool fRecurse, 
             CLR_RT_TypeDef_Instance cls; cls.InitializeFromIndex( ptr->ObjectCls() );
             int                    totFields = cls.CrossReference().m_totalFields;
 
-            while(totFields-- > 0)
+            if (totFields > 0)
             {
-                crc = GetHashCode( ++ptr, false, crc );
+                while(totFields-- > 0)
+                {
+                    crc = GetHashCode( ++ptr, false, crc );
+                }
+            }
+            else
+            {
+                crc = SUPPORT_ComputeCRC( &ptr, sizeof(ptr), crc );
             }
         }
         break;


### PR DESCRIPTION
## Description
I've improved the GetHashCode method and return the CRC32 of the heap block address if the instance has no fields.

## Motivation and Context
- Fixes nanoFramework/Home#390

## How Has This Been Tested?<!-- (if applicable) -->
```
object a = new object();
object b = new object();
object c = a;
int ha = a.GetHashCode();
int hb = b.GetHashCode();
int hc = c.GetHashCode();
```
With the code changes ha, hb and hc are no longer zero and ha equals hc because that's the same object.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>