### PR TITLE
Update Esp32 Ethernet for alternate clock modes

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Esp32_Ethernet_Lan8720.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Esp32_Ethernet_Lan8720.cpp
@@ -33,6 +33,11 @@ extern struct netif * Esp32_find_netif(esp_interface_t esp_if);
 //#define CONFIG_PIN_PHY_POWER		12     // Olimex_POE
 //#define CONFIG_PIN_PHY_POWER		5      // Olimex_gateway revs newer than C
 
+// Uncomment one of these lines to elect alternate clock modes
+#define CONFIG_PHY_CLOCK_MODE		ETH_CLOCK_GPIO0_IN		// Default
+//#define CONFIG_PHY_CLOCK_MODE		ETH_CLOCK_GPIO17_OUT    // Olimex_POE, Olimex_POE-ISO
+//#define CONFIG_PHY_CLOCK_MODE		ETH_CLOCK_GPIO0_OUT     // 
+//#define CONFIG_PHY_CLOCK_MODE		ETH_CLOCK_GPIO16_OUT    // 
 
 
 #ifdef CONFIG_PHY_LAN8720
@@ -91,6 +96,7 @@ esp_err_t Esp32_InitialiseEthernet( uint8_t * pMacAdr)
     config.phy_addr = PHY0;
     config.gpio_config = eth_gpio_config_rmii;
     config.tcpip_input = tcpip_adapter_eth_input;
+	config.clock_mode = CONFIG_PHY_CLOCK_MODE;
 
 #ifdef CONFIG_PIN_PHY_POWER
 	config.phy_power_enable = phy_device_power_enable_via_gpio;

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Esp32_Ethernet_Lan8720.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Esp32_Ethernet_Lan8720.cpp
@@ -33,7 +33,7 @@ extern struct netif * Esp32_find_netif(esp_interface_t esp_if);
 //#define CONFIG_PIN_PHY_POWER		12     // Olimex_POE
 //#define CONFIG_PIN_PHY_POWER		5      // Olimex_gateway revs newer than C
 
-// Uncomment one of these lines to elect alternate clock modes
+// Uncomment one of these lines to select alternate clock modes
 #define CONFIG_PHY_CLOCK_MODE		ETH_CLOCK_GPIO0_IN		// Default
 //#define CONFIG_PHY_CLOCK_MODE		ETH_CLOCK_GPIO17_OUT    // Olimex_POE, Olimex_POE-ISO
 //#define CONFIG_PHY_CLOCK_MODE		ETH_CLOCK_GPIO0_OUT     // 
@@ -70,18 +70,18 @@ static void eth_gpio_config_rmii(void)
 #ifdef CONFIG_PIN_PHY_POWER
 static void phy_device_power_enable_via_gpio(bool enable)
 {
-	if (!enable)
-		phy_lan8720_default_ethernet_config.phy_power_enable(false);
+    if (!enable)
+        phy_lan8720_default_ethernet_config.phy_power_enable(false);
 
-	gpio_pad_select_gpio((gpio_num_t)CONFIG_PIN_PHY_POWER);
-	gpio_set_direction((gpio_num_t)CONFIG_PIN_PHY_POWER, GPIO_MODE_OUTPUT);
-	gpio_set_level((gpio_num_t)CONFIG_PIN_PHY_POWER, (int)enable);
+    gpio_pad_select_gpio((gpio_num_t)CONFIG_PIN_PHY_POWER);
+    gpio_set_direction((gpio_num_t)CONFIG_PIN_PHY_POWER, GPIO_MODE_OUTPUT);
+    gpio_set_level((gpio_num_t)CONFIG_PIN_PHY_POWER, (int)enable);
 
-	// Allow the power up/down to take effect, min 300us
-	vTaskDelay(1);
+    // Allow the power up/down to take effect, min 300us
+    vTaskDelay(1);
 
-	if (enable)
-		phy_lan8720_default_ethernet_config.phy_power_enable(true);
+    if (enable)
+        phy_lan8720_default_ethernet_config.phy_power_enable(true);
 }
 #endif
 
@@ -96,10 +96,10 @@ esp_err_t Esp32_InitialiseEthernet( uint8_t * pMacAdr)
     config.phy_addr = PHY0;
     config.gpio_config = eth_gpio_config_rmii;
     config.tcpip_input = tcpip_adapter_eth_input;
-	config.clock_mode = CONFIG_PHY_CLOCK_MODE;
+    config.clock_mode = CONFIG_PHY_CLOCK_MODE;
 
 #ifdef CONFIG_PIN_PHY_POWER
-	config.phy_power_enable = phy_device_power_enable_via_gpio;
+    config.phy_power_enable = phy_device_power_enable_via_gpio;
 #endif
     esp_err_t ret = esp_eth_init(&config);
     if(ret != ESP_OK) return ret;
@@ -131,7 +131,7 @@ int  Esp32_Ethernet_Open(int index, HAL_Configuration_NetworkInterface * config)
             pNetIf = Esp32_find_netif(ESP_IF_ETH);
             if (pNetIf != NULL) break; 
         }
-	    if (pNetIf != NULL)  return pNetIf->num;
+        if (pNetIf != NULL)  return pNetIf->num;
    }
 
     return SOCK_SOCKET_ERROR; 


### PR DESCRIPTION
## Description
Adds an configuration option to select an alternate Phy Clock mode as used by the ESP32 Olimex POE series of devices. 

## Motivation and Context
Support issue on forum 

## How Has This Been Tested?<!-- (if applicable) -->
Fixed tested by andylyonette

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
