### PR TITLE
Seperate FatFS from ChibiOS

### DIFF
--- a/CMake/FatFS.CMakeLists.cmake.in
+++ b/CMake/FatFS.CMakeLists.cmake.in
@@ -17,8 +17,9 @@ ExternalProject_Add(
     GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
     TIMEOUT 10
     LOG_DOWNLOAD 1
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
+
     # Disable all other steps
-    INSTALL_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
 )

--- a/CMake/FatFS.CMakeLists.cmake.in
+++ b/CMake/FatFS.CMakeLists.cmake.in
@@ -7,12 +7,12 @@ project(FatFS-download NONE)
 
 include(ExternalProject)
 
-# download FatFS source from MateuszKlatecki git repo
+# download FatFS source from nanoframework git repo
 ExternalProject_Add( 
     FatFS
     PREFIX FatFS
     SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
-    GIT_REPOSITORY https://github.com/MateuszKlatecki/fatfs.git
+    GIT_REPOSITORY https://github.com/abbrev/fatfs.git #TODO: switch to nF org
     GIT_TAG ${FATFS_VERSION_TAG}  # target specified branch
     GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
     TIMEOUT 10

--- a/CMake/Modules/FindCHIBIOS_FATFS.cmake
+++ b/CMake/Modules/FindCHIBIOS_FATFS.cmake
@@ -3,14 +3,15 @@
 # See LICENSE file in the project root for full license information.
 #
 
-execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar xvf ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs-0.13_patched.7z
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/
-)
+# execute_process(
+#     COMMAND ${CMAKE_COMMAND} -E tar xvf ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs-0.13_patched.7z
+#     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/
+# )
 
 
 # List of the required FatFs include files.
