### PR TITLE
Fix check for datatype in GetType

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Object.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Object.cpp
@@ -44,7 +44,7 @@ HRESULT Library_corlib_native_System_Object::GetType___SystemType( CLR_RT_StackF
 
     pObj = arg0.Dereference();
 
-    if(pObj && pObj->DataType() == DATATYPE_REFLECTION)
+    if(pObj && arg0.DataType() == DATATYPE_REFLECTION)
     {
         idx.m_kind               = REFLECTION_TYPE;
         idx.m_levels             = 0;


### PR DESCRIPTION
## Description
- Replace check of dereferenced object with the one from the object.

## Motivation and Context
- The current check doesn't work for primitive numeric types.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: Antonio Fagundes<antonio.fagundes@eclo.solutions>
