### PR TITLE
Fixes related with BlockStorage

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/main.c
@@ -53,9 +53,10 @@ int main(void) {
   // start kernel, after this main() will behave like a thread with priority osPriorityNormal
   osKernelStart();
 
-  // initialize block storage device
+  // initialize block storage list and devices
   // in CLR this is called in nanoHAL_Initialize()
   // for nanoBooter we have to init it in order to provide the flash map for Monitor_FlashSectorMap command
+  BlockStorageList_Initialize();
   BlockStorage_AddDevices();
 
   //  Normal main() thread

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoBooter/main.c
@@ -53,9 +53,10 @@ int main(void) {
   // start kernel, after this main() will behave like a thread with priority osPriorityNormal
   osKernelStart();
 
-  // initialize block storage device
+  // initialize block storage list and devices
   // in CLR this is called in nanoHAL_Initialize()
   // for nanoBooter we have to init it in order to provide the flash map for Monitor_FlashSectorMap command
+  BlockStorageList_Initialize();
   BlockStorage_AddDevices();
 
   //  Normal main() thread

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/main.c
@@ -52,9 +52,10 @@ int main(void) {
   // start kernel, after this main() will behave like a thread with priority osPriorityNormal
   osKernelStart();
 
-  // initialize block storage device
+  // initialize block storage list and devices
   // in CLR this is called in nanoHAL_Initialize()
   // for nanoBooter we have to init it in order to provide the flash map for Monitor_FlashSectorMap command
+  BlockStorageList_Initialize();
   BlockStorage_AddDevices();
 
   //  Normal main() thread

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
@@ -68,9 +68,10 @@ int main(void) {
   // start kernel, after this main() will behave like a thread with priority osPriorityNormal
   osKernelStart();
 
-  // initialize block storage device
+  // initialize block storage list and devices
   // in CLR this is called in nanoHAL_Initialize()
   // for nanoBooter we have to init it in order to provide the flash map for Monitor_FlashSectorMap command
+  BlockStorageList_Initialize();
   BlockStorage_AddDevices();
 
   //  Normal main() thread

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/main.c
@@ -69,7 +69,7 @@ int main(void) {
   // start kernel, after this main() will behave like a thread with priority osPriorityNormal
   osKernelStart();
 
-  // initialize block storage device
+  // initialize block storage list and devices
   // in CLR this is called in nanoHAL_Initialize()
   // for nanoBooter we have to init it in order to provide the flash map for Monitor_FlashSectorMap command
   BlockStorageList_Initialize();


### PR DESCRIPTION
## Description
- Improve ContiguousBlockAssemblies to deal with non XIP assemblies.
- Add missing call in nanoBooter.

## Motivation and Context
- All targets except STM32F769 were missing the required BS init in nanoBooter.
- CLRStartup wasn't handling correctly the loading of assemblies from non XIP storage.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
