### PR TITLE
Fix DMA conflict on STM32F429_DISCO

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/mcuconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/mcuconf.h
@@ -302,7 +302,7 @@
 #define STM32_UART_USE_USART1               TRUE
 #define STM32_UART_USE_USART2               FALSE
 #define STM32_UART_USE_USART3               TRUE
-#define STM32_UART_USE_UART4                TRUE
+#define STM32_UART_USE_UART4                FALSE
 #define STM32_UART_USE_UART5                FALSE
 #define STM32_UART_USE_USART6               TRUE
 #define STM32_UART_USART1_RX_DMA_STREAM     STM32_DMA_STREAM_ID(2, 5)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_nf_devices_onewire_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_nf_devices_onewire_config.cpp
@@ -7,14 +7,15 @@
 #include <nf_devices_onewire_native.h>
 
 ///////////
-// UART4 //
+// UART6 //
 ///////////
 
-// pin configuration for UART4
+// pin configuration for UART6
 // port for TX pin is: GPIOC
-// TX pin: is GPIOC_10
-// GPIO alternate pin function is 8 (see "Table 9. STM32F405xx and STM32F407xx alternate function mapping" in STM32F405xx/STM32F407xx datasheet)
-UART_CONFIG_PINS(4, GPIOC, 10, 8)
+// TX pin: is GPIOC_6
+// GPIO alternate pin function is 8 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
+UART_CONFIG_PINS(6, GPIOC, 6, 8)
+
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -22,8 +23,8 @@ UART_CONFIG_PINS(4, GPIOC, 10, 8)
 #if defined(__GNUC__)
 __attribute__((aligned (32)))
 #endif
-uint8_t Uart4_TxBuffer[UART4_TX_SIZE];
+uint8_t Uart6_TxBuffer[UART6_TX_SIZE];
 #if defined(__GNUC__)
 __attribute__((aligned (32)))
 #endif
-uint8_t Uart4_RxBuffer[UART4_RX_SIZE];
+uint8_t Uart6_RxBuffer[UART6_RX_SIZE];

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_nf_devices_onewire_config.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_nf_devices_onewire_config.h
@@ -4,14 +4,14 @@
 //
 
 ///////////
-// UART4 //
+// UART6 //
 ///////////
 
 // enable USART4
-#define NF_ONEWIRE_STM32_UART_USE_USART4    TRUE
+#define NF_ONEWIRE_STM32_UART_USE_USART6    TRUE
 
 // buffers size
 // tx buffer size: 32 bytes
-#define UART4_TX_SIZE  32
+#define UART6_TX_SIZE  32
 // rx buffer size: 32 bytes
-#define UART4_RX_SIZE  32
+#define UART6_RX_SIZE  32

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_serialcommunication_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_serialcommunication_config.cpp
@@ -66,35 +66,3 @@ UART_INIT(3, UART3_TX_SIZE, UART3_RX_SIZE)
 
 // un-initialization for UART3
 UART_UNINIT(3)
-
-
-///////////
-// UART6 //
-///////////
-
-// pin configuration for UART6
-// port for TX pin is: GPIOC
-// port for RX pin is: GPIOC
-// TX pin: is GPIOC_6
-// RX pin: is GPIOC_7
-// GPIO alternate pin function is 8 (see "Table 12. STM32F427xx and STM32F429xx alternate function mapping" in STM32F427xx and STM32F429xx datasheet)
-UART_CONFIG_PINS(6, GPIOC, GPIOC, 6, 7, 8)
-
-// buffers
-// buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
-// because of issues with cache coherency and DMA (this is particularly important with Cortex-M7 because of cache)
-#if defined(__GNUC__)
-__attribute__((aligned (32)))
-#endif
-uint8_t Uart6_TxBuffer[UART6_TX_SIZE];
-
-#if defined(__GNUC__)
-__attribute__((aligned (32)))
-#endif
-uint8_t Uart6_RxBuffer[UART6_RX_SIZE];
-
-// initialization for UART6
-UART_INIT(6, UART6_TX_SIZE, UART6_RX_SIZE)
-
-// un-initialization for UART6
-UART_UNINIT(6)

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_serialcommunication_config.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_windows_devices_serialcommunication_config.h
@@ -29,17 +29,3 @@
 #define UART3_TX_SIZE  256
 // rx buffer size: 256 bytes
 #define UART3_RX_SIZE  256
-
-
-///////////
-// UART6 //
-///////////
-
-// enable USART6
-#define NF_SERIAL_COMM_STM32_UART_USE_USART6    TRUE
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART6_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART6_RX_SIZE  256


### PR DESCRIPTION
## Description
- Remove UART6 from serial.
- Replace UART4 with UART6 in 1-Wire configuration.

## Motivation and Context
- Can't use UART4 and I2C3 simultaneously.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
