### PR TITLE
Fix ClrStartup exit

### DIFF
--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -437,6 +437,11 @@ void ClrStartup(CLR_SETTINGS params)
 
     } while( softReboot );
 
+  #if !defined(BUILD_RTM)
+    CLR_Debug::Printf( "Exiting.\r\n" );
+  #endif
+
+    CPU_Reset();
 }
 
 #endif // WIN32


### PR DESCRIPTION
## Description
- Add call to CPU reset after CLRStartup loop. 
- Add debug output announcing exit.


## Motivation and Context
- Fixes serious potential for freezing a target. After the loop is exited the target can be rendered unusable result of the CLR thread being exited and because there are no further actions to restart it.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
