### PR TITLE
Fix endless loop in 1-Wire during ID search

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_onewire/hal_stm32_onewire.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/src/stm32_onewire/hal_stm32_onewire.c
@@ -1012,7 +1012,7 @@ bool oneWireFindNext (bool doReset, bool alarmOnly)
     }
     while (romByteIndex < 8);  // loop until we have all ROM bytes
 
-    if (romBitIndex < (65 || lastcrc8))
+    if ((romBitIndex < 65) || (lastcrc8 != 0))
     {
         // search was unsuccessful reset the last discrepancy
         LastDiscrepancy = 0;

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/nanoFramework.Devices.OneWire/nf_devices_onewire_native_nanoFramework_Devices_OneWire_OneWireController.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/nanoFramework.Devices.OneWire/nf_devices_onewire_native_nanoFramework_Devices_OneWire_OneWireController.cpp
@@ -366,7 +366,7 @@ bool oneWireFindNext (bool doReset, bool alarmOnly)
     }
     while (romByteIndex < 8);  // loop until we have all ROM bytes
 
-    if (romBitIndex < (65 || lastcrc8))
+    if ((romBitIndex < 65) || (lastcrc8 != 0))
     {
         // search was unsuccessful reset the last discrepancy
         LastDiscrepancy = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
- Correct the comparison at the end of FindNext() to terminate de search.
- This fix applies for ESP32 and STM32
- The comparison was not was done in correct way, as per Maxim APP note AN187.
from: `if (romBitIndex <  (65 || lastcrc8)`
goes to: `if ((romBitIndex < 65) || (lastcrc8 != 0))`

## Motivation and Context
- This is required in order to make OneWire drive be able to address more than two devices on the bus.
- Not hanging the application until it reaches out of memory.
- Fixes nanoframework/Home#541.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by:  up-streamer <up_stream@hotmail.com>
