### PR TITLE
Disable optimization on CRC32 calculation

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
@@ -127,7 +127,8 @@ void crc_lld_reset() {
     CRCD1.Instance->CR |= CRC_CR_RESET;
 }
 
-uint32_t crc_lld_compute(const void* buffer, int size, uint32_t initialCrc) {
+
+uint32_t __attribute__((optimize("O0"))) crc_lld_compute(const void* buffer, int size, uint32_t initialCrc) {
 
     int32_t index = 0U;
     uint32_t arg1;


### PR DESCRIPTION
## Description
- Add attribute to disable optimization on CRC32 calculation.

## Motivation and Context
- Optimization "Os" with GNU GCC 8.3 is breaking CRC32 calculation when computing for 1 element (4 bytes = uint32).

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
