### PR TITLE
Fix NBGV var with build version

### DIFF
--- a/azure-pipelines-templates/build-chibios-stm32.yml
+++ b/azure-pipelines-templates/build-chibios-stm32.yml
@@ -8,14 +8,14 @@ steps:
 
   - task: CMake@1
     inputs:
-      cmakeArgs: '-G Ninja -DTOOLCHAIN_PREFIX=$(GNU_GCC_TOOLCHAIN_PATH) -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_VERSION=$(NBGV_Version) -DCHIBIOS_BOARD=$(BoardName) $(BuildOptions) -DTOOL_HEX2DFU_PREFIX=$(HEX2DFU_PATH) ..'
+      cmakeArgs: '-G Ninja -DTOOLCHAIN_PREFIX=$(GNU_GCC_TOOLCHAIN_PATH) -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_VERSION=$(NBGV_AssemblyVersion) -DCHIBIOS_BOARD=$(BoardName) $(BuildOptions) -DTOOL_HEX2DFU_PREFIX=$(HEX2DFU_PATH) ..'
       workingDirectory:  ${{ parameters.buildDirectory }}
     displayName: Setup build with CMake and DFU
     condition: eq(variables['NeedsDFU'], true)
 
   - task: CMake@1
     inputs:
-      cmakeArgs: '-G Ninja -DTOOLCHAIN_PREFIX=$(GNU_GCC_TOOLCHAIN_PATH) -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_VERSION=$(NBGV_Version) -DCHIBIOS_BOARD=$(BoardName) $(BuildOptions) ..'
+      cmakeArgs: '-G Ninja -DTOOLCHAIN_PREFIX=$(GNU_GCC_TOOLCHAIN_PATH) -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_VERSION=$(NBGV_AssemblyVersion) -DCHIBIOS_BOARD=$(BoardName) $(BuildOptions) ..'
       workingDirectory:  ${{ parameters.buildDirectory }}
     displayName: Setup build with CMake without DFU
     condition: eq(variables['NeedsDFU'], false)

--- a/azure-pipelines-templates/build-esp32.yml
+++ b/azure-pipelines-templates/build-esp32.yml
@@ -7,7 +7,7 @@ parameters:
 steps:
   - task: CMake@1
     inputs:
-      cmakeArgs: '-G Ninja -DTOOLCHAIN_PREFIX=$(ESP32_TOOLCHAIN_PATH) -DESP32_IDF_PATH=$(ESP32_IDF_PATH) -DESP32_LIBS_PATH=$(ESP32_LIBS_PATH) -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_VERSION=$(NBGV_Version) -DESP32_BOARD=$(BoardName) $(BuildOptions) ..'
+      cmakeArgs: '-G Ninja -DTOOLCHAIN_PREFIX=$(ESP32_TOOLCHAIN_PATH) -DESP32_IDF_PATH=$(ESP32_IDF_PATH) -DESP32_LIBS_PATH=$(ESP32_LIBS_PATH) -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_VERSION=$(NBGV_AssemblyVersion) -DESP32_BOARD=$(BoardName) $(BuildOptions) ..'
       workingDirectory:  ${{ parameters.buildDirectory }}
     displayName: Setup build with CMake
 

--- a/azure-pipelines-templates/build-ti-simplelink.yml
+++ b/azure-pipelines-templates/build-ti-simplelink.yml
@@ -8,7 +8,7 @@ steps:
 
   - task: CMake@1
     inputs:
-      cmakeArgs: '-G Ninja -DTOOLCHAIN_PREFIX=$(GNU_GCC_TOOLCHAIN_PATH) -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_VERSION=$(NBGV_Version) -DTI_BOARD=$(BoardName) $(BuildOptions) ..'
+      cmakeArgs: '-G Ninja -DTOOLCHAIN_PREFIX=$(GNU_GCC_TOOLCHAIN_PATH) -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_VERSION=$(NBGV_AssemblyVersion) -DTI_BOARD=$(BoardName) $(BuildOptions) ..'
       workingDirectory:  ${{ parameters.buildDirectory }}
     displayName: Setup build with CMake
 

--- a/azure-pipelines-templates/nb-gitversioning.yml
+++ b/azure-pipelines-templates/nb-gitversioning.yml
@@ -19,6 +19,6 @@ steps:
   - task: PowerShell@2
     inputs:
         targetType: 'inline'
-        script: Write-Host "$("##vso[task.setvariable variable=NBGV_Version]")0.0.0.$env:System_PullRequest_PullRequestNumber"
+        script: Write-Host "$("##vso[task.setvariable variable=NBGV_AssemblyVersion]")0.0.0.$env:System_PullRequest_PullRequestNumber"
     condition: eq(variables['system.pullrequest.isfork'], true)
     displayName: Set temporary build number


### PR DESCRIPTION
## Description
-Replace NBGV variable setting build version.

## Motivation and Context
- Latest version of NBGV drop revision number from the var we were using to get the build number, thus breaking the build.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: GITHUB_USER <GITHUB_USER_EMAIL>
