### PR TITLE
remove obsolete parameter BOARD_NAME

### DIFF
--- a/targets/FreeRTOS/ESP32_DevKitC/BUILD-ESP32.md
+++ b/targets/FreeRTOS/ESP32_DevKitC/BUILD-ESP32.md
@@ -55,10 +55,12 @@ On Windows, one may use the `.\install-esp32-tools.ps1` Power Shell script locat
    - `C:\Esp32_Tools`
 
 
-Open Power Shell in the root folder of the repository and run the script specifying `ESP32_DEVKITC` as the target BOARD_NAME. Optionally specify the COM port the ESP32 flash programming utility will use (The COM port is easily changed later. If it is not specified, manually edit tasks.json and change instances of `<COMPORT>` to the required port before flashing the ESP32 nanoCLR firmware.)
+Open Power Shell in the root folder of the repository and run the script specifying the COM port the ESP32 flash programming utility will use (The COM port is easily changed later. If it is not specified, manually edit tasks.json and change instances of `<COMPORT>` to the required port before flashing the ESP32 nanoCLR firmware.)
 
 Example Power Shell command line:
-```.\install-esp32-tools.ps1 -BOARD_NAME ESP32_DEVKITC -COMPORT COM19```
+```
+.\install-esp32-tools.ps1 -COMPORT COM19
+```
 
 You can force the environemnt variables to be updated by adding -Force to the command line. 
 


### PR DESCRIPTION
BOARD_NAME parameter was removed when the `install-tools.ps1` script was made ESP32 specific. This PR fixes a missing edit.  

## Description
Only text change BUILD_ESP32.md

## Motivation and Context
Correction to documentation

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Fix documentation

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: DoingNZ <doingnz@gmail.com>
