### PR TITLE
Rework CLR reboot

### DIFF
--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -203,6 +203,15 @@ HRESULT CLR_RT_ExecutionEngine::DeleteInstance()
 
 void CLR_RT_ExecutionEngine::ExecutionEngine_Cleanup()
 {
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // developer notes:
+    // Most of the following calls are just for pure ceremony and gracefully terminating stuff,
+    // cleaning collections and such.
+    // In particular the previous existing calls to Abort threads were completely irrelevant 
+    // because the execution engine wasn't running anymore so whatever code that is on those threads 
+    // there to be executed wouldn't never be executed anyways.
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+
     NATIVE_PROFILE_CLR_CORE();
     m_fShuttingDown = true;
 
@@ -227,9 +236,6 @@ void CLR_RT_ExecutionEngine::ExecutionEngine_Cleanup()
     m_cctorThread = NULL;
 
     m_timerThread = NULL;
-
-    AbortAllThreads  ( m_threadsReady   );
-    AbortAllThreads  ( m_threadsWaiting );
 
     ReleaseAllThreads( m_threadsReady   );
     ReleaseAllThreads( m_threadsWaiting );

--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -73,7 +73,6 @@ struct CLR_DBG_Commands
         static const unsigned int c_EnterBootloader = 1;
         static const unsigned int c_ClrOnly   = 2;
         static const unsigned int c_WaitForDebugger   = 4;
-        static const unsigned int c_NoShutdown = 8;
 
         unsigned int m_flags;
     };

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/CLRStartup.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/CLRStartup.cpp
@@ -246,11 +246,15 @@ struct Settings
 
     void Cleanup()
     {
-        if(!CLR_EE_REBOOT_IS(NoShutdown))
-        {
-            // OK to delete execution engine 
-            CLR_RT_ExecutionEngine::DeleteInstance();
-        }
+        CLR_RT_ExecutionEngine::DeleteInstance();
+    
+        memset( &g_CLR_RT_ExecutionEngine, 0, sizeof(g_CLR_RT_ExecutionEngine));
+        memset( &g_CLR_RT_WellKnownTypes, 0, sizeof(g_CLR_RT_WellKnownTypes));
+        memset( &g_CLR_RT_WellKnownMethods, 0, sizeof(g_CLR_RT_WellKnownMethods));
+        memset( &g_CLR_RT_TypeSystem, 0, sizeof(g_CLR_RT_TypeSystem));
+        memset( &g_CLR_RT_EventCache, 0, sizeof(g_CLR_RT_EventCache));
+        memset( &g_CLR_RT_GarbageCollector, 0, sizeof(g_CLR_RT_GarbageCollector));
+        memset( &g_CLR_HW_Hardware, 0, sizeof(g_CLR_HW_Hardware));        
 
         m_fInitialized = false;
     }

--- a/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/CLRStartup.cpp
+++ b/targets/FreeRTOS/ESP32_DevKitC/nanoCLR/CLRStartup.cpp
@@ -242,11 +242,15 @@ struct Settings
 
     void Cleanup()
     {
-        if(!CLR_EE_REBOOT_IS(NoShutdown))
-        {
-            // OK to delete execution engine 
-            CLR_RT_ExecutionEngine::DeleteInstance();
-        }
+        CLR_RT_ExecutionEngine::DeleteInstance();
+    
+        memset( &g_CLR_RT_ExecutionEngine, 0, sizeof(g_CLR_RT_ExecutionEngine));
+        memset( &g_CLR_RT_WellKnownTypes, 0, sizeof(g_CLR_RT_WellKnownTypes));
+        memset( &g_CLR_RT_WellKnownMethods, 0, sizeof(g_CLR_RT_WellKnownMethods));
+        memset( &g_CLR_RT_TypeSystem, 0, sizeof(g_CLR_RT_TypeSystem));
+        memset( &g_CLR_RT_EventCache, 0, sizeof(g_CLR_RT_EventCache));
+        memset( &g_CLR_RT_GarbageCollector, 0, sizeof(g_CLR_RT_GarbageCollector));
+        memset( &g_CLR_HW_Hardware, 0, sizeof(g_CLR_HW_Hardware));        
 
         m_fInitialized = false;
     }

--- a/targets/os/win32/nanoCLR/CLRStartup.cpp
+++ b/targets/os/win32/nanoCLR/CLRStartup.cpp
@@ -394,22 +394,15 @@ struct Settings
 
     void Cleanup()
     {
-        if(!CLR_EE_REBOOT_IS(NoShutdown))
-        {
-            // OK to delete execution engine 
-            CLR_RT_ExecutionEngine::DeleteInstance();
-        }
+        CLR_RT_ExecutionEngine::DeleteInstance();
 
-#if defined(_WIN32)
         memset( &g_CLR_RT_ExecutionEngine, 0, sizeof(g_CLR_RT_ExecutionEngine));
         memset( &g_CLR_RT_WellKnownTypes, 0, sizeof(g_CLR_RT_WellKnownTypes));
-
         memset( &g_CLR_RT_WellKnownMethods, 0, sizeof(g_CLR_RT_WellKnownMethods));
         memset( &g_CLR_RT_TypeSystem, 0, sizeof(g_CLR_RT_TypeSystem));
         memset( &g_CLR_RT_EventCache, 0, sizeof(g_CLR_RT_EventCache));
         memset( &g_CLR_RT_GarbageCollector, 0, sizeof(g_CLR_RT_GarbageCollector));
         memset( &g_CLR_HW_Hardware, 0, sizeof(g_CLR_HW_Hardware));
-#endif
 
         m_fInitialized = false;
     }


### PR DESCRIPTION
## Description
- CLR_RT_ExecutionEngine instance is now always deleted on clean-up.
- Add memset to clear all major strucst on clean-up.
- Remove c_NoShutdown option from Monitor_Reboot.
- Remove call to Abort threads and add developer notes about what is happening in ExecutionEngine_Cleanup.

## Motivation and Context
- The CLR reboot workflow wasn't being properly carried out.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
