### PR TITLE
Fix to I2C read so last byte is with a NACK

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -196,12 +196,17 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
             if (i2cStatus != ESP_OK) ESP_LOGE( TAG, "i2c_master_write error:%d", i2cStatus );
 
         }
-        if (readSize != 0 )  // Read
-        {
-            i2c_master_start(cmd);
-            i2c_master_write_byte( cmd, ( slaveAddress << 1 ) | I2C_MASTER_READ, 1);
-            i2cStatus = i2c_master_read(cmd, &readData[0], readSize, I2C_MASTER_ACK );
-            if (i2cStatus != ESP_OK) ESP_LOGE( TAG, "i2c_master_read error:%d", i2cStatus );
+		if (readSize != 0)  // Read
+		{
+			i2c_master_start(cmd);
+			i2c_master_write_byte(cmd, (slaveAddress << 1) | I2C_MASTER_READ, 1);
+			if (readSize > 1)
+			{
+				// Additional read bytes with ACK
+				i2c_master_read(cmd, &readData[0], readSize - 1, I2C_MASTER_ACK);
+			}
+			// Last read byte with NACK
+			i2c_master_read_byte(cmd, &readData[readSize - 1], I2C_MASTER_NACK);
         }
 
         i2c_master_stop(cmd);


### PR DESCRIPTION
## Description
The I2C wasn't using the NACK for the last read byte

## How Has This Been Tested?<!-- (if applicable) -->
Not tested
Should be ok. 
Will leave testing to @andylyonette as he has the hardware with problem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
