### PR TITLE
Fix support for SRAM

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c
@@ -13,6 +13,7 @@
 
 #if (HAL_USE_FSMC == TRUE)
 #include <fsmc_sdram_lld.h>
+#include <fsmc_sram_lld.h>
 #endif
 
 uint32_t WakeupReasonStore;
@@ -46,10 +47,26 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
             // stop watchdog
             wdgStop(&WDGD1);
 
-          #if (HAL_USE_FSMC == TRUE)
-            // shutdown memory
-            fsmcSdramStop(&SDRAMD);
-          #endif
+            #if (HAL_USE_FSMC == TRUE)
+                // shutdown memory
+                #if (STM32_USE_FSMC_SDRAM == TRUE)
+				  fsmcSdramStop(&SDRAMD);
+			    #endif
+			    #if (STM32_USE_FSMC_SRAM == TRUE)
+				    #if (STM32_SRAM_USE_FSMC_SRAM1 == TRUE)
+					    fsmcSramStop(&SRAMD1);
+				    #endif
+				    #if (STM32_SRAM_USE_FSMC_SRAM2 == TRUE)
+					    fsmcSramStop(&SRAMD2);
+				    #endif
+				    #if (STM32_SRAM_USE_FSMC_SRAM3 == TRUE)
+					    fsmcSramStop(&SRAMD3);
+				    #endif
+				    #if (STM32_SRAM_USE_FSMC_SRAM4 == TRUE)
+					    fsmcSramStop(&SRAMD4);
+				    #endif
+			    #endif
+            #endif
 
             // gracefully shutdown everything
             nanoHAL_Uninitialize_C();


### PR DESCRIPTION
## Description
This fixes an issue if someone wants to use FSMC with a external SRAM.

## Motivation and Context
An external memory like a NOR Flash or PSRAM can be connected using the onboard FSMC and the SRAM driver provided by the nf-overlay. The actual code in targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL_Power.c does only support SDRAM. If someone uses the SRAM driver instead of the SDRAM driver, this causes an error.

## How Has This Been Tested?
I am using an external PSRAM on my board which is connected with the SRAMD2 driver, which works fine with the above fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.