### PR TITLE
Add support for including ChibiOS-Contrib repo in build

### DIFF
--- a/CMake/ChibiOS-Contrib.CMakeLists.cmake.in
+++ b/CMake/ChibiOS-Contrib.CMakeLists.cmake.in
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(ChibiOS-Contrib-download NONE)
+
+include(ExternalProject)
+
+# download ChibiOS Community contributions source from GitHub repo
+ExternalProject_Add( 
+    ChibiOS-Contrib
+    PREFIX ChibiOS-Contrib
+    SOURCE_DIR ${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Source
+    GIT_REPOSITORY  https://github.com/ChibiOS/ChibiOS-Contrib
+    GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
+    TIMEOUT 10
+    LOG_DOWNLOAD 1
+    # Disable all other steps
+    INSTALL_COMMAND ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+)

--- a/CMake/Modules/FindCHIBIOS.cmake
+++ b/CMake/Modules/FindCHIBIOS.cmake
@@ -39,6 +39,11 @@ list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/common/
 list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/common/ext/CMSIS/include)
 list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/common/ext/CMSIS/ST/${TARGET_SERIES})
 
+# append dummy include directory when not using ChibiOS-Contrib
+if(NOT CHIBIOS_CONTRIB_REQUIRED)
+    list(APPEND CHIBIOS_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/dummy_includes")
+endif()
+
 # append include directory for boards in the nanoFramework ChibiOS 'overlay'
 list(APPEND CHIBIOS_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/boards/${CHIBIOS_BOARD})
 

--- a/CMake/Modules/FindChibiOS-Contrib.cmake
+++ b/CMake/Modules/FindChibiOS-Contrib.cmake
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2017 The nanoFramework project contributors
+# See LICENSE file in the project root for full license information.
+#
+
+# set include directories for ChibiOS-Contrib
+
+list(APPEND CHIBIOS_CONTRIB_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS-Contrib_Source/os/hal/include/)
+
+####################################################################################
+# WHEN ADDING A NEW ChibiOS-Contrib component add the include directory(ies) bellow
+####################################################################################
+# component IMACOMPONENT
+#list(APPEND CHIBIOS_CONTRIB_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS-Contrib_Source/os/hal/include/IMACOMPONENT)
+
+
+#######################################################################################################################################
+# Because we've "hacked" ChibiOS overlay mechanism used by the community contributions we can't add the "official" hal_community.c
+# Instead we have to add the requried and equivalent calls existing in the official source file
+# in our hal_community.c @ targets\CMSIS-OS\ChibiOS\nf-overlay\os\hal\src\hal_community.c
+#########################################################################################################################
+
+
+####################################################################################################
+# WHEN ADDING A NEW ChibiOS-Contrib component add the source file(s) specific to it bellow 
+####################################################################################################
+# component IMACOMPONENT
+# list(APPEND CHIBIOS_CONTRIB_SOURCES ${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/IMACOMPONENT/source-file-1.c)
+# list(APPEND CHIBIOS_CONTRIB_SOURCES ${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/IMACOMPONENT/source-file-2.c)
+# list(APPEND CHIBIOS_CONTRIB_SOURCES ${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/IMACOMPONENT/source-file-3.c)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(CHIBIOS_CONTRIB DEFAULT_MSG CHIBIOS_CONTRIB_INCLUDE_DIRS CHIBIOS_CONTRIB_SOURCES)

--- a/CMake/toolchain.ChibiOS.GCC.cmake
+++ b/CMake/toolchain.ChibiOS.GCC.cmake
@@ -125,8 +125,10 @@ endfunction()
 
 function(NF_SET_COMPILER_DEFINITIONS TARGET)
 
-    # definition for platform (always ARM here)
-    target_compile_definitions(${TARGET} PUBLIC "-DPLATFORM_ARM ")
+    # definition for platform 
+    # (always ARM here)
+    # ChibiOS HAL community always include (nanoFramework overlay and official community contributions optionally)
+    target_compile_definitions(${TARGET} PUBLIC "-DPLATFORM_ARM -DHAL_USE_COMMUNITY")
 
     # build types that have debugging capabilities AND are NOT RTM have to have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
     if((NOT NF_BUILD_RTM) OR NF_FEATURE_DEBUGGER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,12 @@ if(RTOS_CHIBIOS_CHECK)
     endif()
 
     #################################################################
+        
+    #################################################################
+    # enables use of ChibiOS Community contribution
+    # (default is OFF so ChibiOS Community is NOT included)
+    option(CHIBIOS_CONTRIB_REQUIRED "option to include ChibiOS Community contributions repository")
+    #################################################################
 
 endif()
 
@@ -561,6 +567,14 @@ if(RTOS_CHIBIOS_CHECK)
         endif()
     endif()
 
+    # check if CHIBIOS-Contrib_SOURCE was specified or if it's empty (default is empty)
+    set(NO_CHIBIOS_CONTRIB_SOURCE TRUE)
+    if(CHIBIOS_CONTRIB_SOURCE)
+        if(NOT "${CHIBIOS_CONTRIB_SOURCE}" STREQUAL "")
+            set(NO_CHIBIOS_CONTRIB_SOURCE FALSE)
+        endif()
+    endif()
+
     if(NO_CHIBIOS_SOURCE)
         # no CHIBIOS source specified, download it from it's repo
 
@@ -676,6 +690,92 @@ if(RTOS_CHIBIOS_CHECK)
         # get source dir for ChibiOS CMake project
         ExternalProject_Get_Property(ChibiOS SOURCE_DIR)
 
+    endif()
+
+    if(CHIBIOS_CONTRIB_REQUIRED)
+        if(NO_CHIBIOS_CONTRIB_SOURCE)
+            # no CHIBIOS_CONTRIB source specified, download it from it's repo
+
+            # hack to make the FindGit to work in Windows platforms (check the module comment for details)
+            include(Hack_SetGitSearchPath)
+
+            # check for Git (needed here for advanced warning to user if it's not installed)
+            find_package(Git)
+
+            #  check if Git was found, if not report to user and abort
+            if(NOT GIT_EXECUTABLE)
+            message(FATAL_ERROR "error: could not find Git, make sure you have it installed.")
+            endif()
+
+            message(STATUS "ChibiOS-Contrib source from GitHub repo")
+
+            # need to setup a separate CMake project to download the code from the GitHub repository
+            # otherwise it won't be available before the actual build step
+            configure_file("CMake/ChibiOS-Contrib.CMakeLists.cmake.in"
+                        "${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Download/CMakeLists.txt")
+
+            # setup CMake project for ChibiOS-Contrib download
+            execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+                            RESULT_VARIABLE result
+                            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Download")
+
+            # run build on ChibiOS-Contrib download CMake project to perform the download
+            execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                            RESULT_VARIABLE result
+                            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Download")
+
+            # add ChibiOS-Contrib as external project
+            ExternalProject_Add( 
+                ChibiOS-Contrib
+                PREFIX ChibiOS-Contrib
+                SOURCE_DIR ${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Source
+                GIT_REPOSITORY  https://github.com/ChibiOS/ChibiOS-Contrib
+                GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
+                TIMEOUT 10
+                LOG_DOWNLOAD 1
+                # Disable all other steps
+                INSTALL_COMMAND ""
+                CONFIGURE_COMMAND ""
+                BUILD_COMMAND ""
+            )        
+
+            # get source dir for ChibiOS-Contrib CMake project
+            ExternalProject_Get_Property(ChibiOS-Contrib SOURCE_DIR)
+
+        else()
+            # ChibiOS-Contrib source was specified
+
+            # sanity check is source path exists
+            if(EXISTS "${CHIBIOS_CONTRIB_SOURCE}/")
+                message(STATUS "ChibiOS-Contrib source from: ${CHIBIOS_CONTRIB_SOURCE}")
+
+                # check if we already have the sources, no need to copy again
+                if(NOT EXISTS "${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Source")
+                    file(COPY "${CHIBIOS_CONTRIB_SOURCE}/" DESTINATION "${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Source")
+                else()
+                    message(STATUS "Using local cache of ChibiOS-Contrib source from ${CHIBIOS_CONTRIB_SOURCE}")
+                endif()
+
+                set(CHIBIOS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/ChibiOS_Source/include)
+            else()
+                message(FATAL_ERROR "Couldn't find ChibiOS-Contrib source at ${CHIBIOS_CONTRIB_SOURCE}/")
+            endif()
+
+            # add ChibiOS-Contrib as external project
+            ExternalProject_Add(
+                ChibiOS-Contrib
+                PREFIX ChibiOS-Contrib
+                SOURCE_DIR ${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Source
+                # Disable all other steps
+                INSTALL_COMMAND ""
+                CONFIGURE_COMMAND ""
+                BUILD_COMMAND ""
+            )
+
+            # get source dir for ChibiOS-Contrib CMake project
+            ExternalProject_Get_Property(ChibiOS-Contrib SOURCE_DIR)
+
+        endif()
     endif()
 
     # if mbed TLS is enabled add it to the build

--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -42,6 +42,8 @@
           "SUPPORT_ANY_BASE_CONVERSION" : "<OFF-default-ON-for-adding-support-for-conversion-strings-to-values-on-any-base>",
           "RTOS" : "<one-of-valid-rtos-options----CHIBIOS-FREERTOS>",
           "CHIBIOS_SOURCE" : "<path-to-chibios-source-mind-the-forward-slash>",
+          "CHIBIOS_CONTRIB_REQUIRED" : "OFF-default-ON-to-include_ChibiOS-Contrib-repository-in-the-build",
+          "CHIBIOS_CONTRIB_SOURCE" : "<path-to-local-ChibiOS-contrib-source-mind-the-forward-slash>",
           "CHIBIOS_BOARD" : "<valid-chibios-board-name-from-boards-collection>",
           "SWO_OUTPUT" : "OFF-default-ON-to-enable-ARM-CortexM-Single-Wire-Output",
           "NF_BUILD_RTM" : "OFF-default-ON-to-enable-RTM-build",

--- a/targets/CMSIS-OS/ChibiOS/Include/Target_BlockStorage_STM32FlashDriver.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/Target_BlockStorage_STM32FlashDriver.h
@@ -9,6 +9,7 @@
 #include <ch.h>
 #include <hal.h>
 #include <nanoPAL_BlockStorage.h>
+#include <hal_nf_community.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -30,6 +30,11 @@ find_package(NF_CoreCLR REQUIRED)
 #######################################
 # optional
 
+# ChibiOS contrib repo
+if(CHIBIOS_CONTRIB_REQUIRED)
+    find_package(ChibiOS-Contrib REQUIRED)
+endif()
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
@@ -98,6 +103,7 @@ add_executable(
     ${TARGET_CHIBIOS_NANOCLR_SOURCES}
 
     ${CHIBIOS_SOURCES}
+    ${CHIBIOS_CONTRIB_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
     ${WireProtocol_SOURCES}
@@ -127,6 +133,7 @@ include_directories(
 
     ${WireProtocol_INCLUDE_DIRS}
     ${CHIBIOS_INCLUDE_DIRS}
+    ${CHIBIOS_CONTRIB_INCLUDE_DIRS}
     ${ChibiOSnfOverlay_INCLUDE_DIRS}
 
     ${TARGET_CMSIS_COMMON_INCLUDE_DIRS}

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/halconf_nf.h
@@ -6,11 +6,6 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_
 
-// Enables the ChibiOS community overlay.
-#if !defined(HAL_USE_COMMUNITY) 
-#define HAL_USE_COMMUNITY           TRUE
-#endif
-
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/halconf_nf.h
@@ -6,11 +6,6 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_
 
-// Enables the ChibiOS community overlay.
-#if !defined(HAL_USE_COMMUNITY) 
-#define HAL_USE_COMMUNITY           TRUE
-#endif
-
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
@@ -30,6 +30,11 @@ find_package(NF_CoreCLR REQUIRED)
 #######################################
 # optional
 
+# ChibiOS contrib repo
+if(CHIBIOS_CONTRIB_REQUIRED)
+    find_package(ChibiOS-Contrib REQUIRED)
+endif()
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
@@ -98,6 +103,7 @@ add_executable(
     ${TARGET_CHIBIOS_NANOCLR_SOURCES}
 
     ${CHIBIOS_SOURCES}
+    ${CHIBIOS_CONTRIB_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
     ${WireProtocol_SOURCES}
@@ -127,6 +133,7 @@ include_directories(
 
     ${WireProtocol_INCLUDE_DIRS}
     ${CHIBIOS_INCLUDE_DIRS}
+    ${CHIBIOS_CONTRIB_INCLUDE_DIRS}
     ${ChibiOSnfOverlay_INCLUDE_DIRS}
 
     ${TARGET_CMSIS_COMMON_INCLUDE_DIRS}

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoBooter/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoBooter/halconf_nf.h
@@ -6,11 +6,6 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_
 
-// Enables the ChibiOS community overlay.
-#if !defined(HAL_USE_COMMUNITY) 
-#define HAL_USE_COMMUNITY           TRUE
-#endif
-
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/halconf_nf.h
@@ -6,11 +6,6 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_
 
-// Enables the ChibiOS community overlay.
-#if !defined(HAL_USE_COMMUNITY) 
-#define HAL_USE_COMMUNITY           TRUE
-#endif
-
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
@@ -30,6 +30,11 @@ find_package(NF_CoreCLR REQUIRED)
 #######################################
 # optional
 
+# ChibiOS contrib repo
+if(CHIBIOS_CONTRIB_REQUIRED)
+    find_package(ChibiOS-Contrib REQUIRED)
+endif()
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
@@ -99,6 +104,7 @@ add_executable(
     ${TARGET_CHIBIOS_NANOCLR_SOURCES}
 
     ${CHIBIOS_SOURCES}
+    ${CHIBIOS_CONTRIB_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
     ${WireProtocol_SOURCES}
@@ -128,6 +134,7 @@ include_directories(
     
     ${WireProtocol_INCLUDE_DIRS}
     ${CHIBIOS_INCLUDE_DIRS}
+    ${CHIBIOS_CONTRIB_INCLUDE_DIRS}
     ${ChibiOSnfOverlay_INCLUDE_DIRS}
 
     ${TARGET_CMSIS_COMMON_INCLUDE_DIRS}

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/halconf_nf.h
@@ -6,11 +6,6 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_
 
-// Enables the ChibiOS community overlay.
-#if !defined(HAL_USE_COMMUNITY) 
-#define HAL_USE_COMMUNITY           TRUE
-#endif
-
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/halconf_nf.h
@@ -6,11 +6,6 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_
 
-// Enables the ChibiOS community overlay.
-#if !defined(HAL_USE_COMMUNITY) 
-#define HAL_USE_COMMUNITY           TRUE
-#endif
-
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -30,6 +30,11 @@ find_package(NF_CoreCLR REQUIRED)
 #######################################
 # optional
 
+# ChibiOS contrib repo
+if(CHIBIOS_CONTRIB_REQUIRED)
+    find_package(ChibiOS-Contrib REQUIRED)
+endif()
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
@@ -100,6 +105,7 @@ add_executable(
     ${TARGET_CHIBIOS_NANOCLR_SOURCES}
 
     ${CHIBIOS_SOURCES}
+    ${CHIBIOS_CONTRIB_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
     ${WireProtocol_SOURCES}
@@ -129,6 +135,7 @@ include_directories(
 
     ${WireProtocol_INCLUDE_DIRS}
     ${CHIBIOS_INCLUDE_DIRS}
+    ${CHIBIOS_CONTRIB_INCLUDE_DIRS}
     ${ChibiOSnfOverlay_INCLUDE_DIRS}
 
     ${TARGET_CMSIS_COMMON_INCLUDE_DIRS}

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/halconf_nf.h
@@ -6,11 +6,6 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_
 
-// Enables the ChibiOS community overlay.
-#if !defined(HAL_USE_COMMUNITY) 
-#define HAL_USE_COMMUNITY           TRUE
-#endif
-
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf_nf.h
@@ -6,11 +6,6 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_
 
-// Enables the ChibiOS community overlay.
-#if !defined(HAL_USE_COMMUNITY) 
-#define HAL_USE_COMMUNITY           TRUE
-#endif
-
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
@@ -30,6 +30,11 @@ find_package(NF_CoreCLR REQUIRED)
 #######################################
 # optional
 
+# ChibiOS contrib repo
+if(CHIBIOS_CONTRIB_REQUIRED)
+    find_package(ChibiOS-Contrib REQUIRED)
+endif()
+
 # nF feature: debugger
 if(NF_FEATURE_DEBUGGER)
     find_package(NF_Debugger REQUIRED)
@@ -107,6 +112,7 @@ add_executable(
     ${TARGET_CHIBIOS_NANOCLR_SOURCES}
 
     ${CHIBIOS_SOURCES}
+    ${CHIBIOS_CONTRIB_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
     ${WireProtocol_SOURCES}
@@ -153,6 +159,7 @@ include_directories(
 
     ${WireProtocol_INCLUDE_DIRS}
     ${CHIBIOS_INCLUDE_DIRS}
+    ${CHIBIOS_CONTRIB_INCLUDE_DIRS}
     ${ChibiOSnfOverlay_INCLUDE_DIRS}
 
     ${TARGET_CMSIS_COMMON_INCLUDE_DIRS}

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/halconf_nf.h
@@ -6,11 +6,6 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_
 
-// Enables the ChibiOS community overlay.
-#if !defined(HAL_USE_COMMUNITY) 
-#define HAL_USE_COMMUNITY           TRUE
-#endif
-
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf_nf.h
@@ -6,11 +6,6 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_ 1
 
-// Enables the ChibiOS community overlay.
-#if !defined(HAL_USE_COMMUNITY) 
-#define HAL_USE_COMMUNITY           TRUE
-#endif
-
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/common/mbedtls_entropy_hardware_pool.c
+++ b/targets/CMSIS-OS/ChibiOS/common/mbedtls_entropy_hardware_pool.c
@@ -4,6 +4,7 @@
 //
 
 #include <hal.h>
+#include <hal_nf_community.h>
 
 // Get len bytes of entropy from the hardware RNG.
 int mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen )

--- a/targets/CMSIS-OS/ChibiOS/common/nanoSupport_CRC32.c
+++ b/targets/CMSIS-OS/ChibiOS/common/nanoSupport_CRC32.c
@@ -5,6 +5,7 @@
 //
 
 #include <hal.h>
+#include <hal_nf_community.h>
 
 #if defined(STM32F0XX) || defined(STM32F1XX) || defined(STM32F2XX) || \
 	defined(STM32F4XX) || defined(STM32F7XX) || defined(STM32L0XX) || \

--- a/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
@@ -7,6 +7,7 @@
 #include <cmsis_os.h>
 #include <nanoHAL_v2.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <WireProtocol.h>
 #include <Debugger.h>
 #include <WireProtocol_MonitorCommands.h>

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/CLR_Startup_Thread.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/CLR_Startup_Thread.c
@@ -5,6 +5,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include <nanoCLR_Application.h>

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Devices.OneWire/nf_devices_onewire_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Devices.OneWire/nf_devices_onewire_native.h
@@ -9,6 +9,7 @@
 #include <nanoCLR_Interop.h>
 #include <nanoCLR_Runtime.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 
 struct Library_nf_devices_onewire_native_nanoFramework_Devices_OneWire_OneWireController
 {

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
@@ -8,6 +8,7 @@
 #include <target_platform.h>
 #include <cmsis_os.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <ch.h>
 
 uint32_t WakeupReasonStore;

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetRandom.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetRandom.cpp
@@ -4,6 +4,7 @@
 //
 #include "Core.h"
 #include <hal.h>
+#include <hal_nf_community.h>
 
 void CLR_RT_Random::Initialize()
 {

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/dummy_includes/hal_community.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/dummy_includes/hal_community.h
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#ifndef HAL_COMMUNITY_H
+#define HAL_COMMUNITY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  void halCommunityInit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // HAL_COMMUNITY_H

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/hal_nf_community.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/include/hal_nf_community.h
@@ -31,17 +31,22 @@
 #define HAL_USE_STM32_ONEWIRE                FALSE
 #endif
 
+#if !defined(HAL_USE_STM32_USB_MSD)
+// the default for this driver is NOT to be included
+#define HAL_USE_STM32_USB_MSD                FALSE
+#endif
+
 // Abstract interfaces
 
 // Shared headers
 // #include "hal_nnnn.h"
 
 // Normal drivers
-#include "hal_stm32_flash.h"
-#include "hal_stm32_crc.h"
-#include "hal_stm32_rng.h"
-#include "hal_stm32_fsmc.h"
-#include "hal_stm32_onewire.h"
+#include <hal_stm32_flash.h>
+#include <hal_stm32_crc.h>
+#include <hal_stm32_rng.h>
+#include <hal_stm32_fsmc.h>
+#include <hal_stm32_onewire.h>
 
 // Complex drivers
 // #include "hal_nnnn.h"

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
@@ -14,6 +14,7 @@
 
 
 #include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_CRC == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.h
@@ -7,6 +7,8 @@
 #define CRC_LLD_H
 
 #include "stm32_registry.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_CRC == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.c
@@ -8,7 +8,8 @@
 // This driver has been tested with the following STM32 series: F0
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "hal.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_FLASH == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv1/flash_lld.h
@@ -7,6 +7,7 @@
 #define FLASH_LLD_H
 
 #include "stm32_registry.h"
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_FLASH == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
@@ -8,7 +8,8 @@
 // This driver has been tested with the following STM32 series: F4
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "hal.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_FLASH == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.h
@@ -8,6 +8,7 @@
 #define FLASH_LLD_H
 
 #include "stm32_registry.h"
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_FLASH == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv3/flash_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv3/flash_lld.c
@@ -8,7 +8,8 @@
 // This driver has been tested with the following STM32 series: F0
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "hal.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_FLASH == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv3/flash_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv3/flash_lld.h
@@ -7,6 +7,7 @@
 #define FLASH_LLD_H
 
 #include "stm32_registry.h"
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_FLASH == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_nand_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_nand_lld.c
@@ -4,7 +4,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#include "hal.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_NAND == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_nand_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_nand_lld.h
@@ -8,6 +8,7 @@
 #define HAL_NAND_LLD_H_
 
 #include "hal_stm32_fsmc"
+#include <hal_nf_community.h>
 
 #if (HAL_USE_NAND == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sdram_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sdram_lld.c
@@ -4,7 +4,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#include "hal.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sdram_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sdram_lld.h
@@ -7,6 +7,8 @@
 #ifndef HAL_FMC_SDRAM_H_
 #define HAL_FMC_SDRAM_H_
 
+#include <hal_nf_community.h>
+
 #if (defined(STM32F427xx) || defined(STM32F437xx) || \
      defined(STM32F429xx) || defined(STM32F439xx) || \
 	 defined(STM32F469xx) || defined(STM32F479xx) || \

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sram_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sram_lld.c
@@ -4,7 +4,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#include "hal.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 #include "fsmc_sram_lld.h"
 
 #if (STM32_USE_FSMC_SRAM == TRUE)

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sram_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FSMCv1/fsmc_sram_lld.h
@@ -8,6 +8,7 @@
 #define HAL_FSMC_SRAM_H_
 
 #include "hal_stm32_fsmc.h"
+#include <hal_nf_community.h>
 
 #if (STM32_USE_FSMC_SRAM == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/ONEWIREv1/onewire_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/ONEWIREv1/onewire_lld.c
@@ -6,6 +6,7 @@
 
 
 #include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_ONEWIRE == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/RNGv1/rng_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/RNGv1/rng_lld.c
@@ -10,6 +10,7 @@
 // https://github.com/ChibiOS/ChibiOS-Contrib/blob/master/os/hal/src/hal_rng.c
 
 #include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_RNG == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/RNGv1/rng_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/RNGv1/rng_lld.h
@@ -10,6 +10,8 @@
 #define RNG_LLD_H
 
 #include "stm32_registry.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_RNG == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/hal_community.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/hal_community.c
@@ -3,9 +3,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#include "hal.h"
-
-#if (HAL_USE_COMMUNITY == TRUE) 
+#include <hal.h>
+#include <hal_nf_community.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Driver local definitions.                                                 //
@@ -51,5 +50,3 @@ void halCommunityInit(void) {
 #endif
 
 }
-
-#endif // HAL_USE_COMMUNITY

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_crc/hal_stm32_crc.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_crc/hal_stm32_crc.c
@@ -8,7 +8,8 @@
 // so there is no point on wasting memory with calling functions with dummy arguments.
 
 
-#include "hal.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_CRC == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_flash/hal_stm32_flash.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_flash/hal_stm32_flash.c
@@ -4,6 +4,7 @@
 //
 
 #include "hal.h"
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_FLASH == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_fsmc/hal_stm32_fsmc.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_fsmc/hal_stm32_fsmc.c
@@ -4,7 +4,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#include "hal.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 #include "hal_stm32_fsmc.h"
 
 #if (HAL_USE_FSMC == TRUE)

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_onewire/hal_stm32_onewire.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_onewire/hal_stm32_onewire.c
@@ -7,6 +7,7 @@
  * Hardware Abstraction Layer for ONEWIRE Unit
  */
 #include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_ONEWIRE == TRUE)
 

--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_rng/hal_stm32_rng.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_rng/hal_stm32_rng.c
@@ -6,7 +6,8 @@
 /*
  * Hardware Abstraction Layer for RNG Unit
  */
-#include "hal.h"
+#include <hal.h>
+#include <hal_nf_community.h>
 
 #if (HAL_USE_STM32_RNG == TRUE)
 


### PR DESCRIPTION
## Description
- Add options to cmake-variants-template.
- Rework main CMake to process this option.
- Add CMake module to include ChibiOS-Contrib files and include paths.
- Rework nanoFramework overlay to allow using it side by side with official community contributions.
- Move HAL_USE_COMMUNITY from targets config to ChibiOS CMake toolchain.
- Fix includes on several source file to accommodate these changes.

## Motivation and Context
- Allow inclusion of ChibiOS-Contrib in build.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>