### PR TITLE
Fix wrong call to nanoHAL_Uninitialize

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
@@ -23,7 +23,7 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
     {
         case PowerLevel__Off:
             // gracefully shutdown everything
-            nanoHAL_Initialize_C();
+            nanoHAL_Uninitialize_C();
 
             chSysDisable();
 


### PR DESCRIPTION
## Description
- Fix wrong call to nanoHAL_Initialize. Should be nanoHAL_Uninitialize.

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
