### PR TITLE
Fix WP header verification when CRC32 is not implemented

### DIFF
--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -137,16 +137,16 @@ void WP_Message_Release(WP_Message* message)
 
 int WP_Message_VerifyHeader(WP_Message* message)
 {
-    uint32_t crc = message->m_header.m_crcHeader;
-
-    message->m_header.m_crcHeader = 0;
-
 #if defined(WP_IMPLEMENTS_CRC32)
 
-    uint32_t computedCrc = SUPPORT_ComputeCRC((uint8_t*)&message->m_header, sizeof(message->m_header), 0);
-    message->m_header.m_crcHeader = crc;
+    uint32_t incommingCrc = message->m_header.m_crcHeader;
+    message->m_header.m_crcHeader = 0;
 
-    if(computedCrc != crc)
+    uint32_t computedCrc = SUPPORT_ComputeCRC((uint8_t*)&message->m_header, sizeof(message->m_header), 0);
+
+    message->m_header.m_crcHeader = incommingCrc;
+
+    if(computedCrc != incommingCrc)
     {
         TRACE( TRACE_ERRORS, "Header CRC check failed: computed: 0x%08X; got: 0x%08X\n", computedCrc, message->m_header.m_crcHeader );
         return false;


### PR DESCRIPTION
## Description
- Move code and vars to inside compiler define.
- Rename var for clarity.

## Motivation and Context
- This code bit is only necessary when WP implements CRC32, therefore the compiler will issue a warning about a not used var.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: Antonio Fagundes<antonio.fagundes@eclo.solutions>
