### PR TITLE
Fix GetChannel in PWM 

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmController.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmController.cpp
@@ -102,7 +102,9 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmController::NativeSetD
                 {PWM_OUTPUT_ACTIVE_HIGH, NULL}
             },
             0,
+          #if STM32_PWM_USE_ADVANCED
             0,
+          #endif            
             0,
         };
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmPin.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmPin.cpp
@@ -13,10 +13,7 @@
 
 int Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::GetChannel (int pin, int timerId)
 {
-    (void)pin;
-    (void)timerId;
-
-    int channel = 0;
+    int channel = -1;
 #if defined(STM32F427xx) || defined(STM32F429xx)  || defined(STM32F469xx)  || defined(STM32F479xx)
     switch (timerId)
     {
@@ -881,8 +878,15 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::NativeSetActiveDu
         // Gets the PWM driver associated with the requested timer
         _drv = GetDriver(timerId);
 
+        // get channel for this pin and timer
+        int channelId = GetChannel(pinNumber, timerId);
+        if(channelId < 0)
+        {
+            // no channel available for combination pinNumber/timerId provided
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        }
         // Enables the channel associated with the selected pin on that timer
-        pwmEnableChannel(_drv, GetChannel(pinNumber, timerId),PWM_PERCENTAGE_TO_WIDTH(_drv, dutyCycle));
+        pwmEnableChannel(_drv, channelId ,PWM_PERCENTAGE_TO_WIDTH(_drv, dutyCycle));
     }
     NANOCLR_NOCLEANUP();
 }
@@ -913,9 +917,16 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::NativeStart___VOI
         // Gets the PWM driver associated with the requested timer
         _drv = GetDriver(timerId);
 
+        // get channel for this pin and timer
+        int channelId = GetChannel(pinNumber, timerId);
+        if(channelId < 0)
+        {
+            // no channel available for combination pinNumber/timerId provided
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        }
         // Sets the pin to the correct pwm alternate functin and enables the associated channel
         palSetPadMode(GPIO_PORT(pinNumber), pinNumber % 16, PAL_MODE_ALTERNATE(GetAlternateFunction(timerId)));
-        pwmEnableChannel(_drv, GetChannel(pinNumber, timerId),PWM_PERCENTAGE_TO_WIDTH(_drv, dutyCycle));
+        pwmEnableChannel(_drv, channelId,PWM_PERCENTAGE_TO_WIDTH(_drv, dutyCycle));
     }
 
     NANOCLR_NOCLEANUP();
@@ -932,8 +943,15 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmPin::NativeStop___VOID
         int timerId = (int)(pThis[ FIELD___pwmTimer ].NumericByRef().u4);
         int pinNumber = (int)(pThis[ FIELD___pinNumber ].NumericByRef().u4);
         
+        // get channel for this pin and timer
+        int channelId = GetChannel(pinNumber, timerId);
+        if(channelId < 0)
+        {
+            // no channel available for combination pinNumber/timerId provided
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        }
         // Stops pwm output on the channel associated with the selected pin
-        pwmDisableChannel(GetDriver(timerId), GetChannel(pinNumber, timerId));
+        pwmDisableChannel(GetDriver(timerId), channelId);
     }
 
     NANOCLR_NOCLEANUP();


### PR DESCRIPTION
## Description
- GetChannel now returns -1 if no channel found for pin/timer combination.

## How Has This Been Tested?<!-- (if applicable) -->
- Tested with nf Samples PWM

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: sjmneves <sergio.neves@eclo.solutions>
