### PR TITLE
Fix parsing of X509 certificate for mbedTLS

### DIFF
--- a/src/PAL/COM/sockets/ssl/mbedTLS/ssl_generic_init_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/mbedTLS/ssl_generic_init_internal.cpp
@@ -164,9 +164,12 @@ bool ssl_generic_init_internal( int sslMode, int sslVerify, const char* certific
     // parse certificate if passed
     if(certificate != NULL && certLength > 0)
     {
-        // need to add an extra byte here because the mbed TLS API is expecting 
-        // the buffer length INCLUDING the terminator
-        if(mbedtls_x509_crt_parse( context->x509_crt, (const unsigned char*)certificate, certLength + 1 ) != 0)
+        /////////////////////////////////////////////////////////////////////////////////////////////////
+        // developer notes:                                                                            //
+        // this call parses certificates in both string and binary formats                             //
+        // when the formart is a string it has to include the terminator otherwise the parse will fail //
+        /////////////////////////////////////////////////////////////////////////////////////////////////
+        if(mbedtls_x509_crt_parse( context->x509_crt, (const unsigned char*)certificate, certLength ) != 0)
         {
             // x509_crt_parse_failed
             goto error;


### PR DESCRIPTION

## Description
- Remove hack forcing an extra byte length for terminator. This has to be properly handled by the caller.

## Motivation and Context
- Following nanoframework/lib-nanoFramework.System.Net#52.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
