### PR TITLE
 Add support for nanoBooter on MIMXRT1060

### DIFF
--- a/targets/FreeRTOS/NXP_MIMXRT1060_EVK/common/Device_BlockStorage.c
+++ b/targets/FreeRTOS/NXP_MIMXRT1060_EVK/common/Device_BlockStorage.c
@@ -14,12 +14,12 @@ const BlockRange BlockRange0[] = // 4KB blocks
 
 const BlockRange BlockRange1[] = // 4KB blocks
 {
-    { BlockRange_BLOCKTYPE_CODE,   0, 0xFD }                    // 0x60002000 nanoCLR  
+    { BlockRange_BLOCKTYPE_CODE,   0, 0xFD }                    // 0x60100000 nanoCLR  
 };
 
 const BlockRange BlockRange2[] = // 4KB blocks
 {
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 0xFF }             // 0x60100000 deployment  
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 0xFF }             // 0x60200000 deployment  
 };
 
 const BlockRegionInfo BlockRegions[] = 
@@ -36,7 +36,7 @@ const BlockRegionInfo BlockRegions[] =
     {
         (0),                            // no attributes for this region
         // Allocated in nanoCLR partition 1M
-        0x60002000,                     // start address for block region
+        0x60102000,                     // start address for block region
         0xFE,                           // total number of blocks in this region
         0x1000,   //  4K                // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange1),
@@ -46,7 +46,7 @@ const BlockRegionInfo BlockRegions[] =
     {
         (0),                                // no attributes for this region
         // Allocated in Deployment partition 1M
-        0x60100000,                         // start address for block region
+        0x60200000,                         // start address for block region
         0x100,                              // total number of blocks in this region
         0x1000,   //  4K                    // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange2),

--- a/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoBooter/MIMXRT10xx.ld
+++ b/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoBooter/MIMXRT10xx.ld
@@ -17,7 +17,7 @@ MEMORY
 {
   /* Define each memory region */
   BOARD_FLASH (rx) : ORIGIN = 0x60000000, LENGTH = 0x100000 /* 1M bytes (alias Flash) */  
-  DEPLOYMENT_FLASH (rx) : ORIGIN = 0x60100000, LENGTH = 0x100000 /* 1M bytes */  
+  DEPLOYMENT_FLASH (rx) : ORIGIN = 0x60200000, LENGTH = 0x100000 /* 1M bytes */  
   SRAM_DTC (rwx) : ORIGIN = 0x20000000, LENGTH = 0x20000 /* 128K bytes (alias RAM) */  
   SRAM_ITC (rwx) : ORIGIN = 0x0, LENGTH = 0x20000 /* 128K bytes (alias RAM2) */  
   SRAM_OC (rwx) : ORIGIN = 0x20200000, LENGTH = 0xc0000 /* 768K bytes (alias RAM3) */  

--- a/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoBooter/main.c
+++ b/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoBooter/main.c
@@ -38,8 +38,33 @@ static void blink_task(void *pvParameters)
 
     for (;;)
     {
-        vTaskDelay(1000);
+        vTaskDelay(100);
         GPIO_PortToggle(LED_GPIO, 1u << LED_GPIO_PIN);
+        vTaskDelay(500);
+        GPIO_PortToggle(LED_GPIO, 1u << LED_GPIO_PIN);
+    }
+}
+
+static void  boot_nanoCLR(void){
+
+    uint32_t button = 1;
+
+    /* Define the init structure for the input button pin*/
+    gpio_pin_config_t button_config = {kGPIO_DigitalInput, 0, kGPIO_NoIntmode};
+
+     /* Init input GPIO*/
+    GPIO_PinInit(BOARD_USER_BUTTON_GPIO, BOARD_USER_BUTTON_GPIO_PIN, &button_config);
+    button = GPIO_PinRead(BOARD_USER_BUTTON_GPIO,BOARD_USER_BUTTON_GPIO_PIN);
+
+    /* Load nanoCLR if button is not pressed else init reciver Task */
+    if (button) 
+    {
+        void (*nanoCLR)(void);
+        nanoCLR = (void *) *((uint32_t *) 0x60102004);
+        nanoCLR();
+    } 
+    else 
+    {
     }
 }
 
@@ -49,23 +74,24 @@ int main(void)
     BOARD_InitBootClocks();
     BOARD_InitBootPeripherals();
 
-    SCB_DisableDCache();
+   // SCB_DisableDCache();
 
     for (volatile uint32_t i = 0; i < 100000000; i++) {
         __asm("nop");
     }
 
-    iMXRTFlexSPIDriver_InitializeDevice(NULL);
+    boot_nanoCLR();
 
+    iMXRTFlexSPIDriver_InitializeDevice(NULL);
+    
     // initialize block storage list and devices
     // in CLR this is called in nanoHAL_Initialize()
     // for nanoBooter we have to init it in order to provide the flash map for Monitor_FlashSectorMap command
     BlockStorageList_Initialize();
-    BlockStorage_AddDevices();
+    BlockStorage_AddDevices();    
 
     xTaskCreate(blink_task, "blink_task", configMINIMAL_STACK_SIZE + 10, NULL, configMAX_PRIORITIES - 1, NULL);
     xTaskCreate(ReceiverThread, "ReceiverThread", 2048, NULL, configMAX_PRIORITIES - 1, NULL);
-    
     vTaskStartScheduler();
 
     for (;;)

--- a/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoBooter/main.c
+++ b/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoBooter/main.c
@@ -54,18 +54,16 @@ static void  boot_nanoCLR(void){
 
      /* Init input GPIO*/
     GPIO_PinInit(BOARD_USER_BUTTON_GPIO, BOARD_USER_BUTTON_GPIO_PIN, &button_config);
-    button = GPIO_PinRead(BOARD_USER_BUTTON_GPIO,BOARD_USER_BUTTON_GPIO_PIN);
+    button = GPIO_PinRead(BOARD_USER_BUTTON_GPIO, BOARD_USER_BUTTON_GPIO_PIN);
 
-    /* Load nanoCLR if button is not pressed else init reciver Task */
+    /* Button is active low.
+       Load nanoCLR program through resetISR or if button is pressed init reciver Task */
     if (button) 
     {
         void (*nanoCLR)(void);
-        nanoCLR = (void *) *((uint32_t *) 0x60102004);
+        nanoCLR = (void *) *((uint32_t *) 0x60102004); // resetISR address
         nanoCLR();
     } 
-    else 
-    {
-    }
 }
 
 int main(void)

--- a/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoCLR/MIMXRT10xx.ld
+++ b/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoCLR/MIMXRT10xx.ld
@@ -16,8 +16,8 @@ GROUP (
 MEMORY
 {
   /* Define each memory region */
-  BOARD_FLASH (rx) : ORIGIN = 0x60000000, LENGTH = 0x100000 /* 1M bytes (alias Flash) */  
-  DEPLOYMENT_FLASH (rx) : ORIGIN = 0x60100000, LENGTH = 0x100000 /* 1M bytes */  
+  BOARD_FLASH (rx) : ORIGIN = 0x60100000, LENGTH = 0x100000 /* 1M bytes (alias Flash) */  
+  DEPLOYMENT_FLASH (rx) : ORIGIN = 0x60200000, LENGTH = 0x100000 /* 1M bytes */  
   SRAM_DTC (rwx) : ORIGIN = 0x20000000, LENGTH = 0x20000 /* 128K bytes (alias RAM) */  
   SRAM_ITC (rwx) : ORIGIN = 0x0, LENGTH = 0x20000 /* 128K bytes (alias RAM2) */  
   SRAM_OC (rwx) : ORIGIN = 0x20200000, LENGTH = 0xc0000 /* 768K bytes (alias RAM3) */  
@@ -46,7 +46,7 @@ MEMORY
   __top_BOARD_SDRAM = 0x80000000 + 0x2000000 ; /* 32M bytes */  
   __top_RAM4 = 0x80000000 + 0x2000000 ; /* 32M bytes */  
 
-__flash_start__         = ORIGIN(BOARD_FLASH);
+__flash_start__         = __base_BOARD_FLASH;
 __nanoImage_start__     = ORIGIN(BOARD_FLASH);
 __nanoImage_size__      = LENGTH(BOARD_FLASH);
 __nanoImage_end__       = __nanoImage_start__ + __nanoImage_size__;

--- a/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoCLR/main.c
+++ b/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoCLR/main.c
@@ -25,6 +25,26 @@
 __attribute__((section(".noinit.$SRAM_OC.ucHeap")))
 uint8_t ucHeap[configTOTAL_HEAP_SIZE];
 
+#define LED_GPIO GPIO1
+#define LED_GPIO_PIN (9U)
+
+static void blink_task(void *pvParameters)
+{
+    (void)pvParameters;
+
+    /* Define the init structure for the output LED pin*/
+    gpio_pin_config_t led_config = {kGPIO_DigitalOutput, 0, kGPIO_NoIntmode};
+
+    /* Init output LED GPIO. */
+    GPIO_PinInit(LED_GPIO, LED_GPIO_PIN, &led_config);
+
+    for (;;)
+    {
+        vTaskDelay(1000);
+        GPIO_PortToggle(LED_GPIO, 1u << LED_GPIO_PIN);
+    }
+}
+
 int main(void)
 {
     BOARD_InitBootPins();
@@ -40,6 +60,8 @@ int main(void)
     }
 
     iMXRTFlexSPIDriver_InitializeDevice(NULL);
+
+    xTaskCreate(blink_task, "blink_task", configMINIMAL_STACK_SIZE + 10, NULL, configMAX_PRIORITIES - 1, NULL);
     
     xTaskCreate(ReceiverThread, "ReceiverThread", 2048, NULL, configMAX_PRIORITIES - 1, NULL);
     xTaskCreate(CLRStartupThread, "CLRStartupThread", 8192, NULL, configMAX_PRIORITIES - 2, NULL);

--- a/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoCLR/main.c
+++ b/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoCLR/main.c
@@ -28,23 +28,6 @@ uint8_t ucHeap[configTOTAL_HEAP_SIZE];
 #define LED_GPIO GPIO1
 #define LED_GPIO_PIN (9U)
 
-static void blink_task(void *pvParameters)
-{
-    (void)pvParameters;
-
-    /* Define the init structure for the output LED pin*/
-    gpio_pin_config_t led_config = {kGPIO_DigitalOutput, 0, kGPIO_NoIntmode};
-
-    /* Init output LED GPIO. */
-    GPIO_PinInit(LED_GPIO, LED_GPIO_PIN, &led_config);
-
-    for (;;)
-    {
-        vTaskDelay(1000);
-        GPIO_PortToggle(LED_GPIO, 1u << LED_GPIO_PIN);
-    }
-}
-
 int main(void)
 {
     BOARD_InitBootPins();
@@ -60,8 +43,6 @@ int main(void)
     }
 
     iMXRTFlexSPIDriver_InitializeDevice(NULL);
-
-    xTaskCreate(blink_task, "blink_task", configMINIMAL_STACK_SIZE + 10, NULL, configMAX_PRIORITIES - 1, NULL);
     
     xTaskCreate(ReceiverThread, "ReceiverThread", 2048, NULL, configMAX_PRIORITIES - 1, NULL);
     xTaskCreate(CLRStartupThread, "CLRStartupThread", 8192, NULL, configMAX_PRIORITIES - 2, NULL);


### PR DESCRIPTION
<!--- Add support for nanoBooter on MIMXRT1060 -->
 Add support for nanoBooter on MIMXRT1060

## Description
<!---    -->
Changed linkerscript to store in flash two programs simultaneously in different location. 
nanoBooter - 0x60000000 
nanoCLR - 0x60100000. 
Deployment area is now in 0x60200000.
NanoBooter checks if button is pressed and when it's not it loads nanoCLR.

## Motivation and Context
<!--- -->
 It adds bootloader functionality.

## How Has This Been Tested?<!-- (if applicable) -->
<!----->
 I've tested nanoBooter, it loads from flash memory startup script of nanoCLR. When I press the button after reset, reciverThread is started and I'm able to erase deployment area or flash new  through Visual Studio. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: morali <jeremi.jasinski@gmail.com>
