### PR TITLE
Fix WiFi assembly declaration

### DIFF
--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Wifi/win_dev_wifi_native.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Wifi/win_dev_wifi_native.cpp
@@ -24,6 +24,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
     Library_win_dev_wifi_native_Windows_Devices_WiFi_WiFiAdapter::DisposeNative___VOID,
     Library_win_dev_wifi_native_Windows_Devices_WiFi_WiFiAdapter::NativeInit___VOID,
     Library_win_dev_wifi_native_Windows_Devices_WiFi_WiFiAdapter::NativeConnect___WindowsDevicesWiFiWiFiConnectionStatus__STRING__STRING__WindowsDevicesWiFiWiFiReconnectionKind,

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Wifi/win_dev_wifi_native.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/Windows.Devices.Wifi/win_dev_wifi_native.h
@@ -59,8 +59,7 @@ struct Library_win_dev_wifi_native_Windows_Devices_WiFi_WiFiConnectionResult
 struct Library_win_dev_wifi_native_Windows_Devices_WiFi_WiFiEvent
 {
     static const int FIELD__EventType = 3;
-    static const int FIELD__Flags = 4;
-    static const int FIELD__Time = 5;
+    static const int FIELD__Time = 4;
 
 
     //--//


### PR DESCRIPTION
## Description
- Nanoframework was out of step with WIndows.devices.Wifi
This corrects differences so that it now works again and we don't get wrong type errors.
- Fixes nanoFramework/home#439.

## How Has This Been Tested?<!-- (if applicable) -->
Now runs supplied test program


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
