### PR TITLE
Fix cast issues with socket addresses

### DIFF
--- a/src/HAL/Include/nanoHAL.h
+++ b/src/HAL/Include/nanoHAL.h
@@ -61,7 +61,6 @@
 
 #if defined(_MSC_VER)
 
-#define ADS_PACKED
 #define GNU_PACKED
 
 
@@ -71,7 +70,6 @@
 #elif defined(__GNUC__)
 
 
-#define ADS_PACKED
 #define GNU_PACKED  __attribute__((packed))
 
 

--- a/src/PAL/Include/nanoPAL_Sockets.h
+++ b/src/PAL/Include/nanoPAL_Sockets.h
@@ -248,13 +248,13 @@ typedef struct SOCK_sockaddr {
 
 CT_ASSERT_UNIQUE_NAME(sizeof(SOCK_sockaddr)==(16), SOCK_SOCKADDR)
 
-typedef ADS_PACKED struct GNU_PACKED SOCK_in_addr{  
-    ADS_PACKED union GNU_PACKED {    
-        ADS_PACKED struct GNU_PACKED {      
+typedef struct GNU_PACKED SOCK_in_addr{  
+    union GNU_PACKED {    
+        struct GNU_PACKED {      
             u_char s_b1,s_b2,s_b3,s_b4;    
         } S_un_b;    
         
-        ADS_PACKED struct GNU_PACKED {      
+        struct GNU_PACKED {      
             u_short s_w1,s_w2;    
         } S_un_w;    
         
@@ -262,7 +262,7 @@ typedef ADS_PACKED struct GNU_PACKED SOCK_in_addr{
     } S_un;
 } SOCK_in_addr;
 
-typedef ADS_PACKED struct GNU_PACKED SOCK_sockaddr_in {
+typedef struct GNU_PACKED SOCK_sockaddr_in {
         short   sin_family;
         u_short sin_port;
         SOCK_in_addr sin_addr;

--- a/targets/os/win32/Include/TargetPAL_BlockStorage.h
+++ b/targets/os/win32/Include/TargetPAL_BlockStorage.h
@@ -260,7 +260,6 @@
 // //   V     Byte indicating if the block is valid (a.k.a. bad)
 // //   E     Bytes typically used for by a NAND driver for ECC
 // //
-// ADS_PACKED 
 // struct GNU_PACKED SectorMetadata
 // {
 //     unsigned long dwReserved1; // Used by the FAL to hold the logical to physical sector mapping information.


### PR DESCRIPTION
## Description
- Rework casts of SOCK_sockaddr.
- Rework code in IP addresses to use formal conversions and keeping the compiler happy.
- Remove ADS_PACKED define from unsupported compiler.

## Motivation and Context
- In preparation for GNU gcc v9.
- Improving code quality and readability. 

## How Has This Been Tested?<!-- (if applicable) -->
- Tested with HTTP samples.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
