### PR TITLE
Improve compiler check for Wimplicit-fallthrough

### DIFF
--- a/src/CLR/Core/CLR_RT_UnicodeHelper.cpp
+++ b/src/CLR/Core/CLR_RT_UnicodeHelper.cpp
@@ -126,8 +126,8 @@ int CLR_RT_UnicodeHelper::CountNumberOfBytes( int max )
 // the switch cases to improve the algorithm	
 #ifdef __GNUC__	
 #pragma GCC diagnostic push
-// the GCC compiler for ESP32 doesn't know the -Wimplicit-fallthrough option
-#ifndef PLATFORM_ESP32
+// -Wimplicit-fallthrough option was added in GCC 7
+#if (__GNUC__ >= 7)
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #endif
 #endif


### PR DESCRIPTION
## Description
- Replace condition to use (or not) Wimplicit-fallthrough.

## Motivation and Context
- It was introduced on gcc 7, so checking the version is the correct approach, not so much the platform.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
