### PR TITLE
Add delay on changing debugging execution conditions

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1018,7 +1018,7 @@ bool CLR_DBG_Debugger::Debugging_Execution_ChangeConditions( WP_Message* msg)
 
     // updating the debugging execution conditions requires sometime to propagate
     // make sure we allow enough time for that to happen
-    PLATFORM_DELAY(100);
+    OS_DELAY(100);
 
     if((msg->m_header.m_flags & WP_Flags_c_NonCritical) == 0)
     {

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1016,7 +1016,7 @@ bool CLR_DBG_Debugger::Debugging_Execution_ChangeConditions( WP_Message* msg)
     g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions |=  cmd->FlagsToSet;
     g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions &= ~cmd->FlagsToReset;
 
-    // updating the debugger conditions requires sometime to propagate
+    // updating the debugging execution conditions requires sometime to propagate
     // make sure we allow enough time for that to happen
     PLATFORM_DELAY(100);
 

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1016,6 +1016,10 @@ bool CLR_DBG_Debugger::Debugging_Execution_ChangeConditions( WP_Message* msg)
     g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions |=  cmd->FlagsToSet;
     g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions &= ~cmd->FlagsToReset;
 
+    // updating the debugger conditions requires sometime to propagate
+    // make sure we allow enough time for that to happen
+    PLATFORM_DELAY(100);
+
     if((msg->m_header.m_flags & WP_Flags_c_NonCritical) == 0)
     {
         CLR_DBG_Commands::Debugging_Execution_ChangeConditions::Reply cmdReply;

--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -237,7 +237,11 @@ bool SystemState_QueryNoLock( SYSTEM_STATE_type state );
 #define HAL_COMPLETION_IDLE_VALUE    0x0000FFFFFFFFFFFFull
 
 // provide platform dependent delay to CLR code
+#if defined(_WIN32)
+#define OS_DELAY(milliSecs);
+#else
 #define OS_DELAY(milliSecs)         PLATFORM_DELAY(milliSecs)
+#endif
 
 //--//
 // Function macros

--- a/targets/os/win32/Include/targetHAL.h
+++ b/targets/os/win32/Include/targetHAL.h
@@ -43,6 +43,7 @@ inline bool Target_ConfigUpdateRequiresErase()
 
 #endif  // !defined(BUILD_RTM)
 
+
 inline bool Target_HasNanoBooter() { return false; };
 
 #endif //_TARGET_HAL_H_


### PR DESCRIPTION
## Description
- Add delay on changing debugging execution conditions.
- Add WIN32 platform definition for PLATFORM_WAIT.

## Motivation and Context
-  Updating the debugging execution conditions requires sometime to propagate. Adding this makes sure we allow enough time for that to happen.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>