### PR TITLE
Fix reboot on idle

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL_Events.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetPAL_Events.cpp
@@ -159,6 +159,9 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
         {
             break;
         }
+
+        // feed the watchdog...
+        Watchdog_Reset();
     }
 
     return 0;

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetPAL_Events.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetPAL_Events.cpp
@@ -162,6 +162,9 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
         {
             break;
         }
+        
+        // feed the watchdog...
+        Watchdog_Reset();
     }
 
     return 0;

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL_Events.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL_Events.cpp
@@ -192,6 +192,9 @@ uint32_t Events_WaitForEvents( uint32_t powerLevel, uint32_t wakeupSystemEvents,
         {
             break;
         }
+        
+        // feed the watchdog...
+        Watchdog_Reset();
     }
 
     return 0;


### PR DESCRIPTION
## Description
- Add call to watchdog reset on Events_WaitForEvents loop.
(for all platforms even if they don't explicitly implement watchdog to make it clear on future changes)

## Motivation and Context
- After the fix with #1566 STM32 targets where rebooting on idle. The reason was the watchdog kicking in as the wait now happens inside the Events_WaitForEvents loop, which didn't happen before.

## How Has This Been Tested?<!-- (if applicable) -->
- Tested with simple loop and infinite timeout on main().

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
