### PR TITLE
CMake: Clean up message

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
@@ -47,7 +47,7 @@ if(NO_CHIBIOS_SOURCE)
 
     #  check if Git was found, if not report to user and abort
     if(NOT GIT_EXECUTABLE)
-        message(FATAL_ERROR "error: could not find Git, make sure you have it installed.")
+        message(FATAL_ERROR "Could not find Git, make sure you have it installed.")
     endif()
 
     # ChibiOS version


### PR DESCRIPTION
The message is decorated as error message already. No need to mark it again...

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>
