### PR TITLE
Com port fix

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Include/Esp32_DeviceMapping.h
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Include/Esp32_DeviceMapping.h
@@ -21,9 +21,9 @@ enum Esp32_MapDeviceType
     DEV_TYPE_GPIO,
     DEV_TYPE_SPI,
     DEV_TYPE_I2C,
-    DEV_TYPE_LED_PWM,
     DEV_TYPE_SERIAL,
-    DEV_TYPE_MAX,
+	DEV_TYPE_LED_PWM,
+	DEV_TYPE_MAX,
 };
 
 int  Esp32_GetMappedDevicePins( Esp32_MapDeviceType DevType, int DevNumber, int PinIndex);

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/Esp32_DeviceMapping.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/Esp32_DeviceMapping.cpp
@@ -24,13 +24,13 @@ int8_t Esp32_SPI_DevicePinMap[2][3] =
 int8_t Esp32_SERIAL_DevicePinMap[3][4] = 
 {
     // COM 1 - pins 1, 3, 19, 22
-    {UART_NUM_0_TXD_DIRECT_GPIO_NUM, UART_NUM_0_RXD_DIRECT_GPIO_NUM, UART_NUM_0_RTS_DIRECT_GPIO_NUM, UART_NUM_0_RTS_DIRECT_GPIO_NUM},
+    {UART_NUM_0_TXD_DIRECT_GPIO_NUM, UART_NUM_0_RXD_DIRECT_GPIO_NUM, UART_NUM_0_RTS_DIRECT_GPIO_NUM, UART_NUM_0_CTS_DIRECT_GPIO_NUM},
     
     // COM 2 - 10, 9, 6, 11
-    {UART_NUM_1_TXD_DIRECT_GPIO_NUM, UART_NUM_1_RXD_DIRECT_GPIO_NUM, UART_NUM_1_RTS_DIRECT_GPIO_NUM, UART_NUM_1_RTS_DIRECT_GPIO_NUM},
+    {UART_NUM_1_TXD_DIRECT_GPIO_NUM, UART_NUM_1_RXD_DIRECT_GPIO_NUM, UART_NUM_1_RTS_DIRECT_GPIO_NUM, UART_NUM_1_CTS_DIRECT_GPIO_NUM},
     
     // COM3 - 17, 16, 8, 7
-    {UART_NUM_2_TXD_DIRECT_GPIO_NUM, UART_NUM_2_RXD_DIRECT_GPIO_NUM, UART_NUM_2_RTS_DIRECT_GPIO_NUM, UART_NUM_2_RTS_DIRECT_GPIO_NUM}
+    {UART_NUM_2_TXD_DIRECT_GPIO_NUM, UART_NUM_2_RXD_DIRECT_GPIO_NUM, UART_NUM_2_RTS_DIRECT_GPIO_NUM, UART_NUM_2_CTS_DIRECT_GPIO_NUM}
  };
 
 // =============================================
@@ -84,11 +84,11 @@ int  Esp32_GetMappedDevicePins( Esp32_MapDeviceType deviceType, int DevNumber, i
             case DEV_TYPE_I2C:
                 return (int)Esp32_I2C_DevicePinMap[DevNumber][PinIndex];
             
-            case DEV_TYPE_LED_PWM: 
+			case DEV_TYPE_SERIAL:
+				return (int)Esp32_SERIAL_DevicePinMap[DevNumber][PinIndex];
+			
+			case DEV_TYPE_LED_PWM:
                 return (int)Esp32_LED_DevicePinMap[DevNumber];
-
-            case DEV_TYPE_SERIAL:
-                return (int)Esp32_SERIAL_DevicePinMap[DevNumber][PinIndex];
 
             default:
                 break;
@@ -131,19 +131,20 @@ void Esp32_SetMappedDevicePins( uint8_t pin, int32_t alternateFunction )
             }
             break;
 
-        case DEV_TYPE_LED_PWM:
+		case DEV_TYPE_SERIAL:
+			if (deviceIndex <= 2 && mapping <= 3)
+			{
+				Esp32_SERIAL_DevicePinMap[deviceIndex][mapping] = pin;
+			}
+			break;
+		
+		case DEV_TYPE_LED_PWM:
             if (deviceIndex <= 15 ) 
             {
                 Esp32_LED_DevicePinMap[deviceIndex] = pin;
             }
             break;
 
