### PR TITLE
Fix startocd.bat for Wrover board

### DIFF
--- a/startocd.bat
+++ b/startocd.bat
@@ -34,11 +34,12 @@ set iface=-f interface/ftdi/olimex-arm-usb-ocd-h.cfg -f target/esp32.cfg -c "ada
 goto start
 
 :ESP32_WROVER
-set iface=-f interface/ftdi/esp32_devkitj_v1.cfg -f board/esp-wroom-32.cfg 
+set iface=-f interface/ftdi/esp32_devkitj_v1.cfg -f board/esp32-wrover.cfg 
 goto start
 
 :STM32_STLINK
-set cmd=C:/nanoFramework_Tools/Tools/openocd/bin/openocd.exe -s C:/nanoFramework_Tools/Tools/openocd/bin/scripts
+REM Note: I tried using the Eclipse OpenOCD without much success here, then switched to the ESP32 version, and it works right out of the box!
+REM set cmd=C:/nanoFramework_Tools/Tools/openocd/bin/openocd.exe -s C:/nanoFramework_Tools/Tools/openocd/bin/scripts
 set iface=-f interface/stlink-v2-1.cfg -f board/stm32f7discovery.cfg
 goto start
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
OpenOCD has a Wrover specific board file, switch to use that rather than generic ESP32 one


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: C-Born <DavidAVarley@gmail.com>
