### PR TITLE
Fix build in VS Code

### DIFF
--- a/CMake/toolchain.FreeRtos.ESP32.GCC.cmake
+++ b/CMake/toolchain.FreeRtos.ESP32.GCC.cmake
@@ -20,6 +20,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY )
 set(TOOLCHAIN_BIN_DIR ${TOOLCHAIN_PREFIX}/xtensa-esp32-elf/bin)
 set(TOOLCHAIN_INC_DIR ${ESP32_IDF_PATH}/components/newlib/include)
 set(TOOLCHAIN_LIB_DIR ${TOOLCHAIN_PREFIX}/xtensa-esp32-elf/xtensa-esp32-elf/lib)
+SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 
 # the name of the operating system for which CMake is to build
 set(CMAKE_SYSTEM_NAME Generic)

--- a/CMake/toolchain.FreeRtos.ESP32.GCC.cmake
+++ b/CMake/toolchain.FreeRtos.ESP32.GCC.cmake
@@ -20,7 +20,9 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY )
 set(TOOLCHAIN_BIN_DIR ${TOOLCHAIN_PREFIX}/xtensa-esp32-elf/bin)
 set(TOOLCHAIN_INC_DIR ${ESP32_IDF_PATH}/components/newlib/include)
 set(TOOLCHAIN_LIB_DIR ${TOOLCHAIN_PREFIX}/xtensa-esp32-elf/xtensa-esp32-elf/lib)
-SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
+if(NOT EXECUTABLE_OUTPUT_PATH)
+    SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
+endif()
 
 # the name of the operating system for which CMake is to build
 set(CMAKE_SYSTEM_NAME Generic)


### PR DESCRIPTION
## Description
- Set EXECUTABLE_OUTPUT_PATH in ESP32 toolchain CMake.

## Motivation and Context
- Building ESP32 in VS Code was throwing an error-

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