-        case DEV_TYPE_SERIAL:
-            if (deviceIndex <= 2 &&  mapping <= 3) 
-            {
-                Esp32_SERIAL_DevicePinMap[deviceIndex][mapping] = pin;
-            }
-            break;
 
         default:  // ignore
             break;

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -10,6 +10,7 @@
 // #include <string.h>
 #include <nanoHAL.h>
 #include "win_dev_serial_native.h"
+#include "Esp32_DeviceMapping.h"
 
 
 // buffers size
@@ -229,7 +230,7 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
 {
     NANOCLR_HEADER();
     {
-        uart_config_t uart_config;
+		uart_config_t uart_config;
     
         // get a pointer to the managed object instance and check that it's not NULL
         CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
@@ -289,8 +290,10 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
                 break;
         }
 
-       bool EnableXonXoff = false;
-       switch ((SerialHandshake)pThis[ FIELD___handshake ].NumericByRef().s4)
+	   uart_config.rx_flow_ctrl_thresh = 0;
+
+	   bool EnableXonXoff = false;
+	   switch ((SerialHandshake)pThis[ FIELD___handshake ].NumericByRef().s4)
         {
            default:
             case SerialHandshake_None :
@@ -298,11 +301,13 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
                 break;
            case SerialHandshake_RequestToSend :
                 uart_config.flow_ctrl = UART_HW_FLOWCTRL_RTS ;                      
-                break;
+				uart_config.rx_flow_ctrl_thresh = 122;
+				break;
          
          case SerialHandshake_RequestToSendXOnXOff :
                 uart_config.flow_ctrl = UART_HW_FLOWCTRL_RTS ;     
-                EnableXonXoff = true;                 
+				uart_config.rx_flow_ctrl_thresh = 122;
+				EnableXonXoff = true;
                 break;
 
          case SerialHandshake_XOnXOff :
@@ -315,34 +320,11 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
        if ( EnableXonXoff )
             uart_set_sw_flow_ctrl(uart_num, true, 20, 40);
 
-
-       // By default set the direct GPIO pins
-       int txPin = UART_NUM_0_TXD_DIRECT_GPIO_NUM;      // 1
-       int rxPin = UART_NUM_0_RXD_DIRECT_GPIO_NUM;      // 3
-       int rtsPin = UART_NUM_0_CTS_DIRECT_GPIO_NUM;     // 19
-       int ctsPin = UART_NUM_0_RTS_DIRECT_GPIO_NUM;     // 22
-
-       switch(uart_num)
-       {
-           case UART_NUM_1:
-                txPin = UART_NUM_1_TXD_DIRECT_GPIO_NUM;  // 10
-                rxPin = UART_NUM_1_RXD_DIRECT_GPIO_NUM;  // 9
-                rtsPin = UART_NUM_1_CTS_DIRECT_GPIO_NUM; // 6
-                ctsPin = UART_NUM_1_RTS_DIRECT_GPIO_NUM; // 11
-                break;
-
-           case UART_NUM_2:
-                //txPin = UART_NUM_2_TXD_DIRECT_GPIO_NUM;  // 17
-                txPin = 33;
-                //rxPin = UART_NUM_2_RXD_DIRECT_GPIO_NUM;  // 16  
-                rxPin = 32;
-                rtsPin = UART_NUM_2_CTS_DIRECT_GPIO_NUM; // 8
-                ctsPin = UART_NUM_2_RTS_DIRECT_GPIO_NUM; // 7
-                break;
-
-            default:
-                break;
-       }
+	   // Map to currently assigned pins
+	   int txPin  = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, 0); 
+	   int rxPin  = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, 1);
+	   int rtsPin = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, 2);
+	   int ctsPin = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, 3);
 
        // Don't use RTS/CTS if no hardware handshake enabled
        if ( uart_config.flow_ctrl == UART_HW_FLOWCTRL_DISABLE )


### PR DESCRIPTION
## Description

COM port not using EP32 pin mapping
RX flow threshold not initialized causing config method to fail.
With set pin config from Hardware.ESP32 the device type numbering was different. Changed firmware to match.

## How Has This Been Tested?<!-- (if applicable) -->
Tested with simple C# sample program

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: adriansoundy <adriansoundy@gmail.com>
