### PR TITLE
Entering power off now disables FSMC

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
@@ -3,13 +3,17 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include <ch.h>
+#include <hal.h>
+#include <hal_nf_community.h>
 #include <nanoHAL_Power.h>
 #include <nanoHAL_v2.h>
 #include <target_platform.h>
 #include <cmsis_os.h>
-#include <hal.h>
-#include <hal_nf_community.h>
-#include <ch.h>
+
+#if (HAL_USE_FSMC == TRUE)
+#include <fsmc_sdram_lld.h>
+#endif
 
 uint32_t WakeupReasonStore;
 
@@ -41,6 +45,11 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
         case PowerLevel__Off:
             // stop watchdog
             wdgStop(&WDGD1);
+
+          #if (HAL_USE_FSMC == TRUE)
+            // shutdown memory
+            fsmcSdramStop(&SDRAMD);
+          #endif
 
             // gracefully shutdown everything
             nanoHAL_Uninitialize_C();


### PR DESCRIPTION
## Description
- Add call to stop FSMC before entering power down. Optional only on targets that use this block.

## Motivation and Context
- Improves power consumption on power down by putting the external memory in stand-by mode.

## How Has This Been Tested?<!-- (if applicable) -->
- Stm32.PowerMode from SMT32 sample pack.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
