### PR TITLE
[network] fix wrong get socket error method

### DIFF
--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Sockets_NativeSocket.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Sockets_NativeSocket.cpp
@@ -739,7 +739,7 @@ HRESULT Library_sys_net_native_System_Net_Sockets_NativeSocket::SendRecvHelper( 
         // send/recv/sendto/recvfrom failed
         if(bytes == SOCK_SOCKET_ERROR)
         {
-            CLR_INT32 err = SOCK_getlasterror();
+            CLR_INT32 err = SOCK_getsocklasterror(handle);
             
             if(err != SOCK_EWOULDBLOCK)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
During network tests we found out, that using SOCK_getlasterror() instead of SOCK_getsocklasterror() leads to an infinite loop when a remote client closes the network socket unexpectedly. Hence the watchdog will not be fed anymore and it will trigger a reset.

## How Has This Been Tested?<!-- (if applicable) -->
This has been tested on a custom STM32F427 based MCU board with network capabilities.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: Martin Kuhn martin.kuhn@csa.ch