-list(APPEND CHIBIOS_FATFS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs/src)
+#list(APPEND CHIBIOS_FATFS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs/src)
+list(APPEND CHIBIOS_FATFS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/FatFS_Source/source)
 
 
 set(FATFS_SRCS
@@ -28,7 +29,8 @@ foreach(SRC_FILE ${FATFS_SRCS})
         PATHS 
             #${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/FatFS
             ${PROJECT_BINARY_DIR}/ChibiOS_Source/os/various/fatfs_bindings
-            ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs/src
+            #${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs/src
+            ${PROJECT_BINARY_DIR}/FatFS_Source/source
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )
@@ -54,14 +56,14 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(CHIBIOS_FATFS DEFAULT_MSG CHIBIOS_FATFS_INCLUD
 # setup target to unzip ChibiOS external filesystem components
 add_custom_target( CHIBIOS_FILESYSTEM_COMPONENTS ALL )
 
-add_custom_command(TARGET CHIBIOS_FILESYSTEM_COMPONENTS
-PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E tar xvf ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs-0.13_patched.7z
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/
-    DEPENDS ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs-0.13_patched.7z
+#add_custom_command(TARGET CHIBIOS_FILESYSTEM_COMPONENTS
+# PRE_BUILD
+#     COMMAND ${CMAKE_COMMAND} -E tar xvf ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs-0.13_patched.7z
+#     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/
+#     DEPENDS ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs-0.13_patched.7z
 
-    VERBATIM
-)
+#     VERBATIM
+# )
 
 # this depends on ChibiOS target being already downloaded
 add_dependencies(CHIBIOS_FILESYSTEM_COMPONENTS ChibiOS)

--- a/CMake/Modules/FindCHIBIOS_FATFS.cmake
+++ b/CMake/Modules/FindCHIBIOS_FATFS.cmake
@@ -52,18 +52,3 @@ endif()
 include(FindPackageHandleStandardArgs)
 
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(CHIBIOS_FATFS DEFAULT_MSG CHIBIOS_FATFS_INCLUDE_DIRS CHIBIOS_FATFS_SOURCES)
-
-# setup target to unzip ChibiOS external filesystem components
-add_custom_target( CHIBIOS_FILESYSTEM_COMPONENTS ALL )
-
-#add_custom_command(TARGET CHIBIOS_FILESYSTEM_COMPONENTS
-# PRE_BUILD
-#     COMMAND ${CMAKE_COMMAND} -E tar xvf ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs-0.13_patched.7z
-#     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/
-#     DEPENDS ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs-0.13_patched.7z
-
-#     VERBATIM
-# )
-
-# this depends on ChibiOS target being already downloaded
-add_dependencies(CHIBIOS_FILESYSTEM_COMPONENTS ChibiOS)

--- a/CMake/Modules/FindFATFS.cmake
+++ b/CMake/Modules/FindFATFS.cmake
@@ -6,6 +6,7 @@
 
 # List of the required FatFs include files.
 list(APPEND FATFS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/FatFS_Source/source)
+list(APPEND FATFS_INCLUDE_DIRS ${TARGET_BASE_LOCATION})
 
 set(FATFS_SRCS
 

--- a/CMake/Modules/FindWindows.Storage.cmake
+++ b/CMake/Modules/FindWindows.Storage.cmake
@@ -9,7 +9,8 @@ set(BASE_PATH_FOR_THIS_MODULE "${BASE_PATH_FOR_CLASS_LIBRARIES_MODULES}/Windows.
 
 # set include directories
 if(RTOS_CHIBIOS_CHECK)
-    list(APPEND Windows.Storage_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs/src)
+    #list(APPEND Windows.Storage_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ChibiOS_Source/ext/fatfs/src)
+    list(APPEND Windows.Storage_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/FatFS_Source/source)
     set( PROJECT_COMMON_PATH ${PROJECT_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/common)
 elseif(RTOS_FREERTOS_CHECK)
     list(APPEND Windows.Storage_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/FatFS_Source/source)

--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -52,6 +52,7 @@
           "TI_SL_CC32xx_SDK_SOURCE" : "<path-to-local-TI-SimpleLink-CC32xx-SDK-source-mind-the-forward-slash>",
           "SPIFFS_SOURCE" : "<path-to-local-SPIFFS-source-mind-the-forward-slash>",
           "SWO_OUTPUT" : "OFF-default-ON-to-enable-ARM-CortexM-Single-Wire-Output",
+          "FATFS_VERSION": "<valid-fatfs-version-if-empty-use-default-set-cmake>",
           "NF_BUILD_RTM" : "OFF-default-ON-to-enable-RTM-build",
           "NF_WP_TRACE_ERRORS" : "OFF-default-ON-to-enable-trace-error-messages-wire-protocol",
           "NF_WP_TRACE_HEADERS" : "OFF-default-ON-to-enable-trace-header-messages-wire-protocol",

--- a/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
@@ -214,6 +214,102 @@ if(CHIBIOS_CONTRIB_REQUIRED)
     endif()
 endif()
 
+# check if FATFS_SOURCE was specified or if it's empty (default is empty)
+set(NO_FATFS_SOURCE TRUE)
+if(FATFS_SOURCE)
+    if(NOT "${FATFS_SOURCE}" STREQUAL "")   
+        set(NO_FATFS_SOURCE FALSE)
+    endif()
+endif()
+
+if(NO_FATFS_SOURCE)
+    # FatFS version
+    set(FATFS_VERSION_EMPTY TRUE)
+
+    # check if build was requested with a specifc FatFS version
+    if(DEFINED FATFS_VERSION)
+        if(NOT "${FATFS_VERSION}" STREQUAL "")
+            set(FATFS_VERSION_EMPTY FALSE)
+        endif()
+    endif()
+
+    # check if build was requested with a specifc FatFS version
+    if(FATFS_VERSION_EMPTY)
+        # no FatFS version actualy specified, must be empty which is fine, we'll default to a known good version
+        set(FATFS_VERSION_TAG "R0.13")
+    else()
+        # set version 
+        set(FATFS_VERSION_TAG "${FATFS_VERSION}")
+    endif()
+
+    message(STATUS "FatFS version is: ${FATFS_VERSION}")
+
+    # need to setup a separate CMake project to download the code from the GitHub repository
+    # otherwise it won't be available before the actual build step
+    configure_file("${PROJECT_SOURCE_DIR}/CMake/FatFS.CMakeLists.cmake.in"
+    "${CMAKE_BINARY_DIR}/FatFS_Download/CMakeLists.txt")
+
+    # setup CMake project for FatFS download
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+                    RESULT_VARIABLE result
+                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/FatFS_Download")
+
+    # run build on FatFS download CMake project to perform the download
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                    RESULT_VARIABLE result
+                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/FatFS_Download")
+
+    # add FatFS as external project
+    ExternalProject_Add( 
+        FatFS
+        PREFIX FatFS
+        SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
+        GIT_REPOSITORY https://github.com/abbrev/fatfs.git #TODO: switch to nF org
+        GIT_TAG ${FATFS_VERSION_TAG}  # target specified branch
+        GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
+        TIMEOUT 10
+        LOG_DOWNLOAD 1
+        # Disable all other steps
+        INSTALL_COMMAND ""
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+    )
+
+else()
+    # FatFS source was specified
+
+    # sanity check is source path exists
+    if(EXISTS "${FATFS_SOURCE}/")
+        message(STATUS "FatFS ${FATFS_VERSION} (source from: ${FATFS_SOURCE})")
+
+        # check if we already have the sources, no need to copy again
+        NF_DIRECTORY_EXISTS_NOT_EMPTY(${CMAKE_BINARY_DIR}/FatFS_Source SOURCE_EXISTS)
+
+        if(NOT ${SOURCE_EXISTS})
+            file(COPY "${FATFS_SOURCE}/" DESTINATION "${CMAKE_BINARY_DIR}/FatFS_Source")
+        else()
+            message(STATUS "Using local cache of FatFS source from ${FATFS_SOURCE}")
+        endif()
+    else()
+        message(FATAL_ERROR "Couldn't find FatFS source at ${FATFS_SOURCE}/")
+    endif()
+
+    # add FatFS as external project
+    ExternalProject_Add(
+        FatFS
+        PREFIX FatFS
+        SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
+        # Disable all other steps
+        INSTALL_COMMAND ""
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+    )        
+
+    # get source dir for FatFS CMake project
+    ExternalProject_Get_Property(FatFS SOURCE_DIR)
+
+endif()
+
 # if mbed TLS is enabled add it to the build
 if(NF_SECURITY_MBEDTLS)
 

--- a/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
@@ -269,8 +269,9 @@ if(NO_FATFS_SOURCE)
         GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
         TIMEOUT 10
         LOG_DOWNLOAD 1
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
+
         # Disable all other steps
-        INSTALL_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
     )
@@ -299,8 +300,9 @@ else()
         FatFS
         PREFIX FatFS
         SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
+
         # Disable all other steps
-        INSTALL_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
     )        

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/CMakeLists.txt
@@ -124,13 +124,6 @@ add_executable(
 add_dependencies(${NANOBOOTER_PROJECT_NAME}.elf ChibiOS)
 add_dependencies(${NANOCLR_PROJECT_NAME}.elf ChibiOS)
 
-# add dependencies from CHIBIOS_FILESYSTEM_COMPONENTS (this is required to make sure that ChibiOS filesystem components are unzip at the proper locations before the build starts)
-# only required if filesystem is ON
-if(USE_FILESYSTEM_OPTION)
-    add_dependencies(${NANOBOOTER_PROJECT_NAME}.elf CHIBIOS_FILESYSTEM_COMPONENTS)
-    add_dependencies(${NANOCLR_PROJECT_NAME}.elf CHIBIOS_FILESYSTEM_COMPONENTS)
-endif()
-
 # include common directories
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
@@ -159,13 +159,6 @@ if(USE_NETWORKING_OPTION)
     endif()
 endif()
 
-# add dependencies from CHIBIOS_FILESYSTEM_COMPONENTS (this is required to make sure that ChibiOS filesystem components are unzip at the proper locations before the build starts)
-# only required if filesystem is ON
-if(USE_FILESYSTEM_OPTION)
-    add_dependencies(${NANOBOOTER_PROJECT_NAME}.elf CHIBIOS_FILESYSTEM_COMPONENTS)
-    add_dependencies(${NANOCLR_PROJECT_NAME}.elf CHIBIOS_FILESYSTEM_COMPONENTS)
-endif()
-
 # include common directories
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/targets/FreeRTOS/NXP/CMakeLists.txt
+++ b/targets/FreeRTOS/NXP/CMakeLists.txt
@@ -62,8 +62,9 @@ if(NO_FATFS_SOURCE)
         GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
         TIMEOUT 10
         LOG_DOWNLOAD 1
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
+
         # Disable all other steps
-        INSTALL_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
     )
@@ -92,8 +93,9 @@ else()
         FatFS
         PREFIX FatFS
         SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
+
         # Disable all other steps
-        INSTALL_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
     )        

--- a/targets/FreeRTOS/NXP/CMakeLists.txt
+++ b/targets/FreeRTOS/NXP/CMakeLists.txt
@@ -8,7 +8,7 @@ include(nf_utils)
 # check if FATFS_SOURCE was specified or if it's empty (default is empty)
 set(NO_FATFS_SOURCE TRUE)
 if(FATFS_SOURCE)
-    if(NOT "${FATFS_SOURCE}" STREQUAL "")
+    if(NOT "${FATFS_SOURCE}" STREQUAL "")   
         set(NO_FATFS_SOURCE FALSE)
     endif()
 endif()
@@ -57,7 +57,7 @@ if(NO_FATFS_SOURCE)
         FatFS
         PREFIX FatFS
         SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
-        GIT_REPOSITORY https://github.com/MateuszKlatecki/fatfs.git
+        GIT_REPOSITORY https://github.com/abbrev/fatfs.git #TODO: switch to nF org
         GIT_TAG ${FATFS_VERSION_TAG}  # target specified branch
         GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
         TIMEOUT 10


### PR DESCRIPTION
Continues to use the same version of FatFS as ChibiOS (until builds pass anyway)

TODO:
* Currently not working as cannot find ff.h/ff.c for some storage libs...
* Needs switching to a nF sanctioned repo...
* Possibly breaks NXP target until R0.14 of FatFS is used

Any help appreciated!
