### PR TITLE
Work CD-CI

### DIFF
--- a/azure-pipelines-templates/download-install-arm-gcc-toolchain.yml
+++ b/azure-pipelines-templates/download-install-arm-gcc-toolchain.yml
@@ -6,8 +6,29 @@ steps:
     inputs:
         targetType: 'inline'
         script: |
+
             Write-Host "Downloading ARM GNU GCC toolchain..."
-            $url = "https://bintray.com/nfbot/internal-build-tools/download_file?file_path=gcc-arm-none-eabi-7-2018-q2-update-win32.7z"
+
+            if("$(GccArm_Version)" -ne "")
+            {
+                if("$(GccArm_Version)" -eq "5-2016-q3-update")
+                {
+                    $url = "https://bintray.com/nfbot/internal-build-tools/download_file?file_path=gcc-arm-none-eabi-5-2016-q3-update-win32.7z"
+                }
+                else
+                {
+                    # no valid version specifed, use the default one
+                    # current default is , this is is "7-2018-q2-update"
+                    $url = "https://bintray.com/nfbot/internal-build-tools/download_file?file_path=gcc-arm-none-eabi-7-2018-q2-update-win32.7z"
+                }
+            }
+            else
+            {
+                # no version specifed, use the default one
+                # current default is , this is is "7-2018-q2-update"
+                $url = "https://bintray.com/nfbot/internal-build-tools/download_file?file_path=gcc-arm-none-eabi-7-2018-q2-update-win32.7z"
+            }
+
             $output = "$PSScriptRoot\gcc-arm.7z"
             (New-Object Net.WebClient).DownloadFile($url, $output)
         errorActionPreference: 'stop'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,22 +76,27 @@ jobs:
       MBN_QUAIL:
         BoardName: MBN_QUAIL
         BuildOptions: -DTARGET_SERIES=STM32F4xx -DRTOS=CHIBIOS -DSUPPORT_ANY_BASE_CONVERSION=ON -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DAPI_System.Math=ON -DAPI_Hardware.Stm32=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_nanoFramework.Devices.OneWire=ON
+        GccArm_Version:
         NeedsDFU: true
       NETDUINO3_WIFI:
         BoardName: NETDUINO3_WIFI
         BuildOptions: -DTARGET_SERIES=STM32F4xx -DRTOS=CHIBIOS -DSUPPORT_ANY_BASE_CONVERSION=ON -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DAPI_System.Math=ON -DAPI_Hardware.Stm32=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_nanoFramework.Devices.OneWire=ON -DAPI_Windows.Storage=ON
+        GccArm_Version:
         NeedsDFU: true
       ST_STM32F429I_DISCOVERY:
         BoardName: ST_STM32F429I_DISCOVERY
         BuildOptions: -DTARGET_SERIES=STM32F4xx -DRTOS=CHIBIOS -DSUPPORT_ANY_BASE_CONVERSION=ON -DNF_FEATURE_DEBUGGER=ON -DSWO_OUTPUT=ON -DNF_FEATURE_RTC=ON -DAPI_System.Math=ON -DAPI_Hardware.Stm32=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_nanoFramework.Devices.OneWire=ON -DAPI_nanoFramework.Devices.Can=ON
+        GccArm_Version:
         NeedsDFU: false
       ST_NUCLEO64_F091RC:
         BoardName: ST_NUCLEO64_F091RC
         BuildOptions: -DTARGET_SERIES=STM32F0xx -DRTOS=CHIBIOS -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DUSE_RNG=OFF -DNF_PLATFORM_NO_CLR_TRACE=ON -DNF_CLR_NO_IL_INLINE=ON -DAPI_Hardware.Stm32=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON
+        GccArm_Version: 5-2016-q3-update
         NeedsDFU: false
       ST_STM32F769I_DISCOVERY:
         BoardName: ST_STM32F769I_DISCOVERY
         BuildOptions: -DTARGET_SERIES=STM32F7xx -DRTOS=CHIBIOS -DSUPPORT_ANY_BASE_CONVERSION=ON -DNF_FEATURE_DEBUGGER=ON -DSWO_OUTPUT=ON -DNF_FEATURE_RTC=ON -DAPI_System.Math=ON -DAPI_Hardware.Stm32=ON -DNF_FEATURE_HAS_CONFIG_BLOCK=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=ON -DNF_SECURITY_MBEDTLS=ON -DAPI_nanoFramework.Devices.OneWire=ON -DAPI_nanoFramework.Devices.Can=ON -DAPI_Windows.Storage=ON
+        GccArm_Version:
         NeedsDFU: false 
 
   variables:


### PR DESCRIPTION
## Description
- Add GccArm_Version build variable to allow specify a specific toolchain version for STM32 targets.

## Motivation and Context
- Required to allow building STM32F0 targets with ChibiOS 19.x. The upgrade to this version uncovered a bug in GCC compiler from version 6 onwards. Until that is fixed this is required.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
