### PR TITLE
Deep sleep fix for Esp32 fix

### DIFF
--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_Sleep.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_Sleep.cpp
@@ -93,7 +93,9 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
     // ... and set power level to OFF
     g_CLR_HW_Hardware.m_powerLevel = PowerLevel__Off;
 
-    NANOCLR_NOCLEANUP_NOLABEL();
+    NANOCLR_SET_AND_LEAVE(CLR_E_THREAD_WAITING);
+
+    NANOCLR_NOCLEANUP();
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::NativeGetWakeupCause___STATIC__nanoFrameworkHardwareEsp32SleepWakeupCause( CLR_RT_StackFrame& stack )


### PR DESCRIPTION
## Description
When deep sleep is being executed the interpreter seems to be stuck in schedule threads and doesn't exit so that power level can be changed.

It looked like the Schedule threads continues to run after executing the managed Deep sleep command, probably just finishing its quantum.

Added a return code of CLR_E_THREAD_WAITING in the Deep sleep call to force thread to stop running. This now seems to reliably exit the scheduler and run the deep sleep.  Not sure why it was working when last tested.

May need similar change on STM32

## Motivation and Context
Broken

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>

