### PR TITLE
Add dependency of LWIP module to NXP target

### DIFF
--- a/targets/FreeRTOS/NXP/NXP_MIMXRT1060_EVK/CMakeLists.txt
+++ b/targets/FreeRTOS/NXP/NXP_MIMXRT1060_EVK/CMakeLists.txt
@@ -111,7 +111,7 @@ add_executable(
 
 # add dependency from FreeRTOS (this is required to make sure the FreeRTOS repo is downloaded before the build starts)
 add_dependencies(${NANOBOOTER_PROJECT_NAME}.elf FreeRTOS CMSIS)
-add_dependencies(${NANOCLR_PROJECT_NAME}.elf FreeRTOS CMSIS)
+add_dependencies(${NANOCLR_PROJECT_NAME}.elf FreeRTOS CMSIS LWIP)
 
 # include common directories
 include_directories(


### PR DESCRIPTION
## Description
- Add dependency of LWIP module to NXP target.

## Motivation and Context
- Lacking of this dependency has causing random build failures depending on how Ninja setup the download tasks and how quick they complete.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>