### PR TITLE
Update Storage assembly declaration

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native.cpp
@@ -27,7 +27,6 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
-    NULL,
     Library_win_storage_native_Windows_Storage_Devices_SDCard::MountMMCNative___STATIC__VOID__BOOLEAN,
     Library_win_storage_native_Windows_Storage_Devices_SDCard::MountSpiNative___STATIC__VOID__I4__I4,
     Library_win_storage_native_Windows_Storage_Devices_SDCard::UnmountNative___STATIC__VOID,
@@ -106,7 +105,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Storage =
 {
     "Windows.Storage", 
-    0x53942C94,
+    0x8D8C8026,
     method_lookup,
-    { 1, 0, 0, 1 }
+    { 1, 0, 1, 0 }
 };

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native.h
@@ -13,55 +13,55 @@
 
 struct Library_win_storage_native_Windows_Storage_RemovableDeviceEventArgs
 {
-	static const int FIELD___path = 1;
-	static const int FIELD___event = 2;
+    static const int FIELD___path = 1;
+    static const int FIELD___event = 2;
 
 
-	//--//
+    //--//
 
 };
 
 struct Library_win_storage_native_Windows_Storage_StorageEventManager
 {
-	static const int FIELD_STATIC__RemovableDeviceInserted = 0;
-	static const int FIELD_STATIC__RemovableDeviceRemoved = 1;
+    static const int FIELD_STATIC__RemovableDeviceInserted = 0;
+    static const int FIELD_STATIC__RemovableDeviceRemoved = 1;
 
 
-	//--//
+    //--//
 
 };
 
 struct Library_win_storage_native_Windows_Storage_StorageEventManager__StorageEvent
 {
-	static const int FIELD__EventType = 3;
-	static const int FIELD__DriveIndex = 4;
-	static const int FIELD__Time = 5;
+    static const int FIELD__EventType = 3;
+    static const int FIELD__DriveIndex = 4;
+    static const int FIELD__Time = 5;
 
 
-	//--//
+    //--//
 
 };
 
 struct Library_win_storage_native_Windows_Storage_Devices_SDCard
 {
-	static const int FIELD_STATIC___mounted = 2;
+    static const int FIELD_STATIC___mounted = 2;
 
-	NANOCLR_NATIVE_DECLARE(MountMMCNative___STATIC__VOID__BOOLEAN);
-	NANOCLR_NATIVE_DECLARE(MountSpiNative___STATIC__VOID__I4__I4);
-	NANOCLR_NATIVE_DECLARE(UnmountNative___STATIC__VOID);
+    NANOCLR_NATIVE_DECLARE(MountMMCNative___STATIC__VOID__BOOLEAN);
+    NANOCLR_NATIVE_DECLARE(MountSpiNative___STATIC__VOID__I4__I4);
+    NANOCLR_NATIVE_DECLARE(UnmountNative___STATIC__VOID);
 
-	//--//
+    //--//
 
 };
 
 struct Library_win_storage_native_Windows_Storage_FileIO
 {
-	NANOCLR_NATIVE_DECLARE(WriteBytes___STATIC__VOID__WindowsStorageIStorageFile__SZARRAY_U1);
-	NANOCLR_NATIVE_DECLARE(WriteText___STATIC__VOID__WindowsStorageIStorageFile__STRING);
-	NANOCLR_NATIVE_DECLARE(ReadBufferNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_SZARRAY_U1);
-	NANOCLR_NATIVE_DECLARE(ReadTextNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_STRING);
+    NANOCLR_NATIVE_DECLARE(WriteBytes___STATIC__VOID__WindowsStorageIStorageFile__SZARRAY_U1);
+    NANOCLR_NATIVE_DECLARE(WriteText___STATIC__VOID__WindowsStorageIStorageFile__STRING);
+    NANOCLR_NATIVE_DECLARE(ReadBufferNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_SZARRAY_U1);
+    NANOCLR_NATIVE_DECLARE(ReadTextNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_STRING);
 
-	//--//
+    //--//
 
 };
 
@@ -81,32 +81,32 @@ struct Library_win_storage_native_Windows_Storage_StorageFile
 
 struct Library_win_storage_native_Windows_Storage_StorageFolder
 {
-	static const int FIELD___knownFolderId = 1;
-	static const int FIELD___dateCreated = 2;
-	static const int FIELD___name = 3;
-	static const int FIELD___path = 4;
+    static const int FIELD___knownFolderId = 1;
+    static const int FIELD___dateCreated = 2;
+    static const int FIELD___name = 3;
+    static const int FIELD___path = 4;
 
-	NANOCLR_NATIVE_DECLARE(GetRemovableStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
-	NANOCLR_NATIVE_DECLARE(GetInternalStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
-	NANOCLR_NATIVE_DECLARE(GetStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
-	NANOCLR_NATIVE_DECLARE(GetStorageFilesNative___SZARRAY_WindowsStorageStorageFile__U4__U4);
-	NANOCLR_NATIVE_DECLARE(CreateFileNative___WindowsStorageStorageFile__STRING__U4);
-	NANOCLR_NATIVE_DECLARE(CreateFolderNative___WindowsStorageStorageFolder__STRING__U4);
-	NANOCLR_NATIVE_DECLARE(DeleteFolderNative___VOID);
-	NANOCLR_NATIVE_DECLARE(RenameFolderNative___VOID__STRING);
-	NANOCLR_NATIVE_DECLARE(GetFolderNative___WindowsStorageStorageFolder__STRING);
+    NANOCLR_NATIVE_DECLARE(GetRemovableStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
+    NANOCLR_NATIVE_DECLARE(GetInternalStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
+    NANOCLR_NATIVE_DECLARE(GetStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
+    NANOCLR_NATIVE_DECLARE(GetStorageFilesNative___SZARRAY_WindowsStorageStorageFile__U4__U4);
+    NANOCLR_NATIVE_DECLARE(CreateFileNative___WindowsStorageStorageFile__STRING__U4);
+    NANOCLR_NATIVE_DECLARE(CreateFolderNative___WindowsStorageStorageFolder__STRING__U4);
+    NANOCLR_NATIVE_DECLARE(DeleteFolderNative___VOID);
+    NANOCLR_NATIVE_DECLARE(RenameFolderNative___VOID__STRING);
+    NANOCLR_NATIVE_DECLARE(GetFolderNative___WindowsStorageStorageFolder__STRING);
 
-	//--//
+    //--//
 
 };
 
 struct Library_win_storage_native_Windows_Storage_StorageProvider
 {
-	static const int FIELD___displayName = 1;
-	static const int FIELD___id = 2;
+    static const int FIELD___displayName = 1;
+    static const int FIELD___id = 2;
 
 
-	//--//
+    //--//
 
 };
 

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native.cpp
@@ -27,7 +27,6 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
-    NULL,
     Library_win_storage_native_Windows_Storage_Devices_SDCard::MountMMCNative___STATIC__VOID__BOOLEAN,
     Library_win_storage_native_Windows_Storage_Devices_SDCard::MountSpiNative___STATIC__VOID__I4__I4,
     Library_win_storage_native_Windows_Storage_Devices_SDCard::UnmountNative___STATIC__VOID,
@@ -106,7 +105,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Storage =
 {
     "Windows.Storage", 
-    0x53942C94,
+    0x8D8C8026,
     method_lookup,
-    { 1, 0, 0, 1 }
+    { 1, 0, 1, 0 }
 };

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native.h
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native.h
@@ -13,55 +13,55 @@
 
 struct Library_win_storage_native_Windows_Storage_RemovableDeviceEventArgs
 {
-	static const int FIELD___path = 1;
-	static const int FIELD___event = 2;
+    static const int FIELD___path = 1;
+    static const int FIELD___event = 2;
 
 
-	//--//
+    //--//
 
 };
 
 struct Library_win_storage_native_Windows_Storage_StorageEventManager
 {
-	static const int FIELD_STATIC__RemovableDeviceInserted = 0;
-	static const int FIELD_STATIC__RemovableDeviceRemoved = 1;
+    static const int FIELD_STATIC__RemovableDeviceInserted = 0;
+    static const int FIELD_STATIC__RemovableDeviceRemoved = 1;
 
 
-	//--//
+    //--//
 
 };
 
 struct Library_win_storage_native_Windows_Storage_StorageEventManager__StorageEvent
 {
-	static const int FIELD__EventType = 3;
-	static const int FIELD__DriveIndex = 4;
-	static const int FIELD__Time = 5;
+    static const int FIELD__EventType = 3;
+    static const int FIELD__DriveIndex = 4;
+    static const int FIELD__Time = 5;
 
 
-	//--//
+    //--//
 
 };
 
 struct Library_win_storage_native_Windows_Storage_Devices_SDCard
 {
-	static const int FIELD_STATIC___mounted = 2;
+    static const int FIELD_STATIC___mounted = 2;
 
-	NANOCLR_NATIVE_DECLARE(MountMMCNative___STATIC__VOID__BOOLEAN);
-	NANOCLR_NATIVE_DECLARE(MountSpiNative___STATIC__VOID__I4__I4);
-	NANOCLR_NATIVE_DECLARE(UnmountNative___STATIC__VOID);
+    NANOCLR_NATIVE_DECLARE(MountMMCNative___STATIC__VOID__BOOLEAN);
+    NANOCLR_NATIVE_DECLARE(MountSpiNative___STATIC__VOID__I4__I4);
+    NANOCLR_NATIVE_DECLARE(UnmountNative___STATIC__VOID);
 
-	//--//
+    //--//
 
 };
 
 struct Library_win_storage_native_Windows_Storage_FileIO
 {
-	NANOCLR_NATIVE_DECLARE(WriteBytes___STATIC__VOID__WindowsStorageIStorageFile__SZARRAY_U1);
-	NANOCLR_NATIVE_DECLARE(WriteText___STATIC__VOID__WindowsStorageIStorageFile__STRING);
-	NANOCLR_NATIVE_DECLARE(ReadBufferNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_SZARRAY_U1);
-	NANOCLR_NATIVE_DECLARE(ReadTextNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_STRING);
+    NANOCLR_NATIVE_DECLARE(WriteBytes___STATIC__VOID__WindowsStorageIStorageFile__SZARRAY_U1);
+    NANOCLR_NATIVE_DECLARE(WriteText___STATIC__VOID__WindowsStorageIStorageFile__STRING);
+    NANOCLR_NATIVE_DECLARE(ReadBufferNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_SZARRAY_U1);
+    NANOCLR_NATIVE_DECLARE(ReadTextNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_STRING);
 
-	//--//
+    //--//
 
 };
 
@@ -81,32 +81,32 @@ struct Library_win_storage_native_Windows_Storage_StorageFile
 
 struct Library_win_storage_native_Windows_Storage_StorageFolder
 {
-	static const int FIELD___knownFolderId = 1;
-	static const int FIELD___dateCreated = 2;
-	static const int FIELD___name = 3;
-	static const int FIELD___path = 4;
+    static const int FIELD___knownFolderId = 1;
+    static const int FIELD___dateCreated = 2;
+    static const int FIELD___name = 3;
+    static const int FIELD___path = 4;
 
-	NANOCLR_NATIVE_DECLARE(GetRemovableStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
-	NANOCLR_NATIVE_DECLARE(GetInternalStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
-	NANOCLR_NATIVE_DECLARE(GetStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
-	NANOCLR_NATIVE_DECLARE(GetStorageFilesNative___SZARRAY_WindowsStorageStorageFile__U4__U4);
-	NANOCLR_NATIVE_DECLARE(CreateFileNative___WindowsStorageStorageFile__STRING__U4);
-	NANOCLR_NATIVE_DECLARE(CreateFolderNative___WindowsStorageStorageFolder__STRING__U4);
-	NANOCLR_NATIVE_DECLARE(DeleteFolderNative___VOID);
-	NANOCLR_NATIVE_DECLARE(RenameFolderNative___VOID__STRING);
-	NANOCLR_NATIVE_DECLARE(GetFolderNative___WindowsStorageStorageFolder__STRING);
+    NANOCLR_NATIVE_DECLARE(GetRemovableStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
+    NANOCLR_NATIVE_DECLARE(GetInternalStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
+    NANOCLR_NATIVE_DECLARE(GetStorageFoldersNative___SZARRAY_WindowsStorageStorageFolder);
+    NANOCLR_NATIVE_DECLARE(GetStorageFilesNative___SZARRAY_WindowsStorageStorageFile__U4__U4);
+    NANOCLR_NATIVE_DECLARE(CreateFileNative___WindowsStorageStorageFile__STRING__U4);
+    NANOCLR_NATIVE_DECLARE(CreateFolderNative___WindowsStorageStorageFolder__STRING__U4);
+    NANOCLR_NATIVE_DECLARE(DeleteFolderNative___VOID);
+    NANOCLR_NATIVE_DECLARE(RenameFolderNative___VOID__STRING);
+    NANOCLR_NATIVE_DECLARE(GetFolderNative___WindowsStorageStorageFolder__STRING);
 
-	//--//
+    //--//
 
 };
 
 struct Library_win_storage_native_Windows_Storage_StorageProvider
 {
-	static const int FIELD___displayName = 1;
-	static const int FIELD___id = 2;
+    static const int FIELD___displayName = 1;
+    static const int FIELD___id = 2;
 
 
-	//--//
+    //--//
 
 };
 


### PR DESCRIPTION
- Bump native version to 1.0.1.0.
- Following nanoframework/lib-Windows.Storage#45.
