### PR TITLE
Rework inclusion of UART declarations in STM32

### DIFF
--- a/CMake/Modules/FindWindows.Devices.SerialCommunication.cmake
+++ b/CMake/Modules/FindWindows.Devices.SerialCommunication.cmake
@@ -8,11 +8,8 @@ set(BASE_PATH_FOR_THIS_MODULE "${BASE_PATH_FOR_CLASS_LIBRARIES_MODULES}/Windows.
 
 
 # set include directories
-list(APPEND Windows.Devices.SerialCommunication_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/CLR/Core")
-list(APPEND Windows.Devices.SerialCommunication_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/CLR/Include")
-list(APPEND Windows.Devices.SerialCommunication_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/HAL/Include")
-list(APPEND Windows.Devices.SerialCommunication_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/PAL/Include")
 list(APPEND Windows.Devices.SerialCommunication_INCLUDE_DIRS "${BASE_PATH_FOR_THIS_MODULE}")
+list(APPEND Windows.Devices.SerialCommunication_INCLUDE_DIRS "${TARGET_BASE_LOCATION}")
 
 
 # source files

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_windows_devices_serialcommunication_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -16,12 +17,6 @@
 // RX pin: is GPIOA_10
 // GPIO alternate pin function is 7 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(1, GPIOA,  GPIOA, 9, 10, 7)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART1_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART1_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -54,12 +49,6 @@ UART_UNINIT(1)
 // GPIO alternate pin function is 7 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(2, GPIOD, GPIOD, 5, 6, 7)
 
-// buffers size
-// tx buffer size: 256 bytes
-#define UART2_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART2_RX_SIZE  256
-
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
 // because of issues with cache coherency and DMA (this is particularly important with Cortex-M7 because of cache)
@@ -91,12 +80,6 @@ UART_UNINIT(2)
 // GPIO alternate pin function is 7 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(3, GPIOD, GPIOD, 8, 9, 7)
 
-// buffers size
-// tx buffer size: 256 bytes
-#define UART3_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART3_RX_SIZE  256
-
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
 // because of issues with cache coherency and DMA (this is particularly important with Cortex-M7 because of cache)
@@ -127,12 +110,6 @@ UART_UNINIT(3)
 // RX pin: is GPIOC_7
 // GPIO alternate pin function is 8 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(6, GPIOC, GPIOC, 6, 7, 8)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART6_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART6_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_windows_devices_serialcommunication_config.h
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+///////////
+// UART1 //
+///////////
+
+// enable USART1
+#define NF_SERIAL_COMM_STM32_UART_USE_USART1    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART1_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART1_RX_SIZE  256
+
+
+///////////
+// UART2 //
+///////////
+
+// enable USART2
+#define NF_SERIAL_COMM_STM32_UART_USE_USART2    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART2_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART2_RX_SIZE  256
+
+
+///////////
+// UART3 //
+///////////
+
+// enable USART3
+#define NF_SERIAL_COMM_STM32_UART_USE_USART3    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART3_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART3_RX_SIZE  256
+
+
+///////////
+// UART6 //
+///////////
+
+// enable USART6
+#define NF_SERIAL_COMM_STM32_UART_USE_USART6    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART6_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART6_RX_SIZE  256

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_windows_devices_serialcommunication_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -16,12 +17,6 @@
 // RX pin: is GPIOD_9
 // GPIO alternate pin function is 7 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(3, GPIOD, GPIOD, 8, 9, 7)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART3_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART3_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -52,12 +47,6 @@ UART_UNINIT(3)
 // RX pin: is GPIOC_7
 // GPIO alternate pin function is 7 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(6, GPIOC, GPIOC, 6, 7, 8)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART6_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART6_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_windows_devices_serialcommunication_config.h
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+///////////
+// UART3 //
+///////////
+
+// enable USART3
+#define NF_SERIAL_COMM_STM32_UART_USE_USART3    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART3_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART3_RX_SIZE  256
+
+
+///////////
+// UART6 //
+///////////
+
+// enable USART6
+#define NF_SERIAL_COMM_STM32_UART_USE_USART6    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART6_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART6_RX_SIZE  256

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_windows_devices_serialcommunication_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -16,12 +17,6 @@
 // RX pin: is GPIOD_6
 // GPIO alternate pin function is 7 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(2, GPIOD, GPIOD, 5, 6, 7)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART2_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART2_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -53,12 +48,6 @@ UART_UNINIT(2)
 // RX pin: is GPIOC_7
 // GPIO alternate pin function is 8 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(6, GPIOC, GPIOC, 6, 7, 8)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART6_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART6_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_windows_devices_serialcommunication_config.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+///////////
+// UART2 //
+///////////
+
+// enable USART2
+#define NF_SERIAL_COMM_STM32_UART_USE_USART2    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART2_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART2_RX_SIZE  256
+
+
+///////////
+// UART6 //
+///////////
+
+// enable USART6
+#define NF_SERIAL_COMM_STM32_UART_USE_USART6    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART6_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART6_RX_SIZE  256

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/target_windows_devices_serialcommunication_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ////////////
@@ -16,12 +17,6 @@
 // RX pin: is GPIOC_3
 // GPIO alternate pin function is 1 (see "Table 16. Alternate functions selected through GPIOC_AFR registers for port C" in STM32F091RC datasheet)
 UART_CONFIG_PINS(8, GPIOC, GPIOC, 2, 3, 2)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART8_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART8_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/target_windows_devices_serialcommunication_config.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+////////////
+// USART8 //
+////////////
+
+// enable USART8
+#define NF_SERIAL_COMM_STM32_UART_USE_UART8    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART8_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART8_RX_SIZE  256

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_serialcommunication_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -16,12 +17,6 @@
 // RX pin: is GPIOA_10
 // GPIO alternate pin function is 7 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(1, GPIOA, GPIOA, 9, 10, 7)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART1_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART1_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -54,12 +49,6 @@ UART_UNINIT(1)
 // GPIO alternate pin function is 7 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(3, GPIOD, GPIOD, 8, 9, 7)
 
-// buffers size
-// tx buffer size: 256 bytes
-#define UART3_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART3_RX_SIZE  256
-
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
 // because of issues with cache coherency and DMA (this is particularly important with Cortex-M7 because of cache)
@@ -90,12 +79,6 @@ UART_UNINIT(3)
 // RX pin: is GPIOC_7
 // GPIO alternate pin function is 8 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
 UART_CONFIG_PINS(6, GPIOC, GPIOC, 6, 7, 8)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART6_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART6_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_serialcommunication_config.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+///////////
+// UART1 //
+///////////
+
+// enable USART1
+#define NF_SERIAL_COMM_STM32_UART_USE_USART1    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART1_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART1_RX_SIZE  256
+
+
+///////////
+// UART3 //
+///////////
+
+// enable USART3
+#define NF_SERIAL_COMM_STM32_UART_USE_USART3    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART3_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART3_RX_SIZE  256
+
+
+///////////
+// UART6 //
+///////////
+
+// enable USART6
+#define NF_SERIAL_COMM_STM32_UART_USE_USART6    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART6_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART6_RX_SIZE  256

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_windows_devices_serialcommunication_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -16,12 +17,6 @@
 // RX pin: is GPIOA_3
 // GPIO alternate pin function is 7 (see "Table 9. STM32F405xx and STM32F407xx alternate function mapping" in STM32F405xx/STM32F407xx datasheet)
 UART_CONFIG_PINS(2, GPIOA, GPIOA, 2, 3, 7)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART2_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART2_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -53,12 +48,6 @@ UART_UNINIT(2)
 // RX pin: is GPIOD_9
 // GPIO alternate pin function is 7 (see "Table 9. STM32F405xx and STM32F407xx alternate function mapping" in STM32F405xx/STM32F407xx datasheet)
 UART_CONFIG_PINS(3, GPIOD, GPIOD, 8, 9, 7)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART3_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART3_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_windows_devices_serialcommunication_config.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+///////////
+// UART2 //
+///////////
+
+// enable USART2
+#define NF_SERIAL_COMM_STM32_UART_USE_USART2    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART2_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART2_RX_SIZE  256
+
+
+///////////
+// UART3 //
+///////////
+
+// enable USART3
+#define NF_SERIAL_COMM_STM32_UART_USE_USART3    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART3_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART3_RX_SIZE  256

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_serialcommunication_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_serialcommunication_config.cpp
@@ -3,7 +3,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#include "win_dev_serial_native.h"
+#include "target_windows_devices_serialcommunication_config.h"
+#include <win_dev_serial_native.h>
 
 
 ///////////
@@ -17,12 +18,6 @@
 // RX pin: is GPIOC_7
 // GPIO alternate pin function is 8 (see "Table 13. STM32F765xx, STM32F767xx, STM32F768Ax and STM32F769xx alternate function mapping" in STM32F769I datasheet)
 UART_CONFIG_PINS(6, GPIOC, GPIOC, 6, 7, 8)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART6_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART6_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_serialcommunication_config.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+///////////
+// UART6 //
+///////////
+
+// enable USART6
+#define NF_SERIAL_COMM_STM32_UART_USE_USART6    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART6_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART6_RX_SIZE  256

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native.h
@@ -7,6 +7,7 @@
 #define _WIN_DEV_SERIAL_NATIVE_H_
 
 
+#include <target_windows_devices_serialcommunication_config.h>
 #include <nanoCLR_Interop.h>
 #include <nanoCLR_Runtime.h>
 #include <nanoCLR_Checks.h>
@@ -148,28 +149,28 @@ struct NF_PAL_UART
 ////////////////////////////////////////////
 // declaration of the the UART PAL strucs //
 ////////////////////////////////////////////
-#if STM32_UART_USE_USART1
+#if NF_SERIAL_COMM_STM32_UART_USE_USART1
     extern NF_PAL_UART Uart1_PAL;
 #endif
-#if STM32_UART_USE_USART2
+#if NF_SERIAL_COMM_STM32_UART_USE_USART2
     extern NF_PAL_UART Uart2_PAL;
 #endif
-#if STM32_UART_USE_USART3
+#if NF_SERIAL_COMM_STM32_UART_USE_USART3
     extern NF_PAL_UART Uart3_PAL;
 #endif
-#if STM32_UART_USE_UART4
+#if NF_SERIAL_COMM_STM32_UART_USE_UART4
     extern NF_PAL_UART Uart4_PAL;
 #endif
-#if STM32_UART_USE_UART5
+#if NF_SERIAL_COMM_STM32_UART_USE_UART5
     extern NF_PAL_UART Uart5_PAL;
 #endif
-#if STM32_UART_USE_USART6
+#if NF_SERIAL_COMM_STM32_UART_USE_USART6
     extern NF_PAL_UART Uart6_PAL;
 #endif
-#if STM32_UART_USE_UART7
+#if NF_SERIAL_COMM_STM32_UART_USE_UART7
     extern NF_PAL_UART Uart7_PAL;
 #endif
-#if STM32_UART_USE_UART8
+#if NF_SERIAL_COMM_STM32_UART_USE_UART8
     extern NF_PAL_UART Uart8_PAL;
 #endif
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -72,28 +72,28 @@ enum SerialData
 /////////////////////////////////////////////////////////
 // UART PAL strucs delcared in win_dev_serial_native.h //
 /////////////////////////////////////////////////////////
-#if STM32_UART_USE_USART1
+#if NF_SERIAL_COMM_STM32_UART_USE_USART1
     NF_PAL_UART Uart1_PAL;
 #endif
-#if STM32_UART_USE_USART2
+#if NF_SERIAL_COMM_STM32_UART_USE_USART2
     NF_PAL_UART Uart2_PAL;
 #endif
-#if STM32_UART_USE_USART3
+#if NF_SERIAL_COMM_STM32_UART_USE_USART3
     NF_PAL_UART Uart3_PAL;
 #endif
-#if STM32_UART_USE_UART4
+#if NF_SERIAL_COMM_STM32_UART_USE_UART4
     NF_PAL_UART Uart4_PAL;
 #endif
-#if STM32_UART_USE_UART5
+#if NF_SERIAL_COMM_STM32_UART_USE_UART5
     NF_PAL_UART Uart5_PAL;
 #endif
-#if STM32_UART_USE_USART6
+#if NF_SERIAL_COMM_STM32_UART_USE_USART6
     NF_PAL_UART Uart6_PAL;
 #endif
-#if STM32_UART_USE_UART7
+#if NF_SERIAL_COMM_STM32_UART_USE_UART7
     NF_PAL_UART Uart7_PAL;
 #endif
-#if STM32_UART_USE_UART8
+#if NF_SERIAL_COMM_STM32_UART_USE_UART8
     NF_PAL_UART Uart8_PAL;
 #endif
 
@@ -106,49 +106,49 @@ static void TxEnd1(UARTDriver *uartp)
 
     NF_PAL_UART* palUart;
 
-    #if STM32_UART_USE_USART1
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
     if (uartp == &UARTD1)
     {
         palUart = &Uart1_PAL;
     }
     #endif
-    #if STM32_UART_USE_USART2
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
     if (uartp == &UARTD2)
     {
         palUart = &Uart2_PAL;
     }
     #endif
-    #if STM32_UART_USE_USART3
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
     if (uartp == &UARTD3)
     {
         palUart = &Uart3_PAL;
     }
     #endif
-    #if STM32_UART_USE_UART4
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
     if (uartp == &UARTD4)
     {
         palUart = &Uart4_PAL;
     }
     #endif
-    #if STM32_UART_USE_UART5
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
     if (uartp == &UARTD5)
     {
         palUart = &Uart5_PAL;
     }
     #endif
-    #if STM32_UART_USE_USART6
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
     if (uartp == &UARTD6)
     {
         palUart = &Uart6_PAL;
     }
     #endif
-    #if STM32_UART_USE_UART7
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
     if (uartp == &UARTD7)
     {
         palUart = &Uart7_PAL;
     }
     #endif
-    #if STM32_UART_USE_UART8
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
     if (uartp == &UARTD8)
     {
         palUart = &Uart8_PAL;
@@ -174,56 +174,56 @@ static void RxChar(UARTDriver *uartp, uint16_t c)
     NF_PAL_UART* palUart;
     uint8_t portIndex = 0;
 
-    #if STM32_UART_USE_USART1
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
     if (uartp == &UARTD1)
     {
         palUart = &Uart1_PAL;
         portIndex = 1;
     }
     #endif
-    #if STM32_UART_USE_USART2
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
     if (uartp == &UARTD2)
     {
         palUart = &Uart2_PAL;
         portIndex = 2;
     }
     #endif
-    #if STM32_UART_USE_USART3
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
     if (uartp == &UARTD3)
     {
         palUart = &Uart3_PAL;
         portIndex = 3;
     }
     #endif
-    #if STM32_UART_USE_UART4
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
     if (uartp == &UARTD4)
     {
         palUart = &Uart4_PAL;
         portIndex = 4;
     }
     #endif
-    #if STM32_UART_USE_UART5
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
     if (uartp == &UARTD5)
     {
         palUart = &Uart5_PAL;
         portIndex = 5;
     }
     #endif
-    #if STM32_UART_USE_USART6
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
     if (uartp == &UARTD6)
     {
         palUart = &Uart6_PAL;
         portIndex = 6;
     }
     #endif
-    #if STM32_UART_USE_UART7
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
     if (uartp == &UARTD7)
     {
         palUart = &Uart7_PAL;
         portIndex = 7;
     }
     #endif
-    #if STM32_UART_USE_UART8
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
     if (uartp == &UARTD8)
     {
         palUart = &Uart8_PAL;
@@ -274,28 +274,28 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
     NANOCLR_HEADER();
     {
 
-    #if STM32_UART_USE_USART1
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
         UnInit_UART1();
     #endif
-    #if STM32_UART_USE_USART2
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
         UnInit_UART2();
     #endif
-    #if STM32_UART_USE_USART3
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
         UnInit_UART3();
     #endif
-    #if STM32_UART_USE_UART4
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
         UnInit_UART4();
     #endif
-    #if STM32_UART_USE_UART5
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
         UnInit_UART5();
     #endif
-    #if STM32_UART_USE_USART6
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
         UnInit_UART6();
     #endif
-    #if STM32_UART_USE_UART7
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
         UnInit_UART7();
     #endif
-    #if STM32_UART_USE_UART8
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
         UnInit_UART8();
     #endif
 
@@ -315,56 +315,56 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         // Choose the driver for this SerialDevice
         switch ((int)pThis[ FIELD___portIndex ].NumericByRef().s4)
         {
-    #if STM32_UART_USE_USART1
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
             case 1 :
                 Init_UART1();
                 Uart1_PAL.UartDriver = &UARTD1;
                 palUart = &Uart1_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_USART2
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
             case 2 :
                 Init_UART2();
                 Uart2_PAL.UartDriver = &UARTD2;
                 palUart = &Uart2_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_USART3
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
             case 3 :
                 Init_UART3();
                 Uart3_PAL.UartDriver = &UARTD3;
                 palUart = &Uart3_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART4
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
             case 4 :
                 Init_UART4();
                 Uart4_PAL.UartDriver = &UARTD4;
                 palUart = &Uart4_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART5
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
             case 5 :
                 Init_UART5();
                 Uart5_PAL.UartDriver = &UARTD5;
                 palUart = &Uart5_PAL;
                 break;                
     #endif
-    #if STM32_UART_USE_USART6
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
             case 6 :
                 Init_UART6();
                 Uart6_PAL.UartDriver = &UARTD6;
                 palUart = &Uart6_PAL;
                 break;                
     #endif
-    #if STM32_UART_USE_UART7
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
             case 7 :
                 Init_UART7();
                 Uart7_PAL.UartDriver = &UARTD7;
                 palUart = &Uart7_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART8
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
             case 8 :
                 Init_UART8();
                 Uart8_PAL.UartDriver = &UARTD8;
@@ -400,42 +400,42 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         // Choose the driver for this SerialDevice
         switch ((int)pThis[ FIELD___portIndex ].NumericByRef().s4)
         {
-    #if STM32_UART_USE_USART1
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
             case 1 :
                 palUart = &Uart1_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_USART2
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
             case 2 :
                 palUart = &Uart2_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_USART3
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
             case 3 :
                 palUart = &Uart3_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART4
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
             case 4 :
                 palUart = &Uart4_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART5
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
             case 5 :
                 palUart = &Uart5_PAL;
                 break;                
     #endif
-    #if STM32_UART_USE_USART6
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
             case 6 :
                 palUart = &Uart6_PAL;
                 break;                
     #endif
-    #if STM32_UART_USE_UART7
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
             case 7 :
                 palUart = &Uart7_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART8
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
             case 8 :
                 palUart = &Uart8_PAL;
                 break;
@@ -476,42 +476,42 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         // get pointer to PAL UART        
         switch ((int)pThis[ FIELD___portIndex ].NumericByRef().s4)
         {
-    #if STM32_UART_USE_USART1
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
             case 1 :
                 ConfigPins_UART1();
                 break;
     #endif
-    #if STM32_UART_USE_USART2
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
             case 2 :
                 ConfigPins_UART2();
                 break;
     #endif
-    #if STM32_UART_USE_USART3
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
             case 3 :
                 ConfigPins_UART3();
                 break;
     #endif
-    #if STM32_UART_USE_UART4
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
             case 4 :
                 ConfigPins_UART4();
                 break;
     #endif
-    #if STM32_UART_USE_UART5
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
             case 5 :
                 ConfigPins_UART5();
                 break;                
     #endif
-    #if STM32_UART_USE_USART6
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
             case 6 :
                 ConfigPins_UART6();
                 break;                
     #endif
-    #if STM32_UART_USE_UART7
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
             case 7 :
                 ConfigPins_UART7();
                 break;
     #endif
-    #if STM32_UART_USE_UART8
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
             case 8 :
                 ConfigPins_UART8();
                 break;
@@ -557,42 +557,42 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         // get pointer to PAL UART        
         switch ((int)pThis[ FIELD___portIndex ].NumericByRef().s4)
         {
-    #if STM32_UART_USE_USART1
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
             case 1 :
                 palUart = &Uart1_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_USART2
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
             case 2 :
                 palUart = &Uart2_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_USART3
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
             case 3 :
                 palUart = &Uart3_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART4
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
             case 4 :
                 palUart = &Uart4_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART5
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
             case 5 :
                 palUart = &Uart5_PAL;
                 break;                
     #endif
-    #if STM32_UART_USE_USART6
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
             case 6 :
                 palUart = &Uart6_PAL;
                 break;                
     #endif
-    #if STM32_UART_USE_UART7
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
             case 7 :
                 palUart = &Uart7_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART8
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
             case 8 :
                 palUart = &Uart8_PAL;
                 break;
@@ -652,42 +652,42 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
     // Choose the driver for this SerialDevice
     switch ((int)pThis[ FIELD___portIndex ].NumericByRef().s4)
     {
-#if STM32_UART_USE_USART1
+#if NF_SERIAL_COMM_STM32_UART_USE_USART1
         case 1 :
             palUart = &Uart1_PAL;
             break;
 #endif
-#if STM32_UART_USE_USART2
+#if NF_SERIAL_COMM_STM32_UART_USE_USART2
         case 2 :
             palUart = &Uart2_PAL;
             break;
 #endif
-#if STM32_UART_USE_USART3
+#if NF_SERIAL_COMM_STM32_UART_USE_USART3
         case 3 :
             palUart = &Uart3_PAL;
             break;
 #endif
-#if STM32_UART_USE_UART4
+#if NF_SERIAL_COMM_STM32_UART_USE_UART4
         case 4 :
             palUart = &Uart4_PAL;
             break;
 #endif
-#if STM32_UART_USE_UART5
+#if NF_SERIAL_COMM_STM32_UART_USE_UART5
         case 5 :
             palUart = &Uart5_PAL;
             break;
 #endif
-#if STM32_UART_USE_USART6
+#if NF_SERIAL_COMM_STM32_UART_USE_USART6
         case 6 :
             palUart = &Uart6_PAL;
             break;
 #endif
-#if STM32_UART_USE_UART7
+#if NF_SERIAL_COMM_STM32_UART_USE_UART7
         case 7 :
             palUart = &Uart7_PAL;
             break;
 #endif
-#if STM32_UART_USE_UART8
+#if NF_SERIAL_COMM_STM32_UART_USE_UART8
         case 8 :
             palUart = &Uart8_PAL;
             break;
@@ -831,42 +831,42 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
     // Choose the driver for this SerialDevice
     switch ((int)pThis[ FIELD___portIndex ].NumericByRef().s4)
     {
-#if STM32_UART_USE_USART1
+#if NF_SERIAL_COMM_STM32_UART_USE_USART1
         case 1 :
             palUart = &Uart1_PAL;
             break;
 #endif
-#if STM32_UART_USE_USART2
+#if NF_SERIAL_COMM_STM32_UART_USE_USART2
         case 2 :
             palUart = &Uart2_PAL;
             break;
 #endif
-#if STM32_UART_USE_USART3
+#if NF_SERIAL_COMM_STM32_UART_USE_USART3
         case 3 :
             palUart = &Uart3_PAL;
             break;
 #endif
-#if STM32_UART_USE_UART4
+#if NF_SERIAL_COMM_STM32_UART_USE_UART4
         case 4 :
             palUart = &Uart4_PAL;
             break;
 #endif
-#if STM32_UART_USE_UART5
+#if NF_SERIAL_COMM_STM32_UART_USE_UART5
         case 5 :
             palUart = &Uart5_PAL;
             break;
 #endif
-#if STM32_UART_USE_USART6
+#if NF_SERIAL_COMM_STM32_UART_USE_USART6
         case 6 :
             palUart = &Uart6_PAL;
             break;
 #endif
-#if STM32_UART_USE_UART7
+#if NF_SERIAL_COMM_STM32_UART_USE_UART7
         case 7 :
             palUart = &Uart7_PAL;
             break;
 #endif
-#if STM32_UART_USE_UART8
+#if NF_SERIAL_COMM_STM32_UART_USE_UART8
         case 8 :
             palUart = &Uart8_PAL;
             break;
@@ -1007,42 +1007,42 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         // Choose the driver for this SerialDevice
         switch ((int)pThis[ FIELD___portIndex ].NumericByRef().s4)
         {
-    #if STM32_UART_USE_USART1
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
             case 1 :
                 palUart = &Uart1_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_USART2
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
             case 2 :
                 palUart = &Uart2_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_USART3
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
             case 3 :
                 palUart = &Uart3_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART4
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
             case 4 :
                 palUart = &Uart4_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART5
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
             case 5 :
                 palUart = &Uart5_PAL;
                 break;                
     #endif
-    #if STM32_UART_USE_USART6
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
             case 6 :
                 palUart = &Uart6_PAL;
                 break;                
     #endif
-    #if STM32_UART_USE_UART7
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
             case 7 :
                 palUart = &Uart7_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART8
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
             case 8 :
                 palUart = &Uart8_PAL;
                 break;
@@ -1072,42 +1072,42 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         // Choose the driver for this SerialDevice
         switch ((int)pThis[ FIELD___portIndex ].NumericByRef().s4)
         {
-    #if STM32_UART_USE_USART1
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
             case 1 :
                 palUart = &Uart1_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_USART2
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
             case 2 :
                 palUart = &Uart2_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_USART3
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
             case 3 :
                 palUart = &Uart3_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART4
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
             case 4 :
                 palUart = &Uart4_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART5
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
             case 5 :
                 palUart = &Uart5_PAL;
                 break;                
     #endif
-    #if STM32_UART_USE_USART6
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
             case 6 :
                 palUart = &Uart6_PAL;
                 break;                
     #endif
-    #if STM32_UART_USE_UART7
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
             case 7 :
                 palUart = &Uart7_PAL;
                 break;
     #endif
-    #if STM32_UART_USE_UART8
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
             case 8 :
                 palUart = &Uart8_PAL;
                 break;
@@ -1132,28 +1132,28 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
        // declare the device selector string whose max size is "COM1,COM2,COM3,COM4,COM5,COM6,COM7,COM8," + terminator and init with the terminator
        char deviceSelectorString[ 40 + 1] = { 0 };
 
-   #if STM32_UART_USE_USART1
+   #if NF_SERIAL_COMM_STM32_UART_USE_USART1
        strcat(deviceSelectorString, "COM1,");
    #endif
-   #if STM32_UART_USE_USART2
+   #if NF_SERIAL_COMM_STM32_UART_USE_USART2
        strcat(deviceSelectorString, "COM2,");
    #endif
-   #if STM32_UART_USE_USART3
+   #if NF_SERIAL_COMM_STM32_UART_USE_USART3
        strcat(deviceSelectorString, "COM3,");
    #endif
-   #if STM32_UART_USE_UART4
+   #if NF_SERIAL_COMM_STM32_UART_USE_UART4
        strcat(deviceSelectorString, "COM4,");
    #endif
-   #if STM32_UART_USE_UART5
+   #if NF_SERIAL_COMM_STM32_UART_USE_UART5
        strcat(deviceSelectorString, "COM5,");
    #endif
-   #if STM32_UART_USE_USART6
+   #if NF_SERIAL_COMM_STM32_UART_USE_USART6
        strcat(deviceSelectorString, "COM6,");
    #endif
-   #if STM32_UART_USE_UART7
+   #if NF_SERIAL_COMM_STM32_UART_USE_UART7
        strcat(deviceSelectorString, "COM7,");
    #endif
-   #if STM32_UART_USE_UART8
+   #if NF_SERIAL_COMM_STM32_UART_USE_UART8
        strcat(deviceSelectorString, "COM8,");
    #endif
 


### PR DESCRIPTION
## Description
- Add define in serial communication config files to explicitly declare which UART(s) are used by Windows.Device.SerialCommunication. 

## Motivation and Context
- With the existing code, the UART peripherals inclusion was preventing those from being used on other APIs except Windows.Device.SerialCommunication.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
