### PR TITLE
Fixes with math classes

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_MathInternal.cpp
+++ b/src/CLR/CorLib/corlib_native_System_MathInternal.cpp
@@ -5,99 +5,44 @@
 //
 #include "CorLib.h"
 
-#if !defined(NANOCLR_EMULATED_FLOATINGPOINT)
-    #include "nanoPAL_NativeDouble.h"
+HRESULT Library_corlib_native_System_MathInternal::Abs___STATIC__I4__I4( CLR_RT_StackFrame& stack )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_HEADER();
 
-    HRESULT Library_corlib_native_System_MathInternal::Abs___STATIC__I4__I4( CLR_RT_StackFrame& stack )
-    {
-      #if (DP_FLOATINGPOINT == TRUE)
-        stack.NotImplementedStub();  
-      #else
+    CLR_INT32 d = stack.Arg0().NumericByRefConst().s4;
+    CLR_INT32 res = abs( d );
 
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
+    stack.SetResult_I4( res );
 
-        float d = stack.Arg0().NumericByRefConst().s4;
-        float res = fabs( d );
+    NANOCLR_NOCLEANUP_NOLABEL();
+}
 
-        stack.SetResult_I4( res );
+HRESULT Library_corlib_native_System_MathInternal::Max___STATIC__I4__I4__I4( CLR_RT_StackFrame& stack )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_HEADER();
 
-        NANOCLR_NOCLEANUP_NOLABEL();        
+    CLR_INT32 x = stack.Arg0().NumericByRefConst().s4;
+    CLR_INT32 y = stack.Arg1().NumericByRefConst().s4;
+    CLR_INT32 res = x >= y ? x : y;
 
-      #endif 
-    }
+    stack.SetResult_I4( res );
 
-    HRESULT Library_corlib_native_System_MathInternal::Max___STATIC__I4__I4__I4( CLR_RT_StackFrame& stack )
-    {
-      #if (DP_FLOATINGPOINT == TRUE)
-        return stack.NotImplementedStub();
-      #else
+    NANOCLR_NOCLEANUP_NOLABEL();
+}
 
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
+HRESULT Library_corlib_native_System_MathInternal::Min___STATIC__I4__I4__I4( CLR_RT_StackFrame& stack )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_HEADER();
 
-        float x = stack.Arg0().NumericByRefConst().s4;
-        float y = stack.Arg1().NumericByRefConst().s4;
-        float res = x >= y ? x : y;
+    CLR_INT32 x = stack.Arg0().NumericByRefConst().s4;
+    CLR_INT32 y = stack.Arg1().NumericByRefConst().s4;
+    CLR_INT32 res = x <= y ? x : y;
 
-        stack.SetResult_I4( res );
+    stack.SetResult_I4( res );
 
-        NANOCLR_NOCLEANUP_NOLABEL();
+    NANOCLR_NOCLEANUP_NOLABEL();
+}
 
-      #endif 
-    }
-
-    HRESULT Library_corlib_native_System_MathInternal::Min___STATIC__I4__I4__I4( CLR_RT_StackFrame& stack )
-    {
-      #if (DP_FLOATINGPOINT == TRUE)
-        return stack.NotImplementedStub();
-      #else
-
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
-
-        float x = stack.Arg0().NumericByRefConst().s4;
-        float y = stack.Arg1().NumericByRefConst().s4;
-        float res = x <= y ? x : y;
-
-        stack.SetResult_I4( res );
-
-        NANOCLR_NOCLEANUP_NOLABEL();
-
-      #endif 
-    }
-
-#else
-
-    /// No floating point
-    HRESULT Library_corlib_native_System_MathInternal::Abs___STATIC__I4__I4( CLR_RT_StackFrame& stack )
-    {
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
-
-        NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
-
-        NANOCLR_NOCLEANUP();
-    }
-
-    HRESULT Library_corlib_native_System_MathInternal::Max___STATIC__I4__I4__I4( CLR_RT_StackFrame& stack )
-    {
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
-
-        NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
-
-        NANOCLR_NOCLEANUP();
-    }
-
-    HRESULT Library_corlib_native_System_MathInternal::Min___STATIC__I4__I4__I4( CLR_RT_StackFrame& stack )
-    {
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
-
-        NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
-
-        NANOCLR_NOCLEANUP();
-    }
-
-#endif  // NANOCLR_EMULATED_FLOATINGPOINT

