### PR TITLE
Improve network configuration block management

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/common/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/common/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 # append common source files
 list(APPEND COMMON_PROJECT_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/Device_BlockStorage$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-DEBUG>.c")
+list(APPEND COMMON_PROJECT_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/targetHAL_ConfigurationManager.cpp")
 
 # make var global
 set(COMMON_PROJECT_SOURCES ${COMMON_PROJECT_SOURCES} CACHE INTERNAL "make global")

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/common/targetHAL_ConfigurationManager.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/common/targetHAL_ConfigurationManager.cpp
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <nanoHAL.h>
+#include <nanoHAL_v2.h>
+#include <nanoWeak.h>
+#include <Target_BlockStorage_STM32FlashDriver.h>
+
+// Default initialisation for Network interface config blocks
+// strong implementation replacing ChibiOS 'weak' one
+bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig, uint32_t configurationIndex)
+{
+    (void)configurationIndex;
+
+    // make sure the config block marker is set
+    memcpy(pconfig->Marker, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
+    
+    pconfig->InterfaceType = NetworkInterfaceType_Ethernet;
+    pconfig->StartupAddressMode = AddressMode_DHCP;
+    pconfig->AutomaticDNS = 1;
+    pconfig->SpecificConfigId = 0;
+
+    // set MAC address with ST provided MAC for development boards
+    // 00:80:E1:01:35:D1
+    pconfig->MacAddress[0] = 0x00;
+    pconfig->MacAddress[1] = 0x80;
+    pconfig->MacAddress[2] = 0xE1;
+    pconfig->MacAddress[3] = 0x01;
+    pconfig->MacAddress[4] = 0x35;
+    pconfig->MacAddress[5] = 0xD1;
+
+    return true;
+}

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetHAL_ConfigurationManager.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetHAL_ConfigurationManager.cpp
@@ -294,12 +294,16 @@ void InitialiseWirelessDefaultConfig(HAL_Configuration_Wireless80211 * pconfig, 
 bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig, uint32_t configurationIndex)
 {
     memset( pconfig, 0, sizeof(HAL_Configuration_NetworkInterface));
-    
+
+    // make sure the config block marker is set
+    memcpy(pconfig->Marker, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
+  
     switch(configurationIndex)
     {
         case 0: // Wireless Station
             pconfig->InterfaceType = NetworkInterfaceType_Wireless80211;
             pconfig->StartupAddressMode = AddressMode_DHCP;
+            pconfig->AutomaticDNS = 1;
             pconfig->SpecificConfigId = 0;
             break;
 
@@ -316,8 +320,12 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
         case 2: // Ethernet
             pconfig->InterfaceType = NetworkInterfaceType_Ethernet;
             pconfig->StartupAddressMode = AddressMode_DHCP;
+            pconfig->AutomaticDNS = 1;
             break;
     }
+
+    // get default MAC
+    esp_efuse_mac_get_default(pconfig->MacAddress);
 
     // always good
     return TRUE;

--- a/targets/TI-SimpleLink/common/targetHAL_ConfigurationManager_CC32xx.cpp
+++ b/targets/TI-SimpleLink/common/targetHAL_ConfigurationManager_CC32xx.cpp
@@ -125,14 +125,16 @@ void ConfigurationManager_EnumerateConfigurationBlocks()
     {
         // there is no network config block available, get a default
         HAL_Configuration_NetworkInterface* networkConfig = (HAL_Configuration_NetworkInterface*)platform_malloc(sizeof(HAL_Configuration_NetworkInterface));
-        InitialiseNetworkDefaultConfig(networkConfig, 0);
-        
-        // store it
-        ConfigurationManager_StoreConfigurationBlock(networkConfig, DeviceConfigurationOption_Network, 0, sizeof(HAL_Configuration_NetworkInterface), 0);
-        platform_free(networkConfig);
+        if(InitialiseNetworkDefaultConfig(networkConfig, 0))
+        {
+            // config block created, store it
+            ConfigurationManager_StoreConfigurationBlock(networkConfig, DeviceConfigurationOption_Network, 0, sizeof(HAL_Configuration_NetworkInterface), 0);
+            
+            // have to enumerate again to pick it up
+            networkConfigs = (HAL_CONFIGURATION_NETWORK*)ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks();
+        }
 
-        // have to enumerate again to pick it up
-        networkConfigs = (HAL_CONFIGURATION_NETWORK*)ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks();
+        platform_free(networkConfig);
     }
 
     // find wireless 80211 network configuration blocks
@@ -228,33 +230,11 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
     // requested Index has to exist (array index starts at zero, so need to add one)
     if(configuration == DeviceConfigurationOption_Network)
     {
-        if(g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0)
+        if( g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0 ||
+            (configurationIndex + 1) > g_TargetConfiguration.NetworkInterfaceConfigs->Count)
         {
-            // there is no network config block, init one with default settings
-            if(InitialiseNetworkDefaultConfig((HAL_Configuration_NetworkInterface*)configurationBlock, 0))
-            {
-                // force storing profile
-                if(ConfigurationManager_StoreConfigurationBlock(configurationBlock, DeviceConfigurationOption_Network, 0, sizeof(HAL_Configuration_NetworkInterface), 0))
-                {
-                    // need to enumerate blocks
-                    ConfigurationManager_EnumerateConfigurationBlocks();
-
-                    // done here
-                    return true;
-                }
-                else
-                {
-                    // couldn't store the config block
-                    return false;
-                }
-            }
-        }
-        else
-        {
-            if((configurationIndex + 1) > g_TargetConfiguration.NetworkInterfaceConfigs->Count)
-            {
-                return false;
-            }
+            // the requested config block is beyond the available count
+            return false;
         }
     }
     else if(configuration == DeviceConfigurationOption_Wireless80211Network)
@@ -510,6 +490,8 @@ void InitialiseWirelessDefaultConfig(HAL_Configuration_Wireless80211 * pconfig, 
 //  Default initialisation for Network interface config blocks
 bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig, uint32_t configurationIndex)
 {
+    (void)configurationIndex;
+
     uint16_t macAddressLen = SL_MAC_ADDR_LEN;
 
     memset(pconfig, 0, sizeof(HAL_Configuration_NetworkInterface));
@@ -519,6 +501,7 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
     
     pconfig->InterfaceType = NetworkInterfaceType_Wireless80211;
     pconfig->StartupAddressMode = AddressMode_DHCP;
+    pconfig->AutomaticDNS = 1;
     pconfig->SpecificConfigId = 0;
 
     sl_NetCfgGet(SL_NETCFG_MAC_ADDRESS_GET, 0, &macAddressLen, pconfig->MacAddress);


### PR DESCRIPTION
## Description
- Add default network config block for STM32F769I using default STM MAC address.
- Rework logic to create default network config block on enumeration, only.
- Add setting to use auto DNS on default configuration.
- Default config block for ESP32 now grabs default MAC from device.

## Motivation and Context
- Need to be able to set a default MAC on SMT32 devices otherwise networked enabled devices couldn't boot with network.
- Default network block on ESP32 wasn't grabbing the default MAC address.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
