### PR TITLE
Update CMake for SPIFFS to target nF branch

### DIFF
--- a/CMake/SPIFFS.CMakeLists.cmake.in
+++ b/CMake/SPIFFS.CMakeLists.cmake.in
@@ -13,6 +13,7 @@ ExternalProject_Add(
     PREFIX SPIFFS
     SOURCE_DIR ${CMAKE_BINARY_DIR}/SPIFFS_Source
     GIT_REPOSITORY  https://github.com/nanoframework/spiffs
+    GIT_TAG "nf-build"  # target nanoFramework modified branch
     GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
     TIMEOUT 10
     LOG_DOWNLOAD 1

--- a/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
@@ -397,11 +397,6 @@ endif()
 # if support for SPIFFS is enabled add it to the build
 if(NF_FEATURE_USE_SPIFFS)
 
-    # SPIFFS needs STM Cube package option
-    if(NOT STM32_CUBE_PACKAGE_REQUIRED)
-        message(FATAL_ERROR "error: SPIFFS requires STM Cube package option, make sure you have STM32_CUBE_PACKAGE_REQUIRED build option set to ON.")
-    endif()
-
     # check if SPIFFS_SOURCE was specified or if it's empty (default is empty)
     set(NO_SPIFFS_SOURCE TRUE)
 
@@ -443,6 +438,7 @@ if(NF_FEATURE_USE_SPIFFS)
             PREFIX SPIFFS
             SOURCE_DIR ${CMAKE_BINARY_DIR}/SPIFFS_Source
             GIT_REPOSITORY  https://github.com/nanoframework/spiffs
+            GIT_TAG "nf-build"  # target nanoFramework modified branch
             GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
             TIMEOUT 10
             LOG_DOWNLOAD 1


### PR DESCRIPTION
## Description
- Remove check for STM32 Cube package on SPIFFS (may not require QPSI and use regular SPI driver).
- Change default branch to nF modified branch.

## Motivation and Context
- SPIFFS project doesn't seem to be maintained anymore. We need to incorporate fixes and improvements. Having our own active branch seems to be the best option.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
