### PR TITLE
Update Runtime.Events declaration

### DIFF
--- a/src/nanoFramework.Runtime.Events/nf_rt_events_native.cpp
+++ b/src/nanoFramework.Runtime.Events/nf_rt_events_native.cpp
@@ -61,6 +61,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
     Library_nf_rt_events_native_nanoFramework_Runtime_Events_WeakDelegate::Combine___STATIC__mscorlibSystemDelegate__mscorlibSystemDelegate__mscorlibSystemDelegate,
     Library_nf_rt_events_native_nanoFramework_Runtime_Events_WeakDelegate::Remove___STATIC__mscorlibSystemDelegate__mscorlibSystemDelegate__mscorlibSystemDelegate,
 };
@@ -68,7 +69,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_Runtime_Events =
 {
     "nanoFramework.Runtime.Events", 
-    0x9E949BB1,
+    0x7B4AC2F2,
     method_lookup,
-    { 100, 0, 6, 0 }
+    { 100, 0, 7, 0 }
 };


### PR DESCRIPTION
- Following https://github.com/nanoframework/lib-nanoFramework.Runtime.Events/commit/cac485f7a0f47cbbb72ae1cacd9ab4b74cdf6996