### PR TITLE
gitmodules: Using relative url and appending ".git"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "targets-community"]
 	path = targets-community
-	url = https://github.com/nanoframework/nf-Community-Targets
+	url = ../nf-Community-Targets.git


### PR DESCRIPTION
Makes it more easy to ensure that an own (maybe by purpose frozen) repo of the community ports is fetched, when forking the project.

## Description
Simply replaces the absolute URL with a relative one.

## Motivation and Context
More easy forking of the code. Ensures that an old codebase of the interpreter keeps being compatible with the community ports from the same time

## How Has This Been Tested?<!-- (if applicable) -->
git submodule update --init --recursive

## Screenshots<!-- (if appropriate): -->

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>
