### PR TITLE
Updates GCC toolchain to 8 2019 q3

### DIFF
--- a/CMake/toolchain.FreeRtos.GCC.cmake
+++ b/CMake/toolchain.FreeRtos.GCC.cmake
@@ -98,8 +98,8 @@ function(NF_SET_OPTIMIZATION_OPTIONS TARGET)
 
     target_compile_options(${TARGET} PRIVATE
         $<$<CONFIG:Debug>:-Og -femit-class-debug-always -g3 -ggdb>
-        $<$<CONFIG:Release>:-O3 -flto -fuse-linker-plugin -fno-fat-lto-objects>
-        $<$<CONFIG:MinSizeRel>:-Os -flto -fuse-linker-plugin -fno-fat-lto-objects>
+        $<$<CONFIG:Release>:-O3>
+        $<$<CONFIG:MinSizeRel>:-Os>
         $<$<CONFIG:RelWithDebInfo>:-Os -femit-class-debug-always -g3 -ggdb>
     )
 

--- a/cmake-variants.TEMPLATE-MIMXRT1060.json
+++ b/cmake-variants.TEMPLATE-MIMXRT1060.json
@@ -31,7 +31,7 @@
         "short": "MIMXRT1060_EVK",
         "settings": {
           "BUILD_VERSION": "0.9.99.999",
-          "TOOLCHAIN_PREFIX": "C:/nanoFramework_Tools/GNU_ARM_Toolchain/7 2018-q2-update",
+          "TOOLCHAIN_PREFIX": "C:/nanoFramework_Tools/GNU_ARM_Toolchain/8 2019-q3-update",
           "TARGET_SERIES": "IMXRT10xx",
           "SUPPORT_ANY_BASE_CONVERSION": "ON",
           "RTOS": "FREERTOS",

--- a/targets/FreeRTOS/NXP/common/device/MIMXRT1062_features.h
+++ b/targets/FreeRTOS/NXP/common/device/MIMXRT1062_features.h
@@ -53,7 +53,7 @@
 /* @brief ENC availability on the SoC. */
 #define FSL_FEATURE_SOC_ENC_COUNT (4)
 /* @brief ENET availability on the SoC. */
-#define FSL_FEATURE_SOC_ENET_COUNT (2)
+#define FSL_FEATURE_SOC_ENET_COUNT (3)
 /* @brief EWM availability on the SoC. */
 #define FSL_FEATURE_SOC_EWM_COUNT (1)
 /* @brief FLEXCAN availability on the SoC. */

--- a/targets/FreeRTOS/NXP/common/drivers/fsl_clock.h
+++ b/targets/FreeRTOS/NXP/common/drivers/fsl_clock.h
@@ -48,7 +48,7 @@
 
 /*@}*/
 #define CCM_TUPLE(reg, shift, mask, busyShift)                               \
-    (int)((((uint32_t)(&((CCM_Type *)0U)->reg)) & 0xFFU) | ((shift) << 8U) | \
+    (((uint32_t)offsetof(CCM_Type,reg) & 0xFFU ) | ((shift) << 8U) | \
           ((((mask) >> (shift)) & 0x1FFFU) << 13U) | ((busyShift) << 26U))
 #define CCM_TUPLE_REG(base, tuple) (*((volatile uint32_t *)(((uint32_t)(base)) + ((tuple)&0xFFU))))
 #define CCM_TUPLE_SHIFT(tuple) (((tuple) >> 8U) & 0x1FU)
@@ -60,7 +60,7 @@
 /*!
  * @brief CCM ANALOG tuple macros to map corresponding registers and bit fields.
  */
-#define CCM_ANALOG_TUPLE(reg, shift) ((((uint32_t)(&((CCM_ANALOG_Type *)0U)->reg) & 0xFFFU) << 16U) | (shift))
+#define CCM_ANALOG_TUPLE(reg, shift) ((((uint32_t)offsetof(CCM_ANALOG_Type,reg) & 0xFFFU) << 16U) | (shift))
 #define CCM_ANALOG_TUPLE_SHIFT(tuple) (((uint32_t)tuple) & 0x1FU)
 #define CCM_ANALOG_TUPLE_REG_OFF(base, tuple, off) \
     (*((volatile uint32_t *)((uint32_t)base + (((uint32_t)tuple >> 16U) & 0xFFFU) + off)))


### PR DESCRIPTION
Updates GCC toolchain to 8 2019 q3

- Following nanoframework/nf-interpreter#1401

Signed-off-by: MateuszKlatecki <mateusz.klatecki@gc5.pl>
