### PR TITLE
Fixed several issues in HAL_COMPLETION code

### DIFF
--- a/src/PAL/AsyncProcCall/AsyncCompletions.cpp
+++ b/src/PAL/AsyncProcCall/AsyncCompletions.cpp
@@ -8,217 +8,232 @@
 
 #include <nanoPAL.h>
 
-
 HAL_DblLinkedList<HAL_CONTINUATION> g_HAL_Completion_List;
 
 /***************************************************************************/
 
 void HAL_COMPLETION::Execute()
 {
-    NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
+	NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
 
 #if defined(_DEBUG)
-    this->Start_RTC_Ticks = 0;
+	this->Start_RTC_Ticks = 0;
 #endif
 
-    if(this->ExecuteInISR)
-    {
-        HAL_CONTINUATION* cont = this;
+	if (this->ExecuteInISR)
+	{
+		HAL_CONTINUATION* cont = this;
 
-        cont->Execute();
-    }
-    else
-    {
-        this->Enqueue();
-    }
+		cont->Execute();
+	}
+	else
+	{
+		this->Enqueue();
+	}
 }
 
 //--//
 
 void HAL_COMPLETION::InitializeList()
 {
-    NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
-    g_HAL_Completion_List.Initialize();
+	NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
+	g_HAL_Completion_List.Initialize();
 }
 
 //--//
 
 void HAL_COMPLETION::DequeueAndExec()
 {
-    NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
+	NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
 
-    NANOCLR_LOCKED_ACCESS_DECLARATION(HAL_COMPLETION*, ptr);
-    NANOCLR_LOCKED_ACCESS_DECLARATION(HAL_COMPLETION*, ptrNext);
+	GLOBAL_LOCK();
 
-    NANOCLR_LOCKED_ACCESS_EXECUTE(ptr, (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode());
-    NANOCLR_LOCKED_ACCESS_EXECUTE(ptrNext, (HAL_COMPLETION*)(NANOCLR_LOCKED_ACCESS_GET(ptr))->Next());
+	HAL_COMPLETION* ptr = (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode();
 
-    // waitforevents does not have an associated completion, therefore we need to verify
-    // than their is a next completion and that the current one has expired.
-    if(NANOCLR_LOCKED_ACCESS_GET(ptrNext))
-    {
-        Events_Set(SYSTEM_EVENT_FLAG_SYSTEM_TIMER);
+	// waitforevents does not have an associated completion, therefore we need to verify
+	// than their is a next completion and that the current one has expired.
+	if (ptr->Next())
+	{
+		// Current one expired ?
+		if (HAL_Time_CurrentTime() >= ptr->EventTimeTicks)
+		{
+			Events_Set(SYSTEM_EVENT_FLAG_SYSTEM_TIMER);
 
-        NANOCLR_LOCKED_ACCESS_GET(ptr)->Unlink();
+			ptr->Unlink();
 
-        //
-        // In case there's no other request to serve, set the next interrupt to be 356 years since last powerup (@25kHz).
-        //
-        Time_SetCompare( NANOCLR_LOCKED_ACCESS_GET(ptrNext)->Next() ? NANOCLR_LOCKED_ACCESS_GET(ptrNext)->EventTimeTicks : HAL_COMPLETION_IDLE_VALUE );
+#if defined(_DEBUG)
+			ptr->EventTimeTicks = 0;
+#endif  // defined(_DEBUG)
 
-  #if defined(_DEBUG)
-        NANOCLR_LOCKED_ACCESS_GET(ptr)->EventTimeTicks = 0;
-  #endif  // defined(_DEBUG)
+			//// let the ISR turn on interrupts, if it needs to
+			ptr->Execute();
+		}
 
-        //// let the ISR turn on interrupts, if it needs to
-        NANOCLR_LOCKED_ACCESS_GET(ptr)->Execute();
-    }
+		//
+		// Set the next timer to run otherwise set the next interrupt to be 356 years since last powerup (@25kHz).
+		Time_SetCompare(ptr->Next() ? ptr->EventTimeTicks : HAL_COMPLETION_IDLE_VALUE);
+	}
+
+	GLOBAL_UNLOCK();
 }
 
 //--//
 
-void HAL_COMPLETION::EnqueueTicks( uint64_t eventTimeTicks )
+void HAL_COMPLETION::EnqueueTicks(uint64_t eventTimeTicks)
 {
-    NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
-    ASSERT(eventTimeTicks != 0);
+	NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
+	ASSERT(eventTimeTicks != 0);
 
-    NANOCLR_LOCKED_ACCESS_DECLARATION(HAL_COMPLETION*, ptr);
-    NANOCLR_LOCKED_ACCESS_DECLARATION(HAL_COMPLETION*, ptrNext);
+	this->EventTimeTicks = eventTimeTicks;
 
-    this->EventTimeTicks  = eventTimeTicks;
 #if defined(_DEBUG)
-    this->Start_RTC_Ticks = HAL_Time_CurrentSysTicks();
+	this->Start_RTC_Ticks = HAL_Time_CurrentSysTicks();
 #endif
 
-    NANOCLR_LOCKED_ACCESS_EXECUTE(ptr, (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode());
+	GLOBAL_LOCK();
 
-    do
-    {
-        NANOCLR_LOCKED_ACCESS_EXECUTE(ptrNext, (HAL_COMPLETION*)(NANOCLR_LOCKED_ACCESS_GET(ptr))->Next());
+	HAL_COMPLETION* ptr = (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode();
+	HAL_COMPLETION* ptrNext;
 
-        if( eventTimeTicks < NANOCLR_LOCKED_ACCESS_GET(ptr)->EventTimeTicks )
-        {
-            break;
-        }
+	// If not empty list the find position in Completion list based on time
+	// If empty just add at head.
+	if (!g_HAL_Completion_List.IsEmpty())
+	{
+		do
+		{
+			ptrNext = (HAL_COMPLETION *)ptr->Next();
 
-        NANOCLR_LOCKED_ACCESS_GET(ptr) = NANOCLR_LOCKED_ACCESS_GET(ptrNext);
-    }
-    while(NANOCLR_LOCKED_ACCESS_GET(ptr));
-    
+			if (eventTimeTicks < ptr->EventTimeTicks)
+			{
+				break;
+			}
 
-    GLOBAL_LOCK();
-    g_HAL_Completion_List.InsertBeforeNode( NANOCLR_LOCKED_ACCESS_GET(ptr), this );
-    GLOBAL_UNLOCK();
+			ptr = ptrNext;
+		} while (ptr);
+	}
 
-    NANOCLR_LOCKED_ACCESS_EXECUTE(ptr, (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode());
+	g_HAL_Completion_List.InsertBeforeNode(ptr, this);
 
-    if(this == NANOCLR_LOCKED_ACCESS_GET(ptr))
-    {
-        Time_SetCompare( eventTimeTicks );
-    }
+	if (this == g_HAL_Completion_List.FirstNode())
+	{
+		Time_SetCompare(eventTimeTicks);
+	}
+
+	GLOBAL_UNLOCK();
 }
 
 //--//
 
 void HAL_COMPLETION::Abort()
 {
-    NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
+	NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
 
-    NANOCLR_LOCKED_ACCESS_DECLARATION(HAL_COMPLETION*, firstNode);
+	GLOBAL_LOCK();
 
-    NANOCLR_LOCKED_ACCESS_EXECUTE(firstNode, (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode());
+	HAL_COMPLETION* firstNode = (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode();
 
-    this->Unlink();
+	this->Unlink();
 
 #if defined(_DEBUG)
-    this->Start_RTC_Ticks = 0;
+	this->Start_RTC_Ticks = 0;
 #endif
 
-    if(NANOCLR_LOCKED_ACCESS_GET(firstNode) == this)
-    {
-        uint64_t nextTicks;
+	if (firstNode == this)
+	{
+		uint64_t nextTicks;
 
-        GLOBAL_LOCK();
-        bool completionListIsEmpty = g_HAL_Completion_List.IsEmpty();
-        GLOBAL_UNLOCK();
+		if (g_HAL_Completion_List.IsEmpty())
+		{
+			//
+			// In case there's no other request to serve, set the next interrupt to be 356 years since last powerup (@25kHz).
+			//
+			nextTicks = HAL_COMPLETION_IDLE_VALUE;
+		}
+		else
+		{
+			firstNode = (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode();
 
-        if(completionListIsEmpty)
-        {
-            //
-            // In case there's no other request to serve, set the next interrupt to be 356 years since last power up (@25kHz).
-            //
-            nextTicks = HAL_COMPLETION_IDLE_VALUE;
-        }
-        else
-        {
-            NANOCLR_LOCKED_ACCESS_EXECUTE(firstNode, (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode());
-            //firstNode = (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode();
+			nextTicks = firstNode->EventTimeTicks;
+		}
 
-            nextTicks = NANOCLR_LOCKED_ACCESS_GET(firstNode)->EventTimeTicks;
-        }
+		Time_SetCompare(nextTicks);
+	}
 
-        Time_SetCompare( nextTicks );
-    }
+	GLOBAL_UNLOCK();
 }
 
 //--//
 
+
+//
+//	WaitForInterrupts for expireTimeInTicks time
+//
+//  Interrupts should be disabled
+//
 void HAL_COMPLETION::WaitForInterrupts(uint64_t expireTimeInTicks, uint32_t sleepLevel, uint64_t wakeEvents)
 {
-    NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
+	NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
 
-    const int setCompare   = 1;
-    const int resetCompare = 2;
-    const int nilCompare   = 4;
+	const int setCompare = 1;
+	const int resetCompare = 2;
+	const int nilCompare = 4;
 
-    HAL_COMPLETION* ptr = (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode();
-    int             state;
+	HAL_COMPLETION* ptr = (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode();
+	int             state;
 
-    if(ptr->Next() == NULL)
-    {
-        state = setCompare | nilCompare;
-    }
-    else if(ptr->EventTimeTicks > expireTimeInTicks)
-    {
-        state = setCompare | resetCompare;
-    }
-    else
-    {
-        state = 0;
-    }
+	// Any Completion events been Queued ?
+	if (ptr->Next() == NULL)
+	{
+		// No
+		state = setCompare | nilCompare;
+	}
+	// Is Queued event later than passed expire timeout
+	else if (ptr->EventTimeTicks > expireTimeInTicks)
+	{
+		// Yes
+		state = setCompare | resetCompare;
+	}
+	else
+	{
+		state = 0;
+	}
 
-    if(state & setCompare)
-    {
-        Time_SetCompare(expireTimeInTicks);
-    }
+	if (state & setCompare)
+	{
+		// Set timer for expireTimeInTicks time
+		Time_SetCompare(expireTimeInTicks);
+	}
 
-    CPU_Sleep((SLEEP_LEVEL_type)sleepLevel, wakeEvents);
+	// Wait for next interrupt ( timer etc)
+	CPU_Sleep((SLEEP_LEVEL_type)sleepLevel, wakeEvents);
 
-    if(state & (resetCompare | nilCompare))
-    {   
-        // let's get the first node again
-        // it could have changed since CPU_Sleep re-enabled interrupts
-        ptr = (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode();
-        Time_SetCompare((state & resetCompare) ? ptr->EventTimeTicks : HAL_COMPLETION_IDLE_VALUE);
-    }
+	if (state & (resetCompare | nilCompare))
+	{
+		// let's get the first node again
+		// it could have changed since CPU_Sleep re-enabled interrupts
+		ptr = (HAL_COMPLETION*)g_HAL_Completion_List.FirstNode();
+		Time_SetCompare((state & resetCompare) ? ptr->EventTimeTicks : HAL_COMPLETION_IDLE_VALUE);
+	}
 }
 
 void HAL_COMPLETION::Uninitialize()
 {
-    NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
-    
-    HAL_COMPLETION* ptr;
+	NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
 
-    while(TRUE)
-    {
-        GLOBAL_LOCK();
-        ptr = (HAL_COMPLETION*)g_HAL_Completion_List.ExtractFirstNode();
-        GLOBAL_UNLOCK();
+	HAL_COMPLETION* ptr;
 
-        if(!ptr) 
-        {
-            break;
-        }
-        
-    }
+	GLOBAL_LOCK();
+
+	while (TRUE)
+	{
+		ptr = (HAL_COMPLETION*)g_HAL_Completion_List.ExtractFirstNode();
+
+		if (!ptr)
+		{
+			break;
+		}
+
+	}
+
+	GLOBAL_UNLOCK();
 }


### PR DESCRIPTION
## Description

When doing a new version of GPIO for ESP32 i used a completion to handle the bounce timeout
Found the completions where not working at all. Timers expired nearly straight away randomly.

After further investigation found a number of issues.

The double linked list was no longer protected with locks when items were deleted and inserted. 

When inserting to list (EnqueueTicks) and list was empty it referred to random memory outside list head by using ptr->EventTimeTicks on list head.

Timers ended early due no check if time actually reached when a queued timer was superseded with short wait when CLR has nothing else to do. Although comments said there should be a check.  This was probably hidden before due to CPU_Sleep.

Now we don't have CPU_Sleep implemented so goes wrong all the time.
We should have a CPU_Sleep to allow more time to be given to other tasks in RTOS. 
This should be implemented.




## How Has This Been Tested?<!-- (if applicable) -->
I couldn't see anything else using completion in nanoframework but i know the Env28j60 driver does use it.   Tested with GPIO driver which will be separate PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
