### PR TITLE
Fix setting of ResolutionFailed flag on boot

### DIFF
--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -107,7 +107,7 @@ struct Settings
     {
         NANOCLR_HEADER();
 
-        // cler flag, in case EE wasn't restarted
+        // clear flag (in case EE wasn't restarted)
         CLR_EE_DBG_CLR(StateResolutionFailed);
 
 #if !defined(BUILD_RTM)
@@ -141,8 +141,11 @@ struct Settings
         {
             CLR_Debug::Printf( "Error: %08x\r\n", hr );
 
-            // exception occurred in assembly loading or type resolution
-            CLR_EE_DBG_SET(StateResolutionFailed);
+            if(hr == CLR_E_TYPE_UNAVAILABLE)
+            {
+                // exception occurred during type resolution
+                CLR_EE_DBG_SET(StateResolutionFailed);
+            }
         }
 #endif
 

--- a/targets/os/win32/nanoCLR/CLRStartup.cpp
+++ b/targets/os/win32/nanoCLR/CLRStartup.cpp
@@ -123,6 +123,9 @@ struct Settings
     {
         NANOCLR_HEADER();
 
+        // clear flag (in case EE wasn't restarted)
+        CLR_EE_DBG_CLR(StateResolutionFailed);
+
 #if defined(_WIN32)
         CLR_RT_StringVector vec;
 
@@ -219,7 +222,16 @@ struct Settings
         NANOCLR_CLEANUP();
 
 #if !defined(BUILD_RTM)
-        if(FAILED(hr)) CLR_Debug::Printf( "Error: %08x\r\n", hr );
+        if(FAILED(hr))
+        {
+            CLR_Debug::Printf( "Error: %08x\r\n", hr );
+
+            if(hr == CLR_E_TYPE_UNAVAILABLE)
+            {
+                // exception occurred during type resolution
+                CLR_EE_DBG_SET(StateResolutionFailed);
+            }
+        }
 #endif
 
         NANOCLR_CLEANUP_END();


### PR DESCRIPTION
## Description
- Fix setting of ResolutionFailed flag on boot.
- Also added this to the Win32 test project.

## Motivation and Context
- The flag was wrongly being set on type resolution failed and also when there is no managed app to execute.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
