### PR TITLE
Add support for STM32 Wakeup Reason

### DIFF
--- a/src/HAL/Include/nanoHAL_Power.h
+++ b/src/HAL/Include/nanoHAL_Power.h
@@ -7,6 +7,7 @@
 #define _NANOHAL_POWER_H_ 1
 
 #include <stdbool.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,6 +21,12 @@ typedef enum PowerLevel
     PowerLevel__DeepSleep,
     PowerLevel__Off
 }PowerLevel_type;
+
+
+// this is used to store the CPU wakeup reason
+// a target implementation can use it or not
+// if it's used suggest to add the variable at targetHAL_Power.c 
+extern uint32_t WakeupReasonStore;
 
 bool CPU_IsSoftRebootSupported();
 

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/main.c
@@ -26,6 +26,23 @@ osThreadDef(CLRStartupThread, osPriorityNormal, 4096, "CLRStartupThread");
 //  Application entry point.
 int main(void) {
 
+  // find out wakeup reason
+  if((RTC->ISR & RTC_ISR_ALRAF) == RTC_ISR_ALRAF)
+  {
+    // standby, match WakeupReason_FromStandby enum
+    WakeupReasonStore = 1;
+  }
+  else if((PWR->CSR & PWR_CSR_WUF) == PWR_CSR_WUF)
+  {
+    // wake from pin, match WakeupReason_FromPin enum
+    WakeupReasonStore = 2;
+  }
+  else
+  {
+    // undetermined reason, match WakeupReason_Undetermined enum
+    WakeupReasonStore = 0;
+  }
+
   // first things first: need to clear any possible wakeup flags
   // if this is not done here the next standby -> wakeup sequence won't work
   CLEAR_BIT(RTC->CR, RTC_CR_ALRAIE);

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/main.c
@@ -26,6 +26,23 @@ osThreadDef(CLRStartupThread, osPriorityNormal, 4096, "CLRStartupThread");
 //  Application entry point.
 int main(void) {
 
+  // find out wakeup reason
+  if((RTC->ISR & RTC_ISR_ALRAF) == RTC_ISR_ALRAF)
+  {
+    // standby, match WakeupReason_FromStandby enum
+    WakeupReasonStore = 1;
+  }
+  else if((PWR->CSR & PWR_CSR_WUF) == PWR_CSR_WUF)
+  {
+    // wake from pin, match WakeupReason_FromPin enum
+    WakeupReasonStore = 2;
+  }
+  else
+  {
+    // undetermined reason, match WakeupReason_Undetermined enum
+    WakeupReasonStore = 0;
+  }
+
   // first things first: need to clear any possible wakeup flags
   // if this is not done here the next standby -> wakeup sequence won't work
   CLEAR_BIT(RTC->CR, RTC_CR_ALRAIE);

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/main.c
@@ -24,6 +24,23 @@ osThreadDef(CLRStartupThread, osPriorityNormal, 4096, "CLRStartupThread");
 //  Application entry point.
 int main(void) {
 
+  // find out wakeup reason
+  if((RTC->ISR & RTC_ISR_ALRAF) == RTC_ISR_ALRAF)
+  {
+    // standby, match WakeupReason_FromStandby enum
+    WakeupReasonStore = 1;
+  }
+  else if((PWR->CSR & PWR_CSR_WUF) == PWR_CSR_WUF)
+  {
+    // wake from pin, match WakeupReason_FromPin enum
+    WakeupReasonStore = 2;
+  }
+  else
+  {
+    // undetermined reason, match WakeupReason_Undetermined enum
+    WakeupReasonStore = 0;
+  }
+
   // first things first: need to clear any possible wakeup flags
   // if this is not done here the next standby -> wakeup sequence won't work
   CLEAR_BIT(RTC->CR, RTC_CR_ALRAIE);

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Hardware.Stm32/nf_hardware_stm32_native.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Hardware.Stm32/nf_hardware_stm32_native.cpp
@@ -9,6 +9,7 @@
 static const CLR_RT_MethodHandler method_lookup[] =
 {
     NULL,
+    Library_nf_hardware_stm32_native_nanoFramework_Hardware_Stm32_Power::get_WakeupReason___STATIC__nanoFrameworkHardwareStm32PowerWakeupReasonType,
     Library_nf_hardware_stm32_native_nanoFramework_Hardware_Stm32_Power::DisableWakeupPin___STATIC__VOID__nanoFrameworkHardwareStm32PowerWakeupPin,
     Library_nf_hardware_stm32_native_nanoFramework_Hardware_Stm32_Power::EnableWakeupPin___STATIC__VOID__nanoFrameworkHardwareStm32PowerWakeupPin,
     Library_nf_hardware_stm32_native_nanoFramework_Hardware_Stm32_Power::EnterStandbyMode___STATIC__VOID,
@@ -55,7 +56,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_Hardware_Stm32 =
 {
     "nanoFramework.Hardware.Stm32", 
-    0x6982371A,
+    0xC85F9307,
     method_lookup,
     { 1, 0, 3, 0 }
 };

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Hardware.Stm32/nf_hardware_stm32_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Hardware.Stm32/nf_hardware_stm32_native.h
@@ -12,6 +12,7 @@
 
 struct Library_nf_hardware_stm32_native_nanoFramework_Hardware_Stm32_Power
 {
+    NANOCLR_NATIVE_DECLARE(get_WakeupReason___STATIC__nanoFrameworkHardwareStm32PowerWakeupReasonType);
     NANOCLR_NATIVE_DECLARE(DisableWakeupPin___STATIC__VOID__nanoFrameworkHardwareStm32PowerWakeupPin);
     NANOCLR_NATIVE_DECLARE(EnableWakeupPin___STATIC__VOID__nanoFrameworkHardwareStm32PowerWakeupPin);
     NANOCLR_NATIVE_DECLARE(EnterStandbyMode___STATIC__VOID);

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Hardware.Stm32/nf_hardware_stm32_native_nanoFramework_Hardware_Stm32_Power.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Hardware.Stm32/nf_hardware_stm32_native_nanoFramework_Hardware_Stm32_Power.cpp
@@ -16,6 +16,25 @@ enum WakeupPin
     WakeupPin_Pin3
 };
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// !!! KEEP IN SYNC WITH nanoFramework.Hardware.Stm32.Power.WakeupReason (in managed code) !!!   //
+///////////////////////////////////////////////////////////////////////////////////////////////////
+enum WakeupReason
+{
+    WakeupReason_Undetermined = 0,
+    WakeupReason_FromStandby,
+    WakeupReason_FromPin
+}; 
+
+HRESULT Library_nf_hardware_stm32_native_nanoFramework_Hardware_Stm32_Power::get_WakeupReason___STATIC__nanoFrameworkHardwareStm32PowerWakeupReasonType( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+
+    stack.SetResult_U4( WakeupReasonStore );
+
+    NANOCLR_NOCLEANUP_NOLABEL();
+}
+
 HRESULT Library_nf_hardware_stm32_native_nanoFramework_Hardware_Stm32_Power::DisableWakeupPin___STATIC__VOID__nanoFrameworkHardwareStm32PowerWakeupPin( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
@@ -10,6 +10,8 @@
 #include <hal.h>
 #include <ch.h>
 
+uint32_t WakeupReasonStore;
+
 inline void CPU_Reset(){ NVIC_SystemReset(); };
 
 inline bool CPU_IsSoftRebootSupported() { return true; };


### PR DESCRIPTION
## Description
- Check wakeup flags to determine wakeup reason.
- Add code to all STM32F4 reference targets.
- Add code to Hardware.Stm32 native assembly to support new API.

## Motivation and Context
- Following nanoframework/lib-nanoFramework.Hardware.Stm32#18.

## How Has This Been Tested?<!-- (if applicable) -->
- Tested with nf-Samples STM32 PowerMode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: sjmneves <sergio.neves@eclo.solutions>
