### PR TITLE
Revert changes in FindBuildUtils

### DIFF
--- a/CMake/Modules/FindBuildUtils.cmake
+++ b/CMake/Modules/FindBuildUtils.cmake
@@ -46,7 +46,7 @@ function(NF_GENERATE_BUILD_OUTPUT_FILES TARGET)
                 COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${TARGET_SHORT}.elf> ${TARGET_BIN_FILE}
 
                 # copy target file to build folder (this is only usefull for debugging in VS Code because of path in launch.json)
-                #COMMAND ${CMAKE_OBJCOPY} $<TARGET_FILE:${TARGET_SHORT}.elf> ${PROJECT_SOURCE_DIR}/build/${TARGET_SHORT}.elf
+                COMMAND ${CMAKE_OBJCOPY} $<TARGET_FILE:${TARGET_SHORT}.elf> ${PROJECT_SOURCE_DIR}/build/${TARGET_SHORT}.elf
 
                 COMMENT "Generate nanoBooter HEX and BIN files for deployment")
 
@@ -59,7 +59,7 @@ function(NF_GENERATE_BUILD_OUTPUT_FILES TARGET)
                 COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${TARGET_SHORT}.elf> ${TARGET_BIN_FILE}
 
                 # copy target file to build folder (this is only usefull for debugging in VS Code because of path in launch.json)
-                #COMMAND ${CMAKE_OBJCOPY} $<TARGET_FILE:${TARGET_SHORT}.elf> ${PROJECT_SOURCE_DIR}/build/${TARGET_SHORT}.elf
+                COMMAND ${CMAKE_OBJCOPY} $<TARGET_FILE:${TARGET_SHORT}.elf> ${PROJECT_SOURCE_DIR}/build/${TARGET_SHORT}.elf
 
                 # dump target image as source code listing 
                 # ONLY when DEBUG info is available, this is on 'Debug' and 'RelWithDebInfo'


### PR DESCRIPTION
## Description
- Remove comment on commands copying the ELF to the build folder root.

## Motivation and Context
- Can't remove these commands without having the nF VS Code extension working and templates updated.

CC: @c-born 