### PR TITLE
Replace call to serial stream with channel equivalent that has timeout

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/common/WireProtocol_HAL_Interface.c
+++ b/targets/CMSIS-OS/ChibiOS/common/WireProtocol_HAL_Interface.c
@@ -46,8 +46,8 @@ int WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
         // if the requested number of bytes was actually read
         //////////////////////////////////////////////////////////
 
-        // read from serial stream 
-        size_t read = streamRead(&SDU1, ptr, *size); 
+        // read from serial stream with 250ms timeout
+        size_t read = chnReadTimeout(&SDU1, ptr, *size, TIME_MS2I(250)); 
 
         ptr  += read;
         *size -= read;
@@ -78,8 +78,8 @@ int WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
         // if the requested number of bytes was actually read
         //////////////////////////////////////////////////////////
         
-        // non blocking read from serial port with 100ms timeout
-        volatile size_t read = sdReadTimeout(&SERIAL_DRIVER, ptr, *size, TIME_MS2I(250));
+        // non blocking read from serial port with 250ms timeout
+        volatile size_t read = chnReadTimeout(&SERIAL_DRIVER, ptr, *size, TIME_MS2I(250));
 
         ptr  += read;
         *size -= read;
@@ -115,7 +115,7 @@ int WP_TransmitMessage(WP_Message* message)
     TRACE( TRACE_HEADERS, "TXMSG: 0x%08X, 0x%08X, 0x%08X\n", message->m_header.m_cmd, message->m_header.m_flags, message->m_header.m_size );
 
     // write header to output stream
-    writeResult = streamWrite(&SDU1, (const uint8_t *)&message->m_header, sizeof(message->m_header));
+    writeResult = chnWriteTimeout(&SDU1, (const uint8_t *)&message->m_header, sizeof(message->m_header), TIME_MS2I(250));
 
     if(writeResult == sizeof(message->m_header))
     {
@@ -133,7 +133,7 @@ int WP_TransmitMessage(WP_Message* message)
             // reset flag
             operationResult = false;
 
-            writeResult = streamWrite(&SDU1, message->m_payload, message->m_header.m_size);
+            writeResult = chnWriteTimeout(&SDU1, message->m_payload, message->m_header.m_size, TIME_MS2I(250));
 
             if(writeResult == message->m_header.m_size)
             {


### PR DESCRIPTION
## Description
- The calls to write and read to/from the serial channel where using a function without timeout. 

## Motivation and Context
- The existing code was causing the call to block when the buffer got full because there was no one at the other end to read it. The end result was that the watchdog was kicking in.
When booting the device sends a ping to check if there is a debugger listening. When there is no answer the execution continues happily. If VS is running the system will get a reply to that ping and will set the flag `CLR_EE_DBG_SET( Enabled ); `. 
On any subsequent calls that are checked against that flags, like the `CLR_EE_DBG_EVENT_BROADCAST` their execution has to be timed risking blocking the execution because the debugger may go away for some reason or even that there is no debug session actually going on.
- Resolves nanoFramework/Home#596.

## How Has This Been Tested?<!-- (if applicable) -->
- SPI sample app from samples repo running on a STM32F429 disco. The app now continues execution with or without VS connected.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>