### PR TITLE
Fix events and timer compare

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL_Time.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL_Time.cpp
@@ -64,10 +64,14 @@ void Time_SetCompare ( uint64_t compareValueTicks )
         	// compareValueTicks is in CMSIS ticks (which equals to ms), so we use TIME_MS2I only to round
         	compareValueTicks -= HAL_Time_CurrentSysTicks();
             uint64_t delay = TIME_MS2I(compareValueTicks);
-            // make sure that chVTSet does not get called with zero delay
-            if (delay == 0)
+            
+            // make sure that chVTSet does not get called with zero delay            
+            if (delay == 0) 
             {
-            	delay = 1;
+                // compare value is 0 so dequeue and execute immediately
+                // no need to call the timer
+                HAL_COMPLETION::DequeueAndExec();
+                return;
             }
 
             // no need to stop the timer if it's running because the API does it anyway

--- a/targets/FreeRTOS/common/nanoCLR/targetPAL_Events.cpp
+++ b/targets/FreeRTOS/common/nanoCLR/targetPAL_Events.cpp
@@ -122,7 +122,7 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
     Events_WaitForEvents_Calls++;
   #endif
 
-    uint64_t expireTimeInTicks  = HAL_Time_CurrentTime() + countsRemaining;
+    uint64_t expireTimeInTicks  = HAL_Time_CurrentSysTicks() + countsRemaining;
     bool runContinuations = true;
 
     while(true)
@@ -135,7 +135,7 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
             return events;
         }
 
-        if(expireTimeInTicks <= HAL_Time_CurrentTime())
+        if(expireTimeInTicks <= HAL_Time_CurrentSysTicks())
         {
             break;
         }
@@ -163,6 +163,9 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
         {
             break;
         }
+
+        // feed the watchdog...
+        Watchdog_Reset();
     }
 
     return 0;

--- a/targets/FreeRTOS/common/nanoCLR/targetPAL_Time.cpp
+++ b/targets/FreeRTOS/common/nanoCLR/targetPAL_Time.cpp
@@ -58,8 +58,10 @@ void Time_SetCompare ( uint64_t compareValueTicks )
             // need to subtract the current system time to set when the timer will fire
             compareValueTicks -= HAL_Time_CurrentTime();
             
-            if (compareValueTicks == 0) {
-                // compare value is 0 so dequeue and schedule immediately 
+            if (compareValueTicks == 0) 
+            {
+                // compare value is 0 so dequeue and execute immediately
+                // no need to call the timer
                 HAL_COMPLETION::DequeueAndExec();
                 return;
             }

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetPAL_Events.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetPAL_Events.cpp
@@ -121,7 +121,7 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
     Events_WaitForEvents_Calls++;
   #endif
 
-    uint64_t expireTimeInTicks  = HAL_Time_CurrentTime() + countsRemaining;
+    uint64_t expireTimeInTicks  = HAL_Time_CurrentSysTicks() + countsRemaining;
     bool runContinuations = true;
 
     while(true)
@@ -134,7 +134,7 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
             return events;
         }
 
-        if(expireTimeInTicks <= HAL_Time_CurrentTime())
+        if(expireTimeInTicks <= HAL_Time_CurrentSysTicks())
         {
             break;
         }

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetPAL_Time.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetPAL_Time.cpp
@@ -45,7 +45,7 @@ void Time_SetCompare ( uint64_t compareValueTicks )
     }    
     else
     {
-        if (HAL_Time_CurrentTime() >= compareValueTicks) 
+        if (HAL_Time_CurrentSysTicks() >= compareValueTicks) 
         { 
             // already missed the event, dequeue and execute immediately 
             HAL_COMPLETION::DequeueAndExec();
@@ -56,7 +56,15 @@ void Time_SetCompare ( uint64_t compareValueTicks )
 
             // compareValueTicks is the time (in sys ticks) that is being requested to fire an HAL_COMPLETION::DequeueAndExec()
             // need to subtract the current system time to set when the timer will fire
-            compareValueTicks -= HAL_Time_CurrentTime();
+            compareValueTicks -= HAL_Time_CurrentSysTicks();
+            
+            if (compareValueTicks == 0) 
+            {
+                // compare value is 0 so dequeue and execute immediately
+                // no need to call the timer
+                HAL_COMPLETION::DequeueAndExec();
+                return;
+            }
             
             // no need to stop the timer even if it's running because the API does it anyway
             // need to convert from nF ticks to milliseconds and then to FreeRTOS sys ticks to load the timer

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL_Events.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL_Events.cpp
@@ -151,7 +151,7 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
     Events_WaitForEvents_Calls++;
   #endif
 
-    uint64_t expireTimeInTicks  = HAL_Time_CurrentTime() + countsRemaining;
+    uint64_t expireTimeInTicks  = HAL_Time_CurrentSysTicks() + countsRemaining;
     bool runContinuations = true;
 
     while(true)
@@ -164,7 +164,7 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
             return events;
         }
 
-        if(expireTimeInTicks <= HAL_Time_CurrentTime())
+        if(expireTimeInTicks <= HAL_Time_CurrentSysTicks())
         {
             break;
         }

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL_Time.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL_Time.cpp
@@ -76,9 +76,13 @@ void Time_SetCompare ( uint64_t compareValueTicks )
             // need to subtract the current system time to set when the timer will fire
             compareValueTicks -= HAL_Time_CurrentTime();
             
-            // // no need to stop the timer even if it's running because the API does it anyway
-            // // need to convert from nF ticks to milliseconds and then to FreeRTOS sys ticks to load the timer
-            // xTimerChangePeriod(nextEventTimer, compareValueTicks, 0);
+            if (compareValueTicks == 0) 
+            {
+                // compare value is 0 so dequeue and execute immediately
+                // no need to call the timer
+                HAL_COMPLETION::DequeueAndExec();
+                return;
+            }
 
             Clock_setPeriod(nextEventTimer, compareValueTicks);
             Clock_start(nextEventTimer);


### PR DESCRIPTION
## Description
- Port changes from #1566 to ESP32, NXP and TI platforms.
- Improve check of "no delay" condition and dequeue and execute immediately instead of calling the timer API just because.

## Motivation and Context
- ESP32, NXP and TI platforms where missing this fix.
- Improvement in the "0 delay" condition.

## How Has This Been Tested?<!-- (if applicable) -->
- Blinky app.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>

cc @martin-kuhn 
cc @AdrianSoundy 
cc @MateuszKlatecki 