### PR TITLE
Enable support for multiple block storage devices

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -359,7 +359,7 @@ bool CLR_DBG_Debugger::Monitor_FlashSectorMap( WP_Message* msg)
 
         for(unsigned int i = 0; i < numDevices; i++)
         {
-	        if(i == 0)
+            if(i == 0)
             {
                 devices[i] = BlockStorageList_GetFirstDevice();
             } 

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -354,8 +354,8 @@ bool CLR_DBG_Debugger::Monitor_FlashSectorMap( WP_Message* msg)
 	unsigned int numDevices = BlockStorageList_GetNumDevices();
 
 	// get an array of pointer to all the storage devices in the list and then request the device info
-	BlockStorageDevice* devices[numDevices];
-	DeviceBlockInfo* deviceInfos[numDevices];
+	BlockStorageDevice** devices = (BlockStorageDevice**) platform_malloc(numDevices * sizeof(BlockStorageDevice*));
+	DeviceBlockInfo** deviceInfos = (DeviceBlockInfo**) platform_malloc(numDevices * sizeof(DeviceBlockInfo*));
 
 	for(unsigned int i = 0; i < numDevices; i++){
 	    if(i == 0){
@@ -413,6 +413,8 @@ bool CLR_DBG_Debugger::Monitor_FlashSectorMap( WP_Message* msg)
         WP_ReplyToCommand( msg, true, false, (void*)pData, rangeCount * sizeof (struct Flash_BlockRegionInfo) );
 
         platform_free(pData);
+	platform_free(devices);
+	platform_free(deviceInfos);
     }
 
     return true;

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -334,7 +334,7 @@ bool CLR_DBG_Debugger::Monitor_Ping( WP_Message* msg)
 
 bool CLR_DBG_Debugger::Monitor_FlashSectorMap( WP_Message* msg)
 {
-    NATIVE_PROFILE_CLR_DEBUGGER();
+	NATIVE_PROFILE_CLR_DEBUGGER();
 
     if((msg->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
@@ -351,25 +351,30 @@ bool CLR_DBG_Debugger::Monitor_FlashSectorMap( WP_Message* msg)
         unsigned int rangeIndex = 0;
 
         // get the number of available block storage devices
-	unsigned int numDevices = BlockStorageList_GetNumDevices();
+        unsigned int numDevices = BlockStorageList_GetNumDevices();
 
-	// get an array of pointer to all the storage devices in the list and then request the device info
-	BlockStorageDevice** devices = (BlockStorageDevice**) platform_malloc(numDevices * sizeof(BlockStorageDevice*));
-	DeviceBlockInfo** deviceInfos = (DeviceBlockInfo**) platform_malloc(numDevices * sizeof(DeviceBlockInfo*));
+        // get an array of pointer to all the storage devices in the list and then request the device info
+        BlockStorageDevice** devices = (BlockStorageDevice**) platform_malloc(numDevices * sizeof(BlockStorageDevice*));
+        DeviceBlockInfo** deviceInfos = (DeviceBlockInfo**) platform_malloc(numDevices * sizeof(DeviceBlockInfo*));
 
-	for(unsigned int i = 0; i < numDevices; i++){
-	    if(i == 0){
-		devices[i] = BlockStorageList_GetFirstDevice();
-	    } else {
-		devices[i] = BlockStorageList_GetNextDevice(devices[i-1]);
-	    }
-	    // sanity check
-	    if(devices[i] == NULL){
-		WP_ReplyToCommand( msg, true, false, NULL, 0 );
-		return false;
-	    }
-	    deviceInfos[i] = BlockStorageDevice_GetDeviceInfo(devices[i]);
-	}
+        for(unsigned int i = 0; i < numDevices; i++)
+        {
+	        if(i == 0)
+            {
+                devices[i] = BlockStorageList_GetFirstDevice();
+            } 
+            else
+            {
+                devices[i] = BlockStorageList_GetNextDevice(devices[i-1]);
+            }
+            // sanity check
+            if(devices[i] == NULL)
+            {
+                WP_ReplyToCommand( msg, true, false, NULL, 0 );
+                return false;
+            }
+            deviceInfos[i] = BlockStorageDevice_GetDeviceInfo(devices[i]);
+        }
 	    
         for(int cnt = 0; cnt < 2; cnt++)
         {
@@ -383,38 +388,38 @@ bool CLR_DBG_Debugger::Monitor_FlashSectorMap( WP_Message* msg)
                     return false;
                 }
             }
-	    for(unsigned int i = 0; i < numDevices; i++)
-	    {
-		for(unsigned int j = 0; j < deviceInfos[i]->NumRegions;  j++)
-		{
-		    const BlockRegionInfo* pRegion = &deviceInfos[i]->Regions[ j ];
+            for(unsigned int i = 0; i < numDevices; i++)
+            {
+                for(unsigned int j = 0; j < deviceInfos[i]->NumRegions;  j++)
+                {
+                    const BlockRegionInfo* pRegion = &deviceInfos[i]->Regions[ j ];
 
-		    for(unsigned int k = 0; k < pRegion->NumBlockRanges; k++)
-		    {
+                    for(unsigned int k = 0; k < pRegion->NumBlockRanges; k++)
+                    {
 
-		        if(cnt == 0)
-		        {
-			    rangeCount++;
-		        }
-		        else
-		        {
-			    pData[ rangeIndex ].StartAddress  = BlockRegionInfo_BlockAddress(pRegion, pRegion->BlockRanges[ k ].StartBlock);
-			    pData[ rangeIndex ].NumBlocks = BlockRange_GetBlockCount(pRegion->BlockRanges[k]);
-			    pData[ rangeIndex ].BytesPerBlock = pRegion->BytesPerBlock;
-			    pData[ rangeIndex ].Usage  = pRegion->BlockRanges[ k ].RangeType & BlockRange_USAGE_MASK;
-			    rangeIndex++;
-			}
-		    }
-		}
-	    }
+                        if(cnt == 0)
+                        {
+                            rangeCount++;
+                        }
+                        else
+                        {
+                            pData[ rangeIndex ].StartAddress  = BlockRegionInfo_BlockAddress(pRegion, pRegion->BlockRanges[ k ].StartBlock);
+                            pData[ rangeIndex ].NumBlocks = BlockRange_GetBlockCount(pRegion->BlockRanges[k]);
+                            pData[ rangeIndex ].BytesPerBlock = pRegion->BytesPerBlock;
+                            pData[ rangeIndex ].Usage  = pRegion->BlockRanges[ k ].RangeType & BlockRange_USAGE_MASK;
+                            rangeIndex++;
+                        }
+                    }
+                }
+            }
         }
 
 
         WP_ReplyToCommand( msg, true, false, (void*)pData, rangeCount * sizeof (struct Flash_BlockRegionInfo) );
 
         platform_free(pData);
-	platform_free(devices);
-	platform_free(deviceInfos);
+        platform_free(devices);
+        platform_free(deviceInfos);
     }
 
     return true;

--- a/src/PAL/BlockStorage/nanoPAL_BlockStorage.c
+++ b/src/PAL/BlockStorage/nanoPAL_BlockStorage.c
@@ -866,16 +866,25 @@ BlockStorageDevice* BlockStorageList_GetFirstDevice()
     return NULL;
 }
 
-
-// BlockStorageDevice* BlockStorageList_GetNextDevice(BlockStorageDevice* device)
-// {
-//     return NULL;
-// }
+// returns the next device in BlockStorageList
+BlockStorageDevice* BlockStorageList_GetNextDevice(BlockStorageDevice* device)
+{
+	for(int i = 0; i < TARGET_BLOCKSTORAGE_COUNT; i++)
+    {
+        if(g_BlockStorage.DeviceList[i] == device)
+        {
+			if((i + 1) < TARGET_BLOCKSTORAGE_COUNT){
+				return g_BlockStorage.DeviceList[i + 1];
+			}
+        }
+    }
+    return NULL;
+}
 
 // // returns number of devices has been declared in the system
-// unsigned int BlockStorageList_GetNumDevices()
-// {
-//     return 0;
-// }
+unsigned int BlockStorageList_GetNumDevices()
+{
+    return TARGET_BLOCKSTORAGE_COUNT;
+}
 
 /////////////////////////////////////////////////////

--- a/src/PAL/Include/nanoPAL_BlockStorage.h
+++ b/src/PAL/Include/nanoPAL_BlockStorage.h
@@ -562,9 +562,9 @@ extern "C" {
     // Find the right Device with the corresponding phyiscal address.
     bool BlockStorageList_FindDeviceForPhysicalAddress(BlockStorageDevice** pBSD, unsigned int physicalAddress, ByteAddress* blockAddress);
     BlockStorageDevice* BlockStorageList_GetFirstDevice();
-    // BlockStorageDevice* BlockStorageList_GetNextDevice(BlockStorageDevice* device);
+    BlockStorageDevice* BlockStorageList_GetNextDevice(BlockStorageDevice* device);
     // returns number of devices has been declared in the system
-    // unsigned int BlockStorageList_GetNumDevices();
+    unsigned int BlockStorageList_GetNumDevices();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description
The CLR debugger function Monitor_FlashSectorMap() is accessed in Visual Studio to detect the device capabilities and for deployment. At the moment, it does only include the first block storage device in the list, which is the internal flash of the MCU.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to support the use of an external flash memory in addition to the internal one. Flash memory regions of the external flash have to be included in the FlashSectorMap, otherwise they will not be detected any cannot be accessed from Visual Studio.

## How Has This Been Tested?<!-- (if applicable) -->
This has successfully been tested on a STM32F427 based custom board with just the internal flash and also with the internal and external one.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.