### PR TITLE
Rework SWO output

### DIFF
--- a/targets/CMSIS-OS/common/swo.cpp
+++ b/targets/CMSIS-OS/common/swo.cpp
@@ -12,6 +12,9 @@
     #error "ITM port is not available on Cortex-M0(+) cores. Need to set CMake option SWO_OUTPUT to OFF."
 #else
 
+// number of attempts to write to the ITM port before quit
+#define ITM_WRITE_ATTEMPTS      10
+
 extern "C" void SwoInit()
 {
     // set SWO pin (PB3) to alternate mode (0 == the status after RESET) 
@@ -57,7 +60,30 @@ extern "C" void SwoInit()
 
 extern "C" void SwoPrintChar(char c)
 {
-    ITM_SendChar(c);
+    ASSERT((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL);
+    ASSERT((ITM->TER & 1UL               ) != 0UL);
+   
+    uint32_t retryCounter = ITM_WRITE_ATTEMPTS;
+    bool okToTx = ITM->PORT[0U].u32 == 0UL;
+
+    // wait (with timeout) until ITM port TX buffer is available
+    while( !okToTx &&
+           (retryCounter > 0) )
+    {
+        // do... nothing
+        __NOP();
+
+        // decrease retry counter
+        retryCounter--;
+
+        // check again
+        okToTx = (ITM->PORT[0U].u32 == 0UL);
+    }
+
+    if(okToTx)
+    {
+        ITM->PORT[0U].u8 = (uint8_t)c;
+    }
 }
 
 extern "C" void SwoPrintString(const char *s)
@@ -75,25 +101,39 @@ __STATIC_INLINE uint32_t GenericPort_Write_CMSIS(int portNum, const char* data, 
 {
     (void)portNum;
 
+    ASSERT((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL);
+    ASSERT((ITM->TER & 1UL               ) != 0UL);
+
     char* p = (char*)data;
     uint32_t counter = 0;
+    uint32_t retryCounter;
+    bool okToTx = ITM->PORT[0U].u32 == 0UL;
 
-    // check if ITM port is enabled before start sending
-    if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
-        ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+    while(  *p != '\0' && 
+            counter < size )
     {
-        while(*p != '\0' || counter < size)
+        retryCounter = ITM_WRITE_ATTEMPTS;
+
+        // wait (with timeout) until ITM port TX buffer is available
+        while( !okToTx &&
+               (retryCounter > 0) )
         {
-            // wait until TX buffer is available
-            while (ITM->PORT[0U].u32 == 0UL)
-            {
-                __NOP();
-            }
+            // do... nothing
+            __NOP();
 
-            ITM->PORT[0U].u8 = (uint8_t)*p++;
+            // decrease retry counter
+            retryCounter--;
 
-            counter++;
+            // check again
+            okToTx = (ITM->PORT[0U].u32 == 0UL);
         }
+
+        if(okToTx)
+        {
+            ITM->PORT[0U].u8 = (uint8_t)*p++;
+        }
+
+        counter++;
     }
 
     return counter;


### PR DESCRIPTION
## Description
- Replace initial checks for ITM port enable (waste of time on each call) with ASSERT. This will cause the assertion to fire in debug mode in case the `SwoInit` wasn't called for some reason.
- Rework while conditions.
- Replace call to CMSIS `ITM_SendChar` with our own implementation (the CMSIS code has the potential to trap execution on a endless loop if the ITM trace buffer gets filled).
- Rework loop in `GenericPort_Write_CMSIS` has the check for the ITM trace buffer being full has the potential to trap execution on a endless loop.

## Motivation and Context
- Fixes nanoFramework/Home#528.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
