### PR TITLE
Fix configuration manager initialization

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/common/targetHAL_ConfigurationManager.cpp
+++ b/targets/CMSIS-OS/ChibiOS/common/targetHAL_ConfigurationManager.cpp
@@ -12,6 +12,9 @@
 // provided as weak so it can be replaced at target level, if required because of the target implementing the storage with a mechanism other then saving to flash
 __nfweak void ConfigurationManager_Initialize()
 {
+    // init g_TargetConfiguration
+    memset(&g_TargetConfiguration, 0, sizeof(HAL_TARGET_CONFIGURATION));
+
     // enumerate the blocks
     ConfigurationManager_EnumerateConfigurationBlocks();
 };
@@ -151,8 +154,9 @@ __nfweak bool ConfigurationManager_StoreConfigurationBlock(void* configurationBl
 
     if(configuration == DeviceConfigurationOption_Network)
     {
-        if( g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0 &&
-            configurationIndex == 0 )
+        if( g_TargetConfiguration.NetworkInterfaceConfigs == NULL || 
+            ( g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0 &&
+            configurationIndex == 0 ))
         {
             // there is no network config block, we are storing the default one
             // THIS IS THE ONLY CONFIG BLOCK THAT'S AUTO-CREATED
@@ -182,8 +186,9 @@ __nfweak bool ConfigurationManager_StoreConfigurationBlock(void* configurationBl
     }
     else if(configuration == DeviceConfigurationOption_Wireless80211Network)
     {
-        if( g_TargetConfiguration.Wireless80211Configs->Count == 0 ||
-            (configurationIndex + 1) > g_TargetConfiguration.Wireless80211Configs->Count)
+        if( g_TargetConfiguration.Wireless80211Configs == NULL ||
+            (g_TargetConfiguration.Wireless80211Configs->Count == 0 ||
+            (configurationIndex + 1) > g_TargetConfiguration.Wireless80211Configs->Count))
         {
             // there is no room for this block, or there are no blocks stored at all
             // failing the operation
@@ -201,8 +206,9 @@ __nfweak bool ConfigurationManager_StoreConfigurationBlock(void* configurationBl
     }
     else if(configuration == DeviceConfigurationOption_X509CaRootBundle)
     {
-        if( g_TargetConfiguration.CertificateStore->Count == 0 ||
-            (configurationIndex + 1) > g_TargetConfiguration.CertificateStore->Count)
+        if( g_TargetConfiguration.Wireless80211Configs == NULL ||
+            (g_TargetConfiguration.CertificateStore->Count == 0 ||
+            (configurationIndex + 1) > g_TargetConfiguration.CertificateStore->Count))
         {
             // there is no room for this block, or there are no blocks stored at all
             // failing the operation


### PR DESCRIPTION
## Description
- Add missing memset to cleanup struct.
- Add check for empty struct when storing default network config block.

## Motivation and Context
- Causing hard fault on initializing a completely erased device.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
