### PR TITLE
Fix type mismatch of SetResult functions

### DIFF
--- a/src/CLR/Core/CLR_RT_Interop.cpp
+++ b/src/CLR/Core/CLR_RT_Interop.cpp
@@ -366,13 +366,13 @@ void SetResult_UINT8( CLR_RT_StackFrame &stackFrame, unsigned char value )
     stackFrame.SetResult( value, DATATYPE_U1 );
 }
 
-void SetResult_UINT16( CLR_RT_StackFrame &stackFrame, signed short value )
+void SetResult_UINT16( CLR_RT_StackFrame &stackFrame, unsigned short value )
 {
     NATIVE_PROFILE_CLR_CORE();
     stackFrame.SetResult( value, DATATYPE_U2 );
 }
 
-void SetResult_UINT32( CLR_RT_StackFrame &stackFrame, signed int value )
+void SetResult_UINT32( CLR_RT_StackFrame &stackFrame, unsigned int value )
 {
     NATIVE_PROFILE_CLR_CORE();
     stackFrame.SetResult( value, DATATYPE_U4 );


### PR DESCRIPTION
## Description
The parameter list of the functions SetResult_UINT16() and SetResult_UINT32() were not consistent with the header file.

## Motivation and Context
The use of the Interop function SetResult_UINT16(…), which is defined in nanoCLR_Interop.h, caused a undefined reference error. The parameter "value" was specified as unsigned short in the headerfile, whereas in the sourcefile it was specified as signed short. I changed it to unsigned in the sourcefile, which is obviously the desired one.

## How Has This Been Tested?
This function has been tested with the use of an own Interop Library.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
