### PR TITLE
ESP32_WROOM_32: Correcting logical dependency

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/CMakeLists.txt
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/CMakeLists.txt
@@ -268,7 +268,7 @@ set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_F
 #set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_FLAGS " -Wl,--verbose ")
 
 # add dependency for networking
-if(USE_SECURITY_MBEDTLS_OPTION)
+if(USE_NETWORKING_OPTION)
     add_dependencies(${NANOCLR_PROJECT_NAME}.elf NetworkLib)
 endif()
 


### PR DESCRIPTION
Whenever building CLR when USE_NETWORKING_OPTION is enabled, we want to be sure NetworkLib is built before.
That is way we use add_dependencies(...) to tell CMake to ensure NetworkLib needs to be built before ${NANOCLR_PROJECT_NAME}.elf.
However, the if-clause was checking for USE_SECURITY_MBEDTLS_OPTION, which is an option that is relevant after USE_NETWORKING_OPTION gets enabled. Therefore we benefit of add_dependencies only if we build with USE_NETWORKING_OPTION && USE_SECURITY_MBEDTLS_OPTION.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>
