### PR TITLE
Spi SDcard fix

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_Devices_SDCard.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_Devices_SDCard.cpp
@@ -63,7 +63,7 @@ HRESULT Library_win_storage_native_Windows_Storage_Devices_SDCard::MountSpiNativ
     CSPin = stack.Arg1().NumericByRef().s4;
 
     // Get current gpio pins used by SPI device 
-	spiBus--;  // Spi devnumber 0 & 1
+    spiBus--;  // Spi devnumber 0 & 1
     int mosiPin =  Esp32_GetMappedDevicePins(DEV_TYPE_SPI, spiBus, 0);
     int misoPin =  Esp32_GetMappedDevicePins(DEV_TYPE_SPI, spiBus, 1);
     int clockPin = Esp32_GetMappedDevicePins(DEV_TYPE_SPI, spiBus, 2);

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_Devices_SDCard.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_Devices_SDCard.cpp
@@ -56,13 +56,14 @@ HRESULT Library_win_storage_native_Windows_Storage_Devices_SDCard::MountSpiNativ
 	mountPoint[1] = mountPoint[0]; 
 	mountPoint[0] = '/';
 
-    // Get passed SPi bus number
+    // Get passed SPi bus number 1 or 2
     spiBus = stack.Arg0().NumericByRef().s4;
 
     // get Gpio pin for Chip select
     CSPin = stack.Arg1().NumericByRef().s4;
 
     // Get current gpio pins used by SPI device 
+	spiBus--;  // Spi devnumber 0 & 1
     int mosiPin =  Esp32_GetMappedDevicePins(DEV_TYPE_SPI, spiBus, 0);
     int misoPin =  Esp32_GetMappedDevicePins(DEV_TYPE_SPI, spiBus, 1);
     int clockPin = Esp32_GetMappedDevicePins(DEV_TYPE_SPI, spiBus, 2);


### PR DESCRIPTION
## Description
Using wrong offset for SPI device in mapping table. This was fixed for SPI device but Sdcard was missed.
 
## How Has This Been Tested?<!-- (if applicable) -->
Using small test program to mount card

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
