### PR TITLE
Update to Config Manager for Certificate bundles over multiple blocks

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -6,7 +6,6 @@
 #include <nanoCLR_Runtime.h>
 #include <nanoCLR_Debugging.h>
 #include <nanoHAL.h>
-#include <nanoHAL_v2.h>
 #include <WireProtocol.h>
 #include <WireProtocol_Message.h>
 #include <WireProtocol_MonitorCommands.h>
@@ -871,8 +870,8 @@ bool CLR_DBG_Debugger::Monitor_QueryConfiguration( WP_Message* message)
                 success = true;
 
                 WP_ReplyToCommand( message, success, false, (uint8_t*)configNetworkInterface, size );
-                platform_free(configNetworkInterface);
             }            
+            platform_free(configNetworkInterface);
             break;
 
         case DeviceConfigurationOption_Wireless80211Network:
@@ -885,13 +884,13 @@ bool CLR_DBG_Debugger::Monitor_QueryConfiguration( WP_Message* message)
                 success = true;
 
                 WP_ReplyToCommand( message, success, false, (uint8_t*)configWireless80211NetworkInterface, size );
-                platform_free(configWireless80211NetworkInterface);
             }
+            platform_free(configWireless80211NetworkInterface);
             break;
     
         case DeviceConfigurationOption_X509CaRootBundle:
 
-            if(g_TargetConfiguration.CertificateStore->Count > 0)
+            if(g_TargetConfiguration.CertificateStore->Count > cmd->BlockIndex )
             {
                 // because X509 certificate has a variable length need to compute the block size in two steps
                 sizeOfBlock = offsetof(HAL_Configuration_X509CaRootBundle, Certificate);
@@ -906,8 +905,8 @@ bool CLR_DBG_Debugger::Monitor_QueryConfiguration( WP_Message* message)
                 success = true;
 
                 WP_ReplyToCommand( message, success, false, (uint8_t*)x509Certificate, size );
-                platform_free(x509Certificate);
             }
+            platform_free(x509Certificate);
             break;
     
         case DeviceConfigurationOption_WirelessNetworkAP:

--- a/targets/FreeRTOS/ESP32_DevKitC/IDF/CMakeLists.txt
+++ b/targets/FreeRTOS/ESP32_DevKitC/IDF/CMakeLists.txt
@@ -54,6 +54,8 @@ list(APPEND TARGET_ESP32_IDF_INCLUDES "${COMPONENT_PATH}/ulp/include")
 
 list(APPEND TARGET_ESP32_IDF_INCLUDES "${COMPONENT_PATH}/ulp/include")
 
+list(APPEND TARGET_ESP32_IDF_INCLUDES "${COMPONENT_PATH}/spiffs/include")
+
 #sdkconfig reference
 list(APPEND TARGET_ESP32_IDF_INCLUDES "${ESP32_IDF_PATH}/examples/get-started/blink/build/include")
 
@@ -335,6 +337,7 @@ list(APPEND DIRECT_LINK_LIBS ${DIRECT_LINK_PATH}/libpthread.a)
 list(APPEND DIRECT_LINK_LIBS ${DIRECT_LINK_PATH}/libwear_levelling.a)
 list(APPEND DIRECT_LINK_LIBS ${DIRECT_LINK_PATH}/libxtensa-debug-module.a)
 list(APPEND DIRECT_LINK_LIBS ${DIRECT_LINK_PATH}/libsmartconfig_ack.a)
+list(APPEND DIRECT_LINK_LIBS ${DIRECT_LINK_PATH}/libspiffs.a)
 
 # Lwip lib is built separately 
 #list(APPEND DIRECT_LINK_LIBS ${DIRECT_LINK_PATH}/liblwip.a)

--- a/targets/FreeRTOS/ESP32_DevKitC/IDF/partitions_nanoclr_2mb.csv
+++ b/targets/FreeRTOS/ESP32_DevKitC/IDF/partitions_nanoclr_2mb.csv
@@ -3,6 +3,8 @@
 nvs,      data, nvs,     0x9000,  0x4000,
 phy_init, data, phy,     0xf000,  0x1000,
 factory,  0,    0,       0x10000,  1M,
-deploy,   data, 0x84,    0x110000,  512K,
+# Config data for Network, Wireless, certificates, user data  64K
+config,   data, spiffs,  0x110000,  64K,
+deploy,   data, 0x84,    0x120000,  448K,
 
 

--- a/targets/FreeRTOS/ESP32_DevKitC/IDF/partitions_nanoclr_4mb.csv
+++ b/targets/FreeRTOS/ESP32_DevKitC/IDF/partitions_nanoclr_4mb.csv
@@ -3,6 +3,8 @@
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,
 factory,  0,    0,      0x10000,  1M,
-deploy,   data, 0x84,   0x110000,  2M,
-
+# Config data for Network, Wireless, certificates, user data  256K
+config,   data, spiffs, 0x110000, 256K, 
+# Deployment area for Managed code 1792K
+deploy,   data, 0x84,   0x150000, 0x1C0000, 
 

--- a/targets/FreeRTOS/ESP32_DevKitC/Include/esp32_os.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/Include/esp32_os.h
@@ -29,6 +29,7 @@
 #include "ledc.h"
 #include "adc.h"
 #include "timer.h"
