### PR TITLE
Add sanity check to valid image verification

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/common/LaunchCLR.c
+++ b/targets/CMSIS-OS/ChibiOS/common/LaunchCLR.c
@@ -7,6 +7,7 @@
 #include <ch.h>
 #include <hal.h>
 #include <vectors.h>
+#include <target_common.h>
 
 void LaunchCLR(uint32_t address)
 {
@@ -49,6 +50,13 @@ bool CheckValidCLRImage(uint32_t address)
     // 2nd check: the content pointed by the reset vector has to be 0xE002 
     // that's an assembly "b.n" (branch instruction) the very first one in the Reset_Handler function
     // see os\common\startup\ARMCMx\compilers\GCC\vectors.S
+
+    // sanity check for invalid address (out of flash range which causes a hard fault)
+    if( (uint32_t)((uint32_t*)nanoCLRVectorTable->reset_handler) > (FLASH1_MEMORY_StartAddress + FLASH1_MEMORY_Size) )
+    {
+        // check failed, doesn't seem to be a valid CLR image
+        return false;
+    }
 
     // the linker can place this anywhere on the address space because of optimizations so we better check where the reset pointer points to
     uint32_t opCodeAddress = (uint32_t)((uint32_t**)nanoCLRVectorTable->reset_handler);


### PR DESCRIPTION
## Description
- Add sanity check to flash address.

## Motivation and Context
- When the flash content at the address where the Reset vector is supposed to be has a number which will be used as address to check for the content falls off the valid flash address a hard fault occurs locking the board. This sanity check relies on the flash start address and size defined for the target to perform a sanity check on that address value.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: António Fagundes<antonio.fagundes@eclo.solutions>

