### PR TITLE
Fix drive enumeration for Storage API

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/common/Target_Windows_Storage.c
+++ b/targets/CMSIS-OS/ChibiOS/common/Target_Windows_Storage.c
@@ -21,22 +21,18 @@ extern void PostManagedEvent(uint8_t category, uint8_t subCategory, uint16_t dat
 // the drive indexes have to be used instead of fixed drive letters because a target can have one or more 
 // and those have to follow the sequence that is used in ChibiOS FatFS wrappers
 // SD Card (or SPI) is 1st and USB MAS is 2nd (if SD Card is enabled)
-#if defined(HAL_USE_SDC) && defined(HAL_USBH_USE_MSD)
+// this is also mapped in the FatFS configuration
+#if defined(HAL_USE_SDC)
 
-#define SD_CARD_DRIVE_INDEX             "0"
+#define SD_CARD_DRIVE_INDEX             "0:"
 #define SD_CARD_DRIVE_INDEX_NUMERIC     (0)
-#define USB_MSD_DRIVE_INDEX             "1"
+
+#endif
+
+#if defined(HAL_USE_SDC)
+
+#define USB_MSD_DRIVE_INDEX             "1:"
 #define USB_MSD_DRIVE_INDEX_NUMERIC     (1)
-
-#elif defined(HAL_USE_SDC) && !defined(HAL_USBH_USE_MSD)
-
-#define SD_CARD_DRIVE_INDEX             "0"
-#define SD_CARD_DRIVE_INDEX_NUMERIC     (0)
-
-#elif !defined(HAL_USE_SDC) && defined(HAL_USBH_USE_MSD)
-
-#define USB_MSD_DRIVE_INDEX             "0"
-#define USB_MSD_DRIVE_INDEX_NUMERIC     (0)
 
 #endif
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
@@ -68,6 +68,8 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetRemovableSt
     hbObj->SetObjectReference( NULL );
 
   #if HAL_USE_SDC
+    bool sdCardEnumerated = false;
+
     // is the SD card file system ready?
     if(sdCardFileSystemReady)
     {
@@ -77,6 +79,8 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetRemovableSt
   #endif
 
   #if HAL_USBH_USE_MSD
+    bool usbMsdEnumerated = false;
+
     // is the USB mass storage device file system ready?
     if(usbMsdFileSystemReady)
     {
@@ -109,21 +113,28 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetRemovableSt
         for(; driveIterator < driveCount; driveIterator++ )
         {
             // fill the folder name and path
-            switch(driveIterator)
+
+          #if HAL_USE_SDC
+            // is the SD card file system ready?
+            if(sdCardFileSystemReady && !sdCardEnumerated)
             {
-                case 0:
-                    memcpy(workingDrive, INDEX0_DRIVE_PATH, DRIVE_PATH_LENGTH);
-                    break;
+                memcpy(workingDrive, INDEX0_DRIVE_PATH, DRIVE_PATH_LENGTH);
 
-                case 1:
-                    memcpy(workingDrive, INDEX1_DRIVE_PATH, DRIVE_PATH_LENGTH);
-                    break;
-
-                default:
-                    // shouldn't reach here
-                    NANOCLR_SET_AND_LEAVE(CLR_E_NOT_SUPPORTED);
-                    break;
+                // flag as enumerated
+                sdCardEnumerated = true;
             }
+          #endif
+
+          #if HAL_USBH_USE_MSD
+            // is the USB mass storage device file system ready?
+            if(usbMsdFileSystemReady && !usbMsdEnumerated)
+            {
+                memcpy(workingDrive, INDEX1_DRIVE_PATH, DRIVE_PATH_LENGTH);
+                
+                // flag as enumerated
+                usbMsdEnumerated = true;
+            }    
+          #endif
 
             // dereference the object in order to reach its fields
             hbObj = storageFolder->Dereference();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- Drive volumes in FatFS require a ':'.
- Enumeration algorithm was failing when support for multiple drives is enabled but not all are connected.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
