### PR TITLE
Fix UpdateConfigurationBlock

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/common/targetHAL_ConfigurationManager.cpp
+++ b/targets/CMSIS-OS/ChibiOS/common/targetHAL_ConfigurationManager.cpp
@@ -344,7 +344,7 @@ __nfweak bool ConfigurationManager_UpdateConfigurationBlock(void* configurationB
             blockAddressInCopy = configSectorCopy + blockOffset;
             
             // replace config block with new content by replacing memory
-            memcpy(blockAddressInCopy, configSectorCopy, blockSize);
+            memcpy(blockAddressInCopy, configurationBlock, blockSize);
 
             // copy the config block copy back to the config block storage
             success = STM32FlashDriver_Write(NULL, (uint32_t)&__nanoConfig_start__, sizeOfConfigSector, (unsigned char*)configSectorCopy, true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The ConfigurationManager_UpdateConfigurationBlock() method is supposed to apply changes to the existing config block. It saves the existing config block to the RAM, then it erases the corresponding flash sector and finally stores the changed config back to the flash. Because of a copy/paste error, the old config got restored instead of applying the changes.

## Motivation and Context
To make use of the update method, the source of the memcpy statement had to be changed to configurationBlock, which is the updated one.

## How Has This Been Tested?<!-- (if applicable) -->
This has been tested on a custom STM32F427 based MCU board with networking capabilities. The config block is used to save the network config.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: Martin Kuhn martin.kuhn@csa.ch
