### PR TITLE
Use HSE as RTC clock source

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/mcuconf.h
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/mcuconf.h
@@ -41,8 +41,10 @@
 #define STM32_HPRE                          STM32_HPRE_DIV1
 #define STM32_PPRE1                         STM32_PPRE1_DIV4
 #define STM32_PPRE2                         STM32_PPRE2_DIV2
-#define STM32_RTCSEL                        STM32_RTCSEL_LSI
-#define STM32_RTCPRE_VALUE                  8       // 8
+#define STM32_RTCSEL                        STM32_RTCSEL_HSEDIV
+#define STM32_RTCPRE_VALUE                  25
+#define STM32_RTC_PRESA_VALUE               125
+#define STM32_RTC_PRESS_VALUE               8000
 #define STM32_MCO1SEL                       STM32_MCO1SEL_HSI
 #define STM32_MCO1PRE                       STM32_MCO1PRE_DIV1
 #define STM32_MCO2SEL                       STM32_MCO2SEL_SYSCLK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed RTC clock source to use HSE since LSE is not available and LSI is to inaccurate.
Two new defines are needed for clock prescaler. See AN4759 on page 9 and 10 for more details on what values to use for those two new defines.
It has to be noted that ChibiOS does auto reduce the divisors for async and sync prescaler.
The new values must use 124+1 and 7999+1 for the prescaler defines as can be seen in the changed file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template below (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes RTC Clock source and inaccuracy

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a simple timer that gets called every second and compared the timer being in sync with the second of the boards time.

## Screenshots<!-- (if appropriate): -->
![image](https://user-images.githubusercontent.com/10466039/59876101-f079a600-93a2-11e9-91e0-678674fc0efd.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: piwi1263 <piwi1263@gmail.com>
