### PR TITLE
Rework I2C native code

### DIFF
--- a/CMake/Modules/FindWindows.Devices.I2c.cmake
+++ b/CMake/Modules/FindWindows.Devices.I2c.cmake
@@ -21,6 +21,7 @@ set(Windows.Devices.I2c_SRCS
     win_dev_i2c_native.cpp
     win_dev_i2c_native.h
     win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+    win_dev_i2c_native_Windows_Devices_I2c_I2cController.cpp
 
     target_windows_devices_i2c_config.cpp
 )

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_windows_devices_i2c_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_windows_devices_i2c_config.cpp
@@ -5,6 +5,16 @@
 
 #include "win_dev_i2c_native.h"
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// THIS FILE IS BLANK ON PURPOSE BECAUSE THIS TARGET DOESN'T REQUIRE THIS SPECIFIC CONFIGURATION //
-///////////////////////////////////////////////////////////////////////////////////////////////////
+#include "win_dev_i2c_native.h"
+
+//////////
+// I2C1 //
+//////////
+
+// pin configuration for I2C1
+// port for SCL pin is: GPIOB
+// port for SDA pin is: GPIOB
+// SCL pin: is GPIOB_6
+// SDA pin: is GPIOB_7
+// GPIO alternate pin function is 4 (see alternate function mapping table in device datasheet)
+I2C_CONFIG_PINS(1, GPIOB, GPIOB, 6, 7, 4)

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_windows_devices_i2c_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_windows_devices_i2c_config.cpp
@@ -5,6 +5,14 @@
 
 #include "win_dev_i2c_native.h"
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// THIS FILE IS BLANK ON PURPOSE BECAUSE THIS TARGET DOESN'T REQUIRE THIS SPECIFIC CONFIGURATION //
-///////////////////////////////////////////////////////////////////////////////////////////////////
+//////////
+// I2C1 //
+//////////
+
+// pin configuration for I2C1
+// port for SCL pin is: GPIOB
+// port for SDA pin is: GPIOB
+// SCL pin: is GPIOB_6
+// SDA pin: is GPIOB_7
+// GPIO alternate pin function is 4 (see alternate function mapping table in device datasheet)
+I2C_CONFIG_PINS(1, GPIOB, GPIOB, 6, 7, 4)

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_windows_devices_i2c_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_windows_devices_i2c_config.cpp
@@ -5,6 +5,26 @@
 
 #include "win_dev_i2c_native.h"
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// THIS FILE IS BLANK ON PURPOSE BECAUSE THIS TARGET DOESN'T REQUIRE THIS SPECIFIC CONFIGURATION //
-///////////////////////////////////////////////////////////////////////////////////////////////////
+//////////
+// I2C1 //
+//////////
+
+// pin configuration for I2C1
+// port for SCL pin is: GPIOB
+// port for SDA pin is: GPIOB
+// SCL pin: is GPIOB_8
+// SDA pin: is GPIOB_9
+// GPIO alternate pin function is 4 (see alternate function mapping table in device datasheet)
+I2C_CONFIG_PINS(1, GPIOB, GPIOB, 8, 9, 4)
+
+//////////
+// I2C2 //
+//////////
+
+// pin configuration for I2C2
+// port for SCL pin is: GPIOF
+// port for SDA pin is: GPIOF
+// SCL pin: is GPIOB_0
+// SDA pin: is GPIOB_1
+// GPIO alternate pin function is 4 (see alternate function mapping table in device datasheet)
+I2C_CONFIG_PINS(2, GPIOF, GPIOF, 0, 1, 4)

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/target_windows_devices_i2c_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/target_windows_devices_i2c_config.cpp
@@ -5,6 +5,14 @@
 
 #include "win_dev_i2c_native.h"
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// THIS FILE IS BLANK ON PURPOSE BECAUSE THIS TARGET DOESN'T REQUIRE THIS SPECIFIC CONFIGURATION //
-///////////////////////////////////////////////////////////////////////////////////////////////////
+//////////
+// I2C1 //
+//////////
+
+// pin configuration for I2C1
+// port for SCL pin is: GPIOB
+// port for SDA pin is: GPIOB
+// SCL pin: is GPIOB_8
+// SDA pin: is GPIOB_9
+// GPIO alternate pin function is 4 (see alternate function mapping table in device datasheet)
+I2C_CONFIG_PINS(1, GPIOB, GPIOB, 8, 9, 4)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_i2c_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_i2c_config.cpp
@@ -5,6 +5,14 @@
 
 #include "win_dev_i2c_native.h"
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// THIS FILE IS BLANK ON PURPOSE BECAUSE THIS TARGET DOESN'T REQUIRE THIS SPECIFIC CONFIGURATION //
-///////////////////////////////////////////////////////////////////////////////////////////////////
+//////////
+// I2C3 //
+//////////
+
+// pin configuration for I2C3
+// port for SCL pin is: GPIOA
+// port for SDA pin is: GPIOC
+// SCL pin: is GPIOA_8
+// SDA pin: is GPIOC_9
+// GPIO alternate pin function is 4 (see alternate function mapping table in device datasheet)
+I2C_CONFIG_PINS(3, GPIOA, GPIOC, 8, 9, 4)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_windows_devices_i2c_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_windows_devices_i2c_config.cpp
@@ -5,6 +5,14 @@
 
 #include "win_dev_i2c_native.h"
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// THIS FILE IS BLANK ON PURPOSE BECAUSE THIS TARGET DOESN'T REQUIRE THIS SPECIFIC CONFIGURATION //
-///////////////////////////////////////////////////////////////////////////////////////////////////
+//////////
+// I2C1 //
+//////////
+
+// pin configuration for I2C1
+// port for SCL pin is: GPIOB
+// port for SDA pin is: GPIOB
+// SCL pin: is GPIOB_8
+// SDA pin: is GPIOB_9
+// GPIO alternate pin function is 4 (see alternate function mapping table in device datasheet)
+I2C_CONFIG_PINS(1, GPIOB, GPIOB, 8, 9, 4)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_i2c_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_i2c_config.cpp
@@ -5,6 +5,14 @@
 
 #include "win_dev_i2c_native.h"
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// THIS FILE IS BLANK ON PURPOSE BECAUSE THIS TARGET DOESN'T REQUIRE THIS SPECIFIC CONFIGURATION //
-///////////////////////////////////////////////////////////////////////////////////////////////////
+//////////
+// I2C1 //
+//////////
+
+// pin configuration for I2C1
+// port for SCL pin is: GPIOB
+// port for SDA pin is: GPIOB
+// SCL pin: is GPIOB_8
+// SDA pin: is GPIOB_9
+// GPIO alternate pin function is 4 (see alternate function mapping table in device datasheet)
+I2C_CONFIG_PINS(1, GPIOB, GPIOB, 8, 9, 4)

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
@@ -21,6 +21,10 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController::NativeInit___VOID,
+    NULL,
+    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController::GetDeviceSelector___STATIC__STRING,
+    NULL,
     NULL,
     NULL,
     NULL,
