### PR TITLE
Fix bug with infinite timeout handling

### DIFF
--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -2854,7 +2854,12 @@ HRESULT CLR_RT_ExecutionEngine::InitTimeout( CLR_INT64& timeExpire, const CLR_IN
 
     if(timeout < 0)
     {
-        if(timeout != -1L)
+        // because we are expecting the timeout value to be in ticks
+        // need to check for two possible infinite timeouts:
+        // 1. when coding in native it's supposed to use -1L as a timeout infinite
+        // 2. in managed code the constant System.Threading.Timeout.Infinite is -1 milliseconds, therefore needs to be converted to ticks
+        if( (timeout != -1L) &&
+            (timeout != -1L * TIME_CONVERSION__TO_MILLISECONDS))
         {
             NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_RANGE);
         }


### PR DESCRIPTION
## Description
- The timeout infinite handling was incomplete because C# constant `System.Threading.Timeout.Infinite` is -1, but in milliseconds. The native code expectes a value in ticks, so it was considered invalid.

## Motivation and Context
- Fixes nanoFramework/Home#422

## How Has This Been Tested?<!-- (if applicable) -->
- Serial sample, scenario 4. The same as the developer mentioned in the issue.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
