### PR TITLE
Replace gitversion from Chocolatey

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -19,7 +19,7 @@ branches:
     regex: dev(elop)?(ment)?$
     mode: ContinuousDeployment
     tag: preview
-    increment: Minor
+    increment: Patch
     prevent-increment-of-merged-branch-version: false
     track-merge-target: true
     tracks-release-branches: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,11 +50,11 @@ environment:
   BinTrayKey:
     secure: Wz0wwFOzMkDwwzzax1HPzKZB3r/aTprlleqFYX5arxpH9pP3D9glINxEuY+P/BaN
 
-  matrix:
-    - BOARD_NAME: 'STM32'
-    - BOARD_NAME: 'ESP32_DEVKITC'
-      BUILD_OPTIONS: '-DTARGET_SERIES=ESP32 -DRTOS=FREERTOS -DNF_WP_IMPLEMENTS_CRC32=OFF -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=ON -DAPI_Windows.Devices.Wifi=ON -DNF_SECURITY_OPENSSL=ON -DAPI_Hardware.Esp32=ON -DSUPPORT_ANY_BASE_CONVERSION=ON'
-    - BOARD_NAME: 'NANOCLR_WINDOWS'
+  # matrix:
+  #   - BOARD_NAME: 'STM32'
+  #   - BOARD_NAME: 'ESP32_DEVKITC'
+  #     BUILD_OPTIONS: '-DTARGET_SERIES=ESP32 -DRTOS=FREERTOS -DNF_WP_IMPLEMENTS_CRC32=OFF -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=ON -DAPI_Windows.Devices.Wifi=ON -DNF_SECURITY_OPENSSL=ON -DAPI_Hardware.Esp32=ON -DSUPPORT_ANY_BASE_CONVERSION=ON'
+  #   - BOARD_NAME: 'NANOCLR_WINDOWS'
 
 matrix:
   fast_finish: true
@@ -81,7 +81,7 @@ install:
 - bundle config --local path vendor/bundle
 - gem install bundler --quiet --no-ri --no-rdoc
 - gem install github_changelog_generator --quiet --no-ri --no-rdoc
-- choco install gitversion.portable -pre -y
+- dotnet tool install -g --version 4.0.0-pullrequest1422-1625 --add-source https://ci.appveyor.com/nuget/gitversion-8nigugxjftrw GitVersion.CommandLine.DotNetCore.Tool
 - ps: |
 
     If($env:BOARD_NAME -eq "NANOCLR_WINDOWS")
@@ -116,7 +116,7 @@ before_build:
     }
     Else
     {
-      C:\ProgramData\chocolatey\lib\GitVersion.Portable\tools\GitVersion.exe /l console /output buildserver
+      dotnet-gitversion /l console /output buildserver
 
       &  cd build > $null
       $cmake = "cmake"


### PR DESCRIPTION
- Replace with dotnet tool version. Despite preliminary it's a better option as Chocolatey is constantly down preventing builds from happening
- Change gitversion config to bump patch on develop branch

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
