### PR TITLE
Update GCC tools to 7-2018-q2-update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@
 
   environment:
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
-    GNU_GCC_TOOLCHAIN_PATH: 'C:\GNU_Tools_ARM_Embedded\7-2017-q4-major'
+    GNU_GCC_TOOLCHAIN_PATH: 'C:\GNU_Tools_ARM_Embedded'
     ESP32_TOOLCHAIN_PATH: 'C:\ESP32_Tools\1.22.0-80'
     NINJA_PATH: 'C:\mytools\ninja'
     HEX2DFU_PATH: 'C:\mytools\hex2dfu'
@@ -317,7 +317,7 @@
 
   environment:
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
-    GNU_GCC_TOOLCHAIN_PATH: 'C:\GNU_Tools_ARM_Embedded\7-2017-q4-major'
+    GNU_GCC_TOOLCHAIN_PATH: 'C:\GNU_Tools_ARM_Embedded'
     ESP32_TOOLCHAIN_PATH: 'C:\ESP32_Tools\1.22.0-80'
     NINJA_PATH: 'C:\mytools\ninja'
     HEX2DFU_PATH: 'C:\mytools\hex2dfu'
@@ -609,7 +609,7 @@
 
   environment:
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
-    GNU_GCC_TOOLCHAIN_PATH: 'C:\GNU_Tools_ARM_Embedded\7-2017-q4-major'
+    GNU_GCC_TOOLCHAIN_PATH: 'C:\GNU_Tools_ARM_Embedded'
     ESP32_TOOLCHAIN_PATH: 'C:\ESP32_Tools\1.22.0-80'
     NINJA_PATH: 'C:\mytools\ninja'
     HEX2DFU_PATH: 'C:\mytools\hex2dfu'

--- a/install-arm-gcc-toolchain.ps1
+++ b/install-arm-gcc-toolchain.ps1
@@ -9,7 +9,7 @@ If($GnuGccPathExists -eq $False)
 
     Write-Host "Downloading ARM GNU GCC toolchain..."
     
-    $url = "https://bintray.com/nfbot/internal-build-tools/download_file?file_path=gcc-arm-none-eabi-7-2017-q4-major-win32.7z"
+    $url = "https://bintray.com/nfbot/internal-build-tools/download_file?file_path=gcc-arm-none-eabi-7-2018-q2-update-win32.7z"
     $output = "$PSScriptRoot\gcc-arm.7z"
     
     # download 7zip with toolchain

--- a/install-stm32-tools.ps1
+++ b/install-stm32-tools.ps1
@@ -18,7 +18,7 @@ If($buildPathExists -eq $False)
 Write-Host "BOARD_NAME=" $env:BOARD_NAME
 If([string]::IsNullOrEmpty($env:GNU_GCC_TOOLCHAIN_PATH) -or $force)
 {
-	$env:GNU_GCC_TOOLCHAIN_PATH='C:\GNU_Tools_ARM_Embedded\7-2017-q4-major'
+	$env:GNU_GCC_TOOLCHAIN_PATH='C:\GNU_Tools_ARM_Embedded\7-2018-q2-update'
 	Write-Host ("Set User Environment GNU_GCC_TOOLCHAIN_PATH='"+$env:GNU_GCC_TOOLCHAIN_PATH+"'")
 	[System.Environment]::SetEnvironmentVariable("GNU_GCC_TOOLCHAIN_PATH", $env:GNU_GCC_TOOLCHAIN_PATH, "User")
 }


### PR DESCRIPTION
## Description
- Remove version from path on appveyor (doesn't make much sense as it's temporary anyway and on update requires updating two different files)

## Motivation and Context
- Closes nanoFramework/Home#380

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
