### PR TITLE
Rework CLR Debug class

### DIFF
--- a/src/CLR/Core/Core.cpp
+++ b/src/CLR/Core/Core.cpp
@@ -79,9 +79,4 @@ CLR_HW_Hardware            g_CLR_HW_Hardware;
 //    { 995, -105 },
 //};
 
-// UNDONE: FIXME: the Arm 3.0 compiler drags in a bunch of ABI methods (for initialization) if struct arrays are not initialized
-CLR_UINT32        g_scratchDebugger         [ sizeof(CLR_DBG_Debugger) ];
-CLR_UINT32        g_scratchDebuggerMessaging[ sizeof(CLR_Messaging) ];
-CLR_DBG_Debugger *g_CLR_DBG_Debugger;
-
 //--//

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -33,6 +33,8 @@ char const* const AccessMemoryModeNames[] = {
 extern const CLR_RT_NativeAssemblyData *g_CLR_InteropAssembliesNativeData[];
 extern uint16_t g_CLR_InteropAssembliesCount;
 
+CLR_DBG_Debugger* g_CLR_DBG_Debugger;
+
 BlockStorageDevice* CLR_DBG_Debugger::m_deploymentStorageDevice = NULL;
 
 //--//
@@ -58,13 +60,23 @@ HRESULT CLR_DBG_Debugger::CreateInstance()
     NATIVE_PROFILE_CLR_DEBUGGER();
     NANOCLR_HEADER();
 
-    g_CLR_DBG_Debugger = (CLR_DBG_Debugger*)&g_scratchDebugger[0];
+    // alloc memory for debugger
+    g_CLR_DBG_Debugger = (CLR_DBG_Debugger*)platform_malloc(sizeof(CLR_DBG_Debugger));
 
+    // sanity check...    
+    FAULT_ON_NULL(g_CLR_DBG_Debugger);
 
+    //... and clear memory
+    memset(g_CLR_DBG_Debugger, 0, sizeof(CLR_DBG_Debugger));
 
-    CLR_RT_Memory::ZeroFill( g_CLR_DBG_Debugger, sizeof(CLR_DBG_Debugger) );
+    // alloc memory for debugger messaging
+    g_CLR_DBG_Debugger->m_messaging = (CLR_Messaging*)platform_malloc(sizeof(CLR_Messaging));
+   
+    // sanity check...    
+    FAULT_ON_NULL(g_CLR_DBG_Debugger->m_messaging);
 
-    g_CLR_DBG_Debugger->m_messaging = (CLR_Messaging*)&g_scratchDebuggerMessaging[0];
+    //... and clear memory
+    memset(g_CLR_DBG_Debugger->m_messaging, 0, sizeof(CLR_Messaging));
 
     NANOCLR_CHECK_HRESULT(g_CLR_DBG_Debugger->Debugger_Initialize(HalSystemConfig.DebuggerPort));
 
@@ -105,6 +117,12 @@ HRESULT CLR_DBG_Debugger::DeleteInstance()
     NANOCLR_HEADER();
 
     g_CLR_DBG_Debugger->Debugger_Cleanup();
+
+    // free messaging
+    platform_free(g_CLR_DBG_Debugger->m_messaging);
+
+    // free debugger
+    platform_free(g_CLR_DBG_Debugger);
 
     NANOCLR_NOCLEANUP_NOLABEL();
 }
@@ -516,15 +534,15 @@ bool CLR_DBG_Debugger::CheckPermission( ByteAddress address, int mode )
     return hasPermission;
 }
 
-bool CLR_DBG_Debugger::AccessMemory( CLR_UINT32 location, unsigned int lengthInBytes, unsigned char* buf, int mode, unsigned int* errorCode )
+bool CLR_DBG_Debugger::AccessMemory( uint32_t location, uint32_t lengthInBytes, uint8_t* buf, uint32_t mode, uint32_t& errorCode )
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     TRACE("AccessMemory( 0x%08X, 0x%08x, 0x%08X, %s)\n", location, lengthInBytes, buf, AccessMemoryModeNames[mode] );
 
