### PR TITLE
Fix OemInfo command

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1077,11 +1077,11 @@ static void GetClrReleaseInfo(CLR_DBG_Commands::Debugging_Execution_QueryCLRCapa
         VERSION_BUILD, 
         VERSION_REVISION, 
         OEMSYSTEMINFOSTRING, 
-        hal_strlen_s(OEMSYSTEMINFOSTRING),
+        ARRAYSIZE(OEMSYSTEMINFOSTRING),
         TARGETNAMESTRING,
-        hal_strlen_s(TARGETNAMESTRING),
+        ARRAYSIZE(TARGETNAMESTRING),
         PLATFORMNAMESTRING,
-        hal_strlen_s(PLATFORMNAMESTRING)
+        ARRAYSIZE(PLATFORMNAMESTRING)
         );
 
     if ( g_CLR_RT_TypeSystem.m_assemblyMscorlib &&

--- a/src/CLR/Debugger/Debugger_stub.cpp
+++ b/src/CLR/Debugger/Debugger_stub.cpp
@@ -56,18 +56,32 @@ __nfweak void NFReleaseInfo::Init(
     const char *platform, 
     size_t platformLen)
 {
+    size_t len;
+
     NFVersion::Init( NFReleaseInfo.Version, major, minor, build, revision );
+    
+    // better set these to empty strings, in case there is nothing to fill in
     NFReleaseInfo.InfoString[ 0 ] = 0;
-    if ( NULL != info && infoLen > 0 )
+    NFReleaseInfo.TargetName[ 0 ] = 0;
+    NFReleaseInfo.PlatformName[ 0 ] = 0;
+
+    // fill each one, if it was provided
+    if ( NULL != info )
     {
-        size_t len = MIN(infoLen, sizeof(NFReleaseInfo.InfoString)-1);
-        hal_strncpy_s( (char*)&NFReleaseInfo.InfoString[0], sizeof(NFReleaseInfo.InfoString), info, len );
-        
-        len = MIN(targetLen, sizeof(NFReleaseInfo.TargetName)-1);
-        hal_strncpy_s( (char*)&NFReleaseInfo.TargetName[0], sizeof(NFReleaseInfo.TargetName), target, len );
-        
-        len = MIN(platformLen, sizeof(NFReleaseInfo.PlatformName)-1);
-        hal_strncpy_s( (char*)&NFReleaseInfo.PlatformName[0], sizeof(NFReleaseInfo.PlatformName), platform, len );
+        len = MIN(infoLen, sizeof(NFReleaseInfo.InfoString));
+        memcpy(NFReleaseInfo.InfoString, info, len);
+    }
+
+    if ( NULL != target )
+    {
+        len = MIN(targetLen, sizeof(NFReleaseInfo.TargetName));
+        memcpy(NFReleaseInfo.TargetName, target, len);
+    }
+
+    if ( NULL != platform )
+    {
+        len = MIN(platformLen, sizeof(NFReleaseInfo.PlatformName));
+        memcpy(NFReleaseInfo.PlatformName, platform, len);
     }
 }
 

--- a/src/CLR/Include/WireProtocol.h
+++ b/src/CLR/Include/WireProtocol.h
@@ -185,8 +185,9 @@ typedef struct ReleaseInfo
 {
 
     VersionInfo version;
-
-    uint8_t infoString[64-sizeof(VersionInfo)];
+    uint8_t InfoString[128];
+    uint8_t TargetName[32];
+    uint8_t PlatformName[32];
 
 }ReleaseInfo;
 

--- a/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
@@ -22,9 +22,11 @@ int NanoBooter_GetReleaseInfo(ReleaseInfo* releaseInfo)
     releaseInfo->version.usMajor = VERSION_MAJOR;
     releaseInfo->version.usMinor = VERSION_MINOR;
     releaseInfo->version.usBuild = VERSION_BUILD;
-    releaseInfo->version.usRevision = 0;
+    releaseInfo->version.usRevision = VERSION_REVISION;
 
-    memcpy(&releaseInfo->infoString, OEMSYSTEMINFOSTRING, sizeof(releaseInfo->infoString));
+    memcpy(&releaseInfo->InfoString, OEMSYSTEMINFOSTRING, ARRAYSIZE(OEMSYSTEMINFOSTRING));
+    memcpy(&releaseInfo->TargetName, TARGETNAMESTRING, ARRAYSIZE(TARGETNAMESTRING));
+    memcpy(&releaseInfo->PlatformName, PLATFORMNAMESTRING, ARRAYSIZE(PLATFORMNAMESTRING));
 
     return true;
 }


### PR DESCRIPTION
## Description
- Current implementation was missing the new fields with target and platform names.
- Improve code of NFReleaseInfo::Init().
- Improve code on GetClrReleaseInfo() to use static values for string lengths.

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
