### PR TITLE
Remove ADC channel using PB8

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/managed_helpers/STM32F769I_DISCOVERY.Adc.cs
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/managed_helpers/STM32F769I_DISCOVERY.Adc.cs
@@ -36,23 +36,18 @@ namespace nanoFramework.Targets.STM32F769I_DISCOVERY
         public const int Channel_4 = 4;
 
         /// <summary>
-        /// Channel 5, exposed on A5, connected to PB8 (ADC3 - IN7)
+        /// Channel 5, internal temperature sensor, connected to ADC1
         /// </summary>
-        public const int Channel_5 = 5;
+        public const int Channel_TemperatureSensor = 5;
 
         /// <summary>
-        /// Channel 6, internal temperature sensor, connected to ADC1
+        /// Channel 6, internal voltage reference, connected to ADC1
         /// </summary>
-        public const int Channel_TemperatureSensor = 6;
+        public const int Channel_VrefIn = 6;
 
         /// <summary>
-        /// Channel 7, internal voltage reference, connected to ADC1
+        /// Channel 7, connected to VBatt pin, ADC1
         /// </summary>
-        public const int Channel_VrefIn = 7;
-
-        /// <summary>
-        /// Channel 8, connected to VBatt pin, ADC1
-        /// </summary>
-        public const int Channel_Vbatt = 8;
+        public const int Channel_Vbatt = 7;
     }
 }

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_adc_config.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_adc_config.cpp
@@ -15,7 +15,6 @@ const NF_PAL_ADC_PORT_PIN_CHANNEL AdcPortPinConfig[] = {
 
     // ADC3
     {3, GPIOF, 8, ADC_CHANNEL_IN6},
-    {3, GPIOB, 8, ADC_CHANNEL_IN7},
 
     // these are the internal sources, available only at ADC1
     {1, NULL, 0, ADC_CHANNEL_SENSOR},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed the use of PB8 for an ADC channel. Pin PB8 is used primary for I2C. 

- Removed the config for the channel
- Updated helper class for C#

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template below (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes nanoFramework/Home#492

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: piwi1263 <piwi1263@gmail.com>
