### PR TITLE
Add support for platform delay in CLR code

### DIFF
--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -237,7 +237,7 @@ bool SystemState_QueryNoLock( SYSTEM_STATE_type state );
 #define HAL_COMPLETION_IDLE_VALUE    0x0000FFFFFFFFFFFFull
 
 // provide platform dependent delay to CLR code
-#define PLATFORM_DELAY(milliSecs)
+#define OS_DELAY(milliSecs)         PLATFORM_DELAY(milliSecs)
 
 //--//
 // Function macros

--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -236,6 +236,9 @@ bool SystemState_QueryNoLock( SYSTEM_STATE_type state );
 
 #define HAL_COMPLETION_IDLE_VALUE    0x0000FFFFFFFFFFFFull
 
+// provide platform dependent delay to CLR code
+#define PLATFORM_DELAY(milliSecs)
+
 //--//
 // Function macros
 

--- a/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/targetHAL.h
@@ -14,6 +14,9 @@
 #define GLOBAL_UNLOCK(x);           chSysUnlock();
 #define ASSERT_IRQ_MUST_BE_OFF()    // TODO need to determine if this needs implementation
 
+// platform dependent delay
+#define PLATFORM_DELAY(milliSecs)   osDelay(milliSecs);
+
 // Definitions for Sockets/Network
 #define GLOBAL_LOCK_SOCKETS(x)       
 

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Include/targetHAL.h
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Include/targetHAL.h
@@ -14,6 +14,9 @@ extern portMUX_TYPE globalLockMutex;
 #define GLOBAL_UNLOCK(x)            portEXIT_CRITICAL(&globalLockMutex);
 #define ASSERT_IRQ_MUST_BE_OFF()   // TODO need to determine if this needs implementation
 
+// platform dependent delay
+#define PLATFORM_DELAY(milliSecs)   vTaskDelay(milliSecs);
+
 // Definitions for Sockets/Network
 #define GLOBAL_LOCK_SOCKETS(x)   
 


### PR DESCRIPTION
## Description
- Add support for platform delay in CLR code.
- Add implementation of PLATFORM_DELAY for STM32 and ESP32 platforms.

## Motivation and Context
- There are places in the CLR code (which has to be kept platform independent) that require a delay on the execution. Providing this call implemented at platform level makes that possible.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
