### PR TITLE
Set nanoframework for ChibiOS contrib repo

### DIFF
--- a/CMake/ChibiOS-Contrib.CMakeLists.cmake.in
+++ b/CMake/ChibiOS-Contrib.CMakeLists.cmake.in
@@ -5,11 +5,13 @@ project(ChibiOS-Contrib-download NONE)
 include(ExternalProject)
 
 # download ChibiOS Community contributions source from GitHub repo
+# need to specify nanoframework as the active branch
 ExternalProject_Add( 
     ChibiOS-Contrib
     PREFIX ChibiOS-Contrib
     SOURCE_DIR ${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Source
     GIT_REPOSITORY  https://github.com/ChibiOS/ChibiOS-Contrib
+    GIT_TAG nanoframework  # target specified branch
     GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
     TIMEOUT 10
     LOG_DOWNLOAD 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -792,11 +792,13 @@ if(RTOS_CHIBIOS_CHECK)
                             WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Download")
 
             # add ChibiOS-Contrib as external project
+            # need to specify nanoframework as the active branch
             ExternalProject_Add( 
                 ChibiOS-Contrib
                 PREFIX ChibiOS-Contrib
                 SOURCE_DIR ${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Source
                 GIT_REPOSITORY  https://github.com/ChibiOS/ChibiOS-Contrib
+                GIT_TAG nanoframework  # target specified branch
                 GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
                 TIMEOUT 10
                 LOG_DOWNLOAD 1


### PR DESCRIPTION
## Description
- Set nanoframework as active branch for ChibiOS contrib repo cloning.

## Motivation and Context
- ChibiOS contrib repo is not very active and our PRs can be left there hanging for a while. To overcome this we now have a _nanoframework_ branch on our fork that takes our PRs right away.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>