### PR TITLE
Fixes for issue #416

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -8,7 +8,10 @@
 // compose sprintf format string according to requested parameters
 void nf_GetFormatString(char* formatStr, char formatCh, int precision, bool isLong, bool isFloat, bool isSigned)
 {
-    sprintf(formatStr, "%%%s%d%s%s", isFloat ? "." : isSigned ? "-0" : "0", precision, isLong ? "ll" : isFloat ? "f" : "", formatCh == 'X' ? "X" :  isFloat ? "" : isSigned ? "d" : "u");
+    if(formatCh == 'X' || formatCh=='x')
+		sprintf(formatStr, "%%0%d%sX", precision, isLong ? "ll" : "");
+    else
+        sprintf(formatStr, "%%%s%d%s%s", isFloat ? "." : isSigned ? "-0" : "0", precision, isLong ? "ll" : isFloat ? "f" : "", formatCh == 'X' ? "X" :  isFloat ? "" : isSigned ? "d" : "u");
 }
 
 // remove the prepended zeros and (if possible) the decimal point in a float that's formated as string. e.g. "47.1100815000000" => "47.1100815" or "8.0000E-12" => "8E-12"

--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -11,7 +11,7 @@ void nf_GetFormatString(char* formatStr, char formatCh, int precision, bool isLo
     if(formatCh == 'X' || formatCh=='x')
 		sprintf(formatStr, "%%0%d%sX", precision, isLong ? "ll" : "");
     else
-        sprintf(formatStr, "%%%s%d%s%s", isFloat ? "." : isSigned ? "-0" : "0", precision, isLong ? "ll" : isFloat ? "f" : "", formatCh == 'X' ? "X" :  isFloat ? "" : isSigned ? "d" : "u");
+        sprintf(formatStr, "%%%s%d%s%s", isFloat ? "." : isSigned ? "-0" : "0", precision, isLong ? "ll" : isFloat ? "f" : "", isFloat ? "" : isSigned ? "d" : "u");
 }
 
 // remove the prepended zeros and (if possible) the decimal point in a float that's formated as string. e.g. "47.1100815000000" => "47.1100815" or "8.0000E-12" => "8E-12"


### PR DESCRIPTION
## Description
Fixed format generation for hexadecimal numbers that was causing issues with ToString("Xnn") calls.

## Motivation and Context
For hexadecimal numbers, there is no concept of signed/unsigned.  Also, floats are not represented in hexadecimal formatting like normal int/long. 
- Fixes nanoFramework/Home#416

## How Has This Been Tested?<!-- (if applicable) -->
Tested with the following code:


            //Integer test            
            Console.WriteLine("Min UInt32=" + UInt32.MinValue + ",as Hex=0x" + UInt32.MinValue.ToString("X16"));
            Console.WriteLine("Max UInt32=" + UInt32.MaxValue + ",as Hex=0x" + UInt32.MaxValue.ToString("X16"));
            Console.WriteLine("Min Int32=" + Int32.MinValue + ",as Hex=0x" + Int32.MinValue.ToString("X16"));
            Console.WriteLine("Max Int32=" + Int32.MaxValue + ",as Hex=0x" + Int32.MaxValue.ToString("X16"));
            
            //Float test
            Console.WriteLine("Min float=" + float.MinValue + ",as formatted=" + float.MinValue.ToString("f16"));
            Console.WriteLine("Max float=" + float.MaxValue + ",as formatted=" + float.MaxValue.ToString("f16"));
                         
            //long test
            Console.WriteLine("Min UInt64=" + UInt64.MinValue + ",as formatted=0x" + UInt64.MinValue.ToString("x16"));
            Console.WriteLine("Max UInt64=" + UInt64.MaxValue + ",as formatted=0x" + UInt64.MaxValue.ToString("x16"));
            Console.WriteLine("Min Int64=" + Int64.MinValue + ",as formatted=0x" + Int64.MinValue.ToString("x16"));
            Console.WriteLine("Max Int64=" + Int64.MaxValue + ",as formatted=0x" + Int64.MaxValue.ToString("x16"));
            

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: @sharmavishnu
