### PR TITLE
Fix inclusion of Configuration Manager source code files

### DIFF
--- a/CMake/Modules/FindNF_CoreCLR.cmake
+++ b/CMake/Modules/FindNF_CoreCLR.cmake
@@ -162,6 +162,9 @@ set(NF_CoreCLR_SRCS
     nanoHAL_Time.cpp
     nanoHAL_Watchdog.c
 
+    # HAL stubs
+    nanoHAL_ConfigurationManager_stubs.c
+    
     # PAL
     nanoPAL_BlockStorage.c
     nanoPAL_NativeDouble.cpp
@@ -174,13 +177,9 @@ set(NF_CoreCLR_SRCS
     GenericPort_stubs.c
 )
 
-# include configuration manager file
+# include configuration manager implementation, if feature is enabled
 if(NF_FEATURE_HAS_CONFIG_BLOCK)
-    # feature enabled, full support
     list(APPEND NF_CoreCLR_SRCS nanoHAL_ConfigurationManager.c)
-else()
-    # feature disabled, stubs only
-    list(APPEND NF_CoreCLR_SRCS nanoHAL_ConfigurationManager_stubs.c)
 endif()
 
 foreach(SRC_FILE ${NF_CoreCLR_SRCS})

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,7 +148,7 @@ jobs:
     matrix:
       ESP32_DEVKITC:
         BoardName: ESP32_DEVKITC
-        BuildOptions: -DTARGET_SERIES=ESP32 -DRTOS=FREERTOS -DNF_WP_IMPLEMENTS_CRC32=OFF -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DAPI_System.Math=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=ON -DAPI_Windows.Devices.Wifi=ON -DNF_SECURITY_OPENSSL=ON -DAPI_Hardware.Esp32=ON -DSUPPORT_ANY_BASE_CONVERSION=ON
+        BuildOptions: -DTARGET_SERIES=ESP32 -DRTOS=FREERTOS -DNF_WP_IMPLEMENTS_CRC32=OFF -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DNF_FEATURE_HAS_CONFIG_BLOCK=ON -DAPI_System.Math=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=ON -DAPI_Windows.Devices.Wifi=ON -DNF_SECURITY_OPENSSL=ON -DAPI_Hardware.Esp32=ON -DSUPPORT_ANY_BASE_CONVERSION=ON
 
   variables:
     ESP32_TOOLCHAIN_PATH: $(Agent.TempDirectory)\ESP32_Tools

--- a/targets/FreeRTOS/ESP32_DevKitC/CMakeLists.txt
+++ b/targets/FreeRTOS/ESP32_DevKitC/CMakeLists.txt
@@ -70,9 +70,6 @@ add_executable(
 
     "${CMAKE_CURRENT_SOURCE_DIR}/target_common.c"
 
-    # need to add configuration manager to allow get/store configuration blocks
-    "${PROJECT_SOURCE_DIR}/src/HAL/nanoHAL_ConfigurationManager.c"
-
     ${COMMON_PROJECT_SOURCES}
     ${TARGET_ESP32_COMMON_SOURCES}
     


### PR DESCRIPTION
## Description
- Stubbed version is now always included.
- Real implementation is included if feature is enabled.
- Remove unecessary entry for ESP32 CMake.
- Add feature to ESP32 build options.

## Motivation and Context
- The inclusion of the source code files for this feature wasn't being handled correctly.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
