### PR TITLE
Remove ESP32 version from ESP32_TOOLS_PATH and xtensa-esp32-elf in install-esp32-tools.ps1 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ build:
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
   GNU_GCC_TOOLCHAIN_PATH: 'C:\GNU_Tools_ARM_Embedded'
-  ESP32_TOOLCHAIN_PATH: 'C:\ESP32_Tools\1.22.0-80'
+  ESP32_TOOLCHAIN_PATH: 'C:\ESP32_Tools'
   NINJA_PATH: 'C:\mytools\ninja'
   HEX2DFU_PATH: 'C:\mytools\hex2dfu'
   ESP32_TOOLS_PATH: 'C:/ESP32_TOOLS'

--- a/install-esp32-tools.ps1
+++ b/install-esp32-tools.ps1
@@ -35,13 +35,13 @@ If([string]::IsNullOrEmpty($env:ESP32_TOOLS_PATH) -or $force)
 }
 If([string]::IsNullOrEmpty($env:ESP32_TOOLCHAIN_PREFIX) -or $force)
 {
-	$env:ESP32_TOOLCHAIN_PREFIX= ($env:ESP32_TOOLS_PATH+'\1.22.0-80')
+	$env:ESP32_TOOLCHAIN_PREFIX= ($env:ESP32_TOOLS_PATH)
 	Write-Host ("Set User Environment ESP32_TOOLCHAIN_PREFIX='"+$env:ESP32_TOOLCHAIN_PREFIX+"'")
 	[System.Environment]::SetEnvironmentVariable("ESP32_TOOLCHAIN_PREFIX", $env:ESP32_TOOLCHAIN_PREFIX, "User")
 }
 If([string]::IsNullOrEmpty($env:ESP32_TOOLCHAIN_PATH) -or $force)
 {
-	$env:ESP32_TOOLCHAIN_PATH= ($env:ESP32_TOOLS_PATH+'\1.22.0-80\xtensa-esp32-elf')
+	$env:ESP32_TOOLCHAIN_PATH= ($env:ESP32_TOOLS_PATH)
 	Write-Host ("Set User Environment ESP32_TOOLCHAIN_PATH='"+$env:ESP32_TOOLCHAIN_PATH+"'")
 	[System.Environment]::SetEnvironmentVariable("ESP32_TOOLCHAIN_PATH", $env:ESP32_TOOLCHAIN_PATH, "User")
 }

--- a/targets/FreeRTOS/ESP32_DevKitC/BUILD-ESP32.md
+++ b/targets/FreeRTOS/ESP32_DevKitC/BUILD-ESP32.md
@@ -66,7 +66,7 @@ You can force the environemnt variables to be updated by adding -Force to the co
 
 The script will create the following subfolders (see manual install below and appveyor.yml)
 
-   - `C:\Esp32_Tools\1.22.0-80`
+   - `C:\Esp32_Tools`
    - `C:\Esp32_Tools\esp-idf-v3.1`
    - `C:\Esp32_Tools\libs-v3.1`
    - `C:\Esp32_Tools\ninja`  
