### PR TITLE
Add file dependencies to DFU custom command

### DIFF
--- a/CMake/Modules/FindBuildUtils.cmake
+++ b/CMake/Modules/FindBuildUtils.cmake
@@ -15,6 +15,8 @@ function(NF_GENERATE_DFU_PACKAGE FILE1 ADDRESS1 FILE2 ADDRESS2 OUTPUTFILENAME)
         
         WORKING_DIRECTORY ${TOOL_HEX2DFU_PREFIX} 
         
+        DEPENDS ${FILE1} ${FILE2}
+
         COMMENT "exporting bin files to DFU image" 
     )
 


### PR DESCRIPTION
## Description
- Add file dependencies to DFU custom command.

## Motivation and Context
- On occasions the CLR target gets build before booter target. Because this custom command is associated with the CLR target it gets executed before the booter output is available, thus failing. Adding an explicit dependency on both bin output files takes care of this. 

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
