### PR TITLE
Remove unnecessary quotes from CMake vars

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/CMakeLists.txt
@@ -110,12 +110,12 @@ add_executable(
     ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
-    "${NF_CoreCLR_SOURCES}"
-    "${NF_Debugger_SOURCES}"
-    "${NF_Diagnostics_SOURCES}"
+    ${NF_CoreCLR_SOURCES}
+    ${NF_Debugger_SOURCES}
+    ${NF_Diagnostics_SOURCES}
 
     # sources for nanoFramework APIs
-    "${TARGET_NANO_APIS_SOURCES}"
+    ${TARGET_NANO_APIS_SOURCES}
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)
@@ -131,7 +131,7 @@ endif()
 
 # include common directories
 include_directories(
-    "${CMAKE_CURRENT_BINARY_DIR}"
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${PROJECT_SOURCE_DIR}/src/CLR/Core
@@ -159,22 +159,22 @@ target_include_directories(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC
 
 # include directories for nanoCLR
 target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
-    "${CMAKE_CURRENT_BINARY_DIR}/nanoCLR"
+    ${CMAKE_CURRENT_BINARY_DIR}/nanoCLR
     ${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR
 
     ${TARGET_CMSIS_NANOCLR_INCLUDE_DIRS}
     ${TARGET_CHIBIOS_NANOCLR_INCLUDE_DIRS}
 
     # directories for nanoFramework libraries
-    "${NF_CoreCLR_INCLUDE_DIRS}"
-    "${NF_Debugger_INCLUDE_DIRS}"
-    "${NF_Diagnostics_INCLUDE_DIRS}"
+  ${NF_CoreCLR_INCLUDE_DIRS}
+    ${NF_Debugger_INCLUDE_DIRS}
+    ${NF_Diagnostics_INCLUDE_DIRS}
 
     # includes for nanoFramework APIs
-    "${TARGET_NANO_APIS_INCLUDES}"
+    ${TARGET_NANO_APIS_INCLUDES}
 
     # includes for ChibiOS LwIP
-    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
+    ${CHIBIOS_LWIP_INCLUDE_DIRS}
 )
 
 # set compiler options

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
@@ -110,15 +110,15 @@ add_executable(
     ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
-    "${NF_CoreCLR_SOURCES}"
-    "${NF_Debugger_SOURCES}"
-    "${NF_Diagnostics_SOURCES}"
+    ${NF_CoreCLR_SOURCES}
+    ${NF_Debugger_SOURCES}
+    ${NF_Diagnostics_SOURCES}
 
     # sources for ChibiOS FatFS
-    "${CHIBIOS_FATFS_SOURCES}"
+    ${CHIBIOS_FATFS_SOURCES}
 
     # sources for nanoFramework APIs
-    "${TARGET_NANO_APIS_SOURCES}"
+    ${TARGET_NANO_APIS_SOURCES}
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)
@@ -134,7 +134,7 @@ endif()
 
 # include common directories
 include_directories(
-    "${CMAKE_CURRENT_BINARY_DIR}"
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${PROJECT_SOURCE_DIR}/src/CLR/Core
@@ -162,25 +162,25 @@ target_include_directories(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC
 
 # include directories for nanoCLR
 target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
-    "${CMAKE_CURRENT_BINARY_DIR}/nanoCLR"
+    ${CMAKE_CURRENT_BINARY_DIR}/nanoCLR
     ${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR
 
     ${TARGET_CMSIS_NANOCLR_INCLUDE_DIRS}
     ${TARGET_CHIBIOS_NANOCLR_INCLUDE_DIRS}
 
     # directories for nanoFramework libraries
-    "${NF_CoreCLR_INCLUDE_DIRS}"
-    "${NF_Debugger_INCLUDE_DIRS}"
-    "${NF_Diagnostics_INCLUDE_DIRS}"
+  ${NF_CoreCLR_INCLUDE_DIRS}
+    ${NF_Debugger_INCLUDE_DIRS}
+    ${NF_Diagnostics_INCLUDE_DIRS}
 
     # includes for nanoFramework APIs
-    "${TARGET_NANO_APIS_INCLUDES}"
+    ${TARGET_NANO_APIS_INCLUDES}
 
     # includes for ChibiOS FatFS
-    "${CHIBIOS_FATFS_INCLUDE_DIRS}"
+    ${CHIBIOS_FATFS_INCLUDE_DIRS}
 
     # includes for ChibiOS LwIP
-    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
+    ${CHIBIOS_LWIP_INCLUDE_DIRS}
 )
 
 # set compiler options

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
@@ -111,15 +111,15 @@ add_executable(
     ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
-    "${NF_CoreCLR_SOURCES}"
-    "${NF_Debugger_SOURCES}"
-    "${NF_Diagnostics_SOURCES}"
+    ${NF_CoreCLR_SOURCES}
+    ${NF_Debugger_SOURCES}
+    ${NF_Diagnostics_SOURCES}
 
     # sources for ChibiOS FatFS
-    "${CHIBIOS_FATFS_SOURCES}"
+    ${CHIBIOS_FATFS_SOURCES}
 
     # sources for nanoFramework APIs
-    "${TARGET_NANO_APIS_SOURCES}"
+    ${TARGET_NANO_APIS_SOURCES}
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)
@@ -128,7 +128,7 @@ add_dependencies(${NANOCLR_PROJECT_NAME}.elf ChibiOS)
 
 # include common directories
 include_directories(
-    "${CMAKE_CURRENT_BINARY_DIR}"
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${PROJECT_SOURCE_DIR}/src/CLR/Core
@@ -156,25 +156,25 @@ target_include_directories(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC
 
 # include directories for nanoCLR
 target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
-    "${CMAKE_CURRENT_BINARY_DIR}/nanoCLR"
+    ${CMAKE_CURRENT_BINARY_DIR}/nanoCLR
      ${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR
 
      ${TARGET_CMSIS_NANOCLR_INCLUDE_DIRS}
      ${TARGET_CHIBIOS_NANOCLR_INCLUDE_DIRS}
 
     # directories for nanoFramework libraries
-    "${NF_CoreCLR_INCLUDE_DIRS}"
-    "${NF_Debugger_INCLUDE_DIRS}"
-    "${NF_Diagnostics_INCLUDE_DIRS}"
+  ${NF_CoreCLR_INCLUDE_DIRS}
+    ${NF_Debugger_INCLUDE_DIRS}
+    ${NF_Diagnostics_INCLUDE_DIRS}
     
     # includes for nanoFramework APIs
-    "${TARGET_NANO_APIS_INCLUDES}"
+    ${TARGET_NANO_APIS_INCLUDES}
 
     # includes for ChibiOS FatFS
-    "${CHIBIOS_FATFS_INCLUDE_DIRS}"
+    ${CHIBIOS_FATFS_INCLUDE_DIRS}
 
     # includes for ChibiOS LwIP
-    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
+    ${CHIBIOS_LWIP_INCLUDE_DIRS}
 )
 
 # set compiler options

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/CMakeLists.txt
@@ -112,15 +112,15 @@ add_executable(
     ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
-    "${NF_CoreCLR_SOURCES}"
-    "${NF_Debugger_SOURCES}"
-    "${NF_Diagnostics_SOURCES}"
+    ${NF_CoreCLR_SOURCES}
+    ${NF_Debugger_SOURCES}
+    ${NF_Diagnostics_SOURCES}
 
     # sources for ChibiOS FatFS
-    "${CHIBIOS_FATFS_SOURCES}"
+    ${CHIBIOS_FATFS_SOURCES}
 
     # sources for nanoFramework APIs
-    "${TARGET_NANO_APIS_SOURCES}"
+    ${TARGET_NANO_APIS_SOURCES}
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)
@@ -129,7 +129,7 @@ add_dependencies(${NANOCLR_PROJECT_NAME}.elf ChibiOS)
 
 # include common directories
 include_directories(
-    "${CMAKE_CURRENT_BINARY_DIR}"
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${PROJECT_SOURCE_DIR}/src/CLR/Core
@@ -157,25 +157,25 @@ target_include_directories(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC
 
 # include directories for nanoCLR
 target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
-    "${CMAKE_CURRENT_BINARY_DIR}/nanoCLR"
+    ${CMAKE_CURRENT_BINARY_DIR}/nanoCLR
     ${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR
 
     ${TARGET_CMSIS_NANOCLR_INCLUDE_DIRS}
     ${TARGET_CHIBIOS_NANOCLR_INCLUDE_DIRS}
 
     # directories for nanoFramework libraries
-    "${NF_CoreCLR_INCLUDE_DIRS}"
-    "${NF_Debugger_INCLUDE_DIRS}"
-    "${NF_Diagnostics_INCLUDE_DIRS}"
+  ${NF_CoreCLR_INCLUDE_DIRS}
+    ${NF_Debugger_INCLUDE_DIRS}
+    ${NF_Diagnostics_INCLUDE_DIRS}
 
     # includes for nanoFramework APIs
-    "${TARGET_NANO_APIS_INCLUDES}"
+    ${TARGET_NANO_APIS_INCLUDES}
 
     # includes for ChibiOS FatFS
-    "${CHIBIOS_FATFS_INCLUDE_DIRS}"
+    ${CHIBIOS_FATFS_INCLUDE_DIRS}
 
     # includes for ChibiOS LwIP
-    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
+    ${CHIBIOS_LWIP_INCLUDE_DIRS}
 )
 
 # set compiler options

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
@@ -125,23 +125,23 @@ add_executable(
     ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
-    "${NF_CoreCLR_SOURCES}"
-    "${NF_Debugger_SOURCES}"
-    "${NF_Diagnostics_SOURCES}"
+    ${NF_CoreCLR_SOURCES}
+    ${NF_Debugger_SOURCES}
+    ${NF_Diagnostics_SOURCES}
 
     # sources for ChibiOS FatFS
-    "${CHIBIOS_FATFS_SOURCES}"
+    ${CHIBIOS_FATFS_SOURCES}
     
     # sources for nanoFramework Network LWIP, Sockets and TLS
-    "${CHIBIOS_LWIP_SOURCES}"
-    "${NF_Networking_SOURCES}"
-    "${mbedTLS_SOURCES}"
+    ${CHIBIOS_LWIP_SOURCES}
+    ${NF_Networking_SOURCES}
+    ${mbedTLS_SOURCES}
 
     # sources for SPIFFS
-    "${SPIFFS_SOURCES}"
+    ${SPIFFS_SOURCES}
 
     # sources for nanoFramework APIs
-    "${TARGET_NANO_APIS_SOURCES}"
+    ${TARGET_NANO_APIS_SOURCES}
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)
@@ -169,7 +169,7 @@ endif()
 
 # include common directories
 include_directories(
-    "${CMAKE_CURRENT_BINARY_DIR}"
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${PROJECT_SOURCE_DIR}/src/CLR/Core
@@ -189,44 +189,44 @@ include_directories(
 
 # include directories for nanoBooter
 target_include_directories(${NANOBOOTER_PROJECT_NAME}.elf PUBLIC
-    "${CMAKE_CURRENT_BINARY_DIR}/nanoBooter"
+    ${CMAKE_CURRENT_BINARY_DIR}/nanoBooter
      ${CMAKE_CURRENT_SOURCE_DIR}/nanoBooter
 
      ${TARGET_CMSIS_NANOBOOTER_INCLUDE_DIRS}
      ${TARGET_CHIBIOS_NANOBOOTER_INCLUDE_DIRS}
 
     # includes for ChibiOS LwIP
-    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
+    ${CHIBIOS_LWIP_INCLUDE_DIRS}
 )
 
 # include directories for nanoCLR
 target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
-    "${CMAKE_CURRENT_BINARY_DIR}/nanoCLR"
+    ${CMAKE_CURRENT_BINARY_DIR}/nanoCLR
      ${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR
 
      ${TARGET_CMSIS_NANOCLR_INCLUDE_DIRS}
      ${TARGET_CHIBIOS_NANOCLR_INCLUDE_DIRS}
 
     # directories for nanoFramework libraries
-    "${NF_CoreCLR_INCLUDE_DIRS}"
-    "${NF_Debugger_INCLUDE_DIRS}"
-    "${NF_Diagnostics_INCLUDE_DIRS}"
+    ${NF_CoreCLR_INCLUDE_DIRS}
+    ${NF_Debugger_INCLUDE_DIRS}
+    ${NF_Diagnostics_INCLUDE_DIRS}
     
     # includes for nanoFramework APIs
-    "${TARGET_NANO_APIS_INCLUDES}"
+    ${TARGET_NANO_APIS_INCLUDES}
 
     # includes for ChibiOS FatFS
-    "${CHIBIOS_FATFS_INCLUDE_DIRS}"
+    ${CHIBIOS_FATFS_INCLUDE_DIRS}
 
     # includes for ChibiOS LwIP
-    "${CHIBIOS_LWIP_INCLUDE_DIRS}"
+    ${CHIBIOS_LWIP_INCLUDE_DIRS}
 
     # incudes for Networking and TLS
-    "${NF_Networking_INCLUDE_DIRS}"
-    "${mbedTLS_INCLUDE_DIRS}"
+    ${NF_Networking_INCLUDE_DIRS}
+    ${mbedTLS_INCLUDE_DIRS}
 
     # includes for SPIFFS
-    "${SPIFFS_INCLUDE_DIRS}"
+    ${SPIFFS_INCLUDE_DIRS}
 )
 
 # set compiler options

--- a/targets/CMSIS-OS/common/Include/CMakeLists.txt
+++ b/targets/CMSIS-OS/common/Include/CMakeLists.txt
@@ -7,7 +7,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/swo.h.in"
 "${CMAKE_CURRENT_BINARY_DIR}/swo.h" @ONLY)
 
 # append include directory for target CMSIS, need this to be the binary dir because the header is a config file
-list(APPEND TARGET_CMSIS_COMMON_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}")
+list(APPEND TARGET_CMSIS_COMMON_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR})
 
 # make var global
 set(TARGET_CMSIS_COMMON_INCLUDE_DIRS ${TARGET_CMSIS_COMMON_INCLUDE_DIRS} CACHE INTERNAL "make global")

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/CMakeLists.txt
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/CMakeLists.txt
@@ -57,7 +57,7 @@ add_subdirectory("nanoCLR")
 # Build the networking components as a separate library
 # This is done this way to stop "Createprocess: file no found" errors in linker when object input file is greater than 32k
 if(USE_NETWORKING_OPTION)
-add_library(NetworkLib STATIC "${NF_Networking_SOURCES}" "${TARGET_ESP32_NETWORK_SOURCES}"  "${TARGET_LWIP_SOURCES}" )
+add_library(NetworkLib STATIC ${NF_Networking_SOURCES} "${TARGET_ESP32_NETWORK_SOURCES}"  "${TARGET_LWIP_SOURCES}" )
 endif()
 
 
@@ -81,17 +81,17 @@ add_executable(
     ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
-    "${NF_CoreCLR_SOURCES}"
-    "${NF_Debugger_SOURCES}"
-    "${NF_Diagnostics_SOURCES}"
+    ${NF_CoreCLR_SOURCES}
+    ${NF_Debugger_SOURCES}
+    ${NF_Diagnostics_SOURCES}
     
 	# sources for nanoFramework Network sockets & LWIP
-#    "${NF_Networking_SOURCES}"
+#    ${NF_Networking_SOURCES}
 #    "${TARGET_ESP32_NETWORK_SOURCES}"  
 #    "${TARGET_LWIP_SOURCES}"
     
     # # sources for nanoFramework APIs
-    "${TARGET_NANO_APIS_SOURCES}"
+    ${TARGET_NANO_APIS_SOURCES}
 )
 
 
@@ -139,7 +139,7 @@ set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_F
 
 # include common directories
 include_directories(
-    "${CMAKE_CURRENT_BINARY_DIR}"
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/common
@@ -159,24 +159,24 @@ include_directories(
 
 # include directories for nanoCLR
 target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
-    "${CMAKE_CURRENT_BINARY_DIR}/nanoCLR"
+    ${CMAKE_CURRENT_BINARY_DIR}/nanoCLR
      ${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR
 
     # directories for nanoFramework libraries
-    "${NF_CoreCLR_INCLUDE_DIRS}"
-    "${NF_Debugger_INCLUDE_DIRS}"
-	"${NF_Networking_INCLUDE_DIRS}"
+  ${NF_CoreCLR_INCLUDE_DIRS}
+    ${NF_Debugger_INCLUDE_DIRS}
+	${NF_Networking_INCLUDE_DIRS}
 
     # includes for nanoFramework APIs
-    "${TARGET_NANO_APIS_INCLUDES}"
+    ${TARGET_NANO_APIS_INCLUDES}
 )
 
 # Set Includes & compile definition for Network library
 if(USE_NETWORKING_OPTION)
     target_include_directories(NetworkLib PUBLIC
-        "${CMAKE_CURRENT_BINARY_DIR}/nanoCLR"
-        "${NF_CoreCLR_INCLUDE_DIRS}"
-        "${NF_Networking_INCLUDE_DIRS}"
+        ${CMAKE_CURRENT_BINARY_DIR}/nanoCLR
+      ${NF_CoreCLR_INCLUDE_DIRS}
+        ${NF_Networking_INCLUDE_DIRS}
     )
 
     target_compile_definitions(NetworkLib PUBLIC "-DPLATFORM_ESP32 " )

--- a/targets/TI-SimpleLink/TI_CC3220SF_LAUNCHXL/CMakeLists.txt
+++ b/targets/TI-SimpleLink/TI_CC3220SF_LAUNCHXL/CMakeLists.txt
@@ -59,12 +59,12 @@ add_executable(
     ${WireProtocol_SOURCES}
 
     # sources for nanoFramework libraries
-    "${NF_CoreCLR_SOURCES}"
-    "${NF_Debugger_SOURCES}"
-    "${NF_Diagnostics_SOURCES}"
+    ${NF_CoreCLR_SOURCES}
+    ${NF_Debugger_SOURCES}
+    ${NF_Diagnostics_SOURCES}
 
     # sources for nanoFramework APIs
-    "${TARGET_NANO_APIS_SOURCES}"
+    ${TARGET_NANO_APIS_SOURCES}
 )
 
 # add dependency from TI SimpleLink CC32xx SDK and FreeRTOS (this is required to make sure that those repos are downloaded before the build starts)
@@ -73,7 +73,7 @@ add_dependencies(${NANOCLR_PROJECT_NAME}.elf SimpleLinkCC32xxSDK)
 
 # include common directories
 include_directories(
-    "${CMAKE_CURRENT_BINARY_DIR}"
+    ${CMAKE_CURRENT_BINARY_DIR}
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/common"
     "${PROJECT_SOURCE_DIR}/src/CLR/Core"
@@ -89,18 +89,18 @@ include_directories(
 
 # include directories for nanoCLR
 target_include_directories(${NANOCLR_PROJECT_NAME}.elf PUBLIC
-    "${CMAKE_CURRENT_BINARY_DIR}/nanoCLR"
+    ${CMAKE_CURRENT_BINARY_DIR}/nanoCLR
     "${CMAKE_CURRENT_SOURCE_DIR}/nanoCLR"
 
     "${TARGET_TI_SimpleLink_NANOCLR_INCLUDE_DIRS}"
 
     # directories for nanoFramework libraries
-    "${NF_CoreCLR_INCLUDE_DIRS}"
-    "${NF_Debugger_INCLUDE_DIRS}"
-    "${NF_Diagnostics_INCLUDE_DIRS}"
+  ${NF_CoreCLR_INCLUDE_DIRS}
+    ${NF_Debugger_INCLUDE_DIRS}
+    ${NF_Diagnostics_INCLUDE_DIRS}
     
     # includes for nanoFramework APIs
-    "${TARGET_NANO_APIS_INCLUDES}"
+    ${TARGET_NANO_APIS_INCLUDES}
 )
 
 # set compiler options


### PR DESCRIPTION
## Description
- Remove unnecessary quotes from CMake vars.

## Motivation and Context
- Quoting CMake vars that represent list can cause issues. See CMake documentation [here](https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#quoted-argument) and explanation on Stackoverflow [here](https://stackoverflow.com/questions/13582282/cmake-difference-between-and).

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
