### PR TITLE
Fix alarm wakeup for STM32F7

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
@@ -111,8 +111,14 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
           #endif
 
           #if defined(STM32F7XX)
-            SET_BIT(RTC->CR, RTC_CR_ALRAIE);
+            
+            //////////////////////////////////////////////////////////////////////////////////////////////////////
+            // workaround recommended in section 2.2.2 at STM32F77xxx errata document (DM00257543 - ES0334 Rev 5) //
+            PWR->CSR1 |= PWR_CSR1_EIWUP;
+            //////////////////////////////////////////////////////////////////////////////////////////////////////
+
             SET_BIT(PWR->CR1, PWR_CR1_PDDS);
+
           #endif
 
           #if defined(STM32H7XX)


### PR DESCRIPTION
## Description
- Fix alarm wakeup for STM32F7.

## Motivation and Context
- Wakeup from alarm wasn't working on STM32F7 series. Had to implement workaround suggested in STM errata for this series.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
