### PR TITLE
Update default serial baud rate

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/README.md
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/README.md
@@ -6,7 +6,7 @@ In _halconf.g_ (in both nanoBooter and nanoCLR folders), when compared with a de
 - HAL_USE_SERIAL to TRUE
 - HAL_USE_SERIAL_USB to TRUE
 - HAL_USE_USB to TRUE
-- SERIAL_DEFAULT_BITRATE to 115200
+- SERIAL_DEFAULT_BITRATE to 921600
 
 In _mcuconf.h_ (in both nanoBooter and nanoCLR folders), when compared with a default file:
 - STM32_SERIAL_USE_USART2 to TRUE

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/halconf.h
@@ -378,7 +378,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE              115200
+#define SERIAL_DEFAULT_BITRATE              921600
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/halconf.h
@@ -390,7 +390,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE              115200
+#define SERIAL_DEFAULT_BITRATE              921600
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/target_common.c
@@ -15,7 +15,7 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
 
     1,  //ConvertCOM_DebugHandle(1),
     0,  //ConvertCOM_DebugHandle(0),
-    115200,
+    921600,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoBooter/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoBooter/halconf.h
@@ -378,7 +378,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE              115200
+#define SERIAL_DEFAULT_BITRATE              921600
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/halconf.h
@@ -390,7 +390,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE              115200
+#define SERIAL_DEFAULT_BITRATE              921600
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/target_common.c
@@ -15,7 +15,7 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
 
     1,  //ConvertCOM_DebugHandle(1),
     0,  //ConvertCOM_DebugHandle(0),
-    115200,
+    921600,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/README.md
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/README.md
@@ -4,7 +4,7 @@ For a successful build the following changes are required:
 
 In _halconf.g_ (in both nanoBooter and nanoCLR folders), when compared with a default file:
 - HAL_USE_SERIAL to TRUE
-- SERIAL_DEFAULT_BITRATE to 115200
+- SERIAL_DEFAULT_BITRATE to 921600
 - SERIAL_BUFFERS_SIZE has to be at least 64 (2x the Wire Protocol packet size) otherwise the transmission will be garbled as the packets overrun each other
 
 In _mcuconf.h_ (in both nanoBooter and nanoCLR folders), when compared with a default file:

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/halconf.h
@@ -378,7 +378,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE              115200
+#define SERIAL_DEFAULT_BITRATE              921600
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/halconf.h
@@ -389,7 +389,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE              115200
+#define SERIAL_DEFAULT_BITRATE              921600
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/target_common.c
@@ -14,7 +14,7 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
 
     1,  //ConvertCOM_DebugHandle(1),
     0,  //ConvertCOM_DebugHandle(0),
-    115200,
+    921600,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/README.md
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/README.md
@@ -6,7 +6,7 @@ In _halconf.g_ (in both nanoBooter and nanoCLR folders), when compared with a de
 - HAL_USE_SERIAL to TRUE
 - HAL_USE_SERIAL_USB to TRUE
 - HAL_USE_USB to TRUE
-- SERIAL_DEFAULT_BITRATE to 115200
+- SERIAL_DEFAULT_BITRATE to 921600
 
 In _mcuconf.h_ (in both nanoBooter and nanoCLR folders), when compared with a default file:
 - STM32_SERIAL_USE_USART2 to TRUE

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/halconf.h
@@ -385,7 +385,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE      115200
+#define SERIAL_DEFAULT_BITRATE              921600
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf.h
@@ -390,7 +390,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE              115200
+#define SERIAL_DEFAULT_BITRATE              921600
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/target_common.c
@@ -14,7 +14,7 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
 
     1,  //ConvertCOM_DebugHandle(1),
     0,  //ConvertCOM_DebugHandle(0),
-    115200,
+    921600,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/README.md
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/README.md
@@ -6,7 +6,7 @@ For memory maps, uuid etc. the reference document used was: http://www.st.com/co
 
 In _halconf.g_ (in both nanoBooter and nanoCLR folders), when compared with a default file available from (https://github.com/ChibiOS/ChibiOS/tree/master/demos/STM32/RT-STM32F769I-DISCOVERY):
 - HAL_USE_SERIAL to TRUE
-- SERIAL_DEFAULT_BITRATE to 115200
+- SERIAL_DEFAULT_BITRATE to 921600
 
 In _mcuconf.h_ (in both nanoBooter and nanoCLR folders), when compared with a default file available from (https://github.com/ChibiOS/ChibiOS/tree/master/demos/STM32/RT-STM32F769I-DISCOVERY):
 - STM32_SERIAL_USE_USART1 to TRUE

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/halconf.h
@@ -384,7 +384,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE              115200
+#define SERIAL_DEFAULT_BITRATE              921600
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf.h
@@ -402,7 +402,7 @@
  *          default configuration.
  */
 #if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
-#define SERIAL_DEFAULT_BITRATE              115200
+#define SERIAL_DEFAULT_BITRATE              921600
 #endif
 
 /**

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_common.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_common.c
@@ -14,7 +14,7 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
 
     1, //ConvertCOM_DebugHandle(1),
     0,//ConvertCOM_DebugHandle(0),
-    115200,
+    921600,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/WireProtocol_HAL_Interface.c
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/WireProtocol_HAL_Interface.c
@@ -45,7 +45,7 @@ bool WP_Initialise(COM_HANDLE port)
     if ( WP_Port > UART_NUM_2 ) return false;
  
     uart_config_t uart_config = {
-        .baud_rate = 115200,                                 //baudrate
+        .baud_rate = 921600,                                 //baudrate
         .data_bits = UART_DATA_8_BITS,                       //data bit mode
         .parity    = UART_PARITY_DISABLE,                    //parity mode
         .stop_bits = UART_STOP_BITS_1,                       //stop bit mode

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/target_common.c
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/target_common.c
@@ -16,7 +16,7 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
 
     1,  //ConvertCOM_DebugHandle(1),
     0,  //ConvertCOM_DebugHandle(0),
-    115200,
+    921600,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },

--- a/targets/TI-SimpleLink/TI_CC3220SF_LAUNCHXL/CC3220SF_LAUNCHXL.c
+++ b/targets/TI-SimpleLink/TI_CC3220SF_LAUNCHXL/CC3220SF_LAUNCHXL.c
@@ -272,7 +272,7 @@ static uint_least8_t sharpDisplayBuf[BOARD_DISPLAY_SHARP_SIZE * BOARD_DISPLAY_SH
 
 const DisplayUart_HWAttrs displayUartHWAttrs = {
     .uartIdx = 0,
-    .baudRate = 115200,
+    .baudRate = 921600,
     .mutexTimeout = (unsigned int)(-1),
     .strBuf = displayBuf,
     .strBufLen = MAXPRINTLEN

--- a/targets/TI-SimpleLink/TI_CC3220SF_LAUNCHXL/target_common.c
+++ b/targets/TI-SimpleLink/TI_CC3220SF_LAUNCHXL/target_common.c
@@ -14,7 +14,7 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
 
     1, //ConvertCOM_DebugHandle(1),
     0,//ConvertCOM_DebugHandle(0),
-    115200,
+    921600,
     0,  // STDIO = COM2 or COM1
 
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL.c
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL.c
@@ -36,7 +36,7 @@ void ConfigUART()
     uartParams.readDataMode = UART_DATA_BINARY;
     uartParams.readReturnMode = UART_RETURN_FULL;
     uartParams.readEcho = UART_ECHO_OFF;
-    uartParams.baudRate = 115200;
+    uartParams.baudRate = 921600;
     uartParams.readTimeout = 500;
 
     uart = UART_open(Board_UART0, &uartParams);

--- a/targets/os/win32/nanoCLR/Various.cpp
+++ b/targets/os/win32/nanoCLR/Various.cpp
@@ -59,7 +59,7 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     DEBUGGER_PORT,
 
     DEBUG_TEXT_PORT,
-    115200,
+    921600,
     0,  // STDIO = COM2 or COM1
 
     { 0, 0 },   // { SRAM1_MEMORY_Base, SRAM1_MEMORY_Size },


### PR DESCRIPTION
## Description
- Update default serial baud rate on all targets to 921600.

## Motivation and Context
- Support change in nanoframework/nf-debugger#204.
- All current targets support this baud rate without any problem. This increases Wire Protocol throughput ~8x.
- Transport is actually performed with USB, serial is only used on very short distance on the board, meaning that no transmission issue will raise from this. Even if that's the case the WP layer has error checking mechanism that can be used to detect this, if needed.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>