### PR TITLE
Fix python serial install for ESP32 build

### DIFF
--- a/azure-pipelines-templates/download-install-esp32-build-components.yml
+++ b/azure-pipelines-templates/download-install-esp32-build-components.yml
@@ -59,6 +59,14 @@ steps:
       cleanDestinationFolder: false
     displayName: Installing Espressif IDF
 
+  # Use Python Version 3.7 and add it to path
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.7' 
+      addToPath: true 
+    displayName: Set Python to v3.7
+
+  # in this one have to call Python with full path otherwise it can fail
   - task: PowerShell@2
     inputs:
         targetType: 'inline'


### PR DESCRIPTION
## Description
- Add task to set Python version and add it to path.

## Motivation and Context
- Fix Azure Pipeline build for ESP32. Was failing on pyserial install.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
