### PR TITLE
Fix implementation of HARD_BREAKPOINT

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
@@ -29,9 +29,13 @@
 
 #if !defined(BUILD_RTM)
 
-inline void HARD_Breakpoint() { };
+inline void HARD_Breakpoint() 
+{
+    __BKPT(0);
+    while(true) { /*nop*/ }
+};
 
-#define HARD_BREAKPOINT()     HardFault_Handler()
+#define HARD_BREAKPOINT()     HARD_Breakpoint()
 
 // #if defined(_DEBUG)
 // #define DEBUG_HARD_BREAKPOINT()     HARD_Breakpoint()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- The previous implementation was wrong because the intended outcome was to stop a connected debugger, not processing an hard fault.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