--- a/src/CLR/System.Math/nf_native_system_math_System_Math.cpp
+++ b/src/CLR/System.Math/nf_native_system_math_System_Math.cpp
@@ -20,22 +20,16 @@
 
     HRESULT Library_nf_native_system_math_System_Math::Max___STATIC__R4__R4__R4( CLR_RT_StackFrame& stack )
     {
-      #if (DP_FLOATINGPOINT == TRUE)
-        return stack.NotImplementedStub();
-      #else
+      NATIVE_PROFILE_CLR_CORE();
+      NANOCLR_HEADER();
 
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
+      float x = stack.Arg0().NumericByRefConst().r4;
+      float y = stack.Arg1().NumericByRefConst().r4;
+      float res = x >= y ? x : y;
 
-        float x = stack.Arg0().NumericByRefConst().r4;
-        float y = stack.Arg1().NumericByRefConst().r4;
-        float res = x >= y ? x : y;
+      stack.SetResult_R4( res );
 
-        stack.SetResult_R4( res );
-
-        NANOCLR_NOCLEANUP_NOLABEL();
-
-      #endif 
+      NANOCLR_NOCLEANUP_NOLABEL();
     }
 
     HRESULT Library_nf_native_system_math_System_Math::Max___STATIC__R8__R8__R8( CLR_RT_StackFrame& stack )
@@ -60,22 +54,16 @@
 
     HRESULT Library_nf_native_system_math_System_Math::Min___STATIC__R4__R4__R4( CLR_RT_StackFrame& stack )
     {
-      #if (DP_FLOATINGPOINT == TRUE)
-        return stack.NotImplementedStub();
-      #else
+      NATIVE_PROFILE_CLR_CORE();
+      NANOCLR_HEADER();
 
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
+      float x = stack.Arg0().NumericByRefConst().r4;
+      float y = stack.Arg1().NumericByRefConst().r4;
+      float res = x <= y ? x : y;
 
-        float x = stack.Arg0().NumericByRefConst().r4;
-        float y = stack.Arg1().NumericByRefConst().r4;
-        float res = x <= y ? x : y;
+      stack.SetResult_R4( res );
 
-        stack.SetResult_R4( res );
-
-        NANOCLR_NOCLEANUP_NOLABEL();
-
-      #endif 
+      NANOCLR_NOCLEANUP_NOLABEL();
     }
 
     HRESULT Library_nf_native_system_math_System_Math::Min___STATIC__R8__R8__R8( CLR_RT_StackFrame& stack )
@@ -119,21 +107,15 @@
 
     HRESULT Library_nf_native_system_math_System_Math::Abs___STATIC__R4__R4( CLR_RT_StackFrame& stack )
     {
-      #if (DP_FLOATINGPOINT == TRUE)
-        return stack.NotImplementedStub();
-      #else
+      NATIVE_PROFILE_CLR_CORE();
+      NANOCLR_HEADER();
 
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
+      float d = stack.Arg0().NumericByRefConst().r4;
+      float res = fabsf( d );
 
-        float d = stack.Arg0().NumericByRefConst().r4;
-        float res = fabsf( d );
+      stack.SetResult_R4( res );
 
-        stack.SetResult_R4( res );
-
-        NANOCLR_NOCLEANUP_NOLABEL();        
-
-      #endif 
+      NANOCLR_NOCLEANUP_NOLABEL();
     }
 
     HRESULT Library_nf_native_system_math_System_Math::Acos___STATIC__R8__R8( CLR_RT_StackFrame& stack )