@@ -42,7 +46,8 @@ static const CLR_RT_MethodHandler method_lookup[] =
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1,
     NULL,
     NULL,
-    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::GetDeviceSelector___STATIC__STRING,
+    NULL,
+    NULL,
     NULL,
     NULL,
     NULL,
@@ -57,7 +62,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_I2c =
 {
     "Windows.Devices.I2c", 
-    0x63C82A4C,
+    0x7F0ABA1C,
     method_lookup,
-    { 1, 0, 2, 15 }
+    { 1, 0, 2, 20 }
 };

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
@@ -25,9 +25,21 @@ struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cConnectionSettings
 struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController
 {
     static const int FIELD_STATIC___syncLock = 0;
-    static const int FIELD_STATIC__s_instance = 1;
-    static const int FIELD_STATIC__s_deviceCollection = 2;
-    static const int FIELD_STATIC__s_busIdCollection = 3;
+
+    static const int FIELD___controllerId = 1;
+    static const int FIELD__s_deviceCollection = 2;
+
+    NANOCLR_NATIVE_DECLARE(NativeInit___VOID);
+    NANOCLR_NATIVE_DECLARE(GetDeviceSelector___STATIC__STRING);
+
+    //--//
+
+};
+
+struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cControllerManager
+{
+    static const int FIELD_STATIC___syncLock = 1;
+    static const int FIELD_STATIC__s_controllersCollection = 2;
 
 
     //--//
@@ -36,17 +48,18 @@ struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController
 
 struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice
 {
-    static const int FIELD___syncLock = 1;
-    static const int FIELD___deviceId = 2;
-    static const int FIELD___connectionSettings = 3;
-    static const int FIELD___disposed = 4;
+    static const int FIELD_STATIC___syncLock = 3;
+
+    static const int FIELD___deviceId = 1;
+    static const int FIELD___connectionSettings = 2;
+    static const int FIELD___disposed = 3;
 
     NANOCLR_NATIVE_DECLARE(NativeInit___VOID);
     NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
     NANOCLR_NATIVE_DECLARE(NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1);
-    NANOCLR_NATIVE_DECLARE(GetDeviceSelector___STATIC__STRING);
 
     //--//
+
     static void GetI2cConfig(CLR_RT_HeapBlock* managedConfig, I2CConfig* llConfig);
     static bool IsLongRunningOperation(uint16_t writeSize, uint16_t readSize, float byteTime, uint32_t& estimatedDurationMiliseconds);
 };
@@ -94,5 +107,24 @@ struct NF_PAL_I2C
 #if STM32_I2C_USE_I2C4
     extern NF_PAL_I2C I2C4_PAL;
 #endif
+
+
+// the following macro defines a function that configures the GPIO pins for a STM32 I2C peripheral
+// it gets called in the Windows_Devices_I2c_I2cDevice::NativeInit function
+// this is required because the I2C peripherals can use multiple GPIO configuration combinations
+#define I2C_CONFIG_PINS(num, gpio_port_scl, gpio_port_sda, scl_pin, sda_pin, alternate_function) void ConfigPins_I2C##num() \
+{ \
+    palSetPadMode(gpio_port_scl, scl_pin, (PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_OTYPE_OPENDRAIN) ); \
+    palSetPadMode(gpio_port_sda, sda_pin, (PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_OTYPE_OPENDRAIN)); \
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// when an I2C is defined the declarations bellow will have the real function/configuration //
+// in the target folder @ target_windows_devices_i2c_config.cpp                             //
+//////////////////////////////////////////////////////////////////////////////////////////////
+void ConfigPins_I2C1();
+void ConfigPins_I2C2();
+void ConfigPins_I2C3();
+void ConfigPins_I2C4();
 
 #endif  //_WIN_DEV_I2C_NATIVE_H_

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -160,15 +160,18 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
         // see the comments in the I2cDevice() constructor in managed code for details
         uint8_t busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
 
+        // config GPIO pins used by the I2C peripheral
         // init the PAL struct for this I2C bus and assign the respective driver
         // all this occurs if not already done
-        // why do we need this? because several I2cDevice objects can be created associated to the same bus just using different addresses
+        // why do we need to check if this is already done? because several I2cDevice objects can be created associated to the same bus just using different addresses
         switch (busIndex)
         {
     #if STM32_I2C_USE_I2C1
             case 1:
                 if(I2C1_PAL.Driver == NULL)
                 {
+                    ConfigPins_I2C1();
+
                     I2C1_PAL.Driver = &I2CD1;
                     palI2c = &I2C1_PAL;
                 }
@@ -178,6 +181,8 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
             case 2:
                 if(I2C2_PAL.Driver == NULL)
                 {
+                    ConfigPins_I2C2();
+
                     I2C2_PAL.Driver = &I2CD2;
                     palI2c = &I2C2_PAL;
                 }
@@ -187,6 +192,8 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
             case 3:
                 if(I2C3_PAL.Driver == NULL)
                 {
+                    ConfigPins_I2C3();
+
                     I2C3_PAL.Driver = &I2CD3;
                     palI2c = &I2C3_PAL;
                 }
@@ -196,6 +203,8 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
             case 4:
                 if(I2C4_PAL.Driver == NULL)
                 {
+                    ConfigPins_I2C4();
+
                     I2C4_PAL.Driver = &I2CD4;
                     palI2c = &I2C4_PAL;
                 }
@@ -498,33 +507,4 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
 
     }
     NANOCLR_NOCLEANUP();
-}
-
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::GetDeviceSelector___STATIC__STRING( CLR_RT_StackFrame& stack )
-{
-    NANOCLR_HEADER();
-    {
-       // declare the device selector string whose max size is "I2C1,I2C2,I2C3,I2C4," + terminator and init with the terminator
-       char deviceSelectorString[20 + 1] = { 0 };
-
-    #if STM32_I2C_USE_I2C1
-        strcat(deviceSelectorString, "I2C1,");
-    #endif
-    #if STM32_I2C_USE_I2C2
-        strcat(deviceSelectorString, "I2C2,");
-    #endif
-    #if STM32_I2C_USE_I2C3
-        strcat(deviceSelectorString, "I2C3,");
-    #endif
-    #if STM32_I2C_USE_I2C4
-        strcat(deviceSelectorString, "I2C4,");
-    #endif
-        // replace the last comma with a terminator
-       deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
-
-       // because the caller is expecting a result to be returned
-       // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
-       stack.SetResult_String(deviceSelectorString);
-    }
-    NANOCLR_NOCLEANUP_NOLABEL();
 }

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2c_I2cController.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2c_I2cController.cpp
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <ch.h>
+#include <hal.h>
+#include <string.h>
+#include <targetPAL.h>
+#include <nanoHAL.h>
+#include "win_dev_i2c_native.h"
+
+
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController::NativeInit___VOID( CLR_RT_StackFrame& stack )
+{
+    (void)stack;
+
+    NANOCLR_HEADER();
+    {
+
+    }
+    NANOCLR_NOCLEANUP_NOLABEL();
+}
+
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController::GetDeviceSelector___STATIC__STRING( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+    {
+       // declare the device selector string whose max size is "I2C1,I2C2,I2C3,I2C4," + terminator and init with the terminator
+       char deviceSelectorString[20 + 1] = { 0 };
+
+    #if STM32_I2C_USE_I2C1
+        strcat(deviceSelectorString, "I2C1,");
+    #endif
+    #if STM32_I2C_USE_I2C2
+        strcat(deviceSelectorString, "I2C2,");
+    #endif
+    #if STM32_I2C_USE_I2C3
+        strcat(deviceSelectorString, "I2C3,");
+    #endif
+    #if STM32_I2C_USE_I2C4
+        strcat(deviceSelectorString, "I2C4,");
+    #endif
+        // replace the last comma with a terminator
+       deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+
+       // because the caller is expecting a result to be returned
+       // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
+       stack.SetResult_String(deviceSelectorString);
+    }
+    NANOCLR_NOCLEANUP_NOLABEL();
+}

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
@@ -21,6 +21,10 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController::NativeInit___VOID,
+    NULL,
+    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController::GetDeviceSelector___STATIC__STRING,
+    NULL,
     NULL,
     NULL,
     NULL,
@@ -42,7 +46,8 @@ static const CLR_RT_MethodHandler method_lookup[] =
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1,
     NULL,
     NULL,
-    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::GetDeviceSelector___STATIC__STRING,
+    NULL,
+    NULL,
     NULL,
     NULL,
     NULL,
@@ -57,7 +62,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_I2c =
 {
     "Windows.Devices.I2c", 
-    0x63C82A4C,
+    0x7F0ABA1C,
     method_lookup,
-    { 1, 0, 2, 15 }
+    { 1, 0, 2, 20 }
 };

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
@@ -24,9 +24,21 @@ struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cConnectionSettings
 struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController
 {
     static const int FIELD_STATIC___syncLock = 0;
-    static const int FIELD_STATIC__s_instance = 1;
-    static const int FIELD_STATIC__s_deviceCollection = 2;
-    static const int FIELD_STATIC__s_busIdCollection = 3;
+
+    static const int FIELD___controllerId = 1;
+    static const int FIELD__s_deviceCollection = 2;
+
+    NANOCLR_NATIVE_DECLARE(NativeInit___VOID);
+    NANOCLR_NATIVE_DECLARE(GetDeviceSelector___STATIC__STRING);
+
+    //--//
+
+};
+
+struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cControllerManager
+{
+    static const int FIELD_STATIC___syncLock = 1;
+    static const int FIELD_STATIC__s_controllersCollection = 2;
 
 
     //--//
@@ -35,17 +47,18 @@ struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController
 
 struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice
 {
-    static const int FIELD___syncLock = 1;
-    static const int FIELD___deviceId = 2;
-    static const int FIELD___connectionSettings = 3;
-    static const int FIELD___disposed = 4;
+    static const int FIELD_STATIC___syncLock = 3;
+
+    static const int FIELD___deviceId = 1;
+    static const int FIELD___connectionSettings = 2;
+    static const int FIELD___disposed = 3;
 
     NANOCLR_NATIVE_DECLARE(NativeInit___VOID);
     NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
     NANOCLR_NATIVE_DECLARE(NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1);
-    NANOCLR_NATIVE_DECLARE(GetDeviceSelector___STATIC__STRING);
 
     //--//
+
     static void SetConfig(i2c_port_t bus, CLR_RT_HeapBlock* config);
 };
 

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -239,19 +239,3 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
    }
     NANOCLR_NOCLEANUP();
 }
-
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::GetDeviceSelector___STATIC__STRING( CLR_RT_StackFrame& stack )
-{
-    NANOCLR_HEADER();
-   {
-       // declare the device selector string whose max size is "I2C1,I2C2,I2C3," + terminator and init with the terminator
-       char deviceSelectorString[ 15 + 1] = { 0 };
-
-       strcat(deviceSelectorString, "I2C1,I2C2");
-    
-       // because the caller is expecting a result to be returned
-       // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
-       stack.SetResult_String(deviceSelectorString);
-   }
-   NANOCLR_NOCLEANUP_NOLABEL();
-}

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2c_I2cController.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2c_I2cController.cpp
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <string.h>
+#include <targetPAL.h>
+#include "win_dev_i2c_native.h"
+#include "Esp32_DeviceMapping.h"
+
+
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController::NativeInit___VOID( CLR_RT_StackFrame& stack )
+{
+    (void)stack;
+
+    NANOCLR_HEADER();
+    {
+
+    }
+    NANOCLR_NOCLEANUP_NOLABEL();
+}
+
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cController::GetDeviceSelector___STATIC__STRING( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+   {
+       // declare the device selector string whose max size is "I2C1,I2C2,I2C3," + terminator and init with the terminator
+       char deviceSelectorString[ 15 + 1] = { 0 };
+
+       strcat(deviceSelectorString, "I2C1,I2C2");
+    
+       // because the caller is expecting a result to be returned
+       // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
+       stack.SetResult_String(deviceSelectorString);
+   }
+   NANOCLR_NOCLEANUP_NOLABEL();
+}


### PR DESCRIPTION
## Description
- Update I2C native classes following new implementation of class library.
- Move some code from device class to controller class.
- Add defines and declarations for I2C pin config.
- Add I2C config on all SMT32 targets.

## Motivation and Context
- Required for nanoframework/lib-Windows.Devices.I2c#36.
- Closes nanoFramework/Home#432.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