+#include "esp_spiffs.h"
 
 // Uncomment to support Ethernet 
 //#define ESP32_ETHERNET_SUPPORT 1

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/CMakeLists.txt
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/CMakeLists.txt
@@ -20,6 +20,10 @@ list(APPEND TARGET_ESP32_NANOCLR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/nanoHAL.cp
 # append target HAL source files
 list(APPEND TARGET_ESP32_NANOCLR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/targetHAL_Power.c")
 list(APPEND TARGET_ESP32_NANOCLR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/targetHAL_Time.cpp")
+
+# Either NVS or SPIFSS storage for config, NVS is unable to store large Certificate bundles(over 1864 bytes)
+#list(APPEND TARGET_ESP32_NANOCLR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/targetHAL_ConfigStorageNVS.cpp")
+list(APPEND TARGET_ESP32_NANOCLR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/targetHAL_ConfigStorageSPIFFS.cpp")
 list(APPEND TARGET_ESP32_NANOCLR_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/targetHAL_ConfigurationManager.cpp")
 
 # append target PAL source files

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL_ConfigStorage.h
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL_ConfigStorage.h
@@ -1,0 +1,93 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <nanoHAL.h>
+#include <nanoHAL_v2.h>
+#include <nanoWeak.h>
+#include "Esp32_os.h"
+
+#define CONFIG_ERROR      0xffffffff
+
+#define CONFIG_TYPE_NETWORK     'C'
+#define CONFIG_TYPE_WIRELESS    'W'
+#define CONFIG_TYPE_WIRELESSAP  'A'
+#define CONFIG_TYPE_CERTIFICATE 'X'
+
+
+// Config_Initialise
+//
+// Initialise underlying filesystem
+//
+void Config_Initialise();
+
+//
+//  Config_OpenFile -
+//
+//  Open file for configuration / index
+//  For the case of NVS we just open the NVS partition, save file details, handle
+//  
+// Parameters:-
+//   configuration      : Type of configuration block to open
+//   configurationIndex : Index of type to open
+//   write              : True to create/overwrite file
+//
+// Return :-
+//    true  : returns handle
+//    false -1
+//
+uint32_t Config_OpenFile( DeviceConfigurationOption configuration, uint32_t configurationIndex, bool write );
+
+//
+//  Config_CloseFile - Close opened file / NVS system
+//  
+// Parameters:-
+//   handle : Handle returned from Config_openFile
+//
+// return:-
+//    true - File closed ok 
+//    false- Error/File not open/Invalid handle
+//
+bool Config_CloseFile( uint32_t handle );
+
+//
+//  Config_FileSize - Return size of file
+//
+// Parameters:-
+//   handle : Handle returned from Config_openFile
+//
+// return:-
+//    File size 
+//    -1 = Error/Not found/Invalid handle
+//
+int32_t Config_FileSize( uint32_t handle );
+
+//
+//  Config_WriteFile -  Write data to file system
+//
+// Parameters:-
+//   handle    : Handle returned from Config_openFile
+//   pData     : Pointer data to write
+//   writeSize : Size of data to write
+//
+// return:-
+//    true - OK 
+//    false- Error/Not found
+//
+bool Config_WriteFile(uint32_t handle, uint8_t * pData, int32_t writeSize );
+
+
+//
+// Config_ReadFile - Read the data from opened file
+//
+// Parameters:-
+//   handle : Handle returned from Config_openFile
+//   pData  : Ponter to where data is to be stored
+//
+// return:-
+//    true - read length 
+//    false- -1 , Error/Not found/Invalid handle
+//
+int32_t Config_ReadFile( uint32_t handle, uint8_t * pData, int32_t maxSizeData );
+

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL_ConfigStorageNVS.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL_ConfigStorageNVS.cpp
@@ -1,0 +1,216 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <nanoHAL.h>
+#include <nanoHAL_v2.h>
+#include <nanoWeak.h>
+#include "Esp32_os.h"
+#include "targetHAL_ConfigStorage.h"
+
+// NVS parameters for Interface config
+#define NVS_NAMESPACE	    "nanoF"
+
+
+// Save File details
+static nvs_handle configHandle = -1;
+static DeviceConfigurationOption configType;
+static uint32_t configIndex;
+
+enum  ConfigIoType { Read, Write, GetSize };
+
+void Config_Initialise()
+{
+    
+}
+
+
+//  Create config name in NVS from option/index
+//  return name in configName
+void Config_GetConfigFileName(DeviceConfigurationOption configuration, uint32_t configurationIndex, char * configName)
+{
+	switch (configuration)
+	{
+	case DeviceConfigurationOption_Network:
+		*configName++ = CONFIG_TYPE_NETWORK;
+		break;
+
+	case DeviceConfigurationOption_Wireless80211Network:
+		*configName++ = CONFIG_TYPE_WIRELESS;
+		break;
+
+	case DeviceConfigurationOption_WirelessNetworkAP:
+		*configName++ = CONFIG_TYPE_WIRELESSAP;
+		break;
+
+	case DeviceConfigurationOption_X509CaRootBundle:
+		*configName++ = CONFIG_TYPE_CERTIFICATE;
+		break;
+
+	default:
+		*configName++ = '?';
+		break;
+	}
+
+	itoa(configurationIndex, configName, 10);
+}
+
+//
+//  Config_OpenFile -
+//
+//  Open file for configuration / index
+//  For the case of NVS we just open the NVS partition, save file details, handle
+//  
+// Parameters:-
+//   configuration      : Type of configuration block to open
+//   configurationIndex : Index of type to open
+//
+// Return :-
+//    true  : returns handle
+//    false -1
+//
+uint32_t Config_OpenFile( DeviceConfigurationOption configuration, uint32_t configurationIndex )
+{
+    // Open NVS storage using NanoFramework namespace
+    esp_err_t ret = nvs_open( NVS_NAMESPACE, NVS_READWRITE, &configHandle);
+    if ( ret == ESP_OK ) 
+    {
+        configType = configuration;
+        configIndex = configurationIndex;
+        return configHandle;
+    }
+
+    return CONFIG_ERROR;
+}
+
+
+//
+//  Config_CloseFile - Close opened file / NVS system
+//  
+// Parameters:-
+//   handle : Handle returned from Config_openFile
+//
+// return:-
+//    true - File closed ok 
+//    false- Error/File not open/Invalid handle
+//
+bool Config_CloseFile( uint32_t handle )
+{
+    // Check valid handle
+    if ( handle != configHandle) return false;
+
+    nvs_close(configHandle);
+    configHandle = CONFIG_ERROR;
+    return true;
+}
+
+//
+//  Shared IO 
+//
+uint32_t Config_IO(uint32_t handle, ConfigIoType ioType, uint8_t * pData, int32_t size )
+{
+    int32_t result = CONFIG_ERROR;
+    char configName[10];
+    esp_err_t ret;
+    size_t blobSize;
+
+    // Check valid handle
+    if ( handle != configHandle) return CONFIG_ERROR;
+
+    // Build file system name
+    Config_GetConfigFileName( configType, configIndex, configName);
+
+    while(true)
+    {
+        if ( ioType == GetSize || ioType == Read )
+        {
+                // Get size of blob before we read it
+                ret = nvs_get_blob(configHandle, configName, (void *)0, &blobSize);
+                if (ret != ESP_OK) break;
+                result = (int32_t)blobSize;
+
+                // If GetSize then finnish
+                if ( ioType == GetSize) break;
+            
+                // Do read
+                // Check room in buffer
+                if ( (int32_t)blobSize > size ) break;   // error
+
+                // Read blob into pData 
+                
+                ret = nvs_get_blob(configHandle, configName, (void *)pData, &blobSize);
+                if (ret == ESP_OK) 
+                    result = (int32_t)blobSize;
+                else
+                    result = CONFIG_ERROR;
+                
+                break;
+        }
+        else if ( ioType == Write )
+        {
+            ret = nvs_set_blob(configHandle, configName, (const void *)pData, (size_t)size);
+            if ( ret == ESP_OK ) 
+            {
+                // Write OK so commit it
+                ret = nvs_commit(configHandle);
+                if (ret == ESP_OK) result = 0;
+            }
+            break;
+        }
+        else
+            break;
+       
+    } // while
+
+    return result;
+}
+
+//
+//  Config_FileSize - Return size of file
+//
+// Parameters:-
+//   handle : Handle returned from Config_openFile
+//
+// return:-
+//    File size 
+//    -1 = Error/Not found/Invalid handle
+//
+int32_t Config_FileSize( uint32_t handle )
+{
+    return Config_IO( handle, GetSize, 0, 0);
+}
+
+//
+//  Config_WriteFile -  Write data to NVS system
+//
+// Parameters:-
+//   handle    : Handle returned from Config_openFile
+//   pData     : Pointer data to write
+//   writeSize : Size of data to write
+//
+// return:-
+//    true - OK 
+//    false- Error/Not found
+//
+bool Config_WriteFile(uint32_t handle, uint8_t * pData, int32_t writeSize )
+{
+    return ( Config_IO( handle, Write, pData, writeSize) != CONFIG_ERROR);
+}
+
+//
+// Config_ReadFile - Read the data from file opened in NVS
+//
+// Parameters:-
+//   handle : Handle returned from Config_openFile
+//   pData  : Ponter to where data is to be stored
+//
+// return:-
+//    Read size 
+//    -1 = Error/Not found/Invalid handle
+//
+int32_t Config_ReadFile( uint32_t handle, uint8_t * pData, int32_t maxSizeData )
+{
+    return Config_IO( handle, Read, pData, maxSizeData);
+}
+

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL_ConfigStorageSPIFFS.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL_ConfigStorageSPIFFS.cpp
@@ -1,0 +1,242 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <nanoHAL.h>
+#include <nanoHAL_v2.h>
+#include <nanoWeak.h>
+#include "Esp32_os.h"
+#include "targetHAL_ConfigStorage.h"
+
+// SPIFFS config
+#define SPIFFS_Base_Path        "/config"
+#define SPIFFS_Base_Config_Name "config_"
+#define SPIFFS_Partition_Label  "config"
+#define SPIFFS_MaxFileNameLen   20
+
+static const char *TAG = "Config"; 
+
+enum  ConfigIoType { Read, Write, GetSize };
+
+// Initialise SPIFFS
+void Config_Initialise()
+{ 
+    esp_err_t ret; 
+    
+     esp_vfs_spiffs_conf_t conf = {
+      .base_path = SPIFFS_Base_Path,
+      .partition_label = SPIFFS_Partition_Label,
+      .max_files = 5,
+      .format_if_mount_failed = true
+    };
+    
+    ret = esp_vfs_spiffs_register(&conf);
+    if (ret != ESP_OK) {
+        if (ret == ESP_FAIL) {
+            ESP_LOGE(TAG, "Failed to mount or format filesystem");
+        } else if (ret == ESP_ERR_NOT_FOUND) {
+            ESP_LOGE(TAG, "Failed to find SPIFFS partition");
+        } else {
+            ESP_LOGE(TAG, "Failed to initialize SPIFFS (%s)", esp_err_to_name(ret));
+        } 
+    }
+
+    size_t total = 0, used = 0;
+    ret = esp_spiffs_info(SPIFFS_Partition_Label, &total, &used);
+    if (ret == ESP_OK) 
+    {
+        ESP_LOGI(TAG, "SPIFFS Partition size: total: %d, used: %d", total, used);
+    }
+}
+
+//  Create config name in NVS from option/index
+//  return name in configName
+//
+//  Return filename
+//   "/config/"
+void Config_GetConfigFileName(DeviceConfigurationOption configuration, uint32_t configurationIndex, char * configName)
+{
+    char * startName = configName;
+
+    // Add filesystem name
+    hal_strcpy_s(configName, SPIFFS_MaxFileNameLen, SPIFFS_Base_Path );
+    configName += hal_strlen_s(configName);
+    
+    *configName++ = '/';
+
+    // Add basename
+    hal_strcpy_s( configName, SPIFFS_MaxFileNameLen - (int)(configName-startName), SPIFFS_Base_Config_Name );
+    configName += hal_strlen_s(configName);
+
+	switch (configuration)
+	{
+	case DeviceConfigurationOption_Network:
+		*configName++ = CONFIG_TYPE_NETWORK;
+		break;
+
+	case DeviceConfigurationOption_Wireless80211Network:
+		*configName++ = CONFIG_TYPE_WIRELESS;
+		break;
+
+	case DeviceConfigurationOption_WirelessNetworkAP:
+		*configName++ = CONFIG_TYPE_WIRELESSAP;
+		break;
+
+	case DeviceConfigurationOption_X509CaRootBundle:
+		*configName++ = CONFIG_TYPE_CERTIFICATE;
+		break;
+
+	default:
+		*configName++ = '?';
+		break;
+	}
+
+	itoa(configurationIndex, configName, 10);
+}
+
+//
+//  Config_OpenFile -
+//
+//  Open file for configuration / index
+//  For the case of NVS we just open the NVS partition, save file details, handle
+//  
+// Parameters:-
+//   configuration      : Type of configuration block to open
+//   configurationIndex : Index of type to open
+//
+// Return :-
+//    true  : returns handle
+//    false -1
+//
+uint32_t Config_OpenFile( DeviceConfigurationOption configuration, uint32_t configurationIndex, bool write )
+{
+    char FileName[SPIFFS_MaxFileNameLen+1] = {0};
+
+    Config_GetConfigFileName( configuration, configurationIndex, FileName);
+
+    // Open SPIFFS config storage 
+    FILE * file = fopen( FileName, write?"wb":"rb" );
+    if ( file != NULL ) 
+    {
+        return (uint32_t)file;
+    }
+
+    ESP_LOGE(TAG, "Failed to open file (%s)", FileName );
+    return CONFIG_ERROR;
+}
+
+
+//
+//  Config_CloseFile - Close opened file / NVS system
+//  
+// Parameters:-
+//   handle : Handle returned from Config_openFile
+//
+// return:-
+//    true - File closed ok 
+//    false- Error/File not open/Invalid handle
+//
+bool Config_CloseFile( uint32_t handle )
+{
+    fclose( (FILE *)handle);
+    return true;
+}
+
+//
+//  Shared IO 
+//
+uint32_t Config_IO(uint32_t handle, ConfigIoType ioType, uint8_t * pData, int32_t size )
+{
+    FILE * file = (FILE *)handle;
+    int32_t result = CONFIG_ERROR;
+    size_t  ret;
+    long  blobSize;
+
+    while(true)
+    {
+        if ( ioType == GetSize || ioType == Read )
+        {
+                // Get size of blob before we read it
+                fseek(file, 0, SEEK_END);
+                blobSize = ftell(file);
+
+                result = (int32_t)blobSize;
+
+                // If GetSize then finnish
+                if ( ioType == GetSize) break;
+            
+                // Do read
+                // Check room in buffer
+                if ( (int32_t)blobSize > size ) break;   // error
+
+                // Read blob into pData 
+                fseek(file, 0, SEEK_SET);
+                ret = fread( (void *)pData, 1, (size_t)blobSize, file);
+                if (ret != (size_t)blobSize) 
+                    result = CONFIG_ERROR;
+                
+                break;
+        }
+        else if ( ioType == Write )
+        {
+            ret = fwrite( (const void *)pData, 1, (size_t)size, file);
+            if ( ret == (size_t)size ) result = 0;
+            break;
+        }
+        else
+            break;
+       
+    } // while
+
+    return result;
+}
+
+//
+//  Config_FileSize - Return size of file
+//
+// Parameters:-
+//   handle : Handle returned from Config_openFile
+//
+// return:-
+//    File size 
+//    -1 = Error/Not found/Invalid handle
+//
+int32_t Config_FileSize( uint32_t handle )
+{
+    return Config_IO( handle, GetSize, 0, 0);
+}
+
+//
+//  Config_WriteFile -  Write data to NVS system
+//
+// Parameters:-
+//   handle    : Handle returned from Config_openFile
+//   pData     : Pointer data to write
+//   writeSize : Size of data to write
+//
+// return:-
+//    true - OK 
+//    false- Error/Not found
+//
+bool Config_WriteFile(uint32_t handle, uint8_t * pData, int32_t writeSize )
+{
+    return ( Config_IO( handle, Write, pData, writeSize) != CONFIG_ERROR);
+}
+
+//
+// Config_ReadFile - Read the data from file opened in NVS
+//
+// Parameters:-
+//   handle : Handle returned from Config_openFile
+//   pData  : Ponter to where data is to be stored
+//
+// return:-
+//    Read size 
+//    -1 = Error/Not found/Invalid handle
+//
+int32_t Config_ReadFile( uint32_t handle, uint8_t * pData, int32_t maxSizeData )
+{
+    return Config_IO( handle, Read, pData, maxSizeData);
+}
+

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL_ConfigurationManager.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/targetHAL_ConfigurationManager.cpp
@@ -7,11 +7,19 @@
 #include <nanoHAL_v2.h>
 #include <nanoWeak.h>
 #include "Esp32_os.h"
+#include "targetHAL_ConfigStorage.h"
+#include <target_platform.h>
 
 // NVS parameters for Interface config
 #define NVS_NAMESPACE	    "nanoF"
 
-//#define DEBUG_CONFIG        1
+
+// #define DEBUG_CONFIG        1
+
+// Saves the remaining bundle size for multiple block cert configs
+static int32_t savedBundleSize;
+static int32_t remainingBundleSize;
+static int32_t savedBundleOffset;
 
 #ifdef DEBUG_CONFIG
 void PrintBlock( char * pBlock, int bsize )
@@ -56,31 +64,108 @@ void PrintBlock( char * pBlock, int bsize )
 // provided as weak so it can be replaced at target level, if required because of the target implementing the storage with a mechanism other then saving to flash
 void ConfigurationManager_Initialize()
 {
+    memset( (void*)&g_TargetConfiguration, 0, sizeof(g_TargetConfiguration));
+
+    Config_Initialise();
+    
     // enumerate the blocks
     ConfigurationManager_EnumerateConfigurationBlocks();
 };
 
-// Allocate HAL_CONFIGURATION_NETWORK block
+
+int32_t ConfigurationManager_FindConfigurationBlockSize(DeviceConfigurationOption configuration, uint32_t configurationIndex)
+{
+	uint32_t handle;
+	int32_t configSize = 0;
+
+    handle = Config_OpenFile(configuration, configurationIndex, false);
+    if ( handle != CONFIG_ERROR )
+    {
+        configSize = Config_FileSize(handle);
+#ifdef DEBUG_CONFIG
+        ets_printf( "Find type %d index %d, length %d\n", (int)configuration, configurationIndex, configSize);
+#endif
+        Config_CloseFile(handle);
+    }
+
+	return configSize;
+}
+
+bool ConfigurationManager_GetConfigurationBlockFromStorage( DeviceConfigurationOption configuration, uint32_t configurationIndex, void* configurationBlock, int32_t maxBlockSize)
+{
+	uint32_t handle;
+	uint32_t  readSize = CONFIG_ERROR;
+
+#ifdef DEBUG_CONFIG
+    ets_printf("GetConfigFromStorage %d, %d\n", (int)configuration, configurationIndex);
+#endif
+
+    handle = Config_OpenFile(configuration, configurationIndex, false);
+    if ( handle != CONFIG_ERROR )
+    {
+        readSize = Config_ReadFile(handle, (uint8_t *)configurationBlock, maxBlockSize );
+        Config_CloseFile(handle);
+    }
+
+	return (readSize != CONFIG_ERROR);
+}
+
+
+
+// Allocate HAL_CONFIGURATION_NETWORK block if required
 void ConfigurationManager_allocate_network( uint32_t configCount )
 {
-    uint32_t sizeOfNetworkInterfaceConfigs = offsetof(HAL_CONFIGURATION_NETWORK, Configs) +  configCount * sizeof(HAL_Configuration_NetworkInterface *);
-    g_TargetConfiguration.NetworkInterfaceConfigs = (HAL_CONFIGURATION_NETWORK*)platform_malloc(sizeOfNetworkInterfaceConfigs);
-    g_TargetConfiguration.NetworkInterfaceConfigs->Count = configCount;
+    if ( g_TargetConfiguration.NetworkInterfaceConfigs == 0)
+    {
+        uint32_t sizeOfNetworkInterfaceConfigs = offsetof(HAL_CONFIGURATION_NETWORK, Configs) +  configCount * sizeof(HAL_Configuration_NetworkInterface *);
+        g_TargetConfiguration.NetworkInterfaceConfigs = (HAL_CONFIGURATION_NETWORK*)platform_malloc(sizeOfNetworkInterfaceConfigs);
+        memset( (void *)g_TargetConfiguration.NetworkInterfaceConfigs, 0,  sizeOfNetworkInterfaceConfigs);
+    }
 }
 
-// Allocate HAL_CONFIGURATION_WIRELESS80211 block
+// Allocate HAL_CONFIGURATION_WIRELESS80211 block if required
 void ConfigurationManager_allocate_wireless( uint32_t configCount )
 {
-    uint32_t sizeOfWireless80211Configs = offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) + configCount * sizeof(HAL_Configuration_Wireless80211 *);
-    g_TargetConfiguration.Wireless80211Configs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211*)platform_malloc(sizeOfWireless80211Configs);
-    g_TargetConfiguration.Wireless80211Configs->Count = configCount;
+    if ( g_TargetConfiguration.Wireless80211Configs == 0 )
+    {
+        uint32_t sizeOfWireless80211Configs = offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) + configCount * sizeof(HAL_Configuration_Wireless80211 *);
+        g_TargetConfiguration.Wireless80211Configs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211*)platform_malloc(sizeOfWireless80211Configs);
+        memset( (void *)g_TargetConfiguration.Wireless80211Configs, 0,  sizeOfWireless80211Configs);
+    }
 }
 
-// Allocate HAL_CONFIGURATION_X509_CERTIFICATE block
-// TODO FIXME
-// void ConfigurationManager_allocate_certificates( uint32_t certificateCount )
-// {
-// }
+// Allocate HAL_CONFIGURATION_X509_CERTIFICATE block if required
+void ConfigurationManager_allocate_certificates( uint32_t certificateCount )
+{
+    if ( g_TargetConfiguration.CertificateStore == 0)
+    {
+        uint32_t sizeOfX509CertificateStore = offsetof(HAL_CONFIGURATION_X509_CERTIFICATE, Certificates) + certificateCount * sizeof(g_TargetConfiguration.CertificateStore->Certificates[0]);
+        g_TargetConfiguration.CertificateStore = (HAL_CONFIGURATION_X509_CERTIFICATE*)platform_malloc(sizeOfX509CertificateStore);
+        memset( (void *)g_TargetConfiguration.CertificateStore, 0,  sizeOfX509CertificateStore);
+    }
+    
+    // Init pointers to cert bundles to 0 ( not allocated )
+    for( uint32_t index=0; index < certificateCount; index++ )
+        g_TargetConfiguration.CertificateStore->Certificates[index] = 0;
+}
+
+bool StoreConfigBlock(DeviceConfigurationOption configType, uint32_t configurationIndex, void * pConfigBlock, size_t writeSize )
+{
+    bool result = false;
+    uint32_t fileHandle;
+
+    fileHandle = Config_OpenFile(configType, configurationIndex, true);
+    if (fileHandle != CONFIG_ERROR )
+    {
+        result = Config_WriteFile(fileHandle, (uint8_t*)pConfigBlock, writeSize) ;
+#ifdef DEBUG_CONFIG
+        ets_printf( "store type %d index %d, length %d result %d\n", (int)configType, configurationIndex, writeSize, (int)result);
+#endif
+        Config_CloseFile(fileHandle);
+    }
+
+    return result;
+}
 
 // Enumerates the configuration blocks from the configuration flash sector 
 // it's implemented with 'weak' attribute so it can be replaced at target level if a different persistance mechanism is used
@@ -92,30 +177,77 @@ void ConfigurationManager_EnumerateConfigurationBlocks()
     int wirelessCount = 2;
     int certificateCount = 1;
   
+    // Allocate main structures for each type
     ConfigurationManager_allocate_network( networkCount );
     ConfigurationManager_allocate_wireless( wirelessCount );
-    // TODO FIXME
-    //ConfigurationManager_allocate_certificates( certificateCount );
-    (void)certificateCount;
+    ConfigurationManager_allocate_certificates( certificateCount );
     
+    // For each network interface allocate Network config if required and load from storage
     for( int configIndex = 0; configIndex < networkCount; configIndex++)
     {
-        g_TargetConfiguration.NetworkInterfaceConfigs->Configs[configIndex] = (HAL_Configuration_NetworkInterface*)platform_malloc(sizeof(HAL_Configuration_NetworkInterface));
-        ConfigurationManager_GetConfigurationBlock(g_TargetConfiguration.NetworkInterfaceConfigs->Configs[configIndex], DeviceConfigurationOption_Network, configIndex);
-    }
+        if ( g_TargetConfiguration.NetworkInterfaceConfigs->Configs[configIndex] == 0)
+        {
+            g_TargetConfiguration.NetworkInterfaceConfigs->Configs[configIndex] = (HAL_Configuration_NetworkInterface*)platform_malloc(sizeof(HAL_Configuration_NetworkInterface));
+        }
 
+        if ( ConfigurationManager_GetConfigurationBlockFromStorage( 
+                    DeviceConfigurationOption_Network, 
+                    configIndex, 
+                    g_TargetConfiguration.NetworkInterfaceConfigs->Configs[configIndex], 
+                    sizeof(HAL_Configuration_NetworkInterface) 
+                    ) == false )
+        {
+            // No config saved so init default block
+            HAL_Configuration_NetworkInterface* configPtr = g_TargetConfiguration.NetworkInterfaceConfigs->Configs[configIndex];
+            InitialiseNetworkDefaultConfig(configPtr,configIndex);
+            StoreConfigBlock(DeviceConfigurationOption_Network, configIndex, configPtr, sizeof(HAL_Configuration_NetworkInterface) );
+        }
+    } 
+
+    g_TargetConfiguration.NetworkInterfaceConfigs->Count = networkCount;
+
+    // For each Wireless interface allocate Wireless config if required and load from storage
     for( int configIndex = 0; configIndex < wirelessCount; configIndex++)
     {
-        g_TargetConfiguration.Wireless80211Configs->Configs[configIndex] = (HAL_Configuration_Wireless80211*)platform_malloc(sizeof(HAL_Configuration_Wireless80211));
-        ConfigurationManager_GetConfigurationBlock( g_TargetConfiguration.Wireless80211Configs->Configs[configIndex], DeviceConfigurationOption_Wireless80211Network, configIndex);
+        if ( g_TargetConfiguration.Wireless80211Configs->Configs[configIndex] == 0 )
+        {
+            g_TargetConfiguration.Wireless80211Configs->Configs[configIndex] = (HAL_Configuration_Wireless80211*)platform_malloc(sizeof(HAL_Configuration_Wireless80211));
+        }
+        if ( ConfigurationManager_GetConfigurationBlockFromStorage( 
+                    DeviceConfigurationOption_Wireless80211Network, 
+                    configIndex, 
+                    g_TargetConfiguration.Wireless80211Configs->Configs[configIndex], 
+                    sizeof(HAL_Configuration_Wireless80211)
+                    ) == false )
+        {
+            HAL_Configuration_Wireless80211* configPtr = g_TargetConfiguration.Wireless80211Configs->Configs[configIndex];
+            InitialiseWirelessDefaultConfig(configPtr,configIndex);
+            StoreConfigBlock(DeviceConfigurationOption_Wireless80211Network, configIndex, configPtr, sizeof(HAL_Configuration_Wireless80211) );
+        }
     }
