### PR TITLE
Fix for GetStorageFilesNative when using SPIFFS

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
@@ -25,6 +25,10 @@ extern bool sdCardFileSystemReady;
 #if (HAL_USBH_USE_MSD == TRUE)
 extern bool usbMsdFileSystemReady;
 #endif
+#if USE_SPIFFS_FOR_STORAGE
+extern bool spiffsFileSystemReady;
+extern spiffs fs;
+#endif
 
 void CombinePath(char * outpath, const char * path1, const char * path2)
 {
@@ -665,7 +669,7 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetStorageFile
         // ... that the path is the drive root (because SPIFFS doesn't support folders)
       #if (USE_SPIFFS_FOR_STORAGE == TRUE)
         if( (WORKING_DRIVE_IS_INTERNAL_DRIVE) &&
-            (hal_strlen_s(workingPath) == DRIVE_PATH_LENGTH))
+            (hal_strlen_s(workingPath) == DRIVE_PATH_LENGTH - 1))
         {
             // this is the SPIFFS drive
             spiffs_DIR drive;
@@ -714,6 +718,7 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetStorageFile
                 // and reset the file iterator vars too
                 itemIndex = 0;
                 fileCount = 0;
+                pe = &e;
                 
                 while ((pe = SPIFFS_readdir(&drive, pe)))
                 {


### PR DESCRIPTION
## Description
- Add missing declarations to use SPIFFS.
- Fix var reset on second call to list directory content.

## Motivation and Context
- Resolves nanoFramework/Home#536

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: António Fagundes<antonio.fagundes@eclo.solutions>

