### PR TITLE
Update Devices.Spi assemblies

### DIFF
--- a/CMake/Modules/FindWindows.Devices.Spi.cmake
+++ b/CMake/Modules/FindWindows.Devices.Spi.cmake
@@ -19,6 +19,7 @@ list(APPEND Windows.Devices.Spi_INCLUDE_DIRS "${BASE_PATH_FOR_THIS_MODULE}")
 set(Windows.Devices.Spi_SRCS
 
     win_dev_spi_native_Windows_Devices_Spi_SpiBusInfo.cpp
+    win_dev_spi_native_Windows_Devices_Spi_SpiController.cpp
     win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
     win_dev_spi_native.cpp
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.cpp
@@ -39,12 +39,13 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    Library_win_dev_spi_native_Windows_Devices_Spi_SpiController::GetDeviceSelector___STATIC__STRING,
     NULL,
     NULL,
     NULL,
-    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer___VOID__SZARRAY_U1__SZARRAY_U1__BOOLEAN,
-    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer___VOID__SZARRAY_U2__SZARRAY_U2__BOOLEAN,
-    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___VOID,
+    NULL,
+    NULL,
+    NULL,
     NULL,
     NULL,
     NULL,
@@ -58,16 +59,21 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::DisposeNative___VOID,
+    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer___VOID__SZARRAY_U1__SZARRAY_U1__BOOLEAN,
+    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer___VOID__SZARRAY_U2__SZARRAY_U2__BOOLEAN,
+    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___VOID,
     NULL,
     NULL,
-    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::GetDeviceSelector___STATIC__STRING,
+    NULL,
+    NULL,
+    NULL,
     NULL,
 };
 
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_Spi =
 {
     "Windows.Devices.Spi", 
-    0x83B879F7,
+    0x3DE083A4,
     method_lookup,
-    { 1, 0, 2, 11 }
+    { 1, 0, 2, 15 }
 };

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.h
@@ -41,7 +41,20 @@ struct Library_win_dev_spi_native_Windows_Devices_Spi_SpiConnectionSettings
 
 struct Library_win_dev_spi_native_Windows_Devices_Spi_SpiController
 {
-    static const int FIELD_STATIC__DeviceCollection = 0;
+    static const int FIELD___syncLock = 1;
+    static const int FIELD___controllerId = 2;
+    static const int FIELD__s_deviceCollection = 3;
+
+    NANOCLR_NATIVE_DECLARE(GetDeviceSelector___STATIC__STRING);
+
+    //--//
+
+};
+
+struct Library_win_dev_spi_native_Windows_Devices_Spi_SpiControllerManager
+{
+    static const int FIELD_STATIC___syncLock = 0;
+    static const int FIELD_STATIC__s_controllersCollection = 1;
 
 
     //--//
@@ -56,11 +69,10 @@ struct Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice
     static const int FIELD___connectionSettings = 4;
     static const int FIELD___disposedValue = 5;
 
+    NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
     NANOCLR_NATIVE_DECLARE(NativeTransfer___VOID__SZARRAY_U1__SZARRAY_U1__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(NativeTransfer___VOID__SZARRAY_U2__SZARRAY_U2__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(NativeInit___VOID);
-    NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
-    NANOCLR_NATIVE_DECLARE(GetDeviceSelector___STATIC__STRING);
 
     //--//
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiController.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiController.cpp
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+
+#include "win_dev_spi_native.h"
+
+
+HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiController::GetDeviceSelector___STATIC__STRING( CLR_RT_StackFrame& stack )
+{
+   NANOCLR_HEADER();
+   {
+       // declare the device selector string whose max size is "SPI1,SPI2,SPI3,SPI4,SPI5,SPI6," + terminator and init with the terminator
+       char deviceSelectorString[ 30 + 1] = { 0 };
+
+   #if STM32_SPI_USE_SPI1
+       strcat(deviceSelectorString, "SPI1,");
+   #endif
+   #if STM32_SPI_USE_SPI2
+       strcat(deviceSelectorString, "SPI2,");
+   #endif
+   #if STM32_SPI_USE_SPI3
+       strcat(deviceSelectorString, "SPI3,");
+   #endif
+   #if STM32_SPI_USE_SPI4
+       strcat(deviceSelectorString, "SPI4,");
+   #endif
+   #if STM32_SPI_USE_SPI5
+       strcat(deviceSelectorString, "SPI5,");
+   #endif
+   #if STM32_SPI_USE_SPI6
+       strcat(deviceSelectorString, "SPI6,");
+   #endif
+
+       // replace the last comma with a terminator
+       deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+
+       // because the caller is expecting a result to be returned
+       // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
+       stack.SetResult_String(deviceSelectorString);
+   }
+   NANOCLR_NOCLEANUP_NOLABEL();
+}

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -778,39 +778,3 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::DisposeNative_
     }
     NANOCLR_NOCLEANUP_NOLABEL();
 }
-
-HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::GetDeviceSelector___STATIC__STRING( CLR_RT_StackFrame& stack )
-{
-   NANOCLR_HEADER();
-   {
-       // declare the device selector string whose max size is "SPI1,SPI2,SPI3,SPI4,SPI5,SPI6," + terminator and init with the terminator
-       char deviceSelectorString[ 30 + 1] = { 0 };
-
-   #if STM32_SPI_USE_SPI1
-       strcat(deviceSelectorString, "SPI1,");
-   #endif
-   #if STM32_SPI_USE_SPI2
-       strcat(deviceSelectorString, "SPI2,");
-   #endif
-   #if STM32_SPI_USE_SPI3
-       strcat(deviceSelectorString, "SPI3,");
-   #endif
-   #if STM32_SPI_USE_SPI4
-       strcat(deviceSelectorString, "SPI4,");
-   #endif
-   #if STM32_SPI_USE_SPI5
-       strcat(deviceSelectorString, "SPI5,");
-   #endif
-   #if STM32_SPI_USE_SPI6
-       strcat(deviceSelectorString, "SPI6,");
-   #endif
-
-       // replace the last comma with a terminator
-       deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
-
-       // because the caller is expecting a result to be returned
-       // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
-       stack.SetResult_String(deviceSelectorString);
-   }
-   NANOCLR_NOCLEANUP_NOLABEL();
-}

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.cpp
@@ -39,12 +39,13 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    Library_win_dev_spi_native_Windows_Devices_Spi_SpiController::GetDeviceSelector___STATIC__STRING,
     NULL,
     NULL,
     NULL,
-    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer___VOID__SZARRAY_U1__SZARRAY_U1__BOOLEAN,
-    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer___VOID__SZARRAY_U2__SZARRAY_U2__BOOLEAN,
-    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___VOID,
+    NULL,
+    NULL,
+    NULL,
     NULL,
     NULL,
     NULL,
@@ -58,16 +59,21 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::DisposeNative___VOID,
+    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer___VOID__SZARRAY_U1__SZARRAY_U1__BOOLEAN,
+    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer___VOID__SZARRAY_U2__SZARRAY_U2__BOOLEAN,
+    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___VOID,
     NULL,
     NULL,
-    Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::GetDeviceSelector___STATIC__STRING,
+    NULL,
+    NULL,
+    NULL,
     NULL,
 };
 
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_Spi =
 {
     "Windows.Devices.Spi", 
-    0x83B879F7,
+    0x3DE083A4,
     method_lookup,
-    { 1, 0, 2, 11 }
+    { 1, 0, 2, 15 }
 };

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native.h
@@ -54,7 +54,20 @@ struct Library_win_dev_spi_native_Windows_Devices_Spi_SpiConnectionSettings
 
 struct Library_win_dev_spi_native_Windows_Devices_Spi_SpiController
 {
-    static const int FIELD_STATIC__DeviceCollection = 0;
+    static const int FIELD___syncLock = 1;
+    static const int FIELD___controllerId = 2;
+    static const int FIELD__s_deviceCollection = 3;
+
+    NANOCLR_NATIVE_DECLARE(GetDeviceSelector___STATIC__STRING);
+
+    //--//
+
+};
+
+struct Library_win_dev_spi_native_Windows_Devices_Spi_SpiControllerManager
+{
+    static const int FIELD_STATIC___syncLock = 0;
+    static const int FIELD_STATIC__s_controllersCollection = 1;
 
 
     //--//
@@ -69,11 +82,10 @@ struct Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice
     static const int FIELD___connectionSettings = 4;
     static const int FIELD___disposedValue = 5;
 
+    NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
     NANOCLR_NATIVE_DECLARE(NativeTransfer___VOID__SZARRAY_U1__SZARRAY_U1__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(NativeTransfer___VOID__SZARRAY_U2__SZARRAY_U2__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(NativeInit___VOID);
-    NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
-    NANOCLR_NATIVE_DECLARE(GetDeviceSelector___STATIC__STRING);
 
     //--//
 

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiController.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiController.cpp
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include "win_dev_spi_native.h"
+
+HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiController::GetDeviceSelector___STATIC__STRING( CLR_RT_StackFrame& stack )
+{
+   NANOCLR_HEADER();
+   {
+       // declare the device selector string whose max size is "SPI1,SPI2" + terminator and init with the terminator
+       char deviceSelectorString[ 15 ] = { "SPI1,SPI2" };   // HSPI & VSPI
+
+       // because the caller is expecting a result to be returned
+       // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
+       stack.SetResult_String(deviceSelectorString);
+   }
+   NANOCLR_NOCLEANUP_NOLABEL();
+}

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -455,18 +455,3 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::DisposeNative_
     }
     NANOCLR_NOCLEANUP();
 }
-
-HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::GetDeviceSelector___STATIC__STRING( CLR_RT_StackFrame& stack )
-{
-   NANOCLR_HEADER();
-   {
-       // declare the device selector string whose max size is "SPI1,SPI2" + terminator and init with the terminator
-       char deviceSelectorString[ 15 ] = { "SPI1,SPI2" };   // HSPI & VSPI
-
-       // because the caller is expecting a result to be returned
-       // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)
-       stack.SetResult_String(deviceSelectorString);
-   }
-   NANOCLR_NOCLEANUP_NOLABEL();
-}
-


### PR DESCRIPTION
- Following nanoframework/lib-Windows.Devices.Spi#31.
- Add new source code to CMake.
- Update declarations.
- Move code from SpiDevice to SpiController.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
