### PR TITLE
Simplified timeout handling on flash driver v2

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
@@ -55,26 +55,15 @@ void HAL_FLASH_Lock(void)
 }
 
 bool FLASH_WaitForLastOperation(uint32_t timeout)
-{ 
+{
+    (void)timeout;
+
     // Wait for the FLASH operation to complete by polling on BUSY flag to be reset.
     //  Even if the FLASH operation fails, the BUSY flag will be reset and an error
     //  flag will be set
+    // no need to overload this with a timeout workflow as the watchdog will quick-in if execution gets stuck
 
-    systime_t start = chVTGetSystemTime();
-    systime_t end = start + TIME_MS2I(timeout);
-    
-    while(__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY) != RESET) 
-    { 
-        // do nothing until the timeout expires
-        if(chVTIsSystemTimeWithin(start, end))
-        {
-            __NOP();
-        }
-        else
-        {
-            return false;
-        }
-    }
+    while(__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY) != RESET);
     
     if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_ALL_ERRORS) != RESET)
     {


### PR DESCRIPTION
## Description
- Replace loop with calls to ChibiOS time with simple while loop.

## Motivation and Context
- No point wasting calls to ChibiOS time. If the flash operation really goes south there is nothing to do and the watchdog will kick.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>