### PR TITLE
Fix cast on socket select.

### DIFF
--- a/src/PAL/Lwip/lwIP_Sockets.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets.cpp
@@ -613,7 +613,14 @@ int LWIP_SOCKETS_Driver::Select( int nfds, SOCK_fd_set* readfds, SOCK_fd_set* wr
     max_sd = LWIP_SOCKET_OFFSET + MEMP_NUM_NETCONN;
     #endif
 
-    ret = select(max_sd, pR, pW, pE, (struct timeval *)timeout);
+    // developer note: 
+    // our declaration of SOCK_timeval is dependent of "long" type which is platform dependent
+    // so it's not safe to cast it to "timeval"
+    timeval timeoutCopy;
+    timeoutCopy.tv_sec = timeout->tv_sec;
+    timeoutCopy.tv_usec = timeout->tv_usec;
+
+    ret = select(max_sd, pR, pW, pE, &timeoutCopy);
 
     MARSHAL_FDSET_TO_SOCK_FDSET(readfds  , pR);
     MARSHAL_FDSET_TO_SOCK_FDSET(writefds , pW);


### PR DESCRIPTION
## Description
- Add new variable with copy of timeout value.

## Motivation and Context
- The cast on the timeout parameter was causing issues on STM32 (ARM GCC 7.2) because the value on the second field was randomly being casted to a wrong value thus passing a wrong timeout to the select function. With this fix the platform type dependency is removed.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
