### PR TITLE
Add check for reboot and exit conditions on WaitForEvents loop

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL_Events.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL_Events.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <nanoPAL_Events.h>
+#include <nanoCLR_Runtime.h>
 #include <nanoPAL.h>
 #include <target_platform.h>
 #include <hal.h>
@@ -149,6 +150,12 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
 
         // no events, pass control to the OS
         osThreadYield();
+
+        // check if reboot or exit flags were set when the other OS threads executed
+        if(CLR_EE_DBG_IS(RebootPending) || CLR_EE_DBG_IS(ExitPending))
+        {
+            break;
+        }
     }
 
     return 0;

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Events.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetPAL_Events.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <nanoPAL_Events.h>
+#include <nanoCLR_Runtime.h>
 #include <nanoPAL.h>
 #include <target_platform.h>
 #include <Esp32_os.h>
@@ -155,6 +156,12 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
 
         // no events, pass control to the OS
         taskYIELD();
+        
+        // check if reboot or exit flags were set when the other OS threads executed
+        if(CLR_EE_DBG_IS(RebootPending) || CLR_EE_DBG_IS(ExitPending))
+        {
+            break;
+        }
     }
 
     return 0;


### PR DESCRIPTION
## Description
- Add check for reboot and exit conditions on WaitForEvents loop.

## Motivation and Context
- This loop is problematic because it has a serious potential for trapping the CLR execution. When it relinquishes execution to the OS many things can happen _but_ only CLR events and continuations were being checked. A common situation in debug is precisely the end of the debug session, reboot requests, application terminating and such. All those were being ignored. With this change the loop will exit on those allowing the CLR to continue execution smoothly and leaving the debug loops nicely. 

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

