### PR TITLE
Fix Convert::NativeToInt64 for multiple base conversions

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Convert.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Convert.cpp
@@ -25,9 +25,29 @@ HRESULT Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING
         long long minValue = stack.Arg2().NumericByRef().s8;
         long long maxValue = stack.Arg3().NumericByRef().s8;
 
+        // normally we check if the result is in the given range
+        bool check = true;
+        
+        // Int64? => use also strtoull the result will be casted to Int64
+        if (isSigned && maxValue == 0x7FFFFFFFFFFFFFFF) isSigned = false;
+
+        // UInt64? => use also strtoull the result will be casted to Int64 and bypass the range check
+        if (minValue == 0 && maxValue == 0)
+        {
+            isSigned = false;
+            check = false;
+        }
+
+        // convert via strtoll / strtoull
         result = isSigned ? strtoll(str, nullptr, radix) : (long long) strtoull(str, nullptr, radix);
 
-        stack.SetResult_I8 ((result > maxValue || result < minValue) ? zero : result);
+        // the signed values for SByte, Int16 and Int32 are always positive for base 2, 8 or 16 conversions
+        // because the 64-bit function strtoll is used; need the post process the value
+        // if the result is greater max and smaller (max + 1) * 2 this value should be subtracted
+        if (isSigned && result > maxValue && result < (maxValue + 1) * 2) result -= (maxValue + 1) * 2;
+        
+        // for UInt64 the check will be bypassed
+        stack.SetResult_I8 ((check && (result > maxValue || result < minValue)) ? zero : result);
         
       #else
         // support for conversion from base 10 and 16 (partial)


### PR DESCRIPTION
## Description
A few tweaks for fixing issue #412: Convert::NativeToInt64 with SUPPORT_ANY_BASE_CONVERSION delivers incorrect results

## Motivation and Context
- Fixes nanoFramework/Home#412

## How Has This Been Tested?
Tested with various Convert.Toxxx calls. All deliver the correct results. Here is the test code:
```
using System;

namespace NFApp2
{
	public class Program
	{
		public static void Main()
		{
			// -42
			// binary
			sbyte b1 = Convert.ToSByte("11010110", 2);
			// octal
			sbyte b2 = Convert.ToSByte("326", 8);
			// decimal
			sbyte b3 = Convert.ToSByte("-42");
			// hexadecimal
			sbyte b4 = Convert.ToSByte("D6", 16);

			// -17078
			// binary
			short x1 = Convert.ToInt16("1011110101001010", 2);
			// octal
			short x2 = Convert.ToInt16("136512", 8);
			// decimal
			short x3 = Convert.ToInt16("-17078");
			// hexadecimal
			short x4 = Convert.ToInt16("BD4A", 16);

			// -1234567890
			// binary
			int i1 = Convert.ToInt32("10110110011010011111110100101110", 2);
			// octal
			int i2 = Convert.ToInt32("26632376456", 8);
			// decimal
			int i3 = Convert.ToInt32("-1234567890");
			// hexadecimal
			int i4 = Convert.ToInt32("B669FD2E", 16);

			// -4446419168141639693
			// binary
			long l1 = Convert.ToInt64("1100001001001011001001010101001100100000011011011111111111110011", 2);
			// octal
			long l2 = Convert.ToInt64("1411131125144033377763", 8);
			// decimal
			long l3 = Convert.ToInt64("-4446419168141639693");
			// hexadecimal
			long l4 = Convert.ToInt64("C24B2553206DFFF3", 16);

			// 14000324905567911923
			// binary
			ulong u1 = Convert.ToUInt64("1100001001001011001001010101001100100000011011011111111111110011", 2);
			// octal
			ulong u2 = Convert.ToUInt64("1411131125144033377763", 8);
			// decimal
			ulong u3 = Convert.ToUInt64("14000324905567911923");
			// hexadecimal
			ulong u4 = Convert.ToUInt64("C24B2553206DFFF3", 16);
		}
	}
}
```

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>