### PR TITLE
Type correction in Interop (unsigned as signed)

### DIFF
--- a/src/CLR/Core/CLR_RT_Interop.cpp
+++ b/src/CLR/Core/CLR_RT_Interop.cpp
@@ -39,7 +39,7 @@ HRESULT Interop_Marshal_UINT8( const CLR_RT_StackFrame &stackFrame, unsigned int
     NANOCLR_INTEROP_NOCLEANUP();
 }
 
-HRESULT Interop_Marshal_UINT16( const CLR_RT_StackFrame &stackFrame, unsigned int paramIndex, signed short &param )         
+HRESULT Interop_Marshal_UINT16( const CLR_RT_StackFrame &stackFrame, unsigned int paramIndex, unsigned short &param )         
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_INTEROP_CHECK_ARG_TYPE(DATATYPE_I4)
@@ -47,7 +47,7 @@ HRESULT Interop_Marshal_UINT16( const CLR_RT_StackFrame &stackFrame, unsigned in
     NANOCLR_INTEROP_NOCLEANUP();
 }
 
-HRESULT Interop_Marshal_UINT32( const CLR_RT_StackFrame &stackFrame, unsigned int paramIndex, signed int &param )         
+HRESULT Interop_Marshal_UINT32( const CLR_RT_StackFrame &stackFrame, unsigned int paramIndex, unsigned int &param )         
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_INTEROP_CHECK_ARG_TYPE(DATATYPE_I4)


### PR DESCRIPTION

## Description
The parameter list of the functions Interop_Marshal_UINT16() and Interop_Marshal_UINT32() were not consistent with the header file.

## Motivation and Context
The use of the Interop function Interop_Marshal_UINT16(…), which is defined in nanoCLR_Interop.h, caused a undefined reference error. One parameter type was specified as unsigned short/int in the headerfile, whereas in the sourcefile it was specified as signed short/int. I changed it to unsigned in the sourcefile, which is obviously the desired one.

## How Has This Been Tested?
This function has been tested with the use of an own Interop Library.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: NiciAndres nicolas.andres@csa.ch
