### PR TITLE
Update ESP32 flash partitions

### DIFF
--- a/targets/FreeRTOS/ESP32_DevKitC/IDF/partitions_nanoclr_2mb.csv
+++ b/targets/FreeRTOS/ESP32_DevKitC/IDF/partitions_nanoclr_2mb.csv
@@ -2,9 +2,11 @@
 # Note: if you change the phy_init or app partition offset, make sure to change the offset in Kconfig.projbuild
 nvs,      data, nvs,     0x9000,  0x4000,
 phy_init, data, phy,     0xf000,  0x1000,
-factory,  0,    0,       0x10000,  1M,
+# Factory area for NanoCLR - 1MB
+factory,  0,    0,       0x10000, 0x100000,
+# Deployment area for Managed code 448K
+deploy,   data, 0x84,    0x110000, 0x70000,
 # Config data for Network, Wireless, certificates, user data  64K
-config,   data, spiffs,  0x110000,  64K,
-deploy,   data, 0x84,    0x120000,  448K,
+config,   data, spiffs,  0x180000, 0x10000,
 
 

--- a/targets/FreeRTOS/ESP32_DevKitC/IDF/partitions_nanoclr_4mb.csv
+++ b/targets/FreeRTOS/ESP32_DevKitC/IDF/partitions_nanoclr_4mb.csv
@@ -2,9 +2,10 @@
 # Note: if you change the phy_init or app partition offset, make sure to change the offset in Kconfig.projbuild
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,
-factory,  0,    0,      0x10000,  1M,
-# Config data for Network, Wireless, certificates, user data  256K
-config,   data, spiffs, 0x110000, 256K, 
+# Factory area for NanoCLR - 1MB
+factory,  0,    0,      0x10000,  0x100000,
 # Deployment area for Managed code 1792K
-deploy,   data, 0x84,   0x150000, 0x1C0000, 
+deploy,   data, 0x84,   0x110000, 0x1C0000, 
+# Config data for Network, Wireless, certificates, user data  256K
+config,   data, spiffs, 0x2D0000, 0x40000, 
 


### PR DESCRIPTION
Update partitions so flash memory layout is backwards compatible for EspFlasher
4MB and 2MB layouts

Tested by erase flash, flash latest nanoclr.
Checked start up logging for flash layout.
Run Network config from latest VS extension, runs ok

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
