### PR TITLE
Fix API_Hardware.Stm32 option display text

### DIFF
--- a/CMake/Modules/NF_NativeAssemblies.cmake
+++ b/CMake/Modules/NF_NativeAssemblies.cmake
@@ -30,7 +30,7 @@ option(API_Hardware.Esp32                       "option for Hardware.Esp32")
 
 
 # Stm32 only
-option(API_Hardware.Stm32                       "option for Hardware.Esp32")
+option(API_Hardware.Stm32                       "option for Hardware.Stm32")
 
 
 #################################################################


### PR DESCRIPTION
## Description
Fix long-standing typo in option description.

## Motivation and Context
Option for Stm32 was displayed as Esp32 in cmake-gui


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: c-born <DavidAVarley@gmail.com>
