### PR TITLE
Fix enumeration of config blocks when device has no config block

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/main.c
@@ -24,6 +24,7 @@ int main(void) {
   halInit();
   
   // check for valid CLR image at address contiguous to nanoBooter
+  // this target DOES NOT have configuration block, so we need to use the __nanoImage_end__ address here
   if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
   {
     // there seems to be a valid CLR image

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoBooter/main.c
@@ -24,6 +24,7 @@ int main(void) {
   halInit();
   
   // check for valid CLR image at address contiguous to nanoBooter
+  // this target DOES NOT have configuration block, so we need to use the __nanoImage_end__ address here
   if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
   {
     // there seems to be a valid CLR image

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/main.c
@@ -29,6 +29,7 @@ int main(void) {
   if (palReadPad(GPIOC, GPIOC_BUTTON))
   {
     // check for valid CLR image at address contiguous to nanoBooter
+    // this target DOES NOT have configuration block, so we need to use the __nanoImage_end__ address here
     if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
     {
       // there seems to be a valid CLR image

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
@@ -42,6 +42,7 @@ int main(void) {
   if (!palReadPad(GPIOA, GPIOA_BUTTON))
   {
     // check for valid CLR image 
+    // this target DOES NOT have configuration block, so we need to use the __nanoImage_end__ address here
     if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
     {
       // there seems to be a valid CLR image

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/main.c
@@ -41,7 +41,8 @@ int main(void) {
   // the user button in this board has a pull-up resistor so the check has to be inverted
   if (!palReadPad(GPIOA, GPIOA_BUTTON))
   {
-    // check for valid CLR image 
+    // check for valid CLR image
+    // this target DOES NOT have configuration block, so we need to use the __nanoImage_end__ address here
     if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
     {
       // there seems to be a valid CLR image

--- a/targets/CMSIS-OS/ChibiOS/common/targetHAL_ConfigurationManager.cpp
+++ b/targets/CMSIS-OS/ChibiOS/common/targetHAL_ConfigurationManager.cpp
@@ -20,28 +20,36 @@ __nfweak void ConfigurationManager_Initialize()
 // it's implemented with 'weak' attribute so it can be replaced at target level if a different persistance mechanism is used
 __nfweak void ConfigurationManager_EnumerateConfigurationBlocks()
 {
-    // find network configuration blocks
-    HAL_CONFIGURATION_NETWORK* networkConfigs = (HAL_CONFIGURATION_NETWORK*)ConfigurationManager_FindNetworkConfigurationBlocks((uint32_t)&__nanoConfig_start__, (uint32_t)&__nanoConfig_end__);
+    // start checking if this device has config block
+    if(((uint32_t)&__nanoConfig_end__ - (uint32_t)&__nanoConfig_start__) > 0)
+    {
+        // find network configuration blocks
+        HAL_CONFIGURATION_NETWORK* networkConfigs = (HAL_CONFIGURATION_NETWORK*)ConfigurationManager_FindNetworkConfigurationBlocks((uint32_t)&__nanoConfig_start__, (uint32_t)&__nanoConfig_end__);
 
-    // find wireless 80211 network configuration blocks
-    HAL_CONFIGURATION_NETWORK_WIRELESS80211* networkWirelessConfigs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211*)ConfigurationManager_FindNetworkWireless80211ConfigurationBlocks((uint32_t)&__nanoConfig_start__, (uint32_t)&__nanoConfig_end__);
+        // find wireless 80211 network configuration blocks
+        HAL_CONFIGURATION_NETWORK_WIRELESS80211* networkWirelessConfigs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211*)ConfigurationManager_FindNetworkWireless80211ConfigurationBlocks((uint32_t)&__nanoConfig_start__, (uint32_t)&__nanoConfig_end__);
 
-    // alloc memory for g_TargetConfiguration
-    // because this is a struct of structs that use flexible members the memory has to be allocated from the heap
-    // the malloc size for each struct is computed separately 
-    uint32_t sizeOfNetworkInterfaceConfigs = offsetof(HAL_CONFIGURATION_NETWORK, Configs) + networkConfigs->Count * sizeof(networkConfigs->Configs[0]);
-    uint32_t sizeOfWireless80211Configs = offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) + networkWirelessConfigs->Count * sizeof(networkWirelessConfigs->Configs[0]);
+        // alloc memory for g_TargetConfiguration
+        // because this is a struct of structs that use flexible members the memory has to be allocated from the heap
+        // the malloc size for each struct is computed separately 
+        uint32_t sizeOfNetworkInterfaceConfigs = offsetof(HAL_CONFIGURATION_NETWORK, Configs) + networkConfigs->Count * sizeof(networkConfigs->Configs[0]);
+        uint32_t sizeOfWireless80211Configs = offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) + networkWirelessConfigs->Count * sizeof(networkWirelessConfigs->Configs[0]);
 
-    g_TargetConfiguration.NetworkInterfaceConfigs = (HAL_CONFIGURATION_NETWORK*)platform_malloc(sizeOfNetworkInterfaceConfigs);
-    g_TargetConfiguration.Wireless80211Configs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211*)platform_malloc(sizeOfWireless80211Configs);
+        g_TargetConfiguration.NetworkInterfaceConfigs = (HAL_CONFIGURATION_NETWORK*)platform_malloc(sizeOfNetworkInterfaceConfigs);
+        g_TargetConfiguration.Wireless80211Configs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211*)platform_malloc(sizeOfWireless80211Configs);
 
-    // copy structs to g_TargetConfiguration
-    memcpy((HAL_CONFIGURATION_NETWORK*)g_TargetConfiguration.NetworkInterfaceConfigs, networkConfigs, sizeOfNetworkInterfaceConfigs);
-    memcpy((HAL_CONFIGURATION_NETWORK_WIRELESS80211*)g_TargetConfiguration.Wireless80211Configs, networkWirelessConfigs, sizeOfWireless80211Configs);
+        // copy structs to g_TargetConfiguration
+        memcpy((HAL_CONFIGURATION_NETWORK*)g_TargetConfiguration.NetworkInterfaceConfigs, networkConfigs, sizeOfNetworkInterfaceConfigs);
+        memcpy((HAL_CONFIGURATION_NETWORK_WIRELESS80211*)g_TargetConfiguration.Wireless80211Configs, networkWirelessConfigs, sizeOfWireless80211Configs);
 
-    // // now free the memory of the original structs
-    platform_free(networkConfigs);
-    platform_free(networkWirelessConfigs);
+        // // now free the memory of the original structs
+        platform_free(networkConfigs);
+        platform_free(networkWirelessConfigs);
+    }
+    else
+    {
+        // no config block
+    }
 }
 
 // Gets the network configuration block from the configuration flash sector 


### PR DESCRIPTION
## Description
- Fix enumeration of config blocks when device has no config block (was causing issue on code trying to work on NULL pointers because there are actually no config blocks to handle).
- Add comment on booter main for targets that DO NOT have config block to stress that the address being used it's because there is no config block (in case someone needs to change that).

## Motivation and Context
- Fixes nanoFramework/Home#413

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
