### PR TITLE
Fixes in Wire Protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,9 @@ if(RTOS_CHIBIOS_CHECK)
 endif()
 
 #################################################################
+# (default is ON so Wire Protocol implements CRC32)
+option(NF_WP_IMPLEMENTS_CRC32 "option for Wire Protocol to implement CRC32" ON)
+
 # reports Wire Protocol CRC32 implementation
 if(NF_WP_IMPLEMENTS_CRC32)
     message(STATUS "Wire Protocol implements CRC32")

--- a/CMakeSettings.SAMPLE.json
+++ b/CMakeSettings.SAMPLE.json
@@ -120,7 +120,7 @@
         },
         {
           "name": "NF_WP_IMPLEMENTS_CRC32",
-          "value": "OFF",
+          "value": "ON",
           "type": "BOOL"
         },
         {
@@ -375,7 +375,7 @@
         },
         {
           "name": "NF_WP_IMPLEMENTS_CRC32",
-          "value": "OFF",
+          "value": "ON",
           "type": "BOOL"
         },
         {

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -105,7 +105,7 @@
         },
         {
           "name": "NF_WP_IMPLEMENTS_CRC32",
-          "value": "OFF"
+          "value": "ON"
         },
         {
           "name": "NF_FEATURE_DEBUGGER",
@@ -335,8 +335,8 @@
           "value": "OFF"
         },
         {
-          "name": "NF_WP_IMPLEMENTS_CRC32:BOOL", //OFF-default-ON-to-enable-CRC32-wire-protocol
-          "value": "OFF"
+          "name": "NF_WP_IMPLEMENTS_CRC32:BOOL", //ON-default-OFF-to-disable-CRC32-wire-protocol
+          "value": "ON"
         },
         {
           "name": "NF_FEATURE_DEBUGGER:BOOL", //OFF-default-ON-to-include-managed-app-debugging-capability

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,7 +216,7 @@ jobs:
     matrix:
       ESP32_WROOM_32:
         BoardName: ESP32_WROOM_32
-        BuildOptions: -DTARGET_SERIES=ESP32 -DRTOS=FREERTOS_ESP32 -DNF_WP_IMPLEMENTS_CRC32=OFF -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DNF_FEATURE_HAS_CONFIG_BLOCK=ON -DNF_FEATURE_HAS_SDCARD=ON -DAPI_System.Math=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=ON -DAPI_Windows.Devices.Wifi=ON -DAPI_Windows.Storage=ON -DNF_SECURITY_MBEDTLS=ON -DAPI_Hardware.Esp32=ON -DSUPPORT_ANY_BASE_CONVERSION=ON -DAPI_nanoFramework.Devices.OneWire=ON -DAPI_nanoFramework.ResourceManager=ON -DAPI_nanoFramework.System.Collections=ON -DAPI_nanoFramework.System.Text=ON
+        BuildOptions: -DTARGET_SERIES=ESP32 -DRTOS=FREERTOS_ESP32 -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DNF_FEATURE_HAS_CONFIG_BLOCK=ON -DNF_FEATURE_HAS_SDCARD=ON -DAPI_System.Math=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=ON -DAPI_Windows.Devices.Wifi=ON -DAPI_Windows.Storage=ON -DNF_SECURITY_MBEDTLS=ON -DAPI_Hardware.Esp32=ON -DSUPPORT_ANY_BASE_CONVERSION=ON -DAPI_nanoFramework.Devices.OneWire=ON -DAPI_nanoFramework.ResourceManager=ON -DAPI_nanoFramework.System.Collections=ON -DAPI_nanoFramework.System.Text=ON
 
   variables:
     ESP32_TOOLCHAIN_PATH: $(Agent.TempDirectory)\ESP32_Tools

--- a/cmake-variants.TEMPLATE-ESP32.json
+++ b/cmake-variants.TEMPLATE-ESP32.json
@@ -49,7 +49,7 @@
             "NF_WP_TRACE_STATE": "OFF",
             "NF_WP_TRACE_NODATA": "OFF",
             "NF_WP_TRACE_ALL": "OFF",
-            "NF_WP_IMPLEMENTS_CRC32": "OFF",
+            "NF_WP_IMPLEMENTS_CRC32": "ON",
             "NF_FEATURE_DEBUGGER": "ON",
             "NF_FEATURE_RTC": "ON",
             "NF_FEATURE_USE_APPDOMAINS": "OFF",

--- a/cmake-variants.TEMPLATE.json
+++ b/cmake-variants.TEMPLATE.json
@@ -59,7 +59,7 @@
           "NF_WP_TRACE_STATE" : "OFF-default-ON-to-enable-trace-state-messages-wire-protocol",
           "NF_WP_TRACE_NODATA" : "OFF-default-ON-to-enable-trace-no-data-messages-wire-protocol",
           "NF_WP_TRACE_ALL" : "OFF-default-ON-to-enable-trace-all-messages-wire-protocol",
-          "NF_WP_IMPLEMENTS_CRC32" : "OFF-default-ON-to-enable-CRC32-wire-protocol",
+          "NF_WP_IMPLEMENTS_CRC32" : "ON-default-OFF-to-disable-CRC32-wire-protocol",
           "NF_FEATURE_DEBUGGER" : "OFF-default-ON-to-include-managed-app-debugging-capability",
           "NF_FEATURE_RTC" : "OFF-default-ON-to-enable-hardware-RTC",
           "NF_FEATURE_USE_APPDOMAINS" : "OFF-default-ON-to-enable-support-for-Application-Domains",

--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -10,7 +10,7 @@
 #include "WireProtocol_Message.h"
 
 uint8_t receptionBuffer[sizeof(WP_Packet) + WP_PACKET_SIZE];
-static uint16_t lastOutboundMessage;
+static uint16_t lastOutboundMessage = 65535;
 static uint8_t* marker;
 
 // timeout to receive WP payload before bailing out
@@ -137,11 +137,11 @@ void WP_Message_Release(WP_Message* message)
 
 int WP_Message_VerifyHeader(WP_Message* message)
 {
+    uint32_t crc = message->m_header.m_crcHeader;
+
     message->m_header.m_crcHeader = 0;
 
 #if defined(WP_IMPLEMENTS_CRC32)
-
-    uint32_t crc = message->m_header.m_crcHeader;
 
     uint32_t computedCrc = SUPPORT_ComputeCRC((uint8_t*)&message->m_header, sizeof(message->m_header), 0);
     message->m_header.m_crcHeader = crc;


### PR DESCRIPTION
## Description
- Fix wrong order with CRC check on packet header.
- CMake option for CRC32 in Wire Protocol in now ON.
- Remove build WP CRC32 from ESP32 in Azure Pipelines yaml.

## Motivation and Context
- Fixes bug with WP.
- Restores CRC32 implementation in Wire Protocol as disabling it seems to cause issues with communication stability and reliability.

## How Has This Been Tested?<!-- (if applicable) -->
- Debuger lib UWP test app.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

