### PR TITLE
Fixed storage error handling in NXP IMXRT1060 port

### DIFF
--- a/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
+++ b/targets/FreeRTOS/NXP_MIMXRT1060_EVK/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
@@ -249,15 +249,15 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::WriteBytes___STATIC__
         {
             // event occurred
 
-            if(operationResult == FR_DISK_ERR)
+            if(threadOperationResult == FR_DISK_ERR)
             {
                 NANOCLR_SET_AND_LEAVE( CLR_E_FILE_IO );
             }
-            else if(operationResult == FR_NO_FILE)
+            else if(threadOperationResult == FR_NO_FILE)
             {
                 NANOCLR_SET_AND_LEAVE( CLR_E_FILE_NOT_FOUND );
             }
-            else if(operationResult == FR_INVALID_DRIVE)
+            else if(threadOperationResult == FR_INVALID_DRIVE)
             {
                 // failed to change drive
                 NANOCLR_SET_AND_LEAVE(CLR_E_VOLUME_NOT_FOUND);
@@ -498,15 +498,15 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::ReadBufferNative___ST
         {
             // event occurred
 
-            if(operationResult == FR_DISK_ERR)
+            if(threadOperationResult == FR_DISK_ERR)
             {
                 NANOCLR_SET_AND_LEAVE( CLR_E_FILE_IO );
             }
-            else if(operationResult == FR_NO_FILE)
+            else if(threadOperationResult == FR_NO_FILE)
             {
                 NANOCLR_SET_AND_LEAVE( CLR_E_FILE_NOT_FOUND );
             }
-            else if(operationResult == FR_INVALID_DRIVE)
+            else if(threadOperationResult == FR_INVALID_DRIVE)
             {
                 // failed to change drive
                 NANOCLR_SET_AND_LEAVE(CLR_E_VOLUME_NOT_FOUND);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In some cases where file operation thread was spawned error handling was not done correctly

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with Storage samples

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
