### PR TITLE
Clean-up storage. file system and related options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,11 +517,11 @@ endif()
 
 if(API_Windows.Storage)
     set(USE_FILESYSTEM_OPTION TRUE CACHE INTERNAL "NF feature FILESYSTEM")
-    set(HAL_USE_SDC_OPTION TRUE CACHE INTERNAL "HAL SDC for NF_FEATURE_USE_FILESYSTEM")
+    set(HAL_USE_SDC_OPTION TRUE CACHE INTERNAL "HAL SDC for USE_FILESYSTEM_OPTION")
     message(STATUS "Support for filesystem enabled")
 else()
     set(USE_FILESYSTEM_OPTION FALSE CACHE INTERNAL "NF feature FILESYSTEM")
-    set(HAL_USE_SDC_OPTION FALSE CACHE INTERNAL "HAL SDC for NF_FEATURE_USE_FILESYSTEM")
+    set(HAL_USE_SDC_OPTION FALSE CACHE INTERNAL "HAL SDC for USE_FILESYSTEM_OPTION")
 endif()
 
 #################################################################
@@ -686,7 +686,8 @@ if(RTOS_CHIBIOS_CHECK)
 
             # install command has to perform TWO extracts
             # in order to set multiple commands with INSTALL_COMMAND they have to be concatenated by a COMMAND keyword 
-            INSTALL_COMMAND ${CMAKE_COMMAND} -E tar xvf ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip-2.0.3-patched.7z WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/ COMMAND ${CMAKE_COMMAND} -E tar xvf ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs-0.13_patched.7z WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/
+            INSTALL_COMMAND ${CMAKE_COMMAND} -E tar xvf ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/lwip-2.0.3-patched.7z WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/
+                    COMMAND ${CMAKE_COMMAND} -E tar xvf ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs-0.13_patched.7z WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/
             
             # Disable all other steps
             CONFIGURE_COMMAND ""

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -139,10 +139,6 @@
           "value": "OFF"
         },
         {
-          "name": "NF_FEATURE_USE_FILESYSTEM", //OFF-default-ON-to-enable-support
-          "value": "OFF"
-        },
-        {
           "name": "NF_NETWORKING_SNTP", //ON-default-to-add-SNTP-client-requires-networking
           "value": "OFF"
         },
@@ -199,6 +195,10 @@
           "name": "API_Windows.Networking.Sockets", //OFF-default-ON-to-add-this-API
           "value": "OFF"
         },
+        {
+          "name": "API_Windows.Storage", //OFF-default-ON-to-add-this-API
+          "value": "OFF"
+        },    
         {
           "name": "API_Hardware.Esp32", //OFF-default-ON-to-add-this-API
           "value": "OFF"
@@ -348,10 +348,6 @@
           "value": "OFF"
         },
         {
-          "name": "NF_FEATURE_USE_FILESYSTEM", //OFF-default-ON-to-enable-support
-          "value": "OFF"
-        },
-        {
           "name": "NF_NETWORKING_SNTP", //ON-default-to-add-SNTP-client-requires-networking
           "value": "OFF"
         },
@@ -408,6 +404,10 @@
           "name": "API_Windows.Networking.Sockets", //OFF-default-ON-to-add-this-API
           "value": "OFF"
         },
+        {
+          "name": "API_Windows.Storage", //OFF-default-ON-to-add-this-API
+          "value": "OFF"
+        },        
         {
           "name": "API_Hardware.Esp32", //OFF-default-ON-to-add-this-API
           "value": "ON"

--- a/cmake-variants.TEMPLATE-ESP32.json
+++ b/cmake-variants.TEMPLATE-ESP32.json
@@ -50,7 +50,6 @@
             "NF_FEATURE_DEBUGGER" : "ON",
             "NF_FEATURE_RTC" : "ON",
             "NF_FEATURE_USE_APPDOMAINS" : "OFF",
-            "NF_FEATURE_USE_FILESYSTEM" : "OFF",
             "API_System.Net" : "ON",
             "NF_SECURITY_OPENSSL" : "ON",
             "API_Windows.Devices.Wifi": "ON",

--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -61,7 +61,6 @@
           "NF_PLATFORM_NO_CLR_TRACE" : "OFF-default-ON-to-disable-all-trace-on-CLR",
           "NF_CLR_NO_IL_INLINE" : "OFF-default-ON-to-disable-CLR-IL-inlining",
           "NF_INTEROP_ASSEMBLIES" : [ "Assembly1-Namespace", "Assembly2-Namespace" ],
-          "NF_FEATURE_USE_FILESYSTEM" : "OFF-default-ON-to-enable-support",
           "NF_NETWORKING_SNTP" :  "ON-default-to-add-SNTP-client-requires-networking",
           "NF_SECURITY_OPENSSL" : "OFF-default-ON-to-add-network-security-from-OpenSSL",
           "NF_SECURITY_MBEDTLS" : "OFF-default-ON-to-add-network-security-from-mbedTLS",

--- a/targets/FreeRTOS/ESP32_DevKitC/BUILD-ESP32.md
+++ b/targets/FreeRTOS/ESP32_DevKitC/BUILD-ESP32.md
@@ -210,7 +210,6 @@ Note that `.\install-esp32-tools.ps1` will install `pyserial` for you if you ins
           "NF_FEATURE_DEBUGGER" : "ON",
           "NF_FEATURE_RTC" : "ON",
           "NF_FEATURE_USE_APPDOMAINS" : "OFF",
-          "NF_FEATURE_USE_FILESYSTEM" : "OFF",
           "NF_SECURITY_OPENSSL" : "ON",
           "API_System.Net" : "ON",
           "API_Windows.Networking.Sockets" : "OFF",


### PR DESCRIPTION
## Description
- Remove NF_FEATURE_USE_FILESYSTEM build option as it's not required anymore.
- Add API_Windows.Storage build option to VS2017 build settings.
- Fix external project build for ChibiOS on main CMake.

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