@@ -75,7 +75,7 @@ The script will create the following subfolders (see manual install below and ap
 The following Environment Variables will be created for the current Windows User. 
 
    - `ESP32_TOOLS_PATH = C:\ESP32_TOOLS`
-   - `ESP32_TOOLCHAIN_PATH = C:\ESP32_TOOLS\1.22.0-80\xtensa-esp32-elf`
+   - `ESP32_TOOLCHAIN_PATH = C:\ESP32_TOOLS`
    - `ESP32_LIBS_PATH = C:\ESP32_TOOLS\libs-v3.1`
    - `IDF_PATH = C:\ESP32_TOOLS\esp-idf-v3.1`
    - `NINJA_PATH = C:\ESP32_TOOLS\ninja`
@@ -104,7 +104,7 @@ and extract it into `C:\Esp32_Tools\libs-v3.1`.
 
 3. Download the v3.1 IDF source zip file from [here](https://github.com/espressif/esp-idf/releases/download/v3.1/esp-idf-v3.1.zip) and extract it into `C:\Esp32_Tools` so you get `C:\ESP32_Tools\esp-idf-v3.1\components` etc.
 
-4. Download the Esp32 toolchain from [here](https://dl.espressif.com/dl/xtensa-esp32-elf-win32-1.22.0-80-g6c4433a-5.2.0.zip) and extract it into `C:\Esp32_Tools\1.22.0.80` so you get `C:\Esp32_Tools\1.22.0.80\xtensa-esp32-elf`.
+4. Download the Esp32 toolchain from [here](https://dl.espressif.com/dl/xtensa-esp32-elf-win32-1.22.0-80-g6c4433a-5.2.0.zip) and extract it into `C:\Esp32_Tools` so you get `C:\Esp32_Tools\xtensa-esp32-elf`.
 
 5. For on chip debugging of the nanoCLR, download OpenOCD from [here](https://github.com/espressif/openocd-esp32/releases/download/v0.10.0-esp32-20180724/openocd-esp32-win32-0.10.0-esp32-20180724.zip) and extract OpenOCD into `C:\Esp32_Tools` so you get `C:\Esp32_Tools\openocd-esp32`.
 
@@ -113,7 +113,7 @@ and extract it into `C:\Esp32_Tools\libs-v3.1`.
   
 7. Define the environment variables to match the install locations. Default locations are:
    - `ESP32_TOOLS_PATH = C:\ESP32_TOOLS`
-   - `ESP32_TOOLCHAIN_PATH = C:\ESP32_TOOLS\1.22.0-80\xtensa-esp32-elf`
+   - `ESP32_TOOLCHAIN_PATH = C:\ESP32_TOOLS`
    - `ESP32_LIBS_PATH = C:\ESP32_TOOLS\libs-v3.1`
    - `IDF_PATH = C:\ESP32_TOOLS\esp-idf-v3.1`
    - `NINJA_PATH = C:\ESP32_TOOLS\ninja`
@@ -346,7 +346,7 @@ The following example assumes the OpenOCD tool was installed in the default loca
             "type": "cppdbg",
             "request": "launch",
             "MIMode": "gdb",
-            "miDebuggerPath": "C:/ESP32_Tools/1.22.0-80/xtensa-esp32-elf/bin/xtensa-esp32-elf-gdb.exe",
+            "miDebuggerPath": "C:/ESP32_Tools/xtensa-esp32-elf/bin/xtensa-esp32-elf-gdb.exe",
             "stopAtEntry":true,
             "program": "<absolute-path-to-the-build-folder-mind-the-forward-slashes>/targets/FreeRTOS/ESP32_DevKitC/nanoCLR.elf",
 


### PR DESCRIPTION
Remove version of ESP32 tools from install path and subsequently being included in settings and power shell scripts. Remove extra `xtensa-esp32-elf` from `ESP32_TOOLCHAIN_PATH` definition in install-esp32-tools.ps1.

## Description
Remove the version of the ESP32 tools from the definition of `ESP32_TOOLCHAIN_PATH` in appveyor.yml and from all the other files where it was used. Remove extra `xtensa-esp32-elf` from definition for `ESP32_TOOLCHAIN_PATH` in `install-esp32-tools.ps1` as that folder is defined in the ZIp file. 

## Motivation and Context
This will reduce the number of files that must be changed when new tools are released. Only the path to the ZIP of the tools needs to be changed. Remove extra `xtensa-esp32-elf` from path as defined in install-esp32-tools.ps1 to align the automated install location with what is used by appveyor.yml. 

## How Has This Been Tested?
Erased 'C:\ESP32_TOOLS' and ran automated install script `install-esp32-tools.ps1` with the -Force parameter to update the environment variables. Erased build folder to remove cmake cache. Rebuilt project. As these edits are simple changes to the PATH, if the nf-interpreter worked before the cnage, it will work after the change if it builds cleanly.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Changes path to ESP32 tools on appveyor build server, but no functional change. 
- [X] Changes install path for ESP32 tools if automated powershell script used to install ESP32 tools. 

## Checklist:
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly. (`BUILD-ESP32.md`) 
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Doingnz
