### PR TITLE
Fix defines for STM32 series in several locations

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/Include/targetPAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetPAL.h
@@ -17,6 +17,6 @@ extern stm32_gpio_t* gpioPort[];
 //Gets the GPIO according to a pin number
 #define GPIO_PORT(pin) (gpioPort[pin/16])
 
-#endif // defined(STM32F0xx) || defined(STM32F4xx) || defined(STM32F7xx) || defined(STM32H7xx)
+#endif
 
 #endif // _TARGETPAL_H_

--- a/targets/CMSIS-OS/ChibiOS/Include/targetPAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetPAL.h
@@ -9,7 +9,7 @@
 #include <hal.h>
 
 
-#if defined(STM32L0XX) || defined(STM32F0XX) || defined(STM32F4XX) || defined(STM32F7XX) || defined(STM32H7XX)
+#if defined(STM32L0xx_MCUCONF) || defined(STM32F0xx_MCUCONF) || defined(STM32F4xx_MCUCONF) || defined(STM32F7xx_MCUCONF) || defined(STM32H7xx_MCUCONF)
 
 // Contains available GPIO ports for the current board
 extern stm32_gpio_t* gpioPort[];

--- a/targets/CMSIS-OS/ChibiOS/common/hard_fault_handler.c
+++ b/targets/CMSIS-OS/ChibiOS/common/hard_fault_handler.c
@@ -17,7 +17,7 @@ typedef enum {
     UsageFault = 6,
 } FaultType;
 
