### PR TITLE
Update AccessMemoryErrorCodes enum

### DIFF
--- a/src/CLR/Debugger/Debugger.h
+++ b/src/CLR/Debugger/Debugger.h
@@ -91,7 +91,7 @@ typedef enum CLR_DBG_Commands_Debugging
 // enum with AccessMemoryErrorCodes
 typedef enum AccessMemoryErrorCodes
 {
-    AccessMemoryErrorCode_NoError                           = 0x0000,       // no error
+    AccessMemoryErrorCode_NoError                           = 0x0001,       // no error
     AccessMemoryErrorCode_PermissionDenied                  = 0x0010,       // permission denied to execute operation
     AccessMemoryErrorCode_FailedToAllocateReadBuffer        = 0x0020,       // failed to allocate buffer for read operation. better check heap
     AccessMemoryErrorCode_RequestedOperationFailed          = 0x0030,       // the requested operation failed


### PR DESCRIPTION
## Description
- Replace enum value from `0` to `1`.

## Motivation and Context
- Can't use a `0` value here because the enum is loaded into a variable that is used in Wire Protocol. Because of this (and only when LTO linking option is enable) the optimizations this considered as a `NULL` and that causes a stall in the transmit message code.
- Addresses nanoFramework/Home#578

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
