### PR TITLE
Fix System.Double implementations for emulated floating point

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Double.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Double.cpp
@@ -7,6 +7,7 @@
 #include "nanoPAL_NativeDouble.h"
 
 #if !defined(NANOCLR_EMULATED_FLOATINGPOINT)
+
 HRESULT Library_corlib_native_System_Double::CompareTo___STATIC__I4__R8__R8( CLR_RT_StackFrame& stack )
 {
     NATIVE_PROFILE_CLR_CORE();
@@ -72,7 +73,9 @@ HRESULT Library_corlib_native_System_Double::IsPositiveInfinity___STATIC__BOOLEA
 
     NANOCLR_NOCLEANUP_NOLABEL();
 }
+
 #else
+
 HRESULT Library_corlib_native_System_Double::CompareTo___STATIC__I4__R8__R8( CLR_RT_StackFrame& stack )
 {
     NATIVE_PROFILE_CLR_CORE();
@@ -88,41 +91,22 @@ HRESULT Library_corlib_native_System_Double::CompareTo___STATIC__I4__R8__R8( CLR
 
 HRESULT Library_corlib_native_System_Double::IsInfinity___STATIC__BOOLEAN__R8( CLR_RT_StackFrame& stack )
 {
-    NATIVE_PROFILE_CLR_CORE();
-    NANOCLR_HEADER();
-
-    stack.SetResult_Boolean(false);
-
-    NANOCLR_NOCLEANUP_NOLABEL();
+    stack.NotImplementedStub();
 }
 
 HRESULT Library_corlib_native_System_Double::IsNaN___STATIC__BOOLEAN__R8( CLR_RT_StackFrame& stack )
 {
-    NATIVE_PROFILE_CLR_CORE();
-    NANOCLR_HEADER();
-
-    stack.SetResult_Boolean(false);
-
-    NANOCLR_NOCLEANUP_NOLABEL();
+    stack.NotImplementedStub();
 }
 
 HRESULT Library_corlib_native_System_Double::IsNegativeInfinity___STATIC__BOOLEAN__R8( CLR_RT_StackFrame& stack )
 {
-    NATIVE_PROFILE_CLR_CORE();
-    NANOCLR_HEADER();
-
-    stack.SetResult_Boolean(false);
-
-    NANOCLR_NOCLEANUP_NOLABEL();
+    stack.NotImplementedStub();
 }
 
 HRESULT Library_corlib_native_System_Double::IsPositiveInfinity___STATIC__BOOLEAN__R8( CLR_RT_StackFrame& stack )
 {
-    NATIVE_PROFILE_CLR_CORE();
-    NANOCLR_HEADER();
-
-    stack.SetResult_Boolean(false);
-
-    NANOCLR_NOCLEANUP_NOLABEL();
+    stack.NotImplementedStub();
 }
+
 #endif


### PR DESCRIPTION
## Description
- Replace return value from `false` to not implemented exception.
- Minor improvements in coding style.

## Motivation and Context
- Most calls were wrongly returning false when they should be returning not implemented exception.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
