### PR TITLE
Disable Starting Smart config Thread

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Esp32_Wireless.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Esp32_Wireless.cpp
@@ -101,7 +101,11 @@ int  Esp32_Wireless_Open(int index, HAL_Configuration_NetworkInterface * pConfig
 	{
 		// Start Samrt config (if enabled (TODO) )
 		// probably best to have a config flag for this, but for now just start if no Wireless config set up
-		Start_wifi_smart_config();
+	
+		// FIXME
+		// Disable for now, When the smart_config starts it scans for wireless AP
+		// If it doesn't find any AP it ends up with a exception which causes the device to restart
+		//Start_wifi_smart_config();
 	}	
 
 	return Esp32_Wait_NetNumber(ESP_IF_WIFI_STA);


### PR DESCRIPTION
## Description
This disables the starting of the Smart Config Thread.
This is to stop ESP32 getting exceptions when no wireless Access Points found.
Happens about 5 seconds after device booted.

Once fixed will enable again. 
It looks like an IDF problem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
