### PR TITLE
Work on I2C native

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
@@ -40,7 +40,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID,
-    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::DisposeNative___VOID,
+    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose___VOID__BOOLEAN,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1,
     NULL,
     NULL,
@@ -59,7 +59,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_I2c =
 {
     "Windows.Devices.I2c", 
-    0xA44C698B,
+    0x96C7514F,
     method_lookup,
-    { 1, 1, 3, 1 }
+    { 1, 2, 0, 0 }
 };

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
@@ -53,7 +53,7 @@ struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice
     static const int FIELD___disposed = 4;
 
     NANOCLR_NATIVE_DECLARE(NativeInit___VOID);
-    NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
+    NANOCLR_NATIVE_DECLARE(NativeDispose___VOID__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1);
 
     //--//

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -236,15 +236,73 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::DisposeNative___VOID( CLR_RT_StackFrame& stack )
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose___VOID__BOOLEAN( CLR_RT_StackFrame& stack )
 {
-    (void)stack;
-
     NANOCLR_HEADER();
-    {
 
+    uint8_t busIndex;
+    bool disposeController = false;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+
+    // get disposeController
+    disposeController = (bool)stack.Arg0().NumericByRef().u1;
+
+    if(disposeController)
+    {
+        // get bus index
+        // this is coded with a multiplication, need to perform and int division to get the number
+        // see the comments in the I2cDevice() constructor in managed code for details
+        busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
+
+        // get the driver for the I2C bus
+        switch (busIndex)
+        {
+          #if STM32_I2C_USE_I2C1
+            case 1 :
+                // deactivates the I2C peripheral
+                i2cStop(&I2CD1);
+                // nulls driver
+                I2C1_PAL.Driver = NULL;
+                break;
+          #endif
+
+          #if STM32_I2C_USE_I2C2
+            case 2 :
+                // deactivates the I2C peripheral
+                i2cStop(&I2CD2);
+                // nulls driver
+                I2C2_PAL.Driver = NULL;
+                break;
+          #endif
+
+          #if STM32_I2C_USE_I2C3
+            case 3 :
+                // deactivates the I2C peripheral
+                i2cStop(&I2CD3);
+                // nulls driver
+                I2C3_PAL.Driver = NULL;
+                break;
+          #endif
+
+          #if STM32_I2C_USE_I2C4
+            case 4 :
+                // deactivates the I2C peripheral
+                i2cStop(&I2CD4);
+                // nulls driver
+                I2C4_PAL.Driver = NULL;
+                break;
+          #endif
+
+            default:
+                // the requested I2C bus is not valid
+                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+                break;
+        }
     }
-    NANOCLR_NOCLEANUP_NOLABEL();
+
+    NANOCLR_NOCLEANUP();
 }
 
 HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1( CLR_RT_StackFrame& stack )

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
@@ -40,7 +40,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID,
-    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::DisposeNative___VOID,
+    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose___VOID__BOOLEAN,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1,
     NULL,
     NULL,
@@ -59,7 +59,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_I2c =
 {
     "Windows.Devices.I2c", 
-    0xA44C698B,
+    0x96C7514F,
     method_lookup,
-    { 1, 1, 3, 1 }
+    { 1, 2, 0, 0 }
 };

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
@@ -52,7 +52,7 @@ struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice
     static const int FIELD___disposed = 4;
 
     NANOCLR_NATIVE_DECLARE(NativeInit___VOID);
-    NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
+    NANOCLR_NATIVE_DECLARE(NativeDispose___VOID__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1);
 
     //--//

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -117,7 +117,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
    NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::DisposeNative___VOID( CLR_RT_StackFrame& stack )
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose___VOID__BOOLEAN( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
     {

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.cpp
@@ -40,7 +40,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID,
-    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::DisposeNative___VOID,
+    Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose___VOID__BOOLEAN,
     Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1,
     NULL,
     NULL,
@@ -59,7 +59,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_I2c =
 {
     "Windows.Devices.I2c", 
-    0xA44C698B,
+    0x96C7514F,
     method_lookup,
-    { 1, 1, 3, 1 }
+    { 1, 2, 0, 0 }
 };

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native.h
@@ -55,7 +55,7 @@ struct Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice
     static const int FIELD___disposed = 4;
 
     NANOCLR_NATIVE_DECLARE(NativeInit___VOID);
-    NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
+    NANOCLR_NATIVE_DECLARE(NativeDispose___VOID__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1);
 
     //--//


### PR DESCRIPTION
## Description
- Update native assembly declaration.
- Implement dispose code for STM32 and TI CC32xx I2C.

## Motivation and Context
- Hardware resources for I2C are now freed up upon dispose when no more devices associated with the a controller.
- Following nanoframework/lib-Windows.Devices.I2c#52.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