-#if defined(STM32F4XX) || defined(STM32F7XX)
+#if defined(STM32F4xx_MCUCONF) || defined(STM32F7xx_MCUCONF)
 
 void NMI_Handler(void) {
     while(1);
@@ -46,7 +46,7 @@ void HardFault_Handler(void) {
     volatile FaultType faultType = (FaultType)__get_IPSR();
 
     // these are not available in all the STM32 series
-#if defined(STM32F4XX) || defined(STM32F7XX)
+#if defined(STM32F4xx_MCUCONF) || defined(STM32F7xx_MCUCONF)
 
     //Flags about hardfault / busfault
     //See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/Cihdjcfc.html for reference
@@ -99,7 +99,7 @@ void UsageFault_Handler(void) {
     (void)faultType;
 
     // these are not available in all the STM32 series
-#if defined(STM32F4XX) || defined(STM32F7XX)
+#if defined(STM32F4xx_MCUCONF) || defined(STM32F7xx_MCUCONF)
     
     //Flags about hardfault / busfault
     //See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/Cihdjcfc.html for reference
@@ -133,7 +133,7 @@ void MemManage_Handler(void) {
     (void)faultType;
 
     // these are not available in all the STM32 series
-#if defined(STM32F4XX) || defined(STM32F7XX)
+#if defined(STM32F4xx_MCUCONF) || defined(STM32F7xx_MCUCONF)
     
     //For HardFault/BusFault this is the address that was accessed causing the error
     volatile uint32_t faultAddress = SCB->MMFAR;

--- a/targets/CMSIS-OS/ChibiOS/common/nanoSupport_CRC32.c
+++ b/targets/CMSIS-OS/ChibiOS/common/nanoSupport_CRC32.c
@@ -6,9 +6,9 @@
 
 #include <hal.h>
 
-#if defined(STM32F0XX) || defined(STM32F1XX) || defined(STM32F2XX) || \
-	defined(STM32F4XX) || defined(STM32F7XX) || defined(STM32L0XX) || \
-	defined(STM32L1XX) || defined(STM32H7XX) 
+#if defined(STM32F0xx_MCUCONF) || defined(STM32F1xx_MCUCONF) || defined(STM32F2xx_MCUCONF) || \
+	defined(STM32F4xx_MCUCONF) || defined(STM32F7xx_MCUCONF) || defined(STM32L0xx_MCUCONF) || \
+	defined(STM32L1xx_MCUCONF) || defined(STM32H7xx_MCUCONF) 
 
 // strong implementation of this function specific to the STM32 targets
 unsigned int SUPPORT_ComputeCRC(const void* rgBlock, int nLength, unsigned int crc)

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL.c
@@ -5,7 +5,7 @@
 
 #include <hal.h>
 
-#if defined(STM32L0XX) || defined(STM32F0XX) || defined(STM32F4XX) || defined(STM32F7XX) || defined(STM32H7XX)
+#if defined(STM32L0xx_MCUCONF) || defined(STM32F0xx_MCUCONF) || defined(STM32F4xx_MCUCONF) || defined(STM32F7xx_MCUCONF) || defined(STM32H7xx_MCUCONF)
 
 stm32_gpio_t* gpioPort[] = { GPIOA, GPIOB
 #if STM32_HAS_GPIOC
@@ -37,4 +37,4 @@ stm32_gpio_t* gpioPort[] = { GPIOA, GPIOB
 #endif
 };
 
-#endif // defined(STM32F0xx) || defined(STM32F4xx) || defined(STM32F7xx) || defined(STM32H7xx)
+#endif

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/hal_community.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/hal_community.h
@@ -14,12 +14,12 @@
 
 #if !defined(HAL_USE_STM32_CRC)
 // the default for this driver is to be included
-#define HAL_USE_STM32_CRC                           TRUE
+#define HAL_USE_STM32_CRC                    TRUE
 #endif
 
 #if !defined(HAL_USE_STM32_RNG)
 // the default for this driver is to be included
-#define HAL_USE_STM32_RNG                           TRUE
+#define HAL_USE_STM32_RNG                    TRUE
 #endif
 
 #if !defined(HAL_USE_FSMC)

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/stm32_rng/hal_stm32_rng.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/stm32_rng/hal_stm32_rng.h
@@ -8,7 +8,7 @@
 
 #if (HAL_USE_STM32_RNG == TRUE)
 
-#if defined(STM32F0XX)
+#if defined(STM32F0xx_MCUCONF)
 #error "CAN'T ENABLE RNG FOR STM32F0 series"
 #endif
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
@@ -141,7 +141,7 @@ uint32_t crc_lld_compute(const void* buffer, int size, uint32_t initialCrc) {
     // get pointer to buffer
     uint8_t* ptr = (uint8_t*)buffer;
 
-#if defined(STM32F1xx) || defined(STM32L1xx) || defined(STM32F2xx) || defined(STM32F4xx)
+#if defined(STM32F1xx_MCUCONF) || defined(STM32L1xx_MCUCONF) || defined(STM32F2xx_MCUCONF) || defined(STM32F4xx_MCUCONF)
     uint32_t size_remainder = 0;
 
     // need to reset CRC peripheral if:
@@ -208,8 +208,10 @@ uint32_t crc_lld_compute(const void* buffer, int size, uint32_t initialCrc) {
         // Reset CRC Calculation Unit
         crc_lld_reset();
 
+  #if (STM32_CRC_PROGRAMMABLE == TRUE)
         // set initial CRC value
         WRITE_REG(CRCD1.Instance->INIT, initialCrc);
+  #endif 
     }
     
     switch (CRCD1.Config->InputDataFormat)

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
@@ -22,7 +22,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #if (STM32_CRC_PROGRAMMABLE == TRUE) || \
-    defined(STM32F7XX) || defined(STM32L0XX) || defined(STM32H7XX)
+    defined(STM32F7xx_MCUCONF) || defined(STM32L0xx_MCUCONF) || defined(STM32H7xx_MCUCONF)
 
 // CRC default configuration.
 static const crcConfig defaultConfig = {
@@ -71,7 +71,7 @@ void crc_lld_start(const crcConfig *config) {
     rccEnableCRC(FALSE);
 
 #if (STM32_CRC_PROGRAMMABLE == TRUE) || \
-    defined(STM32F7XX) || defined(STM32L0XX) || defined(STM32H7XX)
+    defined(STM32F7xx_MCUCONF) || defined(STM32L0xx_MCUCONF) || defined(STM32H7xx_MCUCONF)
 
     // set configuration, if supplied
     if (config == NULL)
@@ -88,7 +88,7 @@ void crc_lld_start(const crcConfig *config) {
 #endif
 
 #if (STM32_CRC_PROGRAMMABLE == TRUE) || \
-    defined(STM32F7XX) || defined(STM32L0XX) || defined(STM32H7XX)
+    defined(STM32F7xx_MCUCONF) || defined(STM32L0xx_MCUCONF) || defined(STM32H7xx_MCUCONF)
 
     WRITE_REG(CRCD1.Instance->INIT, DEFAULT_CRC_INITVALUE);
 
@@ -141,7 +141,7 @@ uint32_t crc_lld_compute(const void* buffer, int size, uint32_t initialCrc) {
     // get pointer to buffer
     uint8_t* ptr = (uint8_t*)buffer;
 
-#if defined(STM32F1XX) || defined(STM32L1XX) || defined(STM32F2XX) || defined(STM32F4XX)
+#if defined(STM32F1xx) || defined(STM32L1xx) || defined(STM32F2xx) || defined(STM32F4xx)
     uint32_t size_remainder = 0;
 
     // need to reset CRC peripheral if:

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.h
@@ -77,7 +77,7 @@ typedef struct CRCDriver {
 #define rccDisableCRC() rccDisableAPB1(RCC_AHBENR_CRCEN)
 #define rccResetCRC() rccResetAPB1(RCC_AHB1RSTR_CRCRST)
 
-#endif //defined(STM32L0xx_MCUCONF)
+#endif
 
 /** @defgroup CRC_Default_Polynomial_Value    Default CRC generating polynomial
   * @{

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.h
@@ -70,14 +70,14 @@ typedef struct CRCDriver {
 // From STMicroelectronics Cube HAL 
 ///////////////////////////////////////////
 
-#if defined(STM32L0XX)
+#if defined(STM32L0xx_MCUCONF)
 // this series uses different names for the buses
 
 #define rccEnableCRC(lp) rccEnableAPB1(RCC_AHBENR_CRCEN, lp)
 #define rccDisableCRC() rccDisableAPB1(RCC_AHBENR_CRCEN)
 #define rccResetCRC() rccResetAPB1(RCC_AHB1RSTR_CRCRST)
 
-#endif //defined(STM32L0XX)
+#endif //defined(STM32L0xx_MCUCONF)
 
 /** @defgroup CRC_Default_Polynomial_Value    Default CRC generating polynomial
   * @{

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/RNGv1/rng_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/RNGv1/rng_lld.h
@@ -59,7 +59,7 @@ typedef struct RNGDriver {
 // From STMicroelectronics Cube HAL 
 /////////////////////////////////////////////////////////////
 
-#if defined(STM32L0XX)
+#if defined(STM32L0xx_MCUCONF)
 // this series uses different names for the buses
 
 #define rccEnableRNG(lp)  rccEnableAPB2(RCC_AHBENR_RNGEN, lp)


### PR DESCRIPTION
## Description
- Correct upper/lower case and missing _MCUCONF suffix.

## Motivation and Context
- These were missing from one of the last ChibiOS version updates.


## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
