### PR TITLE
Work Windows.Storage background thread

### DIFF
--- a/CMake/Modules/FindNF_CoreCLR.cmake
+++ b/CMake/Modules/FindNF_CoreCLR.cmake
@@ -172,6 +172,7 @@ set(NF_CoreCLR_SRCS
     Async_stubs.cpp
     COM_stubs.c
     GenericPort_stubs.c
+    nanoPAL_Windows_Storage_stubs.c
 
     # target specifics
     target_BlockStorage.c

--- a/src/HAL/Include/nanoHAL_Windows_Storage.h
+++ b/src/HAL/Include/nanoHAL_Windows_Storage.h
@@ -5,6 +5,8 @@
 #ifndef _NANOHAL_WINDOWS_STORAGE_H_
 #define _NANOHAL_WINDOWS_STORAGE_H_ 1
 
+#include <Target_Windows_Storage.h>
+
 // FatFs define for size of file name members
 // ANSI/OEM at DBCS
 #define FF_LFN_BUF  255

--- a/src/PAL/nanoPAL_Windows_Storage_stubs.c
+++ b/src/PAL/nanoPAL_Windows_Storage_stubs.c
@@ -1,0 +1,10 @@
+//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <nanoHAL_v2.h>
+
+__nfweak void Target_FileSystemInit(void)
+{
+};

--- a/targets/CMSIS-OS/ChibiOS/Include/Target_Windows_Storage.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/Target_Windows_Storage.h
@@ -7,11 +7,11 @@
 #define _TARGET_WINDOWS_STORAGE_H_ 1
 
 #define SDCARD_POLLING_INTERVAL                (1000)
-#define SDCARD_POLLING_DELAY                   (2)
+#define SDCARD_POLLING_DELAY                   (10)
 
 
 #define USB_MSD_POLLING_INTERVAL               (1000)
-#define USB_MSD_POLLING_DELAY                  (2)
+#define USB_MSD_POLLING_DELAY                  (10)
 
 // void RemoveHandler(eventid_t id);
 // void InsertHandler(eventid_t id);
@@ -20,7 +20,8 @@
 extern "C" {
 #endif
 
-// declaration of RTOS thread
+// declaration of RTOS working threads
+void SdCardWorkingThread(void const * argument);
 void UsbMsdWorkingThread(void const * argument);
 
 #ifdef __cplusplus

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/main.c
@@ -15,13 +15,10 @@
 #include <nanoPAL_BlockStorage.h>
 #include <nanoHAL_v2.h>
 #include <targetPAL.h>
-#include <Target_Windows_Storage.h>
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
-extern evhandler_t sdcardEventHandler[];
 
 // need to declare the Receiver thread here
 osThreadDef(ReceiverThread, osPriorityHigh, 2048, "ReceiverThread");
@@ -101,11 +98,7 @@ int main(void) {
   // start kernel, after this main() will behave like a thread with priority osPriorityNormal
   osKernelStart();
 
-  // start file system sub-system
-  Target_FileSystemInit();
-
   while (true) { 
-    //osDelay(100);
-    chEvtDispatch(sdcardEventHandler, chEvtWaitOneTimeout(ALL_EVENTS, TIME_MS2I(500)));
+    osDelay(100);
   }
 }

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/main.c
@@ -16,13 +16,10 @@
 #include <nanoPAL_BlockStorage.h>
 #include <nanoHAL_v2.h>
 #include <targetPAL.h>
-#include <Target_Windows_Storage.h>
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
-extern evhandler_t sdcardEventHandler[];
 
 // need to declare the Receiver thread here
 osThreadDef(ReceiverThread, osPriorityHigh, 2048, "ReceiverThread");
@@ -72,11 +69,7 @@ int main(void) {
   // start kernel, after this main() will behave like a thread with priority osPriorityNormal
   osKernelStart();
 
-  // start file system sub-system
-  Target_FileSystemInit();
-
   while (true) { 
-    //osDelay(100);
-    chEvtDispatch(sdcardEventHandler, chEvtWaitOneTimeout(ALL_EVENTS, TIME_MS2I(500)));
+    osDelay(100);
   }
 }

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
@@ -8,7 +8,6 @@
 #include <ff.h>
 #include "win_storage_native.h"
 #include <target_windows_storage_config.h>
-#include <Target_Windows_Storage.h>
 #include <nanoHAL_Windows_Storage.h>
 
 #if HAL_USBH_USE_MSD

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL.cpp
@@ -38,6 +38,8 @@ void nanoHAL_Initialize()
 
     BlockStorageList_InitializeDevices();
 
+    Target_FileSystemInit();
+
     // clear managed heap region
     unsigned char* heapStart = NULL;
     unsigned int heapSize  = 0;

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Include/Target_Windows_Storage.h
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Include/Target_Windows_Storage.h
@@ -1,0 +1,9 @@
+//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#ifndef _TARGET_WINDOWS_STORAGE_H_
+#define _TARGET_WINDOWS_STORAGE_H_ 1
+
+#endif  //_TARGET_WINDOWS_STORAGE_H_

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetHAL.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetHAL.cpp
@@ -58,6 +58,8 @@ void nanoHAL_Initialize()
 
     BlockStorageList_InitializeDevices();
 
+    Target_FileSystemInit();
+
     // clear managed heap region
     unsigned char* heapStart = NULL;
     unsigned int heapSize  = 0;

--- a/targets/os/win32/Include/Target_Windows_Storage.h
+++ b/targets/os/win32/Include/Target_Windows_Storage.h
@@ -1,0 +1,9 @@
+//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#ifndef _TARGET_WINDOWS_STORAGE_H_
+#define _TARGET_WINDOWS_STORAGE_H_ 1
+
+#endif  //_TARGET_WINDOWS_STORAGE_H_


### PR DESCRIPTION
## Description
- Moved call to Target_FileSystemInit() to nanoHAL_Initialize().
- Clean up main on CLR to free it from spefics of file system and storage.
- Add stubs for Windows Storage.
- Improve code for SD card monitor: now runs on its own thread.
- Improve code for USB MSD monitor.
- Add file system init call to ESP32.

## Motivation and Context
- Makes file system and storage initialization transparent to targets, not requiring any specifics on CLR main.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