+    g_TargetConfiguration.Wireless80211Configs->Count = wirelessCount;
 
-    // TODO FIXME
-    // for( int certificateIndex = 0; certificateIndex < certificateCount; configIndex++)
-    // {
-    //     g_TargetConfiguration.CertificateStore->Certificate[certificateIndex] = (HAL_Configuration_X509CaRootBundle*)platform_malloc(sizeof(HAL_Configuration_X509CaRootBundle));
-    //     ConfigurationManager_GetConfigurationBlock( g_TargetConfiguration.CertificateStore->Certificates[certificateIndex], DeviceConfigurationOption_X509CaRootBundle, certificateIndex);
-    // }
+ 
+    // For each Certificate bundle allocate memory and load from storage
+    for( int certificateIndex = 0; certificateIndex < certificateCount; certificateIndex++)
+    {
+        // Free any existing bundles first, we need to reallocate as bundles are variable size
+        if ( g_TargetConfiguration.CertificateStore->Certificates[certificateIndex] != 0 ) 
+        {  
+            platform_free(g_TargetConfiguration.CertificateStore->Certificates[certificateIndex]);
+            g_TargetConfiguration.CertificateStore->Certificates[certificateIndex] = 0;
+        }
+
+        // Find size of saved cert bundle
+		int32_t bundleSize = ConfigurationManager_FindConfigurationBlockSize(DeviceConfigurationOption_X509CaRootBundle, certificateIndex);
+		if (bundleSize > 0)
+		{
+            // Bundle exits
+            g_TargetConfiguration.CertificateStore->Count = certificateIndex+1;
+			g_TargetConfiguration.CertificateStore->Certificates[certificateIndex] = (HAL_Configuration_X509CaRootBundle*)platform_malloc(bundleSize);
+			ConfigurationManager_GetConfigurationBlockFromStorage(  DeviceConfigurationOption_X509CaRootBundle, certificateIndex, g_TargetConfiguration.CertificateStore->Certificates[certificateIndex], bundleSize);
+		}
+    }
 }
 
 //  Default initialisation of wireless config blocks for ESP32 targets
@@ -130,8 +262,8 @@ void InitialiseWirelessDefaultConfig(HAL_Configuration_Wireless80211 * pconfig, 
         case 0: // Wireless Station
 
             // test default data for AP
-           // hal_strcpy_s( (char*)pconfig->Ssid, sizeof(pconfig->Ssid), "myssid" );
-           // hal_strcpy_s( (char*)pconfig->Password, sizeof(pconfig->Password), "mypassphase" );
+           // hal_strcpy_s( (char*)pconfig->Ssid, sizeof(pconfig->Ssid), "MySSID" );
+           // hal_strcpy_s( (char*)pconfig->Password, sizeof(pconfig->Password), "MyPassword" );
 
             pconfig->Authentication = AuthenticationType_WPA2;
             pconfig->Encryption = EncryptionType_WPA2;
@@ -191,14 +323,23 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
     return TRUE;
 }
 
-// Gets a configuration block from the configuration block stored in the NVS block, 
-// maybe better to store each config item under a separate key which would work better if config block changes
+
+//
+// Get the specified configuration block from global memory ( g_TargetConfiguration )
+//
+// Parameters:-
+//   configurationBlock : Destination to copy configuration data
+//   configuration      : Type of configuration block to copy
+//   configurationIndex : Index of type to copy
+//
+// return:-
+//    true - OK 
+//    false- Error/Not found
+//
 bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, DeviceConfigurationOption configuration, uint32_t configurationIndex)
 {
-	bool result = FALSE;
-	nvs_handle out_handle;
-	size_t     blobSize = 0;
-    char configName[10];
+    int sizeOfBlock = 0;
+    uint8_t* blockAddress = NULL;
 
 #ifdef DEBUG_CONFIG
     ets_printf("GetConfig %d, %d\n", (int)configuration, configurationIndex);
@@ -207,18 +348,21 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
     // validate if the requested block exists
     if(configuration == DeviceConfigurationOption_Network)
     {
-        if(g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0 ||
-            (configurationIndex + 1) > g_TargetConfiguration.NetworkInterfaceConfigs->Count)
+        if( g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0 || 
+            (configurationIndex + 1) > g_TargetConfiguration.NetworkInterfaceConfigs->Count )
         {
+            // there is no network config blocks, init one with default settings
 #ifdef DEBUG_CONFIG
             ets_printf("GetConfig CN exit false\n");
 #endif
             return FALSE;
         }
 
-        // set blob size
-        blobSize = sizeof(HAL_Configuration_NetworkInterface);
-        configName[0] = 'N';
+        // set block size
+        sizeOfBlock = sizeof(HAL_Configuration_NetworkInterface);
+
+        // get block address
+        blockAddress = (uint8_t*)g_TargetConfiguration.NetworkInterfaceConfigs->Configs[configurationIndex];
     }
     else if(configuration == DeviceConfigurationOption_Wireless80211Network)
     {
@@ -231,13 +375,15 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
             return FALSE;
         }
 
-        // set blob size
-        blobSize = sizeof(HAL_Configuration_Wireless80211);
-        configName[0] = 'W';
+       // set block size
+        sizeOfBlock = sizeof(HAL_Configuration_Wireless80211);
+
+        // get block address
+        blockAddress = (uint8_t*)g_TargetConfiguration.Wireless80211Configs->Configs[configurationIndex];
     }
     else if(configuration == DeviceConfigurationOption_X509CaRootBundle)
     {
-        if(g_TargetConfiguration.CertificateStore->Count == 0 ||
+        if( g_TargetConfiguration.CertificateStore->Count == 0 ||
             (configurationIndex + 1) > g_TargetConfiguration.CertificateStore->Count)
         {
 #ifdef DEBUG_CONFIG
@@ -246,211 +392,227 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
             return FALSE;
         }
 
-        // set blob size
-        // TODO FIXME
-        blobSize = offsetof(HAL_Configuration_X509CaRootBundle, Certificate);
-        blobSize += ((HAL_Configuration_X509CaRootBundle*)configurationBlock)->CertificateSize;
+        // get block address
+        blockAddress = (uint8_t*)g_TargetConfiguration.CertificateStore->Certificates[configurationIndex];
 
-        configName[0] = 'X';
+        // set block size
+        // because X509 certificate has a variable length need to compute the block size in two steps
+        sizeOfBlock = offsetof(HAL_Configuration_X509CaRootBundle, Certificate);
+        sizeOfBlock += ((HAL_Configuration_X509CaRootBundle*)blockAddress)->CertificateSize;
     }    
 
-    // Anything to get
-    if  (blobSize != 0 ) 
-    {
-        // Open NVS storage using NanoFramework namespace
-        esp_err_t ret = nvs_open( NVS_NAMESPACE, NVS_READWRITE, &out_handle);
-        if ( ret == ESP_OK )
-        {
-            bool storeConfig = false;
-            itoa(configurationIndex, configName+1, 10);
+    // copy the config block content to the pointer in the argument
+    memcpy(configurationBlock, blockAddress, sizeOfBlock);
 
-            // copy the config block content to the pointer in the argument
-            ret = nvs_get_blob(out_handle, configName, (void *)configurationBlock, &blobSize);
-            if (ret != ESP_OK)
+    return TRUE;
+}
+
+
+
+
+DeviceConfigurationOption GetConfigOption( char * pConfig)
+{
+    switch( *pConfig )
+    {
+        case CONFIG_TYPE_NETWORK     : return DeviceConfigurationOption::DeviceConfigurationOption_Network;
+        case CONFIG_TYPE_WIRELESS    : return DeviceConfigurationOption::DeviceConfigurationOption_Wireless80211Network;
+        case CONFIG_TYPE_WIRELESSAP  : return DeviceConfigurationOption::DeviceConfigurationOption_WirelessNetworkAP;
+        case CONFIG_TYPE_CERTIFICATE : return DeviceConfigurationOption::DeviceConfigurationOption_X509CaRootBundle;
+    }
+    return DeviceConfigurationOption_Network; 
+}
+
+bool ConfigurationManager_StoreConfigurationBlockAll(void* configurationBlock, uint32_t blockSize, uint32_t offset)
+{
+    size_t  chunkSize = 0;
+    uint32_t certificateIndex = 0;
+    bool    result = false;
+    uint32_t configurationIndex = 0;
+
+    // All configuration blocks in one block
+    // Separate and update
+
+#ifdef DEBUG_CONFIG
+    ets_printf( "Block size %d\n", blockSize);
+
+    ets_printf( "sizeof HAL_Configuration_NetworkInterface %d\n", sizeof(HAL_Configuration_NetworkInterface));
+    ets_printf( "sizeof HAL_Configuration_Wireless80211 %d\n", sizeof(HAL_Configuration_Wireless80211));
+    ets_printf( "sizeof of X509Certificate varies\n");
+#endif
+
+    configurationIndex = 0;
+
+    char * pConfig = (char *)configurationBlock;
+    char * pEndConfig = (pConfig + blockSize);
+    DeviceConfigurationOption currentConfigType;
+
+    while( pConfig < pEndConfig )
+    {
+        int remainingBlockSize = pEndConfig - pConfig; 
+
+#ifdef DEBUG_CONFIG
+        ets_printf("Parse block %d:%d\n", pConfig, pEndConfig);
+        PrintBlock( (char *)pConfig, 16 );
+#endif
+        currentConfigType = GetConfigOption(pConfig);
+
+            // X509 certificate block ?
+        if (currentConfigType == DeviceConfigurationOption_X509CaRootBundle || offset > 0 )
+        {
+            if ( offset == 0 )
             {
-                if ( configuration == DeviceConfigurationOption_Wireless80211Network )
-                {
-                    InitialiseWirelessDefaultConfig((HAL_Configuration_Wireless80211 *)configurationBlock,configurationIndex);
-                    storeConfig = true;
-                }
-                else if ( configuration == DeviceConfigurationOption_Network )
-                {
-                    // OK to skip checking return value
-                    InitialiseNetworkDefaultConfig((HAL_Configuration_NetworkInterface *)configurationBlock,configurationIndex);
-                    storeConfig = true;
-                }
-                else if ( configuration == DeviceConfigurationOption_X509CaRootBundle )
-                {
-                    // OK to skip checking return value
-                    storeConfig = false;
-                }
-                else
-                {
-                    // If not found just return initialized block
-    //                    memset( configurationBlock, 0, blobSize);
-                }
-            } 
+                HAL_Configuration_X509CaRootBundle * pX509Certificate = (HAL_Configuration_X509CaRootBundle*)pConfig;
+
+                // First block of certificate bundle
+                // set total bundle size including header
+                // because X509 certificate has a variable length need to compute the block size in two steps
+                savedBundleSize = offsetof(HAL_Configuration_X509CaRootBundle, Certificate);
+                savedBundleSize += pX509Certificate->CertificateSize;
+                remainingBundleSize = savedBundleSize;
+                savedBundleOffset = 0;
+
+                // Free if already allocated ( could be different size )
+                if ( g_TargetConfiguration.CertificateStore->Certificates[certificateIndex] != 0 ) 
+                     platform_free((void*)g_TargetConfiguration.CertificateStore->Certificates);
+
+                g_TargetConfiguration.CertificateStore->Certificates[certificateIndex] = (HAL_Configuration_X509CaRootBundle *)platform_malloc(savedBundleSize);
+
+#ifdef DEBUG_CONFIG
+                ets_printf("X509 certificate block total size:%d\n", pX509Certificate->CertificateSize);
+#endif
+            }
+
+            // The current chunk size is what remains in current block
+            // we can't use offset as it relates to flash memory offset, not useful
+            chunkSize = remainingBlockSize;
+
+            // Copy into correct position in memory
+            memcpy( (void *)(g_TargetConfiguration.CertificateStore->Certificates[0] + savedBundleOffset),
+                    (const void *)pConfig,
+                    chunkSize);
+#ifdef DEBUG_CONFIG
+            ets_printf("X509 certificate chunksize:%d reminaing:%d\n", chunkSize, savedBundleSize);
+            PrintBlock( (char *)pConfig, 32 );
+#endif
+            pConfig += chunkSize;
+            remainingBundleSize -= chunkSize;
+            savedBundleOffset += chunkSize;
+            // Return true for partial blocks
+            result = true;
+
+            if ( remainingBundleSize <= 0 ) 
+            {
+                // Save Certificate Bundle to storage
+                result = StoreConfigBlock(  DeviceConfigurationOption_X509CaRootBundle, 
+                                            certificateIndex, 
+                                            (void*)g_TargetConfiguration.CertificateStore->Certificates[certificateIndex], 
+                                            savedBundleSize );
+                certificateIndex++;
+#ifdef DEBUG_CONFIG
+                ets_printf("X509 certificate complete, saving\n");
+#endif                
+            }
+
+#ifdef DEBUG_CONFIG
+            ets_printf("X509 certificate block ret:%d\n", result);
+#endif
+        }            
+        // Network interface block ?
+        else if ( currentConfigType == DeviceConfigurationOption_Network )
+        {
+            HAL_Configuration_NetworkInterface * pNetConfig = (HAL_Configuration_NetworkInterface*)pConfig;
+            pConfig += sizeof(HAL_Configuration_NetworkInterface);
+
+            result = StoreConfigBlock( currentConfigType, configurationIndex, (void*)pNetConfig, sizeof(HAL_Configuration_NetworkInterface) );
+            configurationIndex++;
+
+#ifdef DEBUG_CONFIG
+            ets_printf("Network block %X %X ret:%d\n", pNetConfig->InterfaceType, pNetConfig->SpecificConfigId, result);
+            PrintBlock( (char *)pNetConfig, sizeof(HAL_Configuration_NetworkInterface) );
+#endif
+        }
+        // Wireless block ?
+        else if (currentConfigType == DeviceConfigurationOption_Wireless80211Network )
+        {
+            HAL_Configuration_Wireless80211 * pWirelessConfig = (HAL_Configuration_Wireless80211*)pConfig;
+            pConfig += sizeof(HAL_Configuration_Wireless80211);
+
+            result = StoreConfigBlock( currentConfigType, pWirelessConfig->Id, (void*)pWirelessConfig, sizeof(HAL_Configuration_Wireless80211) );
             
 #ifdef DEBUG_CONFIG
-            PrintBlock( (char*)configurationBlock, blobSize);
+            ets_printf("Wireless block %d ssid:%s password:%s ret:%d\n", pWirelessConfig->Id, pWirelessConfig->Ssid, pWirelessConfig->Password, result);
+            PrintBlock( (char *)pWirelessConfig, sizeof(HAL_Configuration_Wireless80211) );
 #endif
-
-            result = TRUE;
-            nvs_close(out_handle);
-            if ( storeConfig )
-            {
-                // TODO FIXME, offset parameter is 0
-                ConfigurationManager_StoreConfigurationBlock(configurationBlock, configuration, configurationIndex, blobSize, 0);
-            }
         }
-    }
+        else
+            break;
+    } // while
 
 #ifdef DEBUG_CONFIG
-    ets_printf("GetConfig exit %d\n", result);
+    ets_printf("StoreConfig ALL exit %d\n",(int)result);
 #endif
-
     return result;
-}
+} 
 
 
-bool StoreConfigBlock(char ConfigType, uint32_t configurationIndex, void * pConfigBlock, size_t blobSize)
-{
-	nvs_handle out_handle;
-    char configName[10];
-    bool result = false;
-
-    configName[0] = ConfigType;
-
-    // copy the config block content to the pointer in the argument
-    esp_err_t ret = nvs_open( NVS_NAMESPACE, NVS_READWRITE, &out_handle);
-    if ( ret == ESP_OK )
-    {
-        itoa(configurationIndex, configName+1, 10);
-        ret = nvs_set_blob(out_handle, configName, pConfigBlock, blobSize);
-        if ( ret == ESP_OK ) 
-        {
-            ret = nvs_commit(out_handle);
-            if (ret == ESP_OK) result = true;
-        }
-        nvs_close(out_handle);
-    }
-
-    return result;
-}
-
-// Stores the network configuration block to the EPS32 storage 
+//
+// Stores the configuration block to the storage 
+//
+// Parameters:-
+//   configurationBlock : Pointer to block to store
+//   configuration      : Type of configuration block to store or All for block with multiple types
+//   configurationIndex : Index of type to store ( not used for All )
+//   blockSize          : Size of data pointed to by configurationBlock 
+//   offset             : Offset of data when multiple blocks ( currently Certificate Bundles only ), For single type this is offset withing the type
+//                        For ALL type blocks this is the offset in the total data of multiple types.
+// Return:-
+//    true - OK 
+//    false- Error/Not found
+//
 bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, DeviceConfigurationOption configuration, uint32_t configurationIndex, uint32_t blockSize, uint32_t offset)
 {
 	bool result = false;
     bool requiresEnumeration = false;
     size_t  blobSize = 0;
-    //size_t  chunkSize = 0;
-    char ConfigType;
-
-    // TODO FIXME
-    (void)offset;
 
 #ifdef DEBUG_CONFIG
-    ets_printf("StoreConfig %d, %d", (int)configuration, configurationIndex);
+    ets_printf("StoreConfig config:%d, index:%d  size:%d  offset:%d\n", (int)configuration, configurationIndex, blockSize, offset);
 #endif
+
+    if ( configuration == DeviceConfigurationOption_All )
+        return ConfigurationManager_StoreConfigurationBlockAll(configurationBlock, blockSize, offset);
 
     if(configuration == DeviceConfigurationOption_Network)
     {
         // set blob size
         blobSize = sizeof(HAL_Configuration_NetworkInterface);
-        ConfigType = 'N';
     }
     else if(configuration == DeviceConfigurationOption_Wireless80211Network)
     {
         // set blob size
         blobSize = sizeof(HAL_Configuration_Wireless80211);
-        ConfigType = 'W';
     }
     else if(configuration == DeviceConfigurationOption_X509CaRootBundle)
     {
-        // set blob size
+        // set blob size ( Total size of  X509 certificate )
         // because X509 certificate has a variable length need to compute the block size in two steps
         blobSize = offsetof(HAL_Configuration_X509CaRootBundle, Certificate);
         blobSize += ((HAL_Configuration_X509CaRootBundle*)configurationBlock)->CertificateSize;
 
-        ConfigType = 'C';
+#ifdef DEBUG_CONFIG
+        ets_printf("StoreConfig x509 blobSize:%d, certsize:%d", blobSize, ((HAL_Configuration_X509CaRootBundle*)configurationBlock)->CertificateSize);
+#endif
     }
-    else if(configuration == DeviceConfigurationOption_All)
+    else
     {
-        // All configuration blocks in one block
-        // Separate and update
-
-#ifdef DEBUG_CONFIG
-        ets_printf( "Block size %d\n", blockSize);
-    
-        ets_printf( "sizeof HAL_Configuration_NetworkInterface %d\n", sizeof(HAL_Configuration_NetworkInterface));
-        ets_printf( "sizeof HAL_Configuration_Wireless80211 %d\n", sizeof(HAL_Configuration_Wireless80211));
-        ets_printf( "sizeof of X509Certificate varies\n");
-#endif
-
-        configurationIndex = 0;
-
-        char * pConfig = (char *)configurationBlock;
-        while( pConfig < (pConfig + blockSize) )
-        {
-            // Network interface block ?
-            if ( *pConfig == 'N')
-            {
-                HAL_Configuration_NetworkInterface * pNetConfig = (HAL_Configuration_NetworkInterface*)pConfig;
-                pConfig += sizeof(HAL_Configuration_NetworkInterface);
-
-                result = StoreConfigBlock( 'N', configurationIndex, (void*)pNetConfig, sizeof(HAL_Configuration_NetworkInterface) );
-                configurationIndex++;
-
-#ifdef DEBUG_CONFIG
-                ets_printf("Network block %X %X ret:%d\n", pNetConfig->InterfaceType, pNetConfig->SpecificConfigId, result);
-                PrintBlock( (char *)pNetConfig, sizeof(HAL_Configuration_NetworkInterface) );
-#endif
-            }
-            // Wireless block ?
-            else if (*pConfig == 'W')
-            {
-                HAL_Configuration_Wireless80211 * pWirelessConfig = (HAL_Configuration_Wireless80211*)pConfig;
-                pConfig += sizeof(HAL_Configuration_Wireless80211);
-
-                result = StoreConfigBlock( 'W', pWirelessConfig->Id, (void*)pWirelessConfig, sizeof(HAL_Configuration_Wireless80211) );
-                
-#ifdef DEBUG_CONFIG
-                ets_printf("Wireless block %d ssid:%s password:%s ret:%d\n", pWirelessConfig->Id, pWirelessConfig->Ssid, pWirelessConfig->Password, result);
-                PrintBlock( (char *)pWirelessConfig, sizeof(HAL_Configuration_Wireless80211) );
-#endif
-            }
-            // X509 certificate block ?
-            else if (*pConfig == 'C')
-            {
-                // TODO
-//                 HAL_Configuration_X509CaRootBundle * pX509Certificate = (HAL_Configuration_X509CaRootBundle*)pConfig;
-
-//                 // set block size, in case it's not already set
-//                 // because X509 certificate has a variable length need to compute the block size in two steps
-//                 chunkSize = offsetof(HAL_Configuration_X509CaRootBundle, Certificate);
-//                 chunkSize += pX509Certificate->CertificateSize;
-
-//                 pConfig += chunkSize;
-
-//                 result = StoreConfigBlock( 'C', pX509Certificate->Id, (void*)pX509Certificate, chunkSize );
-                
-// #ifdef DEBUG_CONFIG
-//                 ets_printf("X509 certificate block ret:%d\n", result);
-//                 PrintBlock( (char *)pX509Certificate, chunkSize );
-// #endif
-            }            
-            else
-                break;
-        }
-
-        return result;
+        // Invalid Config
+        return false;
     }
-    
+
     // Anything to save
     if  (blobSize != 0 ) 
     {
-        result = StoreConfigBlock( ConfigType, configurationIndex, configurationBlock, blobSize);
+        result = StoreConfigBlock( configuration, configurationIndex, configurationBlock, blobSize);
     }
 
     if(requiresEnumeration)
@@ -466,7 +628,7 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
     return result;
 }
 
-// Updates a configuration block in the configuration flash sector
+// Updates a configuration block in the configuration storage
 bool ConfigurationManager_UpdateConfigurationBlock(void* configurationBlock, DeviceConfigurationOption configuration, uint32_t configurationIndex)
 {
     // figure out the block size first


### PR DESCRIPTION
## Description

Due to item size restrictions in NVS moved config to a Spiffs partition.
For 4MB flash made partition 256K, 2MB is 64K.  This will allow for future user files when storage API is available.

Separated file system logic out of Config manager so any storage method can be used.

The way the current communication over WP works is based on the assumption that storage is a contiguous flash as when ALL used offset are offsets into flash are not individual storage types which makes it difficult for any thing different.

If may be better to only call the individual storage type calls and not have the ALL storing then the offset can be the offset in that particular config type.

To get around this problem i had to store the certificate bundles in to a global config area in memory until i received last block then store whole file.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.comL>
