### PR TITLE
Rework of sdcard storage for NXP MIMXRT1060 port

### DIFF
--- a/targets/FreeRTOS/NXP/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
+++ b/targets/FreeRTOS/NXP/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
@@ -49,9 +49,8 @@ static void ReadTextWorkingThread(void *arg) {
   }
 
   // read string
-  if (f_gets((TCHAR *)fileIoOperation->Content, readLength, &file)) {
-    threadOperationResult = FR_OK;
-  } else {
+  if (!(f_gets((TCHAR *)fileIoOperation->Content, readLength, &file)))
+  {
     threadOperationResult = (FRESULT)f_error(&file);
   }
 
@@ -85,10 +84,10 @@ static void WriteTextWorkingThread(void *arg) {
     vTaskDelete(NULL);
   }
 
-  if (f_puts(fileIoOperation->Content, &file) == (int)fileIoOperation->ContentLength) {
-    // expected number of bytes written
-    threadOperationResult = FR_OK;
-  }
+  if (f_puts(fileIoOperation->Content, &file) != (int)fileIoOperation->ContentLength) 
+  {
+    threadOperationResult = FR_DISK_ERR;
+  } 
 
   // close file
   f_close(&file);

--- a/targets/FreeRTOS/NXP/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
+++ b/targets/FreeRTOS/NXP/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
@@ -20,6 +20,7 @@ typedef Library_win_storage_native_Windows_Storage_StorageFile StorageFile;
 struct FileOperation
 {
     FIL*        File;
+    const char* FileName;
     char*       Content;
     uint32_t    ContentLength;
 };
@@ -28,117 +29,139 @@ struct FileOperation
 static volatile FRESULT threadOperationResult;
 
 // ReadText working thread
-static void ReadTextWorkingThread(void * arg)
-{
+static void ReadTextWorkingThread(void *arg) {
 
-    FileOperation*  fileIoOperation = (FileOperation*)arg;
+  FileOperation *fileIoOperation = (FileOperation *)arg;
 
-    // need an extra one for the terminator
-    uint32_t readLength = fileIoOperation->ContentLength + 1;
-    
-    // read string
-    if(f_gets((TCHAR*)fileIoOperation->Content, readLength, fileIoOperation->File))
-    {
-        threadOperationResult = FR_OK;
-    }
-    else
-    {
-        threadOperationResult = (FRESULT)f_error(fileIoOperation->File);
-    }
+  FIL file;
 
-    // close file
-    f_close(fileIoOperation->File);
+  // need an extra one for the terminator
+  uint32_t readLength = fileIoOperation->ContentLength + 1;
 
+  // open file (which is supposed to already exist)
+  // need to use FA_OPEN_EXISTING because we are reading an existing file content from start
+  threadOperationResult = f_open(&file, fileIoOperation->FileName, FA_OPEN_EXISTING | FA_READ);
+
+  if (threadOperationResult != FR_OK) {
     // free memory
-    platform_free(fileIoOperation->File);
-    platform_free(fileIoOperation);
+    free(fileIoOperation);
+    return;
+  }
 
-    // fire event for FileIO operation complete
-    Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
+  // read string
+  if (f_gets((TCHAR *)fileIoOperation->Content, readLength, &file)) {
+    threadOperationResult = FR_OK;
+  } else {
+    threadOperationResult = (FRESULT)f_error(&file);
+  }
 
-    vTaskDelete(NULL);
+  // close file
+  f_close(&file);
+
+  // free memory
+  free(fileIoOperation);
+
+  // fire event for FileIO operation complete
+  Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
+
+  vTaskDelete(NULL);
 }
 
 // WriteText working thread
-static void WriteTextWorkingThread(void *arg)
-{
+static void WriteTextWorkingThread(void *arg) {
 
-    FileOperation*  fileIoOperation = (FileOperation*)arg;
-    if(f_puts(fileIoOperation->Content, fileIoOperation->File) == (int)fileIoOperation->ContentLength)
-    {
-        // expected number of bytes written
-        threadOperationResult = FR_OK;
-    }
+  FileOperation *fileIoOperation = (FileOperation *)arg;
 
-    // close file
-    f_close(fileIoOperation->File);
+  FIL file;
 
+  // open file (which is supposed to already exist)
+  // need to use FA_OPEN_ALWAYS because we are writting the file content from start
+  threadOperationResult = f_open(&file, fileIoOperation->FileName, FA_OPEN_ALWAYS | FA_WRITE);
+
+  if (threadOperationResult != FR_OK) {
     // free memory
-    platform_free(fileIoOperation->File);
-    platform_free(fileIoOperation);
+    free(fileIoOperation);
+    return;
+  }
 
-    // fire event for FileIO operation complete
-    Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
-  
-    vTaskDelete(NULL);
+  if (f_puts(fileIoOperation->Content, &file) == (int)fileIoOperation->ContentLength) {
+    // expected number of bytes written
+    threadOperationResult = FR_OK;
+  }
+
+  // close file
+  f_close(&file);
+
+  // free memory
+  free(fileIoOperation);
+
+  // fire event for FileIO operation complete
+  Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
+
+  vTaskDelete(NULL);
 }
 
 // WriteBinary working thread
-static void WriteBinaryWorkingThread(void *arg)
-{
-    UINT        bytesWritten;
+static void WriteBinaryWorkingThread(void *arg) {
+  UINT bytesWritten;
 
-    FileOperation*  fileIoOperation = (FileOperation*)arg;
+  FileOperation *fileIoOperation = reinterpret_cast<FileOperation *>(arg);
 
-    threadOperationResult = f_write(fileIoOperation->File, fileIoOperation->Content, fileIoOperation->ContentLength, &bytesWritten);
+  FIL file;
 
-    if( (threadOperationResult == FR_OK) && 
-        (bytesWritten == fileIoOperation->ContentLength))
-    {
-        // expected number of bytes written
-        threadOperationResult = FR_OK;
-    }
+  // open file (which is supposed to already exist)
+  // need to use FA_OPEN_ALWAYS because we are writting the file content from start
+  threadOperationResult = f_open(&file, fileIoOperation->FileName, FA_OPEN_ALWAYS | FA_WRITE);
 
-    // close file
-    f_close(fileIoOperation->File);
-
+  if (threadOperationResult != FR_OK) {
     // free memory
-    platform_free(fileIoOperation->File);
-    platform_free(fileIoOperation);
+    free(fileIoOperation);
+    return;
+  }
 
-    // fire event for FileIO operation complete
-    Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
-  
-    vTaskDelete(NULL);
+  threadOperationResult = f_write(&file, fileIoOperation->Content, fileIoOperation->ContentLength, &bytesWritten);
+
+  if ((threadOperationResult == FR_OK) && (bytesWritten == fileIoOperation->ContentLength)) {
+    // expected number of bytes written
+    threadOperationResult = FR_OK;
+  }
+
+  // close file
+  f_close(&file);
+
+  // free memory
+  free(fileIoOperation);
+
+  // fire event for FileIO operation complete
+  Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
+
+  vTaskDelete(NULL);
 }
 
 // ReadBinary working thread
-static void ReadBinaryWorkingThread(void *arg)
-{
-    UINT        bytesRead;
+static void ReadBinaryWorkingThread(void *arg) {
+  UINT bytesRead;
 
-    FileOperation*  fileIoOperation = (FileOperation*)arg;
+  FileOperation *fileIoOperation = reinterpret_cast<FileOperation *>(arg);
 
-    threadOperationResult = f_read(fileIoOperation->File, fileIoOperation->Content, fileIoOperation->ContentLength, &bytesRead);
+  threadOperationResult = f_read(fileIoOperation->File, fileIoOperation->Content, fileIoOperation->ContentLength, &bytesRead);
 
-    if( (threadOperationResult == FR_OK) && 
-        (bytesRead == fileIoOperation->ContentLength))
-    {
-        // expected number of bytes read
-        threadOperationResult = FR_OK;
-    }
+  if ((threadOperationResult == FR_OK) && (bytesRead == fileIoOperation->ContentLength)) {
+    // expected number of bytes read
+    threadOperationResult = FR_OK;
+  }
 
-    // close file
-    f_close(fileIoOperation->File);
+  // close file
+  f_close(fileIoOperation->File);
 
-    // free memory
-    platform_free(fileIoOperation->File);
-    platform_free(fileIoOperation);
+  // free memory
+  free(fileIoOperation->File);
+  free(fileIoOperation);
 
-    // fire event for FileIO operation complete
-    Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
-  
-    vTaskDelete(NULL);
+  // fire event for FileIO operation complete
+  Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
+
+  vTaskDelete(NULL);
 }
 
 ////////////////////////////////////////////////
@@ -158,20 +181,15 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::WriteBytes___STATIC__
 
     CLR_RT_HeapBlock_Array* bufferArray;
 
-    char workingDrive[DRIVE_LETTER_LENGTH];
-
     CLR_RT_HeapBlock    hbTimeout;
     CLR_INT64*          timeout;
     bool                eventResult = true;
 
-    FileOperation* fileIoOperation;
+    const TCHAR*        filePath;
+    
 
     char*               buffer;
     uint32_t            bufferLength;
-
-    const TCHAR*        filePath;
-    FIL*                file;
-    FRESULT             operationResult;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
@@ -193,51 +211,28 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::WriteBytes___STATIC__
     
     if(stack.m_customState == 1)
     {   
-        // copy the first 2 letters of the path for the drive
-        // path is 'D:\folder\file.txt', so we need 'D:'
-        memcpy(workingDrive, filePath, DRIVE_LETTER_LENGTH);
+        // protect the content buffer from GC so the working thread can access those
+        CLR_RT_ProtectFromGC gcContent( *bufferArray );
 
-        // create file struct
-        file = (FIL*)platform_malloc(sizeof(FIL));
-        // check allocation
-        if(file == NULL)
+        // setup FileIO operation
+        FileOperation *fileIoOperation = reinterpret_cast<FileOperation *>(malloc(sizeof(FileOperation)));
+
+        //fileIoOperation->File = file;
+        fileIoOperation->FileName = filePath;
+        fileIoOperation->Content = buffer;
+        fileIoOperation->ContentLength = bufferLength;
+
+        // spawn working thread to perform the write transaction
+        BaseType_t ret;
+        ret = xTaskCreate(WriteBinaryWorkingThread, "WriteBin", configMINIMAL_STACK_SIZE + 600, fileIoOperation, configMAX_PRIORITIES - 2, NULL);
+
+        if (ret != pdPASS)
         {
-            NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
+            NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
         }
 
-        // open file (which is supposed to already exist)
-        // need to use FA_OPEN_ALWAYS because we are writting the file content from start
-        operationResult = f_open(file, filePath, FA_OPEN_ALWAYS | FA_WRITE);
-        
-        if(operationResult != FR_OK)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_FILE_NOT_FOUND);
-        }
-        else
-        {
-            // protect the StorageFile and the content buffer from GC so the working thread can access those
-            CLR_RT_ProtectFromGC gcStorageFile( *pThis );
-            CLR_RT_ProtectFromGC gcContent( *bufferArray );
-
-            // setup FileIO operation
-            fileIoOperation = (FileOperation*)platform_malloc(sizeof(FileOperation));
-
-            fileIoOperation->File = file;
-            fileIoOperation->Content = buffer;
-            fileIoOperation->ContentLength = bufferLength;
-
-            // spawn working thread to perform the write transaction
-            BaseType_t ret;
-            ret = xTaskCreate(WriteBinaryWorkingThread, "WriteBin", 2048, fileIoOperation, configMAX_PRIORITIES - 2, NULL);
-
-            if (ret != pdPASS)
-            {
-                NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
-            }
-
-            // bump custom state
-            stack.m_customState = 2;
-        }
+        // bump custom state
+        stack.m_customState = 2; 
     }
 
     while(eventResult)
@@ -278,123 +273,83 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::WriteBytes___STATIC__
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_win_storage_native_Windows_Storage_FileIO::WriteText___STATIC__VOID__WindowsStorageIStorageFile__STRING( CLR_RT_StackFrame& stack )
-{
-    NANOCLR_HEADER();
+HRESULT Library_win_storage_native_Windows_Storage_FileIO::WriteText___STATIC__VOID__WindowsStorageIStorageFile__STRING(CLR_RT_StackFrame &stack) {
+  NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock_String* content;
+  CLR_RT_HeapBlock_String *content;
 
-    char workingDrive[DRIVE_LETTER_LENGTH];
+  CLR_RT_HeapBlock hbTimeout;
+  CLR_INT64 *timeout;
+  bool eventResult = true;
 
-    CLR_RT_HeapBlock    hbTimeout;
-    CLR_INT64*          timeout;
-    bool                eventResult = true;
+  const TCHAR *filePath;
 
-    FileOperation*  fileIoOperation;
+  // get a pointer to the managed object instance and check that it's not NULL
+  CLR_RT_HeapBlock *pThis = stack.This();
+  FAULT_ON_NULL(pThis);
 
-    const TCHAR*         filePath;
-    FIL*                file;
-    FRESULT             operationResult;
+  // get a pointer to the content
+  content = stack.Arg1().DereferenceString();
 
-    // get a pointer to the managed object instance and check that it's not NULL
-    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
-        
-    // get a pointer to the content
-    content = stack.Arg1().DereferenceString();
+  // get a pointer to the file path
+  filePath = (TCHAR *)pThis[StorageFile::FIELD___path].DereferenceString()->StringText();
 
-    // get a pointer to the file path
-    filePath = (TCHAR*)pThis[ StorageFile::FIELD___path ].DereferenceString()->StringText();
+  // !! need to cast to CLR_INT64 otherwise it wont setup a proper timeout infinite
+  hbTimeout.SetInteger((CLR_INT64)-1);
 
-    // !! need to cast to CLR_INT64 otherwise it wont setup a proper timeout infinite
-    hbTimeout.SetInteger((CLR_INT64)-1);
+  NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
 
-    NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks( hbTimeout, timeout ));
-    
-    if(stack.m_customState == 1)
-    {   
-        // copy the first 2 letters of the path for the drive
-        // path is 'D:\folder\file.txt', so we need 'D:'
-        memcpy(workingDrive, filePath, DRIVE_LETTER_LENGTH);
+  if (stack.m_customState == 1) {
+    // protect the StorageFile and the content buffer from GC so the working thread can access those
+    CLR_RT_ProtectFromGC gcStorageFile(*pThis);
+    CLR_RT_ProtectFromGC gcContent(*content);
 
-        // create file struct
-        file = (FIL*)platform_malloc(sizeof(FIL));
-        // check allocation
-        if(file == NULL)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
-        }
+    // setup FileIO operation
+    FileOperation *fileIoOperation = (FileOperation *)malloc(sizeof(FileOperation));
 
-        // open file (which is supposed to already exist)
-        // need to use FA_OPEN_ALWAYS because we are writting the file content from start
-        operationResult = f_open(file, filePath, FA_OPEN_ALWAYS | FA_WRITE);
-        
-        if(operationResult != FR_OK)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_FILE_NOT_FOUND);
-        }
-        else
-        {
-            // protect the StorageFile and the content buffer from GC so the working thread can access those
-            CLR_RT_ProtectFromGC gcStorageFile( *pThis );
-            CLR_RT_ProtectFromGC gcContent( *content );
+    fileIoOperation->FileName = filePath;
+    fileIoOperation->Content = (char *)content->StringText();
+    fileIoOperation->ContentLength = hal_strlen_s(fileIoOperation->Content);
 
-            // setup FileIO operation
-            fileIoOperation = (FileOperation*)platform_malloc(sizeof(FileOperation));
+    // spawn working thread to perform the write transaction
+    BaseType_t ret;
+    ret = xTaskCreate(WriteTextWorkingThread, "WriteText", configMINIMAL_STACK_SIZE + 400, fileIoOperation, configMAX_PRIORITIES - 2, NULL);
 
-            fileIoOperation->File = file;
-            fileIoOperation->Content = (char*)content->StringText();
-            fileIoOperation->ContentLength = hal_strlen_s(fileIoOperation->Content);
-
-            // spawn working thread to perform the write transaction
-            BaseType_t ret;
-            ret = xTaskCreate(WriteTextWorkingThread, "WriteText", 2048, fileIoOperation, configMAX_PRIORITIES - 2, NULL);
-
-            if (ret != pdPASS)
-            {
-                NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
-            }
-
-            // bump custom state
-            stack.m_customState = 2;
-        }
+    if (ret != pdPASS) {
+      NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
     }
 
-    while(eventResult)
-    {
-        // non-blocking wait allowing other threads to run while we wait for the write operation to complete
-        NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents( stack.m_owningThread, *timeout, CLR_RT_ExecutionEngine::c_Event_StorageIo, eventResult ));
+    // bump custom state
+    stack.m_customState = 2;
+  }
 
-        if(eventResult)
-        {
-            // event occurred
+  while (eventResult) {
+    // non-blocking wait allowing other threads to run while we wait for the write operation to complete
+    NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, CLR_RT_ExecutionEngine::c_Event_StorageIo, eventResult));
 
-            if(threadOperationResult == FR_DISK_ERR)
-            {
-                NANOCLR_SET_AND_LEAVE( CLR_E_FILE_IO );
-            }
-            else if(threadOperationResult == FR_NO_FILE)
-            {
-                NANOCLR_SET_AND_LEAVE( CLR_E_FILE_NOT_FOUND );
-            }
-            else if(threadOperationResult == FR_INVALID_DRIVE)
-            {
-                // failed to change drive
-                NANOCLR_SET_AND_LEAVE(CLR_E_VOLUME_NOT_FOUND);
-            }
+    if (eventResult) {
+      // event occurred
 
-            // done here
-            break;
-        }
-        else
-        {
-            NANOCLR_SET_AND_LEAVE( CLR_E_TIMEOUT );
-        }
+      if (threadOperationResult == FR_DISK_ERR) {
+        NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
+      } else if (threadOperationResult == FR_NO_FILE) {
+        NANOCLR_SET_AND_LEAVE(CLR_E_FILE_NOT_FOUND);
+      } else if (threadOperationResult == FR_INVALID_DRIVE) {
+        // failed to change drive
+        NANOCLR_SET_AND_LEAVE(CLR_E_VOLUME_NOT_FOUND);
+      }
+
+      // done here
+      break;
+    } else {
+      NANOCLR_SET_AND_LEAVE(CLR_E_TIMEOUT);
     }
+  }
 
-    // pop timeout heap block from stack
-    stack.PopValue();
+  // pop timeout heap block from stack
+  stack.PopValue();
 
-    NANOCLR_NOCLEANUP();
+  NANOCLR_NOCLEANUP();
 }
 
 HRESULT Library_win_storage_native_Windows_Storage_FileIO::ReadBufferNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_SZARRAY_U1( CLR_RT_StackFrame& stack )
@@ -405,13 +360,9 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::ReadBufferNative___ST
     CLR_INT64*          timeout;
     bool                eventResult = true;
 
-    FileOperation*  fileIoOperation;
-
-    char workingDrive[DRIVE_LETTER_LENGTH];
     const TCHAR*        filePath;
 
     FIL*                file;
-    static FILINFO      fileInfo;
     FRESULT             operationResult;
 
     // get a pointer to the managed object instance and check that it's not NULL
@@ -427,15 +378,8 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::ReadBufferNative___ST
    
     if(stack.m_customState == 1)
     {
-        // protect the StorageFile from GC
-        CLR_RT_ProtectFromGC gcStorageFile( *pThis );
-
-        // copy the first 2 letters of the path for the drive
-        // path is 'D:\folder\file.txt', so we need 'D:'
-        memcpy(workingDrive, filePath, DRIVE_LETTER_LENGTH);
-
         // create file struct
-        file = (FIL*)platform_malloc(sizeof(FIL));
+        file = (FIL*)malloc(sizeof(FIL));
         // check allocation
         if(file == NULL)
         {
@@ -450,43 +394,43 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::ReadBufferNative___ST
         {
             NANOCLR_SET_AND_LEAVE(CLR_E_FILE_NOT_FOUND);
         }
-        else
+        
+        // get file details
+        static FILINFO fileInfo;
+        f_stat(filePath, &fileInfo);
+
+        CLR_RT_HeapBlock buffer;
+        buffer.SetObjectReference( NULL );
+        CLR_RT_ProtectFromGC gc2( buffer );
+
+        // create a new byte array with the appropriate size (and type)
+        NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance( buffer, (CLR_INT32)fileInfo.fsize, g_CLR_RT_WellKnownTypes.m_UInt8 ));
+
+        // store this to the argument passed byref
+        NANOCLR_CHECK_HRESULT(buffer.StoreToReference( stack.Arg1(), 0 ));
+
+        // get a pointer to the buffer array to improve readability on the code ahead
+        CLR_RT_HeapBlock_Array* bufferArray = buffer.DereferenceArray();
+
+        // setup FileIO operation
+        FileOperation *fileIoOperation = reinterpret_cast<FileOperation *>(malloc(sizeof(FileOperation)));
+
+        fileIoOperation->File = file;
+        fileIoOperation->Content = (char*)bufferArray->GetFirstElement();
+        fileIoOperation->ContentLength = bufferArray->m_numOfElements;
+
+        // spawn working thread to perform the read transaction
+        BaseType_t ret;
+        ret = xTaskCreate(ReadBinaryWorkingThread, "ReadBin", configMINIMAL_STACK_SIZE + 100, fileIoOperation, configMAX_PRIORITIES - 2, NULL);
+
+        if (ret != pdPASS)
         {
-            // get file details
-            f_stat(filePath, &fileInfo);
-
-            CLR_RT_HeapBlock buffer;
-            buffer.SetObjectReference( NULL );
-            CLR_RT_ProtectFromGC gc2( buffer );
-
-            // create a new byte array with the appropriate size (and type)
-            NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance( buffer, (CLR_INT32)fileInfo.fsize, g_CLR_RT_WellKnownTypes.m_UInt8 ));
-
-            // store this to the argument passed byref
-            NANOCLR_CHECK_HRESULT(buffer.StoreToReference( stack.Arg1(), 0 ));
-
-            // get a pointer to the buffer array to improve readability on the code ahead
-            CLR_RT_HeapBlock_Array* bufferArray = buffer.DereferenceArray();
-
-            // setup FileIO operation
-            fileIoOperation = (FileOperation*)platform_malloc(sizeof(FileOperation));
-
-            fileIoOperation->File = file;
-            fileIoOperation->Content = (char*)bufferArray->GetFirstElement();
-            fileIoOperation->ContentLength = bufferArray->m_numOfElements;
-
-            // spawn working thread to perform the read transaction
-            BaseType_t ret;
-            ret = xTaskCreate(ReadBinaryWorkingThread, "ReadBin", 2048, fileIoOperation, configMAX_PRIORITIES - 2, NULL);
-
-            if (ret != pdPASS)
-            {
-                NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
-            }
-
-            // bump custom state
-            stack.m_customState = 2;
+            NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
         }
