### PR TITLE
Revert minimum CMake to 3.15

### DIFF
--- a/CMake/CMSIS.CMakeLists.cmake.in
+++ b/CMake/CMSIS.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(CMSIS-download NONE)
 

--- a/CMake/ChibiOS.CMakeLists.cmake.in
+++ b/CMake/ChibiOS.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(ChibiOS-download NONE)
 

--- a/CMake/FatFS.CMakeLists.cmake.in
+++ b/CMake/FatFS.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(FatFS-download NONE)
 

--- a/CMake/FreeRTOS.CMakeLists.cmake.in
+++ b/CMake/FreeRTOS.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(FreeRTOS-download NONE)
 

--- a/CMake/LWIP.CMakeLists.cmake.in
+++ b/CMake/LWIP.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(LWIP-download NONE)
 

--- a/CMake/RTXRTOS.CMakeLists.cmake.in
+++ b/CMake/RTXRTOS.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(RTXRTOS-download NONE)
 

--- a/CMake/SPIFFS.CMakeLists.cmake.in
+++ b/CMake/SPIFFS.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(SPIFFS-download NONE)
 

--- a/CMake/STM32.CubePackage.CMakeLists.cmake.in
+++ b/CMake/STM32.CubePackage.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(STM32-CubePackage-download NONE)
 

--- a/CMake/SimpleLinkCC13x2_26x2Sdk.CMakeLists.cmake.in
+++ b/CMake/SimpleLinkCC13x2_26x2Sdk.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(SimpleLinkCC13x2_26x2SDK-download NONE)
 

--- a/CMake/SimpleLinkCC32xxSdk.CMakeLists.cmake.in
+++ b/CMake/SimpleLinkCC32xxSdk.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(SimpleLinkCC32xxSDK-download NONE)
 

--- a/CMake/TI_XDCTools.CMakeLists.cmake.in
+++ b/CMake/TI_XDCTools.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(TI_XDCTools-download NONE)
 

--- a/CMake/mBedOS.CMakeLists.cmake.in
+++ b/CMake/mBedOS.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(mBedOS-download NONE)
 

--- a/CMake/mbedTLS.CMakeLists.cmake.in
+++ b/CMake/mbedTLS.CMakeLists.cmake.in
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 project(mbedTLS-download NONE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 
 include(CMakeToolsHelpers OPTIONAL)
 include(ExternalProject)


### PR DESCRIPTION
## Description
- Revert minimum CMake to 3.15.

## Motivation and Context
- Make the minimum version in sync with the one distributed with VS2019.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
