### PR TITLE
Workaround for bug in FreeLink serial port configuration

### DIFF
--- a/targets/FreeRTOS/NXP/common/WireProtocol_HAL_Interface.c
+++ b/targets/FreeRTOS/NXP/common/WireProtocol_HAL_Interface.c
@@ -33,7 +33,7 @@ static struct _lpuart_handle t_handle;
 uint8_t background_buffer[1024];
 
 lpuart_rtos_config_t lpuart_config = {
-    .baudrate = 921600,
+    .baudrate = 490384,                 //NOTE: is should be 921600 but due to bug in FreeLink serial port configuration real baud is 490384
     .parity = kLPUART_ParityDisabled,
     .stopbits = kLPUART_OneStopBit,
     .buffer = background_buffer,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Due to bug in FreeLink (onboard debugger) serial port configuration after updating baudrate to 921600 real baud is 490384 so to be able communicate with board there is temporary solution until NXP fix the bug.

## How Has This Been Tested?<!-- (if applicable) -->
tested with newest VS extension

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: Mateusz Klatecki <mateusz.klatecki@gc5.pl>
