### PR TITLE
Fix inclusion of FatFS for ChibiOS

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
@@ -214,101 +214,105 @@ if(CHIBIOS_CONTRIB_REQUIRED)
     endif()
 endif()
 
-# check if FATFS_SOURCE was specified or if it's empty (default is empty)
-set(NO_FATFS_SOURCE TRUE)
-if(FATFS_SOURCE)
-    if(NOT "${FATFS_SOURCE}" STREQUAL "")   
-        set(NO_FATFS_SOURCE FALSE)
-    endif()
-endif()
-
-if(NO_FATFS_SOURCE)
-    # FatFS version
-    set(FATFS_VERSION_EMPTY TRUE)
-
-    # check if build was requested with a specifc FatFS version
-    if(DEFINED FATFS_VERSION)
-        if(NOT "${FATFS_VERSION}" STREQUAL "")
-            set(FATFS_VERSION_EMPTY FALSE)
+# include FatFS if SDCard or USB MSD are ON
+if(NF_FEATURE_HAS_SDCARD OR NF_FEATURE_HAS_USB_MSD)
+    # check if FATFS_SOURCE was specified or if it's empty (default is empty)
+    set(NO_FATFS_SOURCE TRUE)
+    if(FATFS_SOURCE)
+        if(NOT "${FATFS_SOURCE}" STREQUAL "")   
+            set(NO_FATFS_SOURCE FALSE)
         endif()
     endif()
 
-    # check if build was requested with a specifc FatFS version
-    if(FATFS_VERSION_EMPTY)
-        # no FatFS version actualy specified, must be empty which is fine, we'll default to a known good version
-        set(FATFS_VERSION_TAG "R0.14")
-    else()
-        # set version 
-        set(FATFS_VERSION_TAG "${FATFS_VERSION}")
-    endif()
+    if(NO_FATFS_SOURCE)
+        # FatFS version
+        set(FATFS_VERSION_EMPTY TRUE)
 
-    message(STATUS "FatFS version is: ${FATFS_VERSION}")
+        # check if build was requested with a specifc FatFS version
+        if(DEFINED FATFS_VERSION)
+            if(NOT "${FATFS_VERSION}" STREQUAL "")
+                set(FATFS_VERSION_EMPTY FALSE)
+            endif()
+        endif()
 
-    # need to setup a separate CMake project to download the code from the GitHub repository
-    # otherwise it won't be available before the actual build step
-    configure_file("${PROJECT_SOURCE_DIR}/CMake/FatFS.CMakeLists.cmake.in"
-    "${CMAKE_BINARY_DIR}/FatFS_Download/CMakeLists.txt")
-
-    # setup CMake project for FatFS download
-    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                    RESULT_VARIABLE result
-                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/FatFS_Download")
-
-    # run build on FatFS download CMake project to perform the download
-    execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                    RESULT_VARIABLE result
-                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/FatFS_Download")
-
-    # add FatFS as external project
-    ExternalProject_Add( 
-        FatFS
-        PREFIX FatFS
-        SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
-        GIT_REPOSITORY https://github.com/abbrev/fatfs.git #TODO: switch to nF org
-        GIT_TAG ${FATFS_VERSION_TAG}  # target specified branch
-        GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
-        TIMEOUT 10
-        LOG_DOWNLOAD 1
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
-
-        # Disable all other steps
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-    )
-
-else()
-    # FatFS source was specified
-
-    # sanity check is source path exists
-    if(EXISTS "${FATFS_SOURCE}/")
-        message(STATUS "FatFS ${FATFS_VERSION} (source from: ${FATFS_SOURCE})")
-
-        # check if we already have the sources, no need to copy again
-        NF_DIRECTORY_EXISTS_NOT_EMPTY(${CMAKE_BINARY_DIR}/FatFS_Source SOURCE_EXISTS)
-
-        if(NOT ${SOURCE_EXISTS})
-            file(COPY "${FATFS_SOURCE}/" DESTINATION "${CMAKE_BINARY_DIR}/FatFS_Source")
+        # check if build was requested with a specifc FatFS version
+        if(FATFS_VERSION_EMPTY)
+            # no FatFS version actualy specified, must be empty which is fine, we'll default to a known good version
+            set(FATFS_VERSION_TAG "R0.14")
         else()
-            message(STATUS "Using local cache of FatFS source from ${FATFS_SOURCE}")
+            # set version 
+            set(FATFS_VERSION_TAG "${FATFS_VERSION}")
         endif()
+
+        message(STATUS "FatFS version is: ${FATFS_VERSION}")
+
+        # need to setup a separate CMake project to download the code from the GitHub repository
+        # otherwise it won't be available before the actual build step
+        configure_file("${PROJECT_SOURCE_DIR}/CMake/FatFS.CMakeLists.cmake.in"
+        "${CMAKE_BINARY_DIR}/FatFS_Download/CMakeLists.txt")
+
+        # setup CMake project for FatFS download
+        execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+                        RESULT_VARIABLE result
+                        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/FatFS_Download")
+
+        # run build on FatFS download CMake project to perform the download
+        execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                        RESULT_VARIABLE result
+                        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/FatFS_Download")
+
+        # add FatFS as external project
+        ExternalProject_Add( 
+            FatFS
+            PREFIX FatFS
+            SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
+            GIT_REPOSITORY https://github.com/abbrev/fatfs.git #TODO: switch to nF org
+            GIT_TAG ${FATFS_VERSION_TAG}  # target specified branch
+            GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
+            TIMEOUT 10
+            LOG_DOWNLOAD 1
+            INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
+
+            # Disable all other steps
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND ""
+        )
+
     else()
-        message(FATAL_ERROR "Couldn't find FatFS source at ${FATFS_SOURCE}/")
+        # FatFS source was specified
+
+        # sanity check is source path exists
+        if(EXISTS "${FATFS_SOURCE}/")
+            message(STATUS "FatFS ${FATFS_VERSION} (source from: ${FATFS_SOURCE})")
+
+            # check if we already have the sources, no need to copy again
+            NF_DIRECTORY_EXISTS_NOT_EMPTY(${CMAKE_BINARY_DIR}/FatFS_Source SOURCE_EXISTS)
+
+            if(NOT ${SOURCE_EXISTS})
+                file(COPY "${FATFS_SOURCE}/" DESTINATION "${CMAKE_BINARY_DIR}/FatFS_Source")
+            else()
+                message(STATUS "Using local cache of FatFS source from ${FATFS_SOURCE}")
+            endif()
+        else()
+            message(FATAL_ERROR "Couldn't find FatFS source at ${FATFS_SOURCE}/")
+        endif()
+
+        # add FatFS as external project
+        ExternalProject_Add(
+            FatFS
+            PREFIX FatFS
+            SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
+            INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
+
+            # Disable all other steps
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND ""
+        )        
+
+        # get source dir for FatFS CMake project
+        ExternalProject_Get_Property(FatFS SOURCE_DIR)
+
     endif()
-
-    # add FatFS as external project
-    ExternalProject_Add(
-        FatFS
-        PREFIX FatFS
-        SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
-
-        # Disable all other steps
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-    )        
-
-    # get source dir for FatFS CMake project
-    ExternalProject_Get_Property(FatFS SOURCE_DIR)
 
 endif()
 


### PR DESCRIPTION
## Description
- Add condition to include FatFS sources in ChibiOS build, only if required.

## Motivation and Context
- FatFS was wrongly being included on the build no matter if needed or not.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
