### PR TITLE
Add state flag to signal failure in type load and/or resolution

### DIFF
--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -2819,6 +2819,7 @@ struct CLR_RT_ExecutionEngine
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     static const int                    c_fDebugger_StateInitialize          = 0x00000000;
+    static const int                    c_fDebugger_StateResolutionFailed    = 0x00000001;
     static const int                    c_fDebugger_StateProgramRunning      = 0x00000400;
     static const int                    c_fDebugger_StateProgramExited       = 0x00000800;
     static const int                    c_fDebugger_StateMask                = c_fDebugger_StateProgramRunning + c_fDebugger_StateProgramExited;

--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -107,6 +107,9 @@ struct Settings
     {
         NANOCLR_HEADER();
 
+        // cler flag, in case EE wasn't restarted
+        CLR_EE_DBG_CLR(StateResolutionFailed);
+
 #if !defined(BUILD_RTM)
         CLR_Debug::Printf( "Create TS.\r\n" );
 #endif
@@ -116,7 +119,7 @@ struct Settings
         CLR_Debug::Printf( "Loading Deployment Assemblies.\r\n" );
 #endif
 
-        LoadDeploymentAssemblies();
+        NANOCLR_CHECK_HRESULT(LoadDeploymentAssemblies());
 
         //--//
 
@@ -134,7 +137,13 @@ struct Settings
         NANOCLR_CLEANUP();
 
 #if !defined(BUILD_RTM)
-        if(FAILED(hr)) CLR_Debug::Printf( "Error: %08x\r\n", hr );
+        if(FAILED(hr))
+        {
+            CLR_Debug::Printf( "Error: %08x\r\n", hr );
+
+            // exception occurred in assembly loading or type resolution
+            CLR_EE_DBG_SET(StateResolutionFailed);
+        }
 #endif
 
         NANOCLR_CLEANUP_END();
@@ -318,7 +327,7 @@ struct Settings
             NANOCLR_SET_AND_LEAVE(CLR_E_NOT_SUPPORTED);
         }
 
-        ContiguousBlockAssemblies(stream);
+        NANOCLR_CHECK_HRESULT(ContiguousBlockAssemblies(stream));
         
         NANOCLR_NOCLEANUP();
     }


### PR DESCRIPTION
## Description
- Add StateResolutionFailed flag to EE debug conditions.
- Add missing check results to several calls.

## Motivation and Context
- Need a way to signal to the debugger that type load or resolution has failed. Currently that situation is output on console messages that can be either missed by VS output or completely hidden on targets that can't output those messages properly.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
