### PR TITLE
Fix issues with nanoCLR restart

### DIFF
--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -236,10 +236,6 @@ void CLR_RT_ExecutionEngine::ExecutionEngine_Cleanup()
     m_cctorThread = NULL;
     m_timerThread = NULL;
 
-    m_threadsReady.DblLinkedList_Release();
-    m_threadsWaiting.DblLinkedList_Release();
-    m_threadsZombie.DblLinkedList_Release();
-
     g_CLR_RT_TypeSystem.TypeSystem_Cleanup();
     g_CLR_RT_EventCache.EventCache_Cleanup();
 

--- a/src/CLR/Core/Hardware/Hardware.cpp
+++ b/src/CLR/Core/Hardware/Hardware.cpp
@@ -115,7 +115,7 @@ void CLR_HW_Hardware::ProcessActivity()
 
             if(!CLR_EE_REBOOT_IS(ClrOnly))
             {
-                CLR_RT_ExecutionEngine::Reboot( true );
+                CLR_RT_ExecutionEngine::Reboot( false );
             }
         }
 #endif


### PR DESCRIPTION
## Description


## Motivation and Context
- Calling execution engine reboot on ProcessActivity() must not force hard reboot.
- Releasing threads linked lists on execution engine clean-up can cause hard faults. It's safe to skip this because those linked lists are always properly initialized on execution engine start.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
