### PR TITLE
Update block storage definition for ESP32

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/Device_BlockStorage-2mb.c
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/Device_BlockStorage-2mb.c
@@ -13,19 +13,19 @@
 const BlockRange BlockRange1[] =
 {
     // factory
-    { BlockRange_BLOCKTYPE_CODE      ,   1, 15 },            // 0x010000   nanoCLR
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 1 },             // 0x010000   nanoCLR
 };
 
 const BlockRange BlockRange2[] =
 {
     // deploy
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 5 },             // 0x110000   deployment  
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 0 },             // 0x110000   deployment  
 };
 
 const BlockRange BlockRange3[] =
 {
     // config
-    { BlockRange_BLOCKTYPE_CONFIG    ,   0, 1 }             // 0x2D0000   config
+    { BlockRange_BLOCKTYPE_CONFIG    ,   0, 0 }              // 0x2D0000   config
 };
 
 const BlockRegionInfo BlockRegions[] = 
@@ -33,8 +33,8 @@ const BlockRegionInfo BlockRegions[] =
     {
         (0),                                // no attributes for this region
         0x010000,                           // start address for block region
-        16,                                 // total number of blocks in this region
-        0x10000,  //  64K                   // total number of bytes per block
+        1,                                  // total number of blocks in this region
+        0x100000,                           // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange1),
         BlockRange1,
     },
@@ -42,8 +42,8 @@ const BlockRegionInfo BlockRegions[] =
     {
         (BlockRegionAttribute_MemoryMapped),    // this region is memory mapped
         0x110000,                               // start address for block region
-        6,                                      // total number of blocks in this region
-        0x10000,  //  64K                       // total number of bytes per block
+        1,                                      // total number of blocks in this region
+        0x70000,                                // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange2),
         BlockRange2,
     },
@@ -51,8 +51,8 @@ const BlockRegionInfo BlockRegions[] =
     {
         (0),                                // no attributes for this region
         0x0,                                // start address for block region
-        2,                                  // total number of blocks in this region
-        0x10000,  //  64K                   // total number of bytes per block
+        1,                                  // total number of blocks in this region
+        0x10000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange3),
         BlockRange3,
     }

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/Device_BlockStorage-4mb.c
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/Device_BlockStorage-4mb.c
@@ -13,19 +13,19 @@
 const BlockRange BlockRange1[] =
 {
     // factory
-    { BlockRange_BLOCKTYPE_CODE      ,   1, 15 },            // 0x010000   nanoCLR
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 },             // 0x010000   nanoCLR
 };
 
 const BlockRange BlockRange2[] =
 {
     // deploy
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 27 },            // 0x110000   deployment  
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 0 },             // 0x110000   deployment  
 };
 
 const BlockRange BlockRange3[] =
 {
     // config
-    { BlockRange_BLOCKTYPE_CONFIG    ,   0, 3 }             // 0x2D0000   config
+    { BlockRange_BLOCKTYPE_CONFIG    ,   0, 0 }              // 0x2D0000   config
 };
 
 const BlockRegionInfo BlockRegions[] = 
@@ -33,8 +33,8 @@ const BlockRegionInfo BlockRegions[] =
     {
         (0),                                // no attributes for this region
         0x010000,                           // start address for block region (initially this is set as the partition start address)
-        16,                                 // total number of blocks in this region
-        0x10000,  //  64K                   // total number of bytes per block
+        1,                                  // total number of blocks in this region
+        0x100000,                           // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange1),
         BlockRange1
     },
@@ -42,8 +42,8 @@ const BlockRegionInfo BlockRegions[] =
     {
         (BlockRegionAttribute_MemoryMapped),    // this region is memory mapped
         0x110000,                               // start address for block region (initially this is set as the partition start address)
-        28,                                     // total number of blocks in this region
-        0x10000,  //  64K                       // total number of bytes per block
+        1,                                      // total number of blocks in this region
+        0x1C0000,                               // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange2),
         BlockRange2
     },
@@ -51,8 +51,8 @@ const BlockRegionInfo BlockRegions[] =
     {
         (0),                                // no attributes for this region
         0x2D0000,                           // start address for block region (initially this is set as the partition start address)
-        4,                                  // total number of blocks in this region
-        0x10000,  //  64K                   // total number of bytes per block
+        1,                                  // total number of blocks in this region
+        0x40000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange3),
         BlockRange3
     }


### PR DESCRIPTION
## Description
- Update block storage definition for ESP32 to have blocks matching partition map.

## Motivation and Context
- The erase operation is performed using EPS32 API. With the block storage definition using the traditional block sector causes this operation to be called over and over with an incredible timing penalty. Using a definition with the full size of the partition as a block overcomes this and does not cause any other issues with the other operations (check erase and write).
- Addresses nanoFramework/Home#465.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
