### PR TITLE
Update Windows.Devices.I2c declaration

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
@@ -32,6 +32,8 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
+    NULL,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::DisposeNative___VOID,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1,
@@ -52,7 +54,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_I2c =
 {
     "Windows.Devices.I2c", 
-    0x7566D8C2,
+    0x383E6224,
     method_lookup,
-    { 1, 0, 2, 4 }
+    { 1, 0, 2, 8 }
 };

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
@@ -32,6 +32,8 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
+    NULL,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::DisposeNative___VOID,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1,
@@ -52,7 +54,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_I2c =
 {
     "Windows.Devices.I2c", 
-    0x7566D8C2,
+    0x383E6224,
     method_lookup,
-    { 1, 0, 2, 4 }
+    { 1, 0, 2, 8 }
 };


### PR DESCRIPTION
- Required for nanoframework/lib-Windows.Devices.I2c#31

[version update]