+
+        // bump custom state
+        stack.m_customState = 2;
+        
     }
 
     while(eventResult)
@@ -527,133 +471,91 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::ReadBufferNative___ST
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_win_storage_native_Windows_Storage_FileIO::ReadTextNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_STRING( CLR_RT_StackFrame& stack )
-{
-    NANOCLR_HEADER();
+HRESULT Library_win_storage_native_Windows_Storage_FileIO::ReadTextNative___STATIC__VOID__WindowsStorageIStorageFile__BYREF_STRING(CLR_RT_StackFrame &stack) {
+  NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock    hbTimeout;
-    CLR_INT64*          timeout;
-    bool                eventResult = true;
+  CLR_RT_HeapBlock hbTimeout;
+  CLR_INT64 *timeout;
+  bool eventResult = true;
 
-    FileOperation*  fileIoOperation;
+  const TCHAR *filePath;
 
-    char workingDrive[DRIVE_LETTER_LENGTH];
-    const TCHAR*        filePath;
+  static FILINFO fileInfo;
 
-    FIL*                file;
-    static FILINFO      fileInfo;
-    FRESULT             operationResult;
+  // get a pointer to the managed object instance and check that it's not NULL
+  CLR_RT_HeapBlock *pThis = stack.This();
+  FAULT_ON_NULL(pThis);
 
-    // get a pointer to the managed object instance and check that it's not NULL
-    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+  // !! need to cast to CLR_INT64 otherwise it wont setup a proper timeout infinite
+  hbTimeout.SetInteger((CLR_INT64)-1);
 
-    // !! need to cast to CLR_INT64 otherwise it wont setup a proper timeout infinite
-    hbTimeout.SetInteger((CLR_INT64)-1);
+  NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
 
-    NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks( hbTimeout, timeout ));
+  // get a pointer to the file path
+  filePath = (TCHAR *)pThis[StorageFile::FIELD___path].DereferenceString()->StringText();
 
-    // get a pointer to the file path
-    filePath = (TCHAR*)pThis[ StorageFile::FIELD___path ].DereferenceString()->StringText();
-   
-    if(stack.m_customState == 1)
-    {
-        // protect the StorageFile and the content buffer from GC so the working thread can access those
-        CLR_RT_ProtectFromGC gcStorageFile( *pThis );
+  if (stack.m_customState == 1) {
+    // protect the StorageFile and the content buffer from GC so the working thread can access those
+    CLR_RT_ProtectFromGC gcStorageFile(*pThis);
 
-        // copy the first 2 letters of the path for the drive
-        // path is 'D:\folder\file.txt', so we need 'D:'
-        memcpy(workingDrive, filePath, DRIVE_LETTER_LENGTH);
+    // get file details
+    f_stat(filePath, &fileInfo);
 
-        // create file struct
-        file = (FIL*)platform_malloc(sizeof(FIL));
-        // check allocation
-        if(file == NULL)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
-        }
+    // create a new string object with the appropriate size
+    CLR_RT_HeapBlock hbText;
+    hbText.SetObjectReference(NULL);
+    CLR_RT_ProtectFromGC gc(hbText);
 
-        // open file (which is supposed to already exist)
-        // need to use FA_OPEN_EXISTING because we are reading an existing file content from start
-        operationResult = f_open(file, filePath, FA_OPEN_EXISTING | FA_READ);
-        
-        if(operationResult != FR_OK)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_FILE_NOT_FOUND);
-        }
-        else
-        {
-            // get file details
-            f_stat(filePath, &fileInfo);
+    CLR_RT_HeapBlock_String *textString = CLR_RT_HeapBlock_String::CreateInstance(hbText, (CLR_UINT32)fileInfo.fsize);
+    FAULT_ON_NULL(textString);
 
-            // create a new string object with the appropriate size
-            CLR_RT_HeapBlock  hbText;
-            hbText.SetObjectReference( NULL );
-            CLR_RT_ProtectFromGC gc( hbText );
+    // store this to the argument passed byref
+    NANOCLR_CHECK_HRESULT(hbText.StoreToReference(stack.Arg1(), 0));
 
-            CLR_RT_HeapBlock_String* textString = CLR_RT_HeapBlock_String::CreateInstance( hbText, (CLR_UINT32)fileInfo.fsize );
-            FAULT_ON_NULL(textString);
+    // setup FileIO operation
+    FileOperation *fileIoOperation = (FileOperation *)malloc(sizeof(FileOperation));
 
-            // store this to the argument passed byref
-            NANOCLR_CHECK_HRESULT(hbText.StoreToReference( stack.Arg1(), 0 ));
+    fileIoOperation->FileName = filePath;
+    fileIoOperation->Content = (char *)textString->StringText();
+    fileIoOperation->ContentLength = fileInfo.fsize;
 
-            // get a pointer to the buffer array to improve readability on the code ahead
-            hbText.DereferenceString();
+    // spawn working thread to perform the read transaction
+    BaseType_t ret;
+    ret = xTaskCreate(ReadTextWorkingThread, "ReadText", configMINIMAL_STACK_SIZE + 300, fileIoOperation, configMAX_PRIORITIES - 2, NULL);
 
-            // setup FileIO operation
-            fileIoOperation = (FileOperation*)platform_malloc(sizeof(FileOperation));
-
-            fileIoOperation->File = file;
-            fileIoOperation->Content = (char*)textString->StringText();
-            fileIoOperation->ContentLength = fileInfo.fsize;
-
-            // spawn working thread to perform the read transaction
-            BaseType_t ret;
-            ret = xTaskCreate(ReadTextWorkingThread, "ReadText", 2048, fileIoOperation, configMAX_PRIORITIES - 2, NULL);
-
-            if (ret != pdPASS)
-            {
-                NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
-            }
-
-            // bump custom state
-            stack.m_customState = 2;
-        }
+    if (ret != pdPASS) {
+      NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
     }
 