-    bool success = false;
+    bool proceed = false;
 
     // reset error code
-    *errorCode = AccessMemoryErrorCode_NoError;
+    errorCode = AccessMemoryErrorCode_RequestedOperationFailed;
 
     //--//
     unsigned int iRegion, iRange;
@@ -536,7 +554,7 @@ bool CLR_DBG_Debugger::AccessMemory( CLR_UINT32 location, unsigned int lengthInB
         // start from the block where the sector sits.
         ByteAddress    accessAddress    = location;
 
-        unsigned char* bufPtr           = buf;
+        uint8_t*       bufPtr           = buf;
         signed int     accessLenInBytes = lengthInBytes;
         signed int     blockOffset      = BlockRegionInfo_OffsetFromBlock(((BlockRegionInfo*)(&deviceInfo->Regions[iRegion])), accessAddress);
 
@@ -573,10 +591,10 @@ bool CLR_DBG_Debugger::AccessMemory( CLR_UINT32 location, unsigned int lengthInB
                     TRACE0("=> Permission check failed!\n");
                     
                     // set error code
-                    *errorCode = AccessMemoryErrorCode_PermissionDenied;
+                    errorCode = AccessMemoryErrorCode_PermissionDenied;
 
                     // done here
-                    return success;
+                    return false;
                 }
 
                 switch(mode)
@@ -586,7 +604,7 @@ bool CLR_DBG_Debugger::AccessMemory( CLR_UINT32 location, unsigned int lengthInB
                         if(deviceInfo->Attribute & MediaAttribute_SupportsXIP)
                         {
                             memcpy( (unsigned char*)bufPtr, (const void*)accessAddress, NumOfBytes );
-                            success = true;
+                            proceed = true;
                         }
                         else
                         {
@@ -599,14 +617,14 @@ bool CLR_DBG_Debugger::AccessMemory( CLR_UINT32 location, unsigned int lengthInB
                                     TRACE0( "=> Failed to allocate data buffer\n");
                                                         
                                     // set error code
-                                    *errorCode = AccessMemoryErrorCode_PermissionDenied;
+                                    errorCode = AccessMemoryErrorCode_PermissionDenied;
 
                                     // done here
-                                    return success;
+                                    return false;
                                 }
                             }
 
-                            success = BlockStorageDevice_Read(m_deploymentStorageDevice, accessAddress , NumOfBytes, (unsigned char *)bufPtr);
+                            proceed = BlockStorageDevice_Read(m_deploymentStorageDevice, accessAddress , NumOfBytes, (unsigned char *)bufPtr);
 
                             if (mode == AccessMemory_Check)
                             {
@@ -618,19 +636,19 @@ bool CLR_DBG_Debugger::AccessMemory( CLR_UINT32 location, unsigned int lengthInB
                         break;
 
                     case AccessMemory_Write:
-                        success = BlockStorageDevice_Write(m_deploymentStorageDevice, accessAddress , NumOfBytes, (unsigned char *)bufPtr, false);
+                        proceed = BlockStorageDevice_Write(m_deploymentStorageDevice, accessAddress , NumOfBytes, (unsigned char *)bufPtr, false);
                         break;
 
                     case AccessMemory_Erase:
                         if (BlockStorageDevice_IsBlockErased(m_deploymentStorageDevice, accessAddress, NumOfBytes))
                         {
-                            // block is erased, we are good
-                            success = true;
+                            // block is already erased, we are good
+                            proceed = true;
                         }
                         else
                         {
                             // need to erase block
-                            success = BlockStorageDevice_EraseBlock(m_deploymentStorageDevice, accessAddress);
+                            proceed = BlockStorageDevice_EraseBlock(m_deploymentStorageDevice, accessAddress);
                         }
                         break;
 
@@ -638,12 +656,9 @@ bool CLR_DBG_Debugger::AccessMemory( CLR_UINT32 location, unsigned int lengthInB
                         break;
                 }
 
-                if(!success)
+                if(!proceed)
                 {
-                    // set error code
-                    *errorCode = AccessMemoryErrorCode_RequestedOperationFailed;
-
-                    break;
+                    return false;
                 }
 
                 accessLenInBytes -= NumOfBytes;
@@ -660,7 +675,7 @@ bool CLR_DBG_Debugger::AccessMemory( CLR_UINT32 location, unsigned int lengthInB
             blockIndex = 0;
             iRange     = 0;
 
-           if ((accessLenInBytes <= 0) || (!success))
+           if ((accessLenInBytes <= 0) || (!proceed))
            {
                break;
            }
@@ -701,7 +716,7 @@ bool CLR_DBG_Debugger::AccessMemory( CLR_UINT32 location, unsigned int lengthInB
         if((sectAddr <ramStartAddress) || (sectAddr >=ramEndAddress) || (sectAddrEnd >ramEndAddress) )
         {
             TRACE(" Invalid address %x and range %x Ram Start %x, Ram end %x\r\n", sectAddr, lengthInBytes, ramStartAddress, ramEndAddress);
-            return success;
+            return false;
         }
         else
       #endif
@@ -735,18 +750,21 @@ bool CLR_DBG_Debugger::AccessMemory( CLR_UINT32 location, unsigned int lengthInB
 
     TRACE0( "=> SUCCESS\n");
 
-    return success;
+    errorCode = AccessMemoryErrorCode_NoError;
+
+    return true;
 }
 
 bool CLR_DBG_Debugger::Monitor_ReadMemory( WP_Message* msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands::Monitor_ReadMemory*       cmd = (CLR_DBG_Commands::Monitor_ReadMemory*)msg->m_payload;
-    CLR_DBG_Commands::Monitor_ReadMemory::Reply* cmdReply = NULL;    
+    CLR_DBG_Commands_Monitor_ReadMemory*       cmd = (CLR_DBG_Commands_Monitor_ReadMemory*)msg->m_payload;
+    uint8_t* buffer;
+    uint32_t errorCode;
 
     uint32_t allocationSize = 0;
-    uint32_t len = cmd->m_length; 
+    uint32_t len = cmd->length; 
     
     // adjust length, if bigger than the WP packet size
     if (len > WP_PACKET_SIZE)
@@ -754,32 +772,29 @@ bool CLR_DBG_Debugger::Monitor_ReadMemory( WP_Message* msg)
         len = WP_PACKET_SIZE;
     }
 
-    if (m_deploymentStorageDevice != NULL)
+    // start computing allocation size, fist the ErrorCode field...
+    allocationSize = sizeof(uint32_t);
+    // ... and the buffer
+    allocationSize += len;
+
+    // allocate memory
+    buffer = (uint8_t*)platform_malloc(allocationSize);
+
+    // sanity check
+    if(buffer != NULL)
     {
-        // start computing allocation size, fist the ErrorCode field...
-        allocationSize = offsetof(CLR_DBG_Commands::Monitor_ReadMemory::Reply, m_data);
-        // ... and the buffer
-        allocationSize += len;
+        // clear allocated memory
+        memset(buffer, 0, allocationSize);
 
-        // allocate memory
-        cmdReply = (CLR_DBG_Commands::Monitor_ReadMemory::Reply*)platform_malloc(allocationSize);
+        g_CLR_DBG_Debugger->AccessMemory( cmd->address, len, (buffer + sizeof(uint32_t)), AccessMemory_Read, errorCode );
 
-        // sanity check
-        if(cmdReply != NULL)
-        {
-            // clear allocated memory
-            memset(cmdReply, 0, allocationSize);
+        WP_ReplyToCommand( msg, true, false, buffer, allocationSize );
 
-            g_CLR_DBG_Debugger->AccessMemory( cmd->m_address, len, (unsigned char*)&cmdReply->m_data, AccessMemory_Read, &cmdReply->ErrorCode );
+        // free allocated memory
+        platform_free(buffer);
 
-            WP_ReplyToCommand( msg, true, false, cmdReply, allocationSize );
-
-            // free allocated memory
-            platform_free(cmdReply);
-
-            // done here
-            return true;
-        }
+        // done here
+        return true;
     }
 
     return false;
@@ -789,55 +804,43 @@ bool CLR_DBG_Debugger::Monitor_WriteMemory( WP_Message* msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands::Monitor_WriteMemory* cmd = (CLR_DBG_Commands::Monitor_WriteMemory*)msg->m_payload;
-    CLR_DBG_Commands::Monitor_WriteMemory::Reply cmdReply;
+    CLR_DBG_Commands_Monitor_WriteMemory* cmd = (CLR_DBG_Commands_Monitor_WriteMemory*)msg->m_payload;
+    CLR_DBG_Commands_Monitor_WriteMemory_Reply cmdReply;
 
-    if (m_deploymentStorageDevice != NULL)
-    {
+    g_CLR_DBG_Debugger->AccessMemory( cmd->address, cmd->length, cmd->data, AccessMemory_Write, cmdReply.ErrorCode );
 
-        g_CLR_DBG_Debugger->AccessMemory( cmd->m_address, cmd->m_length, cmd->m_data, AccessMemory_Write, &cmdReply.ErrorCode );
+    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
-        WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
-
-        return true;
-    }
-
-    return false;
+    return true;
 }
 
 bool CLR_DBG_Debugger::Monitor_CheckMemory( WP_Message* msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands::Monitor_CheckMemory*       cmd      = (CLR_DBG_Commands::Monitor_CheckMemory*)msg->m_payload;
-    CLR_DBG_Commands::Monitor_CheckMemory::Reply cmdReply;
-    unsigned int errorCode;
+    CLR_DBG_Commands_Monitor_CheckMemory*       cmd      = (CLR_DBG_Commands_Monitor_CheckMemory*)msg->m_payload;
+    CLR_DBG_Commands_Monitor_CheckMemory_Reply  cmdReply;
+    uint32_t errorCode;
 
-    g_CLR_DBG_Debugger->AccessMemory( cmd->m_address, cmd->m_length, (unsigned char*)&cmdReply.m_crc, AccessMemory_Check, &errorCode );
+    g_CLR_DBG_Debugger->AccessMemory( cmd->address, cmd->length, (unsigned char*)&cmdReply.crc, AccessMemory_Check, errorCode );
 
     WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
 
     return true;
-
 }
 
 bool CLR_DBG_Debugger::Monitor_EraseMemory( WP_Message* msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands::Monitor_EraseMemory* cmd = (CLR_DBG_Commands::Monitor_EraseMemory*)msg->m_payload;
-    CLR_DBG_Commands::Monitor_EraseMemory::Reply cmdReply;
+    CLR_DBG_Commands_Monitor_EraseMemory* cmd = (CLR_DBG_Commands_Monitor_EraseMemory*)msg->m_payload;
+    CLR_DBG_Commands_Monitor_EraseMemory_Reply cmdReply;
 
-    if (m_deploymentStorageDevice != NULL)
-    {
-        g_CLR_DBG_Debugger->AccessMemory( cmd->m_address, cmd->m_length, NULL, AccessMemory_Erase, &cmdReply.ErrorCode );
+    g_CLR_DBG_Debugger->AccessMemory( cmd->address, cmd->length, NULL, AccessMemory_Erase, cmdReply.ErrorCode );
 
-        WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
+    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
-        return true;
-    }
-
-    return false;
+    return true;
 }
 
 bool CLR_DBG_Debugger::Monitor_Execute( WP_Message* msg)
@@ -2149,7 +2152,7 @@ bool CLR_DBG_Debugger::Debugging_Thread_Resume( WP_Message* msg)
 bool CLR_DBG_Debugger::Debugging_Thread_Get( WP_Message* msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_DBG_Debugger*                       dbg  = (CLR_DBG_Debugger*)&g_scratchDebugger[0];
+    CLR_DBG_Debugger*                       dbg  = g_CLR_DBG_Debugger;
     CLR_DBG_Commands::Debugging_Thread_Get* cmd  = (CLR_DBG_Commands::Debugging_Thread_Get*)msg->m_payload;
     CLR_RT_Thread*                          th   = dbg->GetThreadFromPid( cmd->m_pid );
     CLR_RT_HeapBlock*                       pThread;
@@ -2884,7 +2887,7 @@ bool CLR_DBG_Debugger::Debugging_Value_AllocateArray( WP_Message* msg)
 bool CLR_DBG_Debugger::Profiling_Command( WP_Message* msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_DBG_Debugger*                    dbg     = (CLR_DBG_Debugger*)&g_scratchDebugger[0];
+    CLR_DBG_Debugger*                    dbg     = g_CLR_DBG_Debugger;
     CLR_DBG_Commands::Profiling_Command* cmd     = (CLR_DBG_Commands::Profiling_Command*)msg->m_payload;
     CLR_UINT8                            command = cmd->m_command;
 

--- a/src/CLR/Debugger/Debugger.vcxproj
+++ b/src/CLR/Debugger/Debugger.vcxproj
@@ -22,16 +22,6 @@
     <ClCompile Include="Debugger.cpp" />
     <ClCompile Include="Debugger_full.cpp" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\CorLib\CorLib.vcxproj">
-      <Project>{58e950cc-2ff6-423c-b006-a70a19272f20}</Project>
-      <Private>false</Private>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="Debugger_stub.vcxproj">
-      <Project>{6dabcbf1-245a-4e76-bd36-8bc300c7dd82}</Project>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DD397EC4-844B-4B59-A67B-CAD6B46F1F00}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/CLR/Debugger/Debugger_full.cpp
+++ b/src/CLR/Debugger/Debugger_full.cpp
@@ -7,7 +7,7 @@
 #include <nanoCLR_Debugging.h>
 
 #define DEFINE_CMD(cmd)  {  CLR_DBG_Debugger::Debugging_##cmd, CLR_DBG_Commands::c_Debugging_##cmd }
-#define DEFINE_CMD2(cmd) {  CLR_DBG_Debugger::Monitor_##cmd  , CLR_DBG_Commands::c_Monitor_##cmd   }
+#define DEFINE_CMD2(cmd) {  CLR_DBG_Debugger::Monitor_##cmd  , CLR_DBG_Commands_c_Monitor_##cmd    }
 #define DEFINE_CMD3(cmd) { &CLR_DBG_Debugger::Profiling_##cmd, CLR_DBG_Commands::c_Profiling_##cmd }
 
 const CLR_Messaging_CommandHandlerLookup c_Debugger_Lookup_Request[] =

--- a/src/CLR/Debugger/Debugger_stub.cpp
+++ b/src/CLR/Debugger/Debugger_stub.cpp
@@ -21,7 +21,7 @@ __nfweak void CLR_DBG_Debugger::PurgeCache()
 __nfweak HRESULT CLR_DBG_Debugger::CreateInstance()
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    g_CLR_DBG_Debugger = (CLR_DBG_Debugger*)&g_scratchDebugger[0];
+
     NANOCLR_SYSTEM_STUB_RETURN();
 }
 

--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -220,7 +220,7 @@ void CLR_Debug::Emit( const char *text, int len )
 
             if(CLR_EE_DBG_IS( Enabled ) && !CLR_EE_DBG_IS( Quiet ))
             {
-                CLR_EE_DBG_EVENT_BROADCAST( CLR_DBG_Commands::c_Monitor_Message, s_chars, s_buffer, WP_Flags_c_NonCritical | WP_Flags_c_NoCaching );
+                CLR_EE_DBG_EVENT_BROADCAST( CLR_DBG_Commands_c_Monitor_Message, s_chars, s_buffer, WP_Flags_c_NonCritical | WP_Flags_c_NoCaching );
             }
 
             if(HalSystemConfig.DebugTextPort != HalSystemConfig.DebuggerPort)

--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -11,6 +11,7 @@
 #include <nanoPackStruct.h>
 #include <nanoCLR_Types.h>
 #include <nanoCLR_Messaging.h>
+#include <WireProtocol_MonitorCommands.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -77,30 +78,29 @@ struct CLR_DBG_Commands
         unsigned int m_flags;
     };
 
-    struct Monitor_ReadMemory
-    {
-        unsigned int m_address;
-        unsigned int m_length;
-
-        struct Reply
-        {
-            unsigned int  ErrorCode;
-            unsigned char m_data[ 1 ];
-        };
-    };
-
-    struct Monitor_WriteMemory
-    {
-        unsigned int m_address;
-        unsigned int m_length;
-        unsigned char  m_data[ 1 ];
-
-        struct Reply
-        {
-            unsigned int ErrorCode;
-        };        
-    };
-
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
     struct Monitor_Signature
     {        
         unsigned int m_keyIndex;
@@ -108,27 +108,27 @@ struct CLR_DBG_Commands
         unsigned char  m_signature[ 1 ];
     };
 
-    struct Monitor_CheckMemory
-    {
-        unsigned int m_address;
-        unsigned int m_length;
 
-        struct Reply
-        {
-            unsigned int m_crc;
-        };
-    };
 
-    struct Monitor_EraseMemory
-    {
-        unsigned int m_address;
-        unsigned int m_length;
 
-        struct Reply
-        {
-            unsigned int ErrorCode;
-        };        
-    };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     struct Monitor_Execute
     {
@@ -1039,7 +1039,7 @@ private:
 
     bool CheckPermission( ByteAddress address, int mode );
 
-    bool AccessMemory( CLR_UINT32 location, unsigned int lengthInBytes, unsigned char* buf, int mode, unsigned int* errorCode );
+    bool AccessMemory( uint32_t location, uint32_t lengthInBytes, uint8_t* buf, uint32_t mode, uint32_t& errorCode );
 
 #if defined(NANOCLR_APPDOMAINS)
     CLR_RT_AppDomain*  GetAppDomainFromID ( CLR_UINT32 id );
@@ -1153,9 +1153,7 @@ public:
 
 //--//
 
-extern CLR_UINT32        g_scratchDebugger[];
-extern CLR_UINT32        g_scratchDebuggerMessaging[];
-extern CLR_DBG_Debugger *g_CLR_DBG_Debugger;
+extern CLR_DBG_Debugger* g_CLR_DBG_Debugger;
 
 //--//
 

--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -413,7 +413,7 @@ void ClrStartup(CLR_SETTINGS params)
         {
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
             CLR_EE_DBG_SET_MASK(StateProgramExited, StateMask);
-            CLR_EE_DBG_EVENT_BROADCAST(CLR_DBG_Commands::c_Monitor_ProgramExit, 0, NULL, WP_Flags_c_NonCritical);
+            CLR_EE_DBG_EVENT_BROADCAST(CLR_DBG_Commands_c_Monitor_ProgramExit, 0, NULL, WP_Flags_c_NonCritical);
 #endif //#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
 #if !defined(BUILD_RTM)

--- a/targets/os/win32/nanoCLR/Generated/CLR_RT_InteropAssembliesTable.cpp
+++ b/targets/os/win32/nanoCLR/Generated/CLR_RT_InteropAssembliesTable.cpp
@@ -64,4 +64,4 @@ const CLR_RT_NativeAssemblyData *g_CLR_InteropAssembliesNativeData[] =
     NULL
 };
 
-
+uint16_t g_CLR_InteropAssembliesCount = ARRAYSIZE(g_CLR_InteropAssembliesNativeData) - 1;

--- a/targets/os/win32/nanoCLR/PAL/blockstorageList_stubs.cpp
+++ b/targets/os/win32/nanoCLR/PAL/blockstorageList_stubs.cpp
@@ -53,15 +53,15 @@ BlockStorageDevice* BlockStorageList_GetFirstDevice()
 	return s_primaryDevice;
 }
 
-//BlockStorageDevice* BlockStorageList::GetNextDevice( BlockStorageDevice& device )
-//{ 
-//    return NULL; 
-//}
+BlockStorageDevice* BlockStorageList_GetNextDevice( BlockStorageDevice* device )
+{ 
+    return NULL; 
+}
 
-//unsigned int BlockStorageList::GetNumDevices()            
-//{ 
-//    return 0;  
-//}
+unsigned int BlockStorageList_GetNumDevices()
+{
+	return TARGET_BLOCKSTORAGE_COUNT;
+}
 
 //bool BlockStorageList::FindDeviceForPhysicalAddress( BlockStorageDevice** pBSD, unsigned int PhysicalAddress, ByteAddress &SectAddress)
 //{

--- a/targets/os/win32/nanoCLR/Various.cpp
+++ b/targets/os/win32/nanoCLR/Various.cpp
@@ -87,7 +87,21 @@ int mbedtls_base64_decode(unsigned char *dst, size_t dlen, size_t *olen,
 {
 	return 0;
 }
+__nfweak void NFReleaseInfo::Init(
+	NFReleaseInfo& NFReleaseInfo,
+	unsigned short int major,
+	unsigned short int minor,
+	unsigned short int build,
+	unsigned short int revision,
+	const char *info,
+	size_t infoLen,
+	const char *target,
+	size_t targetLen,
+	const char *platform,
+	size_t platformLen)
+{
 
+}
 //const ConfigurationSector g_ConfigurationSector =
 //{
 //    // ConfigurationLength

--- a/targets/os/win32/nanoCLR/nanoCLR.vcxproj
+++ b/targets/os/win32/nanoCLR/nanoCLR.vcxproj
@@ -98,7 +98,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;VERSION_MAJOR=0;VERSION_MINOR=0;VERSION_BUILD=0;VERSION_REVISION=0;OEMSYSTEMINFOSTRING="WIN_32 PLAYGROUND APP";TARGETNAMESTRING="CLR_WIN32";PLATFORMNAMESTRING="WIN32";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;VERSION_MAJOR=0;VERSION_MINOR=0;VERSION_BUILD=0;VERSION_REVISION=0;OEMSYSTEMINFOSTRING="WIN_32 PLAYGROUND APP";TARGETNAMESTRING="CLR_WIN32";TARGETINFOSTRING="CLR_WIN32";PLATFORMNAMESTRING="WIN32";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\..\src\CLR\Helpers\Base64;.;..\Include;..\..\..\..\src\CLR\Include;..\..\..\..\src\HAL\Include;..\..\..\..\src\PAL\Include;nanoFramework.Runtime.Events</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -125,7 +125,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;VERSION_MAJOR=0;VERSION_MINOR=0;VERSION_BUILD=0;VERSION_REVISION=0;OEMSYSTEMINFOSTRING="WIN_32 PLAYGROUND APP";TARGETNAMESTRING="CLR_WIN32";PLATFORMNAMESTRING="WIN32";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;VERSION_MAJOR=0;VERSION_MINOR=0;VERSION_BUILD=0;VERSION_REVISION=0;OEMSYSTEMINFOSTRING="WIN_32 PLAYGROUND APP";TARGETNAMESTRING="CLR_WIN32";TARGETINFOSTRING="CLR_WIN32";PLATFORMNAMESTRING="WIN32";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\..\src\CLR\Helpers\Base64;.;..\Include;..\..\..\..\src\CLR\Include;..\..\..\..\src\HAL\Include;..\..\..\..\src\PAL\Include;nanoFramework.Runtime.Events</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>


### PR DESCRIPTION
## Description
- Replace CLR_DBG_Commands with the WireProtocol definitions.
- Replace Monitor_ReadMemory, Monitor_WriteMemory, Monitor_CheckMemory and Monitor_EraseMemory with the WireProtocol definitions.
- Drop scratch debugger and debugger messaging vars. These are now created/destroyed as needed.
- Rework CreateInstance() and DeleteInstance() accordingly.
- Improve AccessMemory function. Rework declaration and minor improvements in code.
- Improvements in several functions like removing check of pointer to deployment storage.

## Motivation and Context
- Working towards a C only code base.
- Simplification and code clean up from inherited code base.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>