### PR TITLE
Fix GUID generator

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Guid.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Guid.cpp
@@ -24,6 +24,7 @@ HRESULT Library_corlib_native_System_Guid::GenerateNewGuid___STATIC__SZARRAY_U1(
     NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance( top, 16, g_CLR_RT_WellKnownTypes.m_UInt8 ));
     buf = top.DereferenceArray()->GetFirstElement();
 
+    rand.Initialize();
     rand.NextBytes(buf, 16);           // fill with random numbers
 
     buf[7] =  (buf[7] & 0x0f) | 0x40;  // Set verion


### PR DESCRIPTION
## Description
- Call to init random generator was missing thus the random buffer required to generate a GUID was returning empty.

## Motivation and Context
- GUID generation was returning invalid GUIDs.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

