### PR TITLE
Fix CurrentDateTime dropping microseconds

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetHAL_Time.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetHAL_Time.cpp
@@ -20,7 +20,7 @@ uint64_t  HAL_Time_CurrentDateTime(bool datePartOnly)
     gettimeofday(&tv, NULL);
 
     // Convert from Unix time(year since 1900) to SYSTEMTIME(Years since 1601)
-    int64_t time = ((int64_t)tv.tv_sec * (int64_t)TIME_CONVERSION__TO_SECONDS) + TIME_UNIX_EPOCH_AS_TICKS;
+    int64_t time = ((int64_t)tv.tv_sec * (int64_t)TIME_CONVERSION__TO_SECONDS) + ((int64_t)tv.tv_usec * (int64_t)TIME_CONVERSION__TO_MILLISECONDS ) + TIME_UNIX_EPOCH_AS_TICKS;
 
     HAL_Time_ToSystemTime(time, &st );
 


### PR DESCRIPTION
## Description
- When converting from timeval struct the tv_usec field was being ignored.

## Motivation and Context
- Fixes nanoFramework/Home#483.

## How Has This Been Tested?<!-- (if applicable) -->
- Test code from issue.
- Output is now:

```text
------------------------------------------------------
===== Incrementing time with  500 milliseconds ======
DateTime from reference      : 1970-01-01T12:16:23.016
DateTime from template string: 1970-01-01T12:16:22.019
DateTime from components     : 1970- 1- 1T 0:16:22. 19
------------------------------------------------------
===== Incrementing time with  500 milliseconds ======
DateTime from reference      : 1970-01-01T12:10:26.887
DateTime from template string: 1970-01-01T12:16:22.019
DateTime from components     : 1970- 1- 1T 0:16:22. 19
------------------------------------------------------
===== Incrementing time with  500 milliseconds ======
DateTime from reference      : 1970-01-01T12:10:33.883
DateTime from template string: 1970-01-01T12:16:22.019
DateTime from components     : 1970- 1- 1T 0:16:22. 19
------------------------------------------------------
```

## Screenshots<!-- (if appropriate): -->
![image](https://user-images.githubusercontent.com/1881520/59264861-f30a2c00-8c3b-11e9-8ce6-2dc79f1d57c9.png)

![image](https://user-images.githubusercontent.com/1881520/59264865-f69db300-8c3b-11e9-8612-f96d6957f9d0.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
