### PR TITLE
Fix rename file issue

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFile.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFile.cpp
@@ -86,7 +86,7 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFile::RenameFileNative
 	}
 	else if (operationResult != 0)
 	{
-		// SOem other error
+		// Some other error
 		NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
 	}
 

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
@@ -48,6 +48,18 @@ char * ConvertToESP32Path(const char * filepath)
     return startPath;
 }
 
+void CombinePath(char * outpath, const char * path1, const char * path2)
+{
+	strcat(outpath, path1);
+	
+	// Add "\" to path if required
+	if (outpath[hal_strlen_s(outpath) - 1] != '\\')
+	{
+		strcat(outpath, "\\");
+	}
+	strcat(outpath, path2);
+}
+
 SYSTEMTIME GetDateTime(time_t * time)
 {
     SYSTEMTIME fileTime;
@@ -375,9 +387,7 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetStorageFold
                     memset(workingBuffer, 0, 2 * FF_LFN_BUF + 1);
 
                     // compose return directory path
-                    strcat(workingBuffer, managedPath);
-                    strcat(workingBuffer, "\\");
-                    strcat(workingBuffer, dirInfo->d_name);
+                    CombinePath(workingBuffer, managedPath, (const char*)dirInfo->d_name);
                     
                     NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_String::CreateInstance( hbObj[Library_win_storage_native_Windows_Storage_StorageFolder::FIELD___path ], workingBuffer ));
 
@@ -569,9 +579,7 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetStorageFile
 						memset(workingBuffer, 0, 2 * FF_LFN_BUF + 1);
 
 						// compose file path
-						strcat(workingBuffer, managedPath);
-						strcat(workingBuffer, "\\");
-						strcat(workingBuffer, dirInfo->d_name);
+						CombinePath(workingBuffer, managedPath, (const char*)dirInfo->d_name);
 
 						NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_String::CreateInstance(hbObj[Library_win_storage_native_Windows_Storage_StorageFile::FIELD___path], workingBuffer));
 
@@ -683,15 +691,7 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::CreateFileNati
     memset(filePath, 0, 2 * FF_LFN_BUF + 1);
 
     // compose file path
-    strcat(filePath, managedPath);
-
-	// Add "\" to path if required
-	if (filePath[hal_strlen_s(filePath) - 1] != '\\')
-	{
-		strcat(filePath, "\\");
-	}
-	
-	strcat(filePath, fileName);
+	CombinePath(filePath, managedPath, fileName);
 
     // Convert to ESP32 VFS path 
     // return allocated converted path, must be freed
@@ -846,15 +846,7 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::CreateFolderNa
     memset(folderPath, 0, 2 * FF_LFN_BUF + 1);
 
     // compose folder path
-    strcat(folderPath, managedPath);
-	
-	// Add "\" to path if required
-	if (folderPath[hal_strlen_s(folderPath) - 1] != '\\')
-	{
-		strcat(folderPath, "\\");
-	}
-
-    strcat(folderPath, folderName);
+    CombinePath(folderPath, managedPath, folderName);
 
     // Convert to ESP32 form path ( linux like )
     // return allocated converted path, must be freed
@@ -1096,15 +1088,7 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetFolderNativ
 	memset(folderPath, 0, 2 * FF_LFN_BUF + 1);
 
 	// compose folder path
-	strcat(folderPath, managedPath);
-
-	// Add "\" to path if required
-	if (folderPath[hal_strlen_s(folderPath) - 1] != '\\')
-	{
-		strcat(folderPath, "\\");
-	}
-
-	strcat(folderPath, folderName);
+	CombinePath(folderPath, managedPath, folderName);
 
 	// Convert to ESP32 form path ( linux like )
 	// return allocated converted path, must be freed


### PR DESCRIPTION
## Description
With Internal drive on ESP32 the GetFiles was adding adding an extra "\\" in path which caused rename to fail. I think this is because a \ is seen as part of filename.

Could also be a problem with STM32

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
