### PR TITLE
Add serial configuration to STM32F091

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/common/Device_BlockStorage-DEBUG.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/common/Device_BlockStorage-DEBUG.c
@@ -9,9 +9,9 @@
 //2kB block
 const BlockRange BlockRange1[] = 
 {
-    { BlockRange_BLOCKTYPE_BOOTSTRAP ,    0, 4    },            // 0x08000000 nanoBooter
-    { BlockRange_BLOCKTYPE_CODE      ,    5, 94   },            // 0x08002800 nanoCLR
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   95, 127  }             // 0x0802F800 deployment
+    { BlockRange_BLOCKTYPE_BOOTSTRAP ,    0 , 5    },            // 0x08000000 nanoBooter
+    { BlockRange_BLOCKTYPE_CODE      ,    6 , 101  },            // 0x08003000 nanoCLR
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   102, 127  }             // 0x08033000 deployment
 };
 
 const BlockRegionInfo BlockRegions[] = 

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/STM32F091xC_booter-DEBUG.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/STM32F091xC_booter-DEBUG.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash       : org = 0x08000000, len = 10k     /* space reserved for nanoBooter */
+    flash       : org = 0x08000000, len = 12k     /* space reserved for nanoBooter */
     config      : org = 0x00000000, len = 0       /* space reserved for configuration block */
     deployment  : org = 0x00000000, len = 0       /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0       /* initial RAM address is reserved for a copy of the vector table */

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/main.c
@@ -14,7 +14,19 @@
 #include <LaunchCLR.h>
 
 // need to declare the Receiver thread here
-osThreadDef(ReceiverThread, osPriorityHigh, 2048, "ReceiverThread");
+osThreadDef(ReceiverThread, osPriorityHigh, 512, "ReceiverThread");
+
+// configuration for debugger serial port
+// dev notes:
+// conservative baud rate value as 921600 has a high error percentage on baud rate clocking
+// OVER8 bit on CR1 to further decrease baud rate clocking error 
+static const SerialConfig uartConfig =
+{
+  460800,
+  USART_CR1_OVER8,
+  USART_CR2_STOP1_BITS,
+  0
+};
 
 // Application entry point.
 int main(void) {
@@ -44,7 +56,7 @@ int main(void) {
   osKernelInitialize();
 
   // starts the serial driver
-  sdStart(&SERIAL_DRIVER, NULL);
+  sdStart(&SERIAL_DRIVER, &uartConfig);
 
   // create the receiver thread
   osThreadCreate(osThread(ReceiverThread), NULL);

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/mcuconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/mcuconf.h
@@ -33,11 +33,11 @@
 #define STM32_HSI14_ENABLED                 TRUE
 #define STM32_HSI48_ENABLED                 FALSE
 #define STM32_LSI_ENABLED                   TRUE
-#define STM32_HSE_ENABLED                   FALSE
+#define STM32_HSE_ENABLED                   TRUE
 #define STM32_LSE_ENABLED                   FALSE
 #define STM32_SW                            STM32_SW_PLL
-#define STM32_PLLSRC                        STM32_PLLSRC_HSI_DIV2
-#define STM32_PREDIV_VALUE                  1
+#define STM32_PLLSRC                        STM32_PLLSRC_HSE
+#define STM32_PREDIV_VALUE                  2
 #define STM32_PLLMUL_VALUE                  12
 #define STM32_HPRE                          STM32_HPRE_DIV1
 #define STM32_PPRE                          STM32_PPRE_DIV1

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/STM32F091xC_CLR-DEBUG.ld
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/STM32F091xC_CLR-DEBUG.ld
@@ -12,9 +12,9 @@
  */
 MEMORY
 {
-    flash       : org = 0x08002800, len = 256k - 8k - 66k    /* flash size less the space reserved for nanoBooter and application deployment*/
+    flash       : org = 0x08003000, len = 256k - 12k - 50k   /* flash size less the space reserved for nanoBooter and application deployment*/
     config      : org = 0x00000000, len = 0                  /* space reserved for configuration block */
-    deployment  : org = 0x0802F800, len = 66k                /* space reserved for application deployment */
+    deployment  : org = 0x08033000, len = 50k                /* space reserved for application deployment */
     ramvt       : org = 0x20000000, len = 0xC0               /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x200000C0, len = 32k - 0xC0         /* remaining RAM is free for use */
     ram1        : org = 0x00000000, len = 0

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/main.c
@@ -26,9 +26,21 @@ __IO uint32_t vectorTable[48] __attribute__((section(".RAMVectorTable")));
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 // need to declare the Receiver thread here
-osThreadDef(ReceiverThread, osPriorityHigh, 1024, "ReceiverThread");
+osThreadDef(ReceiverThread, osPriorityHigh, 512, "ReceiverThread");
 // declare CLRStartup thread here 
-osThreadDef(CLRStartupThread, osPriorityNormal, 3072, "CLRStartupThread"); 
+osThreadDef(CLRStartupThread, osPriorityNormal, 4096, "CLRStartupThread"); 
+
+// configuration for debugger serial port
+// dev notes:
+// conservative baud rate value as 921600 has a high error percentage on baud rate clocking
+// OVER8 bit on CR1 to further decrease baud rate clocking error 
+static const SerialConfig uartConfig =
+{
+  460800,
+  USART_CR1_OVER8,
+  USART_CR2_STOP1_BITS,
+  0
+};
 
 //  Application entry point.
 int main(void) {
@@ -61,7 +73,7 @@ int main(void) {
   Watchdog_Init();
 
   // starts the serial driver
-  sdStart(&SERIAL_DRIVER, NULL);
+  sdStart(&SERIAL_DRIVER, &uartConfig);
 
   // create the receiver thread
   osThreadCreate(osThread(ReceiverThread), NULL);

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/mcuconf.h
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/mcuconf.h
@@ -33,11 +33,11 @@
 #define STM32_HSI14_ENABLED                 TRUE
 #define STM32_HSI48_ENABLED                 FALSE
 #define STM32_LSI_ENABLED                   TRUE
-#define STM32_HSE_ENABLED                   FALSE
+#define STM32_HSE_ENABLED                   TRUE
 #define STM32_LSE_ENABLED                   FALSE
 #define STM32_SW                            STM32_SW_PLL
-#define STM32_PLLSRC                        STM32_PLLSRC_HSI_DIV2
-#define STM32_PREDIV_VALUE                  1
+#define STM32_PLLSRC                        STM32_PLLSRC_HSE
+#define STM32_PREDIV_VALUE                  2
 #define STM32_PLLMUL_VALUE                  12
 #define STM32_HPRE                          STM32_HPRE_DIV1
 #define STM32_PPRE                          STM32_PPRE_DIV1


### PR DESCRIPTION
## Description
- Need to decrease baud rate as the 921600 brings along an overkilling error rate.
- Update the MCU config to use the external clock signal (following board datasheet).
- Decrease RTOS thread stack size as there is no need to waste so much RAM.
- Update the block storage definition for debug and minsizerel configuration.

## Motivation and Context
- Resolves nanoFramework/Home#531.
(includes fixes in flash driver v1)

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
