### PR TITLE
Fix simultaneous use of SDcard and USB MSD

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/Include/Target_Windows_Storage.h
+++ b/targets/CMSIS-OS/ChibiOS/Include/Target_Windows_Storage.h
@@ -6,12 +6,41 @@
 #ifndef _TARGET_WINDOWS_STORAGE_H_
 #define _TARGET_WINDOWS_STORAGE_H_ 1
 
+#include <hal.h>
+
+#if HAL_USBH_USE_MSD
+#include "usbh/dev/msd.h"
+#endif
+
 #define SDCARD_POLLING_INTERVAL                (10)
 #define SDCARD_POLLING_DELAY                   (500)
 
 
 #define USB_MSD_POLLING_INTERVAL               (1000)
 #define USB_MSD_POLLING_DELAY                  (1000)
+
+// the drive indexes have to be used instead of fixed drive letters because a target can have one or more 
+// and those have to follow the sequence that is used in ChibiOS FatFS wrappers
+// SD Card (or SPI) is 1st and USB MAS is 2nd (if SD Card is enabled)
+// this is also mapped in the FatFS configuration
+#if defined(HAL_USE_SDC)
+
+#define SD_CARD_DRIVE_INDEX             "0:"
+#define SD_CARD_DRIVE_INDEX_NUMERIC     (0)
+
+#endif
+
+#if defined(HAL_USE_SDC) && defined(HAL_USBH_USE_MSD)
+
+#define USB_MSD_DRIVE_INDEX             "1:"
+#define USB_MSD_DRIVE_INDEX_NUMERIC     (1)
+
+#elif !defined(HAL_USE_SDC) && defined(HAL_USBH_USE_MSD)
+
+#define USB_MSD_DRIVE_INDEX             "0:"
+#define USB_MSD_DRIVE_INDEX_NUMERIC     (0)
+
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/CMSIS-OS/ChibiOS/common/Target_Windows_Storage.c
+++ b/targets/CMSIS-OS/ChibiOS/common/Target_Windows_Storage.c
@@ -18,24 +18,6 @@
 // need to declare this here as extern
 extern void PostManagedEvent(uint8_t category, uint8_t subCategory, uint16_t data1, uint32_t data2);
 
-// the drive indexes have to be used instead of fixed drive letters because a target can have one or more 
-// and those have to follow the sequence that is used in ChibiOS FatFS wrappers
-// SD Card (or SPI) is 1st and USB MAS is 2nd (if SD Card is enabled)
-// this is also mapped in the FatFS configuration
-#if defined(HAL_USE_SDC)
-
-#define SD_CARD_DRIVE_INDEX             "0:"
-#define SD_CARD_DRIVE_INDEX_NUMERIC     (0)
-
-#endif
-
-#if defined(HAL_USE_SDC)
-
-#define USB_MSD_DRIVE_INDEX             "1:"
-#define USB_MSD_DRIVE_INDEX_NUMERIC     (1)
-
-#endif
-
 ///////////////////////////////////////////
 // code specific to SD Card
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
@@ -72,7 +72,7 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetRemovableSt
     char* stringBuffer;
     uint32_t driveCount = 0;
     char workingDrive[sizeof(DRIVE_PATH_LENGTH)];
-    uint16_t driveIterator = 0;
+    uint16_t maxDriveCount = 0;
 
     CLR_RT_HeapBlock* storageFolder;
     CLR_RT_TypeDef_Index storageFolderTypeDef;
@@ -80,10 +80,9 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetRemovableSt
     CLR_RT_HeapBlock& top   = stack.PushValue();
 
   #if HAL_USE_SDC
-    bool sdCardEnumerated = false;
-  #endif
+    // increase max drive count
+    maxDriveCount++;
 
-  #if HAL_USE_SDC
     // is the SD card file system ready?
     if(sdCardFileSystemReady)
     {
@@ -93,8 +92,9 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetRemovableSt
   #endif
 
   #if HAL_USBH_USE_MSD
-    bool usbMsdEnumerated = false;
-
+    // increase max drive count
+    maxDriveCount++;
+    
     // is the USB mass storage device file system ready?
     if(usbMsdFileSystemReady)
     {
@@ -118,37 +118,49 @@ HRESULT Library_win_storage_native_Windows_Storage_StorageFolder::GetRemovableSt
 
         // get a pointer to the first object in the array (which is of type <StorageFolder>)
         storageFolder = (CLR_RT_HeapBlock*)top.DereferenceArray()->GetFirstElement();
-
-        // create an instance of <StorageFolder>
-        NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(*storageFolder, storageFolderTypeDef));
-
+        
         // loop until we've loaded all the possible drives
         // because we are iterating through an enum, need to use its integer values
-        for(; driveIterator < driveCount; driveIterator++ )
+        for(uint16_t driveIterator = 0; driveIterator < maxDriveCount; driveIterator++ )
         {
             // fill the folder name and path
 
           #if HAL_USE_SDC
-            // is the SD card file system ready?
-            if(sdCardFileSystemReady && !sdCardEnumerated)
+            // SD card has index 0
+            if(driveIterator == SD_CARD_DRIVE_INDEX_NUMERIC)
             {
-                memcpy(workingDrive, INDEX0_DRIVE_PATH, DRIVE_PATH_LENGTH);
-
-                // flag as enumerated
-                sdCardEnumerated = true;
+                // is the SD card file system ready?
+                if(sdCardFileSystemReady)
+                {
+                    memcpy(workingDrive, INDEX0_DRIVE_PATH, DRIVE_PATH_LENGTH);
+                }
+                else
+                {
+                    // SD card file system is not ready and/or no drive is enumerated
+                    continue;
+                }
             }
           #endif
 
           #if HAL_USBH_USE_MSD
-            // is the USB mass storage device file system ready?
-            if(usbMsdFileSystemReady && !usbMsdEnumerated)
+            // USB MSD has index 0 or 1, depending on the us of SD card
+            if(driveIterator == USB_MSD_DRIVE_INDEX_NUMERIC)
             {
-                memcpy(workingDrive, INDEX1_DRIVE_PATH, DRIVE_PATH_LENGTH);
-                
-                // flag as enumerated
-                usbMsdEnumerated = true;
-            }    
+                // is the USB mass storage device file system ready?
+                if(usbMsdFileSystemReady)
+                {
+                    memcpy(workingDrive, INDEX1_DRIVE_PATH, DRIVE_PATH_LENGTH);
+                }
+                else
+                {
+                    // USB mass storage file system is not ready and/or no drive is enumerated
+                    continue;
+                }
+            }
           #endif
+
+            // create an instance of <StorageFolder>
+            NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(*storageFolder, storageFolderTypeDef));
 
             // dereference the object in order to reach its fields
             hbObj = storageFolder->Dereference();


### PR DESCRIPTION
## Description
The Windows.Storage library allows file operations on SD cards and USB MSD. 

## Motivation and Context
With the present code, it is only possible to use either the SD card or the USB MSD but not both at the same time. To get this to work, small changes were necessary.

## How Has This Been Tested?<!-- (if applicable) -->
This has been tested on a custom STM32F427 based board with an SD card slot and an USB Host port. With the FileAccess sample from the GitHub repo, which has been adjusted to use two removable devices, the functionality could be verified.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.