### PR TITLE
Fix CRC driver for STM32L0 series

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.h
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.h
@@ -72,12 +72,12 @@ typedef struct CRCDriver {
 // From STMicroelectronics Cube HAL 
 ///////////////////////////////////////////
 
-#if defined(STM32L0xx_MCUCONF)
+#if defined(STM32L0XX)
 // this series uses different names for the buses
 
-#define rccEnableCRC(lp) rccEnableAPB1(RCC_AHBENR_CRCEN, lp)
-#define rccDisableCRC() rccDisableAPB1(RCC_AHBENR_CRCEN)
-#define rccResetCRC() rccResetAPB1(RCC_AHB1RSTR_CRCRST)
+#define rccEnableCRC(lp) rccEnableAHB(RCC_AHBENR_CRCEN, lp)
+#define rccDisableCRC() rccDisableAHB(RCC_AHBENR_CRCEN)
+#define rccResetCRC() rccResetAHB(RCC_AHB1RSTR_CRCRST)
 
 #endif
 


### PR DESCRIPTION
## Description
- The call was being made to the APB1 register instead of AHB.
(only affects the L0 series)

## Motivation and Context
- CRC peripheral wasn't simply working on L0 series.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