-    while(eventResult)
-    {
-        // non-blocking wait allowing other threads to run while we wait for the write operation to complete
-        NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents( stack.m_owningThread, *timeout, CLR_RT_ExecutionEngine::c_Event_StorageIo, eventResult ));
+    // bump custom state
+    stack.m_customState = 2;
+  }
 
-        if(eventResult)
-        {
-            // event occurred
+  while (eventResult) {
+    // non-blocking wait allowing other threads to run while we wait for the write operation to complete
+    NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, CLR_RT_ExecutionEngine::c_Event_StorageIo, eventResult));
 
-            if(threadOperationResult == FR_DISK_ERR)
-            {
-                NANOCLR_SET_AND_LEAVE( CLR_E_FILE_IO );
-            }
-            else if(threadOperationResult == FR_NO_FILE)
-            {
-                NANOCLR_SET_AND_LEAVE( CLR_E_FILE_NOT_FOUND );
-            }
-            else if(threadOperationResult == FR_INVALID_DRIVE)
-            {
-                // failed to change drive
-                NANOCLR_SET_AND_LEAVE(CLR_E_VOLUME_NOT_FOUND);
-            }
+    if (eventResult) {
+      // event occurred
 
-            // done here
-            break;
-        }
-        else
-        {
-            NANOCLR_SET_AND_LEAVE( CLR_E_TIMEOUT );
-        }
+      if (threadOperationResult == FR_DISK_ERR) {
+        NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
+      } else if (threadOperationResult == FR_NO_FILE) {
+        NANOCLR_SET_AND_LEAVE(CLR_E_FILE_NOT_FOUND);
+      } else if (threadOperationResult == FR_INVALID_DRIVE) {
+        // failed to change drive
+        NANOCLR_SET_AND_LEAVE(CLR_E_VOLUME_NOT_FOUND);
+      }
+
+      // done here
+      break;
+    } else {
+      NANOCLR_SET_AND_LEAVE(CLR_E_TIMEOUT);
     }
