### PR TITLE
Add check for NF_FEATURE_HAS_CONFIG_BLOCK on network build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,6 +560,13 @@ if(USE_NETWORKING_OPTION)
         message(STATUS "Support for networking enabled WITHOUT security")
     endif()
 
+    # sanity check for missing configuration block option
+    # which is required for network
+
+    if(NOT NF_FEATURE_HAS_CONFIG_BLOCK)
+        message(FATAL_ERROR "\n\nERROR: network build requires NF_FEATURE_HAS_CONFIG_BLOCK build option to be 'ON'. Make sure you have that on your cmake-variants or in the build command line.")
+    endif()
+
 else()
     set(HAL_USE_MAC_OPTION FALSE CACHE INTERNAL "HAL MAC for USE_NETWORKING_OPTION")
     message(STATUS "Support for networking IS NOT enabled")


### PR DESCRIPTION
## Description
- Add sanity check for NF_FEATURE_HAS_CONFIG_BLOCK when USE_NETWORKING_OPTION is on.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Resolves nanoFramework/Home#455.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
