### PR TITLE
Fix secure socket authentication

### DIFF
--- a/CMake/Modules/TI_SimpleLink_CC32xx_sources.cmake
+++ b/CMake/Modules/TI_SimpleLink_CC32xx_sources.cmake
@@ -193,6 +193,9 @@ set(SLNetWiFi_SRCS
     # drivers
     eventreg.c
     slnetifwifi.c
+
+    # utils
+    clock_sync.c
 )
 
 foreach(SRC_FILE ${SLNetWiFi_SRCS})
@@ -206,6 +209,9 @@ foreach(SRC_FILE ${SLNetWiFi_SRCS})
         # drivers
         "${PROJECT_BINARY_DIR}/SimpleLinkCC32xxSDK_Source/ti/drivers/net/wifi"
         "${PROJECT_BINARY_DIR}/SimpleLinkCC32xxSDK_Source/ti/drivers/net/wifi/slnetif"
+
+        # utils
+        "${PROJECT_BINARY_DIR}/SimpleLinkCC32xxSDK_Source/ti/net/utils"
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )


### PR DESCRIPTION
## Description
- Replace wrong call to SimpleLink API.
- Add call to set Simple Link date time required to validate certs.
- Update CMake to include clock and time source required for time structs conversion.

## Motivation and Context
- Fixes socket authentication (wasn't working).

## How Has This Been Tested?<!-- (if applicable) -->
- SSL sample. Successfully authenticated and download content from www.howsmyssl.com.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