@@ -166,23 +148,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = acosf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = acosf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();        
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }    
 
@@ -216,23 +190,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = asinf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = asinf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -266,23 +232,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = atanf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = atanf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -317,24 +275,16 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float x = stack.Arg0().NumericByRefConst().r4;
+        float y = stack.Arg1().NumericByRefConst().r4;
+        float res = atan2f( x, y );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float x = stack.Arg0().NumericByRefConst().r4;
-          float y = stack.Arg1().NumericByRefConst().r4;
-          float res = atan2f( x, y );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -368,23 +318,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = ceilf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = ceilf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -418,23 +360,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = cosf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = cosf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -468,23 +402,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = coshf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = coshf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -519,24 +445,16 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float x = stack.Arg0().NumericByRefConst().r4;
+        float y = stack.Arg1().NumericByRefConst().r4;
+        float res = remainderf(x, y);
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float x = stack.Arg0().NumericByRefConst().r4;
-          float y = stack.Arg1().NumericByRefConst().r4;
-          float res = remainderf(x, y);
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif      
     }
 
@@ -570,23 +488,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = expf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = expf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();;
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();;
       #endif
     }
 
@@ -620,23 +530,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = floorf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = floorf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -670,23 +572,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = logf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = logf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -720,23 +614,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = log10f( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = log10f( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -761,23 +647,17 @@
 
     HRESULT Library_nf_native_system_math_System_Math::Pow___STATIC__R4__R4__R4( CLR_RT_StackFrame& stack )
     {
-      #if (DP_FLOATINGPOINT == TRUE)
-        return stack.NotImplementedStub();
-      #else
+      NATIVE_PROFILE_CLR_CORE();
+      NANOCLR_HEADER();
 
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
+      float x = stack.Arg0().NumericByRefConst().r4;
+      float y = stack.Arg1().NumericByRefConst().r4;
 
-        float x = stack.Arg0().NumericByRefConst().r4;
-        float y = stack.Arg1().NumericByRefConst().r4;
+      float res = powf( x, y );
 
-        float res = powf( x, y );
+      stack.SetResult_R4( res );
 
-        stack.SetResult_R4( res );
-
-        NANOCLR_NOCLEANUP_NOLABEL();     
-
-      #endif
+      NANOCLR_NOCLEANUP_NOLABEL();
     }
 
     HRESULT Library_nf_native_system_math_System_Math::Round___STATIC__R8__R8( CLR_RT_StackFrame& stack )
@@ -812,31 +692,25 @@
 
     HRESULT Library_nf_native_system_math_System_Math::Round___STATIC__R4__R4( CLR_RT_StackFrame& stack )
     {
-      #if (DP_FLOATINGPOINT == TRUE)
-        return stack.NotImplementedStub();
-      #else
+      NATIVE_PROFILE_CLR_CORE();
+      NANOCLR_HEADER();
 
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
+      float d = stack.Arg0().NumericByRefConst().r4;
+      float hi = d + 0.5;
+      float res = floorf( hi );
 
-        float d = stack.Arg0().NumericByRefConst().r4;
-        float hi = d + 0.5;
-        float res = floorf( hi );
+      //If the number was in the middle of two integers, we need to round to the even one.
+      if(res==hi)
+      {
+          if(fmodf( res, 2.0 ) != 0)
+          {
+              //Rounding up made the number odd so we should round down.
+              res -= 1.0;
+          }
+      }
+      stack.SetResult_R4( res );
 
-        //If the number was in the middle of two integers, we need to round to the even one.
-        if(res==hi)
-        {
-            if(fmodf( res, 2.0 ) != 0)
-            {
-                //Rounding up made the number odd so we should round down.
-                res -= 1.0;
-            }
-        }
-        stack.SetResult_R4( res );
-
-        NANOCLR_NOCLEANUP_NOLABEL();
-
-      #endif
+      NANOCLR_NOCLEANUP_NOLABEL();
     }
 
     HRESULT Library_nf_native_system_math_System_Math::Sign___STATIC__I4__R8( CLR_RT_StackFrame& stack )
@@ -861,24 +735,18 @@
 
     HRESULT Library_nf_native_system_math_System_Math::Sign___STATIC__I4__R4( CLR_RT_StackFrame& stack )
     {
-      #if (DP_FLOATINGPOINT == TRUE)
-        return stack.NotImplementedStub();
-      #else
+      NATIVE_PROFILE_CLR_CORE();
+      NANOCLR_HEADER();
 
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
+      float d = stack.Arg0().NumericByRefConst().r4;
+      int32_t res;
+      if (d < 0) res =  -1;
+      else if (d > 0) res =  +1;
+      else res = 0;
 
-        float d = stack.Arg0().NumericByRefConst().r4;
-        int32_t res;
-        if (d < 0) res =  -1;
-        else if (d > 0) res =  +1;
-        else res = 0;
+      stack.SetResult_I4( res );
 
-        stack.SetResult_I4( res );
-
-        NANOCLR_NOCLEANUP_NOLABEL();     
-
-      #endif
+      NANOCLR_NOCLEANUP_NOLABEL();     
     }
 
     HRESULT Library_nf_native_system_math_System_Math::Sin___STATIC__R8__R8( CLR_RT_StackFrame& stack )
@@ -911,23 +779,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = sinf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = sinf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -961,23 +821,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = sinhf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = sinhf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -1011,23 +863,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = sqrtf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = sqrtf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -1061,23 +905,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = tanf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = tanf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -1111,23 +947,15 @@
       #if (NANOCLR_LIGHT_MATH == TRUE)
         return stack.NotImplementedStub();
       #else
+        NATIVE_PROFILE_CLR_CORE();
+        NANOCLR_HEADER();
 
-        #if (DP_FLOATINGPOINT == TRUE)
-          return stack.NotImplementedStub();
-        #else
+        float d = stack.Arg0().NumericByRefConst().r4;
+        float res = tanhf( d );
 
-          NATIVE_PROFILE_CLR_CORE();
-          NANOCLR_HEADER();
+        stack.SetResult_R4( res );
 
-          float d = stack.Arg0().NumericByRefConst().r4;
-          float res = tanhf( d );
-
-          stack.SetResult_R4( res );
-
-          NANOCLR_NOCLEANUP_NOLABEL();
-
-        #endif
-
+        NANOCLR_NOCLEANUP_NOLABEL();
       #endif
     }
 
@@ -1152,22 +980,16 @@
 
     HRESULT Library_nf_native_system_math_System_Math::Truncate___STATIC__R4__R4( CLR_RT_StackFrame& stack )
     {
-      #if (DP_FLOATINGPOINT == TRUE)
-        return stack.NotImplementedStub();
-      #else
+      NATIVE_PROFILE_CLR_CORE();
+      NANOCLR_HEADER();
 
-        NATIVE_PROFILE_CLR_CORE();
-        NANOCLR_HEADER();
+      float d = stack.Arg0().NumericByRefConst().r4;
+      float res = 0.0;
+      modff(d, &res); 
 
-        float d = stack.Arg0().NumericByRefConst().r4;
-        float res = 0.0;
-        modff(d, &res); 
+      stack.SetResult_R4( res );
 
-        stack.SetResult_R4( res );
-
-        NANOCLR_NOCLEANUP_NOLABEL();
-
-      #endif
+      NANOCLR_NOCLEANUP_NOLABEL();
     }
 
 #else


### PR DESCRIPTION
- remove unnecessary #if (DP_FLOATINGPOINT == TRUE) conditions in R4 (float) functions
- rework Math.Internal class

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template below (mind the link as all issues are open in the Home repository, not in this one) -->
- After this change its possible to use double precision and single precision operations

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: Mateusz Klatecki <mateusz.klatecki@gc5.pl>
