### PR TITLE
Improve sanity check on vector table address

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/common/LaunchCLR.c
+++ b/targets/CMSIS-OS/ChibiOS/common/LaunchCLR.c
@@ -52,7 +52,8 @@ bool CheckValidCLRImage(uint32_t address)
     // see os\common\startup\ARMCMx\compilers\GCC\vectors.S
 
     // sanity check for invalid address (out of flash range which causes a hard fault)
-    if( (uint32_t)((uint32_t*)nanoCLRVectorTable->reset_handler) > (FLASH1_MEMORY_StartAddress + FLASH1_MEMORY_Size) )
+    if( (uint32_t)((uint32_t*)nanoCLRVectorTable->reset_handler) <= FLASH1_MEMORY_StartAddress ||
+        (uint32_t)((uint32_t*)nanoCLRVectorTable->reset_handler) >= (FLASH1_MEMORY_StartAddress + FLASH1_MEMORY_Size) )
     {
         // check failed, doesn't seem to be a valid CLR image
         return false;


### PR DESCRIPTION
## Description
- Improve sanity check on vector table address during launch CLR check on STM32 booter.

## Motivation and Context
- Now the condition is strictly for the address to fall into the flash region.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: António Fagundes<antonio.fagundes@eclo.solutions>

