### PR TITLE
Double interrupt lock with GPIO

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
@@ -100,7 +100,9 @@ static void GpioEventCallback(void *arg)
 		// get IoLine from pin number
 		ioline_t ioLine = GetIoLine(pGpio->pinNumber);
 
+		chSysUnlockFromISR();
 		pGpio->isrPtr(pGpio->pinNumber, palReadLine(ioLine), pGpio->param);
+		chSysLockFromISR();
 	}
 
 	chSysUnlockFromISR();


### PR DESCRIPTION
## Description
The fix is meant to avoid locking interrupts twice during a GPIO ISR. 

## Motivation and Context
If this double locking is not avoided, it leads to chSysHalt due to _dbg_check_lock_from_isr.
This has been discussed here:
https://discordapp.com/channels/478725473862549535/658049492649639946/696982728708456488 (Problem description)
https://discordapp.com/channels/478725473862549535/591956247767547910/702432949089468488 (Fix proposal)
- Fixes nanoframework/Home#604.

## How Has This Been Tested?<!-- (if applicable) -->
The error was very reproducable. After each button push, the target landed in chSysHalt. After the fix, it didn't land there anymore and hasn't since.

## Screenshots<!-- (if appropriate): -->
This was the call stack before the fix:
![call_stack](https://user-images.githubusercontent.com/6176931/80339414-e0521300-885e-11ea-8713-7a8b62a5d3d1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: patrick-haldi
