### PR TITLE
Rework SNTP worker thread

### DIFF
--- a/targets/TI-SimpleLink/Include/targetSimpleLinkCC32xx_Threads.h
+++ b/targets/TI-SimpleLink/Include/targetSimpleLinkCC32xx_Threads.h
@@ -21,6 +21,8 @@
 
 
 #define SL_STOP_TIMEOUT         (200)
+#define NF_TASK_PRIORITY        (5)
+
 
 #define ERR_PRINT(x) 
 


### PR DESCRIPTION
## Description
- Replace calls to sleep to platform API.
- Rework code to check for IP aquired instead of just connected to AP.
- Code now waits for connection event instead of simple sleep.
- SNTP thread now uses same priority as other nF threads.

## Motivation and Context
- Improves SNTP thread.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
