### PR TITLE
Add missing call to close sockets on nanoHAL_Uninitialize

### DIFF
--- a/src/PAL/nanoPAL_Network_stubs.cpp
+++ b/src/PAL/nanoPAL_Network_stubs.cpp
@@ -14,3 +14,8 @@ __nfweak bool  Network_Uninitialize()
 {
     return true;
 };
+
+__nfweak void SOCKETS_CloseConnections()
+{
+    NATIVE_PROFILE_PAL_COM();
+}

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL.cpp
@@ -71,6 +71,13 @@ void nanoHAL_Uninitialize()
     //     }
     // }   
 
+    SOCKETS_CloseConnections();
+
+  #if !defined(HAL_REDUCESIZE)
+    // TODO need to call this but it's preventing the debug session from starting
+    //Network_Uninitialize();
+  #endif
+
     BlockStorageList_UnInitializeDevices();
 
     // need to be sure that all mutexes for drivers that use them are released
@@ -142,9 +149,6 @@ void nanoHAL_Uninitialize()
     #endif
 
 #endif
-
-    // TODO need to call this but it's preventing the debug session from starting
-    //Network_Uninitialize();
 
     Events_Uninitialize();
     

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetHAL.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetHAL.cpp
@@ -93,13 +93,17 @@ void nanoHAL_Uninitialize()
             break;
         }
     }   
-    
+
+    SOCKETS_CloseConnections();
+
+  #if !defined(HAL_REDUCESIZE)
+    // TODO need to call this but it's preventing the debug session from starting
+    //Network_Uninitialize();
+  #endif
+ 
     BlockStorageList_UnInitializeDevices();
 
     //PalEvent_Uninitialize();
-
-    // TODO need to call this but it's preventing the debug session from starting
-    //Network_Uninitialize();
 
     Events_Uninitialize();
 


### PR DESCRIPTION
## Description
- Add missing call to close sockets on nanoHAL_Uninitialize.
- Add stub for SOCKETS_CloseConnections.

## Motivation and Context
- Without this any open socket would remain opened after CLR shutdown causing issues on the next execution. This is because the lwIP threads and network interface persist even after nanoHAL_Uninitialize. 
- STM32 ChibiOS still need a way to gracefully shutdown lwIP.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

