### PR TITLE
Fix hardware CRC32 module inclusion

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoBooter/main.c
@@ -5,6 +5,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include <usbcfg.h>
@@ -35,6 +36,11 @@ int main(void) {
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
+
+  #if (HAL_NF_USE_STM32_CRC == TRUE)
+  // startup crc
+  crcStart(NULL);
+  #endif
 
   //  Initializes a serial-over-USB CDC driver.
   sduObjectInit(&SDU1);

--- a/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/MBN_QUAIL/nanoCLR/main.c
@@ -7,6 +7,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include "usbcfg.h"
@@ -67,6 +68,11 @@ int main(void) {
   // for STM32F4 family if watchdog is enabled can't use standby mode because the IWDG can't be stoped //
   ///////////////////////////////////////////////////////////////////////////////////////////////////////
   Watchdog_Init();
+
+  #if (HAL_NF_USE_STM32_CRC == TRUE)
+  // startup crc
+  crcStart(NULL);
+  #endif
 
   //  Initializes a serial-over-USB CDC driver.
   sduObjectInit(&SDU1);

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoBooter/main.c
@@ -5,6 +5,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include <usbcfg.h>
@@ -35,6 +36,11 @@ int main(void) {
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
+
+  #if (HAL_NF_USE_STM32_CRC == TRUE)
+  // startup crc
+  crcStart(NULL);
+  #endif
 
   //  Initializes a serial-over-USB CDC driver.
   sduObjectInit(&SDU1);

--- a/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/NETDUINO3_WIFI/nanoCLR/main.c
@@ -5,6 +5,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include "usbcfg.h"
@@ -69,6 +70,11 @@ int main(void) {
   // for STM32F4 family if watchdog is enabled can't use standby mode because the IWDG can't be stoped //
   ///////////////////////////////////////////////////////////////////////////////////////////////////////
   Watchdog_Init();
+
+  #if (HAL_NF_USE_STM32_CRC == TRUE)
+  // startup crc
+  crcStart(NULL);
+  #endif
 
   //  Initializes a serial-over-USB CDC driver.
   sduObjectInit(&SDU1);

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/main.c
@@ -5,6 +5,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include <serialcfg.h>
@@ -54,6 +55,11 @@ int main(void) {
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
+
+  #if (HAL_NF_USE_STM32_CRC == TRUE)
+  // startup crc
+  crcStart(NULL);
+  #endif
 
   // starts the serial driver
   sdStart(&SERIAL_DRIVER, &uartConfig);

--- a/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/main.c
@@ -5,6 +5,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include <serialcfg.h>
@@ -71,6 +72,11 @@ int main(void) {
 
   // start watchdog
   Watchdog_Init();
+
+  #if (HAL_NF_USE_STM32_CRC == TRUE)
+  // startup crc
+  crcStart(NULL);
+  #endif
 
   // starts the serial driver
   sdStart(&SERIAL_DRIVER, &uartConfig);

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/main.c
@@ -5,6 +5,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include <usbcfg.h>
@@ -36,6 +37,11 @@ int main(void) {
 
   // the following IF is not mandatory, it's just providing a way for a user to 'force'
   // the board to remain in nanoBooter and not launching nanoCLR
+
+  #if (HAL_NF_USE_STM32_CRC == TRUE)
+  // startup crc
+  crcStart(NULL);
+  #endif
 
   // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
   // the user button in this board has a pull-up resistor so the check has to be inverted

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/main.c
@@ -5,6 +5,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include "usbcfg.h"
@@ -65,6 +66,11 @@ int main(void) {
   // for STM32F4 family if watchdog is enabled can't use standby mode because the IWDG can't be stoped //
   ///////////////////////////////////////////////////////////////////////////////////////////////////////
   Watchdog_Init();
+
+  #if (HAL_NF_USE_STM32_CRC == TRUE)
+  // startup crc
+  crcStart(NULL);
+  #endif
 
   // config and init external memory
   // this has to be called after osKernelInitialize, otherwise an hard fault will occur

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/main.c
@@ -5,6 +5,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include <serialcfg.h>
@@ -55,6 +56,11 @@ int main(void) {
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.
   osKernelInitialize();
+
+  #if (HAL_NF_USE_STM32_CRC == TRUE)
+  // startup crc
+  crcStart(NULL);
+  #endif
 
   // starts the serial driver
   sdStart(&SERIAL_DRIVER, NULL);

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/main.c
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/main.c
@@ -5,6 +5,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <hal_nf_community.h>
 #include <cmsis_os.h>
 
 #include <serialcfg.h>
@@ -55,6 +56,11 @@ int main(void) {
 
   // start watchdog
   Watchdog_Init();
+
+  #if (HAL_NF_USE_STM32_CRC == TRUE)
+  // startup crc
+  crcStart(NULL);
+  #endif
 
   // config and init external memory
   // this has to be called after osKernelInitialize, otherwise an hard fault will occur

--- a/targets/CMSIS-OS/ChibiOS/common/WireProtocol_ReceiverThread.c
+++ b/targets/CMSIS-OS/ChibiOS/common/WireProtocol_ReceiverThread.c
@@ -24,11 +24,6 @@ void ReceiverThread(void const * argument)
 
   osDelay(500);
 
-  #if (HAL_NF_USE_STM32_CRC == TRUE)
-  // startup crc
-  crcStart(NULL);
-  #endif
-
   // loop until thread receives a request to terminate
   while (1) {
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/CLR_Startup_Thread.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/CLR_Startup_Thread.c
@@ -48,11 +48,6 @@ void CLRStartupThread(void const * argument)
 {
     CLR_SETTINGS* clrSettings = (CLR_SETTINGS*)argument;
 
-    #if (HAL_NF_USE_STM32_CRC == TRUE)
-    // startup crc
-    crcStart(NULL);
-    #endif
-
     #if (HAL_NF_USE_STM32_ONEWIRE == TRUE)
     // startup 1-Wire driver
     oneWireStart();

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/target_platform.h.in
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/target_platform.h.in
@@ -49,6 +49,9 @@
 // enable CAN
 #define HAL_USE_CAN @HAL_USE_CAN_OPTION@
 
+// enable CRC32 module
+#define HAL_NF_USE_STM32_CRC        TRUE
+
 // enable STM32 ONEWIRE (from nf overlay)
 #define HAL_NF_USE_STM32_ONEWIRE @HAL_USE_STM32_ONEWIRE_OPTION@
 


### PR DESCRIPTION
## Description
- Move peripheral init to main() (booter and CLR) from CLR startup.

## Motivation and Context
- The hardware needs to be initialized before Receiver thread and type resolution need the CRC32 calculator.
- The previous implementation was working because the CRC32 calculation on WP was disabled. Because WP now implements CRC32 has default it's required on both booter and CLR.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
