### PR TITLE
Add USB CDC Host for FTDI devices

### DIFF
--- a/CMake/ChibiOS-Contrib.CMakeLists.cmake.in
+++ b/CMake/ChibiOS-Contrib.CMakeLists.cmake.in
@@ -10,7 +10,7 @@ ExternalProject_Add(
     ChibiOS-Contrib
     PREFIX ChibiOS-Contrib
     SOURCE_DIR ${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Source
-    GIT_REPOSITORY  https://github.com/ChibiOS/ChibiOS-Contrib
+    GIT_REPOSITORY  https://github.com/nanoframework/ChibiOS-Contrib
     GIT_TAG nanoframework  # target specified branch
     GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
     TIMEOUT 10

--- a/CMake/Modules/FindChibiOS-Contrib.cmake
+++ b/CMake/Modules/FindChibiOS-Contrib.cmake
@@ -38,6 +38,7 @@ list(APPEND CHIBIOS_CONTRIB_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS-Contrib_S
 list(APPEND CHIBIOS_CONTRIB_SOURCES ${PROJECT_BINARY_DIR}/ChibiOS-Contrib_Source/os/hal/src/hal_usbh.c)
 list(APPEND CHIBIOS_CONTRIB_SOURCES ${PROJECT_BINARY_DIR}/ChibiOS-Contrib_Source/os/hal/src/usbh/hal_usbh_msd.c)
 list(APPEND CHIBIOS_CONTRIB_SOURCES ${PROJECT_BINARY_DIR}/ChibiOS-Contrib_Source/os/hal/src/usbh/hal_usbh_desciter.c)
+list(APPEND CHIBIOS_CONTRIB_SOURCES ${PROJECT_BINARY_DIR}/ChibiOS-Contrib_Source/os/hal/src/usbh/hal_usbh_ftdi.c)
 list(APPEND CHIBIOS_CONTRIB_SOURCES ${PROJECT_BINARY_DIR}/ChibiOS-Contrib_Source/os/hal/src/usbh/hal_usbh_hub.c)
 list(APPEND CHIBIOS_CONTRIB_SOURCES ${PROJECT_BINARY_DIR}/ChibiOS-Contrib_Source/os/hal/src/hal_usb_msd.c)
 list(APPEND CHIBIOS_CONTRIB_SOURCES ${PROJECT_BINARY_DIR}/ChibiOS-Contrib_Source/os/hal/ports/STM32/LLD/USBHv1/hal_usbh_lld.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,31 @@ endif()
 
 #################################################################
 
+#################################################################
+# enables USB CDC Host support
+# (default is OFF so USB CDC Host is NOT supported)
+option(NF_FEATURE_HAS_USB_CDC "option to enable USB CDC Host")
+
+if(NF_FEATURE_HAS_USB_CDC)
+
+    # this feature currently is supported only on ChibiOS
+    if(NOT RTOS_CHIBIOS_CHECK)
+        message(FATAL_ERROR "Support for USB CDC Host is only available for ChibiOS Cortex-M targets.")
+    endif()
+
+    # this feature requires inclusion of ChibiOS contribution repository
+    set(CHIBIOS_CONTRIB_REQUIRED ON CACHE INTERNAL "Forcing ChibiOS contribution repo option to ON")
+
+    # force inclusion of Windows.Devices.SerialCommunication API
+    set(API_Windows.Devices.SerialCommunication ON CACHE INTERNAL "Forcing Windows.Devices.SerialCommunication API option to ON")
+
+    message(STATUS "Support for USB CDC Host is included")
+else()
+    message(STATUS "Support for USB CDC Host IS NOT included")
+endif()
+
+#################################################################
+
 if(RTOS_CHIBIOS_CHECK)
 
     #################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,9 +368,9 @@ endif()
 #################################################################
 # enables USB CDC Host support
 # (default is OFF so USB CDC Host is NOT supported)
-option(NF_FEATURE_HAS_USB_CDC "option to enable USB CDC Host")
+option(NF_FEATURE_HAS_USB_CDC_HOST "option to enable USB CDC Host")
 
-if(NF_FEATURE_HAS_USB_CDC)
+if(NF_FEATURE_HAS_USB_CDC_HOST)
 
     # this feature currently is supported only on ChibiOS
     if(NOT RTOS_CHIBIOS_CHECK)
@@ -539,6 +539,12 @@ if(NF_FEATURE_HAS_USB_MSD)
     set(HAL_USBH_USE_MSDC_OPTION TRUE CACHE INTERNAL "HAL USBH_USE_MSD for NF_FEATURE_HAS_USB_MSD")
 else()
     set(HAL_USBH_USE_MSDC_OPTION FALSE CACHE INTERNAL "HAL USBH_USE_MSD for NF_FEATURE_HAS_USB_MSD")
+endif()
+
+if(NF_FEATURE_HAS_USB_CDC_HOST)
+    set(HAL_USBH_USE_CDC_HOST_OPTION TRUE CACHE INTERNAL "HAL USBH_USE_FTDI for NF_FEATURE_HAS_USB_CDC_HOST")
+else()
+    set(HAL_USBH_USE_CDC_HOST_OPTION FALSE CACHE INTERNAL "HAL USBH_USE_FTDI for NF_FEATURE_HAS_USB_CDC_HOST")
 endif()
 
 #################################################################

--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -61,6 +61,7 @@
           "NF_FEATURE_HAS_SDCARD" : "OFF-default-ON-to-enable-support-for-SDCard-storage-device",
           "NF_FEATURE_HAS_USB_MSD" : "OFF-default-ON-to-enable-support-for-USB-Mass-storage-device",
           "NF_FEATURE_USE_SPIFFS" : "OFF-default-ON-to-enable-support-for-SPI-flash-file-system",
+          "NF_FEATURE_HAS_USB_CDC" : "OFF-default-ON-to-enable-support-for-USB-Mass-storage-device",
           "NF_PLATFORM_NO_CLR_TRACE" : "OFF-default-ON-to-disable-all-trace-on-CLR",
           "NF_CLR_NO_IL_INLINE" : "OFF-default-ON-to-disable-CLR-IL-inlining",
           "NF_INTEROP_ASSEMBLIES" : [ "Assembly1-Namespace", "Assembly2-Namespace" ],

--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -61,7 +61,7 @@
           "NF_FEATURE_HAS_SDCARD" : "OFF-default-ON-to-enable-support-for-SDCard-storage-device",
           "NF_FEATURE_HAS_USB_MSD" : "OFF-default-ON-to-enable-support-for-USB-Mass-storage-device",
           "NF_FEATURE_USE_SPIFFS" : "OFF-default-ON-to-enable-support-for-SPI-flash-file-system",
-          "NF_FEATURE_HAS_USB_CDC" : "OFF-default-ON-to-enable-support-for-USB-Mass-storage-device",
+          "NF_FEATURE_HAS_USB_CDC_HOST" : "OFF-default-ON-to-enable-support-for-USB-Mass-storage-device",
           "NF_PLATFORM_NO_CLR_TRACE" : "OFF-default-ON-to-disable-all-trace-on-CLR",
           "NF_CLR_NO_IL_INLINE" : "OFF-default-ON-to-disable-CLR-IL-inlining",
           "NF_INTEROP_ASSEMBLIES" : [ "Assembly1-Namespace", "Assembly2-Namespace" ],

--- a/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
@@ -157,7 +157,7 @@ if(CHIBIOS_CONTRIB_REQUIRED)
             ChibiOS-Contrib
             PREFIX ChibiOS-Contrib
             SOURCE_DIR ${CMAKE_BINARY_DIR}/ChibiOS-Contrib_Source
-            GIT_REPOSITORY  https://github.com/ChibiOS/ChibiOS-Contrib
+            GIT_REPOSITORY  https://github.com/nanoframework/ChibiOS-Contrib
             GIT_TAG nanoframework  # target specified branch
             GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
             TIMEOUT 10

--- a/targets/CMSIS-OS/ChibiOS/Include/Target_CDC_Host.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/Target_CDC_Host.h
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#ifndef _TARGET_USB_CDC_H_
+#define _TARGET_USB_CDC_H_ 1
+
+
+#define USB_FTDI_POLLING_INTERVAL               (1000)
+#define USB_FTDI_POLLING_DELAY                  (1000)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    // declaration of CDC working threads
+    void UsbFtdiWorkingThread(void const * argument);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  //_TARGET_USB_CDC_H_

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf.h
@@ -184,7 +184,7 @@
  * @brief   Enables the USB subsystem.
  */
 #if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
-#define HAL_USE_USB                         FALSE
+#define HAL_USE_USB                         TRUE
 #endif
 
 /**
@@ -530,6 +530,7 @@
 
 // header for nanoFramework overlay
 #include "halconf_nf.h"
+#include "halconf_community.h"
 #endif /* HALCONF_H */
 
 /** @} */

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf_community.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf_community.h
@@ -1,0 +1,98 @@
+//
+// Copyright (c) 2019 The nanoFramework project contributors
+// Portions Copyright (c) Uladzimir Pylinsky aka barthess.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+#ifndef HALCONF_COMMUNITY_H
+#define HALCONF_COMMUNITY_H
+
+/**
+ * @brief   Enables the USBH subsystem.
+ */
+#if !defined(HAL_USE_USBH) || defined(__DOXYGEN__)
+#define HAL_USE_USBH                TRUE
+#endif
+
+
+/*===========================================================================*/
+/* USBH driver related settings.                                             */
+/*===========================================================================*/
+
+/* main driver */
+#define HAL_USBH_PORT_DEBOUNCE_TIME                   200
+#define HAL_USBH_PORT_RESET_TIMEOUT                   500
+#define HAL_USBH_DEVICE_ADDRESS_STABILIZATION         20
+#define HAL_USBH_CONTROL_REQUEST_DEFAULT_TIMEOUT	    OSAL_MS2I(1000)
+
+/* MSD */
+// this option is set at target_platform.h (from config file)
+// #define HAL_USBH_USE_MSD                              TRUE
+
+#define HAL_USBHMSD_MAX_LUNS                          1
+#define HAL_USBHMSD_MAX_INSTANCES                     1
+
+/* FTDI */
+// this option is set at target_platform.h (from config file)
+//#define HAL_USBH_USE_FTDI                             TRUE
+
+#define HAL_USBHFTDI_MAX_PORTS                        1
+#define HAL_USBHFTDI_MAX_INSTANCES                    1
+#define HAL_USBHFTDI_DEFAULT_SPEED                    9600
+#define HAL_USBHFTDI_DEFAULT_FRAMING                  (USBHFTDI_FRAMING_DATABITS_8 | USBHFTDI_FRAMING_PARITY_NONE | USBHFTDI_FRAMING_STOP_BITS_1)
+#define HAL_USBHFTDI_DEFAULT_FRAMING                  (USBHFTDI_FRAMING_DATABITS_8 | USBHFTDI_FRAMING_PARITY_NONE | USBHFTDI_FRAMING_STOP_BITS_1)
+#define HAL_USBHFTDI_DEFAULT_HANDSHAKE                USBHFTDI_HANDSHAKE_NONE
+#define HAL_USBHFTDI_DEFAULT_XON                      0x11
+#define HAL_USBHFTDI_DEFAULT_XOFF                     0x13
+
+// #define HAL_USBH_USE_ADDITIONAL_CLASS_DRIVERS		  TRUE
+
+/* debug */
+#define USBH_DEBUG_ENABLE                             FALSE
+#define USBH_DEBUG_USBHD                              USBHD1
+// #define USBH_DEBUG_SD                                 SD2
+#define USBH_DEBUG_BUFFER                             25000
+
+#define USBH_DEBUG_ENABLE_TRACE                       FALSE
+#define USBH_DEBUG_ENABLE_INFO                        TRUE
+#define USBH_DEBUG_ENABLE_WARNINGS                    TRUE
+#define USBH_DEBUG_ENABLE_ERRORS                      TRUE
+
+#define USBH_LLD_DEBUG_ENABLE_TRACE                   FALSE
+#define USBH_LLD_DEBUG_ENABLE_INFO                    TRUE
+#define USBH_LLD_DEBUG_ENABLE_WARNINGS                TRUE
+#define USBH_LLD_DEBUG_ENABLE_ERRORS                  TRUE
+
+#define USBHHUB_DEBUG_ENABLE_TRACE                    FALSE
+#define USBHHUB_DEBUG_ENABLE_INFO                     TRUE
+#define USBHHUB_DEBUG_ENABLE_WARNINGS                 TRUE
+#define USBHHUB_DEBUG_ENABLE_ERRORS                   TRUE
+
+#define USBHMSD_DEBUG_ENABLE_TRACE                    FALSE
+#define USBHMSD_DEBUG_ENABLE_INFO                     TRUE
+#define USBHMSD_DEBUG_ENABLE_WARNINGS                 TRUE
+#define USBHMSD_DEBUG_ENABLE_ERRORS                   TRUE
+
+#define USBHUVC_DEBUG_ENABLE_TRACE                    FALSE
+#define USBHUVC_DEBUG_ENABLE_INFO                     TRUE
+#define USBHUVC_DEBUG_ENABLE_WARNINGS                 TRUE
+#define USBHUVC_DEBUG_ENABLE_ERRORS                   TRUE
+
+#define USBHFTDI_DEBUG_ENABLE_TRACE                   FALSE
+#define USBHFTDI_DEBUG_ENABLE_INFO                    TRUE
+#define USBHFTDI_DEBUG_ENABLE_WARNINGS                TRUE
+#define USBHFTDI_DEBUG_ENABLE_ERRORS                  TRUE
+
+#define USBHAOA_DEBUG_ENABLE_TRACE                    FALSE
+#define USBHAOA_DEBUG_ENABLE_INFO                     TRUE
+#define USBHAOA_DEBUG_ENABLE_WARNINGS                 TRUE
+#define USBHAOA_DEBUG_ENABLE_ERRORS                   TRUE
+
+#define USBHHID_DEBUG_ENABLE_TRACE                    FALSE
+#define USBHHID_DEBUG_ENABLE_INFO                     TRUE
+#define USBHHID_DEBUG_ENABLE_WARNINGS                 TRUE
+#define USBHHID_DEBUG_ENABLE_ERRORS                   TRUE
+
+#endif /* HALCONF_COMMUNITY_H */
+
+/** @} */

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf_nf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf_nf.h
@@ -6,6 +6,11 @@
 #ifndef _HALCONF_NF_H_
 #define _HALCONF_NF_H_ 1
 
+// Enables the ChibiOS community overlay.
+#if !defined(HAL_USE_COMMUNITY) 
+#define HAL_USE_COMMUNITY           TRUE
+#endif
+
 // enables STM32 Flash driver
 #if !defined(HAL_USE_STM32_FLASH) 
 #define HAL_USE_STM32_FLASH         TRUE

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/main.c
@@ -37,6 +37,10 @@ osThreadDef(SdCardWorkingThread, osPriorityNormal, 1024, "SDCWT");
 osThreadDef(UsbMsdWorkingThread, osPriorityNormal, 1024, "USBMSDWT"); 
 #endif
 
+#if HAL_USBH_USE_FTDI
+    osThreadDef(UsbFtdiWorkingThread, osPriorityNormal, 1024, "USBFTDIWT");
+#endif
+
 //  Application entry point.
 int main(void) {
 
@@ -90,6 +94,11 @@ int main(void) {
   #if HAL_USBH_USE_MSD
   // create the USB MSD working thread
   osThreadCreate(osThread(UsbMsdWorkingThread), &MSBLKD[0]);
+  #endif
+
+   #if HAL_USBH_USE_FTDI
+  // create the USB MSD working thread
+  osThreadCreate(osThread(UsbFtdiWorkingThread), NULL);
   #endif
 
   // start kernel, after this main() will behave like a thread with priority osPriorityNormal

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/mcuconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/mcuconf.h
@@ -376,7 +376,7 @@
 /*
  * USB driver system settings.
  */
-#define STM32_USB_USE_OTG1                  FALSE
+#define STM32_USB_USE_OTG1                  TRUE
 #define STM32_USB_USE_OTG2                  FALSE
 #define STM32_USB_OTG1_IRQ_PRIORITY         14
 #define STM32_USB_OTG2_IRQ_PRIORITY         14
@@ -400,5 +400,6 @@
 
 // header for nanoFramework overlay drivers
 #include "mcuconf_nf.h"
+#include "mcuconf_community.h"
 
 #endif /* MCUCONF_H */

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/mcuconf_community.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/mcuconf_community.h
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2019 The nanoFramework project contributors
+// Portions Copyright (c) Uladzimir Pylinsky aka barthess.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+/*
+ * USBH driver system settings.
+ */
+#define STM32_OTG1_CHANNELS_NUMBER          8
+#define STM32_OTG2_CHANNELS_NUMBER          12
+
+#define STM32_USBH_USE_OTG1                 FALSE
+#define STM32_OTG1_RXFIFO_SIZE              1024
+#define STM32_OTG1_PTXFIFO_SIZE             128
+#define STM32_OTG1_NPTXFIFO_SIZE            128
+
+#define STM32_USBH_USE_OTG2                 TRUE
+#define STM32_OTG2_RXFIFO_SIZE              2048
+#define STM32_OTG2_PTXFIFO_SIZE             1024
+#define STM32_OTG2_NPTXFIFO_SIZE            1024
+
+#define STM32_USBH_MIN_QSPACE               4
+#define STM32_USBH_CHANNELS_NP              4

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_serialcommunication_config.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_devices_serialcommunication_config.h
@@ -28,3 +28,7 @@
 // #define UART6_TX_SIZE  256
 // // rx buffer size: 256 bytes
 // #define UART6_RX_SIZE  256
+
+
+// the following macro maps the USB FTDI CDC Host device driver
+#define USB_FTDI_DRIVER      USBHD2

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_storage_config.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/target_windows_storage_config.h
@@ -3,11 +3,14 @@
 // See LICENSE file in the project root for full license information.
 //
 
-// maps the SD Card driver
+// the following macro maps the SD Card driver
 #define SD_CARD_DRIVER      SDCD2
 
 // maps the SD Card detect GPIO definition (in Target_Windows_Storage.c) to board GPIO line (in board.h)
 #define SDCARD_LINE_DETECT  LINE_SD_DETECT
+
+// the following macro maps the USB mass storage device driver
+#define USB_MSD_DRIVER      USBHD2
 
 // includes SPIFFS in storage
 #define USE_SPIFFS_FOR_STORAGE  FALSE

--- a/targets/CMSIS-OS/ChibiOS/common/Target_CDC_Host.c
+++ b/targets/CMSIS-OS/ChibiOS/common/Target_CDC_Host.c
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <hal.h>
+#include <cmsis_os.h>
+#include <nanoHAL_v2.h>
+
+#if HAL_USBH_USE_FTDI
+#include "usbh/dev/ftdi.h"
+
+__attribute__((noreturn))
+void UsbFtdiWorkingThread(void const * argument)
+{
+    // start USB host
+    usbhStart(&USB_FTDI_DRIVER);
+
+
+    for(;;)
+    {
+        osDelay(USB_FTDI_POLLING_INTERVAL);
+
+        usbhMainLoop(&USB_FTDI_DRIVER);
+    }
+}
+
+#endif

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/target_platform.h.in
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/target_platform.h.in
@@ -55,4 +55,7 @@
 // enable USB MSD (from ChibiOS Contrib)
  #define HAL_USBH_USE_MSD     @HAL_USBH_USE_MSDC_OPTION@
 
+ // enable USB CDC (from ChibiOS Contrib)
+ #define HAL_USBH_USE_FTDI     @HAL_USBH_USE_CDC_HOST_OPTION@
+
 #endif /* _TARGET_CHIBIOS_NANOCLR_H_ */


### PR DESCRIPTION
TODO:
* wire up to the Windows.Devices.SerialCommunication (Help needed)

## Description
The ChibiOS Contrib repo includes support for USB CDC devices using the FTDI chipset. nanoFramework should leverage this as we have done with USB MSD.

## Motivation and Context
New devices use USB extensively, including sensors, and many use CDC for their communication.
- Resolves nanoFramework/Home#527

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