+  }
 
-    // pop timeout heap block from stack
-    stack.PopValue();
+  // pop timeout heap block from stack
+  stack.PopValue();
 
-    NANOCLR_NOCLEANUP();
+  NANOCLR_NOCLEANUP();
 }

--- a/targets/FreeRTOS/NXP/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
+++ b/targets/FreeRTOS/NXP/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
@@ -225,7 +225,7 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::WriteBytes___STATIC__
         CLR_RT_ProtectFromGC gcContent( *bufferArray );
 
         // setup FileIO operation
-        FileOperation *fileIoOperation = reinterpret_cast<FileOperation *>(malloc(sizeof(FileOperation)));
+        FileOperation *fileIoOperation = reinterpret_cast<FileOperation *>(platform_malloc(sizeof(FileOperation)));
 
         //fileIoOperation->File = file;
         fileIoOperation->FileName = filePath;
@@ -315,7 +315,7 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::WriteText___STATIC__V
     CLR_RT_ProtectFromGC gcContent(*content);
 
     // setup FileIO operation
-    FileOperation *fileIoOperation = reinterpret_cast<FileOperation *>(malloc(sizeof(FileOperation)));
+    FileOperation *fileIoOperation = reinterpret_cast<FileOperation *>(platform_malloc(sizeof(FileOperation)));
 
     fileIoOperation->FileName = filePath;
     fileIoOperation->Content = (char *)content->StringText();
@@ -411,7 +411,7 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::ReadBufferNative___ST
         CLR_RT_HeapBlock_Array* bufferArray = buffer.DereferenceArray();
 
         // setup FileIO operation
-        FileOperation *fileIoOperation = reinterpret_cast<FileOperation *>(malloc(sizeof(FileOperation)));
+        FileOperation *fileIoOperation = reinterpret_cast<FileOperation *>(platform_malloc(sizeof(FileOperation)));
 
         fileIoOperation->FileName = filePath;
         fileIoOperation->Content = (char*)bufferArray->GetFirstElement();
@@ -509,7 +509,7 @@ HRESULT Library_win_storage_native_Windows_Storage_FileIO::ReadTextNative___STAT
     NANOCLR_CHECK_HRESULT(hbText.StoreToReference(stack.Arg1(), 0));
 
     // setup FileIO operation
-    FileOperation *fileIoOperation = (FileOperation *)malloc(sizeof(FileOperation));
+    FileOperation *fileIoOperation = (FileOperation *)platform_malloc(sizeof(FileOperation));
 
     fileIoOperation->FileName = filePath;
     fileIoOperation->Content = (char *)textString->StringText();

--- a/targets/FreeRTOS/NXP/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
+++ b/targets/FreeRTOS/NXP/nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_FileIO.cpp
@@ -43,7 +43,7 @@ static void ReadTextWorkingThread(void *arg) {
 
   if (threadOperationResult != FR_OK) {
     // free memory
-    free(fileIoOperation);
+    platform_free(fileIoOperation);
     Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
     vTaskDelete(NULL);
   }
@@ -58,7 +58,7 @@ static void ReadTextWorkingThread(void *arg) {
   f_close(&file);
 
   // free memory
-  free(fileIoOperation);
+  platform_free(fileIoOperation);
 
   // fire event for FileIO operation complete
   Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
@@ -79,7 +79,7 @@ static void WriteTextWorkingThread(void *arg) {
 
   if (threadOperationResult != FR_OK) {
     // free memory
-    free(fileIoOperation);
+    platform_free(fileIoOperation);
     Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
     vTaskDelete(NULL);
   }
@@ -93,7 +93,7 @@ static void WriteTextWorkingThread(void *arg) {
   f_close(&file);
 
   // free memory
-  free(fileIoOperation);
+  platform_free(fileIoOperation);
 
   // fire event for FileIO operation complete
   Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
@@ -115,7 +115,7 @@ static void WriteBinaryWorkingThread(void *arg) {
 
   if (threadOperationResult != FR_OK) {
     // free memory
-    free(fileIoOperation);
+    platform_free(fileIoOperation);
     Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
     vTaskDelete(NULL);
   }
@@ -129,7 +129,7 @@ static void WriteBinaryWorkingThread(void *arg) {
   f_close(&file);
 
   // free memory
-  free(fileIoOperation);
+  platform_free(fileIoOperation);
 
   // fire event for FileIO operation complete
   Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
@@ -153,7 +153,7 @@ static void ReadBinaryWorkingThread(void *arg) {
 
   if (threadOperationResult != FR_OK) {
     // free memory
-    free(fileIoOperation);
+    platform_free(fileIoOperation);
     Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);
     vTaskDelete(NULL);
   }
@@ -167,7 +167,7 @@ static void ReadBinaryWorkingThread(void *arg) {
   // close file
   f_close(&file);
 
-  free(fileIoOperation);
+  platform_free(fileIoOperation);
 
   // fire event for FileIO operation complete
   Events_Set(SYSTEM_EVENT_FLAG_STORAGE_IO);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I've edited read/write binary and read/write text to open file in working thread. Which is a little bit faster and causes less stutter then previous implementation.
Also there was a problem when file write/read would end with error but the nanoCLR wouldn't get an event, which is also fixed.
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This bug caused big slowdown of application cycle while read or write was in progress.
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template below (mind the link as all issues are open in the Home repository, not in this one) -->


## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
I've tested above fix with nanoFramework storage sample and with our own application. Storage read/write were successfull and without errors.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: morali <jeremi.jasinski@gmail.com>
