### PR TITLE
Fix STM32 CRC32 driver

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/CRCv1/crc_lld.c
@@ -135,7 +135,6 @@ uint32_t __attribute__((optimize("O0"))) crc_lld_compute(
 {
     uint32_t index = 0U;
     uint32_t iterations;
-    uint32_t arg1;
     uint32_t crc = 0;
 
     // anything to do here?
@@ -152,6 +151,7 @@ uint32_t __attribute__((optimize("O0"))) crc_lld_compute(
 
 #if defined(STM32F1XX) || defined(STM32L1XX) || defined(STM32F2XX) || defined(STM32F4XX)
     uint32_t size_remainder = 0;
+    uint32_t arg1;
 
     // need to reset CRC peripheral if:
     // - CRC initial value is 0 
@@ -207,7 +207,8 @@ uint32_t __attribute__((optimize("O0"))) crc_lld_compute(
     }
 
 #else
-    uint16_t* ptr16 = (uint16_t*)buffer;
+    uint16_t data;
+    __IO uint16_t *pReg;
     
     // need to reset CRC peripheral if:
     // - CRC initial value is 0 
@@ -223,63 +224,39 @@ uint32_t __attribute__((optimize("O0"))) crc_lld_compute(
         WRITE_REG(CRCD1.Instance->INIT, initialCrc);
   #endif 
     }
-    
-    switch (CRCD1.Config->InputDataFormat)
-    {
-        case CRC_INPUTDATA_FORMAT_WORDS:  
-            // Enter 32-bit input data to the CRC calculator
-            for(index = 0; index < size; index++)
-            {
-                arg1 = ((uint32_t*)buffer)[index];
-                CRCD1.Instance->DR = arg1;
-            }
-            break;
-        
-        case CRC_INPUTDATA_FORMAT_BYTES: 
-            // Specific 8-bit input data handling
-            
-            /* Processing time optimization: 4 bytes are entered in a row with a single word write,
-            * last bytes must be carefully fed to the CRC calculator to ensure a correct type
-            * handling by the IP */
-            for(index = 0; index < iterations; index++)
-            {
-                CRCD1.Instance->DR = (uint32_t)(((uint32_t)(ptr[4*index])<<24) | ((uint32_t)(ptr[4*index + 1])<<16) | ((uint32_t)(ptr[4*index + 2])<<8) | (uint32_t)(ptr[4*index + 3]));
-            }
 
-            // last bytes specific handling
-            if((size % 4) != 0)
-            {
-                if(size % 4 == 1)
-                {
-                    CRCD1.Instance->DR = ptr[4*index];
-                }
-                if(size % 4 == 2)
-                {
-                    CRCD1.Instance->DR = (uint16_t)((uint16_t)((uint16_t)(ptr[4*index])<<8) | (uint16_t)(ptr[4*index + 1]));
-                }
-                if(size % 4 == 3)
-                {
-                    CRCD1.Instance->DR = (uint16_t)((uint16_t)((uint16_t)(ptr[4*index])<<8) | (uint16_t)(ptr[4*index + 1]));
-                    CRCD1.Instance->DR = ptr[4*index + 2];       
-                }
-            }
-            break;
-        
-        case CRC_INPUTDATA_FORMAT_HALFWORDS: 
-            // Specific 16-bit input data handling
+    // Processing time optimization: 4 bytes are entered in a row with a single word write,
+    // last bytes must be carefully fed to the CRC calculator to ensure a correct type
+    // handling by the IP */
+    for(index = 0; index < iterations; index++)
+    {
+        CRCD1.Instance->DR = ((uint32_t)ptr[4*index] << 24) | \
+                             ((uint32_t)ptr[4*index + 1] << 16) | \
+                             ((uint32_t)ptr[4*index + 2] << 8) | \
+                              (uint32_t)ptr[4*index + 3];
+    }
+
+    // last bytes specific handling
+    if((size % 4) != 0)
+    {
+        if(size % 4 == 1)
+        {
+            *(__IO uint8_t *)(__IO void*)(&CRCD1.Instance->DR) = (uint8_t)ptr[4*index];
+        }
+        if(size % 4 == 2)
+        {
+            data = ((uint16_t)((uint16_t)(ptr[4*index])<<8) | (uint16_t)(ptr[4*index + 1]));
+            pReg = (__IO uint16_t *)(__IO void *)(&CRCD1.Instance->DR);
+            *pReg = data;
+        }
+        if(size % 4 == 3)
+        {
+            data = ((uint16_t)((uint16_t)(ptr[4*index])<<8) | (uint16_t)(ptr[4*index + 1]));
+            pReg = (__IO uint16_t *)(__IO void *)(&CRCD1.Instance->DR);
+            *pReg = data;
             
-            /* Processing time optimization: 2 HalfWords are entered in a row with a single word write,
-            * in case of odd length, last HalfWord must be carefully fed to the CRC calculator to ensure 
-            * a correct type handling by the IP */
-            for(index = 0; index < (size / 2); index++)
-            {
-                CRCD1.Instance->DR = (((uint32_t)(ptr16[2*index])<<16) | (uint32_t)(ptr16[2*index + 1]));
-            }
-            if((size % 2) != 0)
-            {
-                CRCD1.Instance->DR = ptr16[2*index]; 
-            }
-            break;
+            *(__IO uint8_t *)(__IO void *)(&CRCD1.Instance->DR) = (uint8_t)ptr[(4*index) + 2];
+        }
     }
 
     crc = CRCD1.Instance->DR;


### PR DESCRIPTION
## Description
- Fix CRC32 calculation for STM32L0-F7-H7.
- Remove code to handle input data formats other than bytes.

## Motivation and Context
- The existing code was failing when buffer size is not multiple of 4.
- Code clean-up: no need to have there code to handle formats that are not used.

## How Has This Been Tested?<!-- (if applicable) -->
- Debugger WPF test app.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>