### PR TITLE
Fix code on enumerating removable and internal storage folders

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
@@ -75,13 +75,11 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetRemovableSt
     CLR_RT_HeapBlock* hbObj;
     CLR_RT_HeapBlock& top   = stack.PushValue();
 
-    //  default to NULL (which is the expected outcome when no devices are connected)
-    hbObj = top.Dereference();
-    hbObj->SetObjectReference( NULL );
-
   #if HAL_USE_SDC
     bool sdCardEnumerated = false;
+  #endif
 
+  #if HAL_USE_SDC
     // is the SD card file system ready?
     if(sdCardFileSystemReady)
     {
@@ -211,10 +209,6 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetInternalSto
     CLR_RT_TypeDef_Index storageFolderTypeDef;
     CLR_RT_HeapBlock* hbObj;
     CLR_RT_HeapBlock& top   = stack.PushValue();
-
-    //  default to NULL (which is the expected outcome when no devices are connected)
-    hbObj = top.Dereference();
-    hbObj->SetObjectReference( NULL );
 
   #if (USE_SPIFFS_FOR_STORAGE == TRUE)
     // is the SPIFFS file system available and mounted?


### PR DESCRIPTION
## Description
- These code lines don't need to be here because, when there are no internal/removable folders the correct return object it's an empty collection of StorageFolder (which is happening). These lines must be a left over from initial coding and were wrongly left there.

<!--- Describe your changes in detail -->

## Motivation and Context
- Fixes nanoFramework/Home#513.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
