### PR TITLE
Fix SPI device getting pin config

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -99,9 +99,11 @@ void Esp32_Spi_UnitializeAll()
 // Inialise the SPI Bus
 static void InitSpiBus( spi_host_device_t bus)
 {
-    gpio_num_t mosiPin  = (gpio_num_t)Esp32_GetMappedDevicePins( DEV_TYPE_SPI, bus, 0);
-    gpio_num_t misoPin  = (gpio_num_t)Esp32_GetMappedDevicePins( DEV_TYPE_SPI, bus, 1);
-    gpio_num_t clockPin = (gpio_num_t)Esp32_GetMappedDevicePins( DEV_TYPE_SPI, bus, 2);
+	int busIndex = bus - 1;
+
+    gpio_num_t mosiPin  = (gpio_num_t)Esp32_GetMappedDevicePins( DEV_TYPE_SPI, busIndex, 0);
+    gpio_num_t misoPin  = (gpio_num_t)Esp32_GetMappedDevicePins( DEV_TYPE_SPI, busIndex, 1);
+    gpio_num_t clockPin = (gpio_num_t)Esp32_GetMappedDevicePins( DEV_TYPE_SPI, busIndex, 2);
  
     spi_bus_config_t bus_config 
     {


### PR DESCRIPTION
## Description
Fix to SPI pin config which was broken by previous change to ESp32 pin configuration

## How Has This Been Tested?<!-- (if applicable) -->
Test with small SPI test program shown on M5Stack forum channel


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
