### PR TITLE
Add support for MDP to output detailed error messages

### DIFF
--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1796,7 +1796,12 @@ HRESULT CLR_RT_Assembly::Resolve_TypeRef()
 #if !defined(BUILD_RTM)
                 CLR_Debug::Printf( "Resolve: unknown scope: %08x\r\n", src->scope );
 #endif
-                NANOCLR_MSG1_SET_AND_LEAVE(CLR_E_FAIL, L"Resolve: unknown scope: %08x\r\n", src->scope);
+
+#if defined(_WIN32)
+				NANOCLR_CHARMSG_SET_AND_LEAVE(CLR_E_FAIL, "Resolve: unknown scope: %08x\r\n", src->scope);
+#else
+				NANOCLR_MSG1_SET_AND_LEAVE(CLR_E_FAIL, L"Resolve: unknown scope: %08x\r\n", src->scope);
+#endif
             }
 
             const char* szName = GetString( src->name );
@@ -1805,7 +1810,12 @@ HRESULT CLR_RT_Assembly::Resolve_TypeRef()
 #if !defined(BUILD_RTM)
                 CLR_Debug::Printf( "Resolve: unknown type: %s\r\n", szName );
 #endif
+
+#if defined(_WIN32)
+				NANOCLR_CHARMSG_SET_AND_LEAVE(CLR_E_FAIL, "Resolve: unknown type: %s\r\n", szName);
+#else
 				NANOCLR_MSG1_SET_AND_LEAVE(CLR_E_FAIL, L"Resolve: unknown type: %s\r\n", szName);
+#endif
             }
         }
         else
@@ -1824,7 +1834,11 @@ HRESULT CLR_RT_Assembly::Resolve_TypeRef()
                 CLR_Debug::Printf( "Resolve: unknown type: %s.%s\r\n", szNameSpace, szName );
 #endif
 
+#if defined(_WIN32)
+				NANOCLR_CHARMSG_SET_AND_LEAVE(CLR_E_FAIL, "Resolve: unknown type: %s.%s\r\n", szNameSpace, szName);
+#else
 				NANOCLR_MSG1_SET_AND_LEAVE(CLR_E_FAIL, L"Resolve: unknown type: %s\r\n", szName);
+#endif
             }
         }
     }
@@ -1849,7 +1863,11 @@ HRESULT CLR_RT_Assembly::Resolve_FieldRef()
             CLR_Debug::Printf( "Resolve Field: unknown scope: %08x\r\n", src->container );
 #endif
 
+#if defined(_WIN32)
+			NANOCLR_CHARMSG_SET_AND_LEAVE(CLR_E_FAIL, "Resolve Field: unknown scope: %08x\r\n", src->container);
+#else
 			NANOCLR_MSG1_SET_AND_LEAVE(CLR_E_FAIL, L"Resolve Field: unknown scope: %08x\r\n", src->container);
+#endif
         }
 
         const char* szName = GetString( src->name );
@@ -1860,7 +1878,11 @@ HRESULT CLR_RT_Assembly::Resolve_FieldRef()
             CLR_Debug::Printf( "Resolve: unknown field: %s\r\n", szName );
 #endif
 
+#if defined(_WIN32)
+			NANOCLR_CHARMSG_SET_AND_LEAVE(CLR_E_FAIL, "Resolve: unknown field: %s\r\n", szName);
+#else
 			NANOCLR_MSG1_SET_AND_LEAVE(CLR_E_FAIL, L"Resolve: unknown field: %s\r\n", szName);
+#endif
         }
     }
 
@@ -1884,7 +1906,11 @@ HRESULT CLR_RT_Assembly::Resolve_MethodRef()
             CLR_Debug::Printf( "Resolve Field: unknown scope: %08x\r\n", src->container );
 #endif
 
+#if defined(_WIN32)
+			NANOCLR_CHARMSG_SET_AND_LEAVE(CLR_E_FAIL, "Resolve Field: unknown scope: %08x\r\n", src->container);
+#else
 			NANOCLR_MSG1_SET_AND_LEAVE(CLR_E_FAIL, L"Resolve Field: unknown scope: %08x\r\n", src->container);
+#endif
         }
 
         const char* name = GetString( src->name );
@@ -1912,7 +1938,11 @@ HRESULT CLR_RT_Assembly::Resolve_MethodRef()
             CLR_Debug::Printf( "Resolve: unknown method: %s.%s.%s\r\n", qASSM->GetString( qTD->nameSpace ), qASSM->GetString( qTD->name ), name );
 #endif
 
+#if defined(_WIN32)
+			NANOCLR_CHARMSG_SET_AND_LEAVE(CLR_E_FAIL, "Resolve: unknown method: %s\r\n", name);
+#else
 			NANOCLR_MSG1_SET_AND_LEAVE(CLR_E_FAIL, L"Resolve: unknown method: %s\r\n", name);
+#endif
         }
     }
 

--- a/src/CLR/Include/nanoCLR_Checks.h
+++ b/src/CLR/Include/nanoCLR_Checks.h
@@ -40,6 +40,9 @@ struct CLR_RT_DUMP
      static void POST_PROCESS_EXCEPTION( CLR_RT_HeapBlock& ref                           ) DECL_POSTFIX;
 
      static const char* GETERRORMESSAGE( HRESULT hrError );
+#if defined(_WIN32)
+	 static const char* GETERRORDETAIL ();
+#endif
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/CLR/Include/nanoCLR_Interop.h
+++ b/src/CLR/Include/nanoCLR_Interop.h
@@ -42,7 +42,8 @@
 #define NANOCLR_SET_AND_LEAVE(expr)					{ hr = (expr); NANOCLR_LEAVE(); }
 #if defined(_MSC_VER)
 #define NANOCLR_MSG_SET_AND_LEAVE(expr, msg)		{ wprintf(msg); hr = (expr); NANOCLR_LEAVE(); }
-#define NANOCLR_MSG1_SET_AND_LEAVE(expr, msg, arg)	{ wprintf(msg, arg); hr = (expr); NANOCLR_LEAVE(); }
+#define NANOCLR_MSG1_SET_AND_LEAVE(expr, msg, ...)	{ wprintf(msg,  __VA_ARGS__); hr = (expr); NANOCLR_LEAVE(); }
+#define NANOCLR_CHARMSG_SET_AND_LEAVE(expr, msg, ...)	{ printf(msg, __VA_ARGS__); hr = (expr); NANOCLR_LEAVE(); }
 #else
 #define NANOCLR_MSG_SET_AND_LEAVE(expr, msg)		{ hr = (expr); NANOCLR_LEAVE(); }
 #define NANOCLR_MSG1_SET_AND_LEAVE(expr, msg, arg)	{ hr = (expr); NANOCLR_LEAVE(); }

--- a/src/CLR/Include/nanoCLR_Types.h
+++ b/src/CLR/Include/nanoCLR_Types.h
@@ -805,6 +805,7 @@ struct CLR_Debug
 
 #if defined(_WIN32)
      static void RedirectToString( std::string* str );
+	 static void SaveMessage	 (std::string str   );
 #endif
 };
 


### PR DESCRIPTION
## Description
- Add new functions to store messages required for MDP to output error descriptions.
- Add new variant of NANOCLR_MSG1_SET_AND_LEAVE to work with chars (NANOCLR_CHARMSG_SET_AND_LEAVE).
- Fix NANOCLR_MSG1_SET_AND_LEAVE define to properly use variable arguments.

## Motivation and Context
- Addresses nanoframework/Home#174.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
