### PR TITLE
ToInt64 now throws exception when appropriate

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Convert.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Convert.cpp
@@ -21,7 +21,7 @@ HRESULT Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING
         // suport for conversion from any base
         char* endptr = NULL;
 
-        bool UInt64 = false;
+        bool isUInt64 = false;
 
         bool isSigned = (bool)stack.Arg1().NumericByRef().u1;
         long long minValue = stack.Arg2().NumericByRef().s8;
@@ -29,7 +29,7 @@ HRESULT Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING
         
         // UInt64? => use also strtoull the result will be casted to Int64
         if (minValue == 0 && maxValue == 0) {
-            UInt64 = true;
+            isUInt64 = true;
             isSigned = false;
 
             //allow spaces before digits
@@ -75,12 +75,9 @@ HRESULT Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING
             if (isSigned && result > maxValue && result < (maxValue + 1) * 2) result -= (maxValue + 1) * 2;
         }
 
-        if (UInt64) {
-            // for UInt64 the check will be bypassed
-            stack.SetResult_I8(result);
-        } else if (!isSigned && maxValue != 0x7FFFFFFFFFFFFFFF && (uint64_t)result > (uint64_t)maxValue) {
+        if (!isUInt64 && !isSigned && (uint64_t)result > (uint64_t)maxValue) {
             NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_RANGE);
-        } else if (result > maxValue || result < minValue) {
+        } else if (!isUInt64 && (result > maxValue || result < minValue)) {
             NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_RANGE);
         } else {
             stack.SetResult_I8(result);
@@ -130,7 +127,7 @@ HRESULT Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING
         stack.SetResult_I8(result);
     }
     NANOCLR_NOCLEANUP_NOLABEL();
-    #endif // defined(SUPPORT_ANY_BASE_CONVERSION)
+#endif // defined(SUPPORT_ANY_BASE_CONVERSION)
     
 }
 

--- a/src/CLR/CorLib/corlib_native_System_Convert.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Convert.cpp
@@ -17,7 +17,7 @@ HRESULT Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING
 		char* str = (char*)stack.Arg0().RecoverString();
         signed int radix = stack.Arg4().NumericByRef().s4;
 
-      #if (SUPPORT_ANY_BASE_CONVERSION == TRUE)
+#if (SUPPORT_ANY_BASE_CONVERSION == TRUE)
         // suport for conversion from any base
         char* endptr = NULL;
 
@@ -85,8 +85,9 @@ HRESULT Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING
         } else {
             stack.SetResult_I8(result);
         }
-        
-      #else
+    }
+    NANOCLR_NOCLEANUP();
+#else
         // support for conversion from base 10 and 16 (partial)
 
         if(radix == 10)
@@ -127,10 +128,10 @@ HRESULT Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING
         }
 
         stack.SetResult_I8(result);
-
-      #endif // defined(SUPPORT_ANY_BASE_CONVERSION)
-	}
-    NANOCLR_NOCLEANUP();
+    }
+    NANOCLR_NOCLEANUP_NOLABEL();
+    #endif // defined(SUPPORT_ANY_BASE_CONVERSION)
+    
 }
 
 HRESULT Library_corlib_native_System_Convert::NativeToDouble___STATIC__R8__STRING( CLR_RT_StackFrame& stack )

--- a/src/CLR/CorLib/corlib_native_System_Convert.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Convert.cpp
@@ -19,36 +19,72 @@ HRESULT Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING
 
       #if (SUPPORT_ANY_BASE_CONVERSION == TRUE)
         // suport for conversion from any base
+        char* endptr = NULL;
 
-        int64_t zero = 0;
+        bool UInt64 = false;
 
         bool isSigned = (bool)stack.Arg1().NumericByRef().u1;
         long long minValue = stack.Arg2().NumericByRef().s8;
         long long maxValue = stack.Arg3().NumericByRef().s8;
-
-        // normally we check if the result is in the given range
-        bool check = true;
         
-        // Int64? => use also strtoull the result will be casted to Int64
-        if (isSigned && maxValue == 0x7FFFFFFFFFFFFFFF) isSigned = false;
-
-        // UInt64? => use also strtoull the result will be casted to Int64 and bypass the range check
-        if (minValue == 0 && maxValue == 0)
-        {
+        // UInt64? => use also strtoull the result will be casted to Int64
+        if (minValue == 0 && maxValue == 0) {
+            UInt64 = true;
             isSigned = false;
-            check = false;
+
+            //allow spaces before digits
+            while (*str == ' ') {
+                str++;
+            }
+
+            //UInt64 can't begin with minus
+            if (*str == '-' ) {
+                NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_RANGE);
+            }
         }
 
         // convert via strtoll / strtoull
-        result = isSigned ? strtoll(str, nullptr, radix) : (long long) strtoull(str, nullptr, radix);
+        result = isSigned ? strtoll(str, &endptr, radix) : (long long) strtoull(str, &endptr, radix);
 
+        // TODO: 
+        // If the value in input string is out of the range of representable values
+        // by a long long int / unsigned long int, the function returns 
+        // LLONG_MAX or LLONG_MIN for signed conversion 
+        // and ULONG_MAX for unsigned conversion
+        // It is necessary to add a check
+
+        // if no valid conversion endptr is equal str
+        if (str == endptr) {
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        }
+
+        // allow spaces after digits
+        while (*endptr == ' ') {
+            endptr++;
+        }
+
+        // should reach end of string no aditional chars
+        if (*endptr != 0) {
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        }
+        
         // the signed values for SByte, Int16 and Int32 are always positive for base 2, 8 or 16 conversions
         // because the 64-bit function strtoll is used; need the post process the value
         // if the result is greater max and smaller (max + 1) * 2 this value should be subtracted
-        if (isSigned && result > maxValue && result < (maxValue + 1) * 2) result -= (maxValue + 1) * 2;
-        
-        // for UInt64 the check will be bypassed
-        stack.SetResult_I8 ((check && (result > maxValue || result < minValue)) ? zero : result);
+        if (radix == 2 || radix == 8 || radix == 16) {
+            if (isSigned && result > maxValue && result < (maxValue + 1) * 2) result -= (maxValue + 1) * 2;
+        }
+
+        if (UInt64) {
+            // for UInt64 the check will be bypassed
+            stack.SetResult_I8(result);
+        } else if (!isSigned && maxValue != 0x7FFFFFFFFFFFFFFF && (uint64_t)result > (uint64_t)maxValue) {
+            NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_RANGE);
+        } else if (result > maxValue || result < minValue) {
+            NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_RANGE);
+        } else {
+            stack.SetResult_I8(result);
+        }
         
       #else
         // support for conversion from base 10 and 16 (partial)
@@ -94,7 +130,7 @@ HRESULT Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING
 
       #endif // defined(SUPPORT_ANY_BASE_CONVERSION)
 	}
-    NANOCLR_NOCLEANUP_NOLABEL();
+    NANOCLR_NOCLEANUP();
 }
 
 HRESULT Library_corlib_native_System_Convert::NativeToDouble___STATIC__R8__STRING( CLR_RT_StackFrame& stack )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Convert function didn't throw exceptions if value in input string isn't correct number or is out of range and returns 0 in above situation. After this change exceptions are thrown.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template below (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes problem with incorrect parse integers

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I wrote a simple program that tests various possibilities. I can add it to example programs.
There is still problem during UInt64 and Int64 Parse. If value is out of range function didn't throw exception but return maximal or minimal allowed value.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
