### PR TITLE
Work on SNTP for CC3220SF

### DIFF
--- a/targets/TI-SimpleLink/TI_CC3220SF_LAUNCHXL/target_sntp_opts.h
+++ b/targets/TI-SimpleLink/TI_CC3220SF_LAUNCHXL/target_sntp_opts.h
@@ -13,12 +13,12 @@
 // Must wait at least 15 sec to retry NTP server (RFC 4330)
 #define SNTP_UPDATE_DELAY       (60 * 60)
 
-// better have a startup delay because we can have DHCP enabled (default 30 seconds)
+// no startup delay for SNTP
 // value in seconds
-#define SNTP_STARTUP_DELAY      30
+#define SNTP_STARTUP_DELAY      (0)
 
-// retry timeout (15 minutes)
+// retry timeout
 // value in seconds
-#define SNTP_RETRY_TIMEOUT      (15 * 60)
+#define SNTP_RETRY_TIMEOUT      (10)
 
 #endif // _TARGET_SNTP_OPTS_H_

--- a/targets/TI-SimpleLink/nanoCLR/targetSimpleLinkCC32xx_Sntp.c
+++ b/targets/TI-SimpleLink/nanoCLR/targetSimpleLinkCC32xx_Sntp.c
@@ -35,7 +35,7 @@ void sntp_init(void)
         pthread_attr_init(&threadAttributes);
         priorityParams.sched_priority = 1;
         retc = pthread_attr_setschedparam(&threadAttributes, &priorityParams);
-        retc |= pthread_attr_setstacksize(&threadAttributes, 2048);
+        retc |= pthread_attr_setstacksize(&threadAttributes, 1024);
         if (retc != 0)
         {
             // failed to set attributes
@@ -324,6 +324,12 @@ void* SntpWorkingThread(void* argument)
     timeval.tv_sec = NTP_REPLY_WAIT_TIME;
     timeval.tv_usec = 0;
 
+    // delay 1st request, if configured
+    if(SNTP_STARTUP_DELAY > 0)
+    {
+        sleep(SNTP_STARTUP_DELAY);
+    }
+
     while(1)
     {
         // Get the time use the SNTP_ServersList
@@ -333,6 +339,9 @@ void* SntpWorkingThread(void* argument)
         {
             // sleep before retrying
             sleep(SNTP_RETRY_TIMEOUT);
+
+            // retry, starting over
+            continue;
         }
 
         currentTime = ntpTimeStamp >> 32;


### PR DESCRIPTION
## Description
- Add missing sleep to execute start delay before 1st request.
- Fix bug with retry workflow, wasn't starting over after sleep.
- Zeroed start delay in target configuration.
- Changed retry time to 10 seconds.
- Reduced stack size of SNTP working thread.

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
