### PR TITLE
Remove unused parameter from BringExecCounterToDate

### DIFF
--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -1012,7 +1012,7 @@ void CLR_RT_ExecutionEngine::AdjustExecutionCounter( CLR_RT_DblLinkedList &threa
     {
         pThread->m_executionCounter += iUpdateValue;
         // Update m_executionCounter if thread is too behind of m_GlobalExecutionCounter
-        pThread->BringExecCounterToDate( m_GlobalExecutionCounter, pThread->GetQuantumDebit() );
+        pThread->BringExecCounterToDate( m_GlobalExecutionCounter );
     }
     NANOCLR_FOREACH_NODE_END()
 }
@@ -1166,9 +1166,9 @@ HRESULT CLR_RT_ExecutionEngine::ScheduleThreads( int maxContextSwitch )
 
             // If thread is way too much behind on its execution, we cutt off extra credit.
             // We garantee the thread will not be scheduled more than 4 consequitive times.
-            th->BringExecCounterToDate( m_GlobalExecutionCounter, debitForEachRun );
+            th->BringExecCounterToDate( m_GlobalExecutionCounter );
             
-            // Substruct the execution counter by debit value ( for executing thread )
+            // Subtract the execution counter by debit value ( for executing thread )
             th->m_executionCounter -= debitForEachRun;
 
             // Keep the track of lowest execution counter. 

--- a/src/CLR/Core/Thread.cpp
+++ b/src/CLR/Core/Thread.cpp
@@ -98,10 +98,8 @@ bool CLR_RT_SubThread::ChangeLockRequestCount( int diff )
     }
 }
 
-void CLR_RT_Thread::BringExecCounterToDate( int iGlobalExecutionCounter, int iDebitForEachRun )
+void CLR_RT_Thread::BringExecCounterToDate( int iGlobalExecutionCounter )
 {
-    (void)iDebitForEachRun;
-
     // Normally the condition is false. It becomes true if thread was out of execution for some time.
     // The value of (ThreadPriority::System_Highest + 1) is 33. 
     // 33 for ThreadPriority::Highest gives up to 16 cycles to catch up.

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -2556,7 +2556,7 @@ struct CLR_RT_Thread : public CLR_RT_ObjectToEvent_Destination // EVENT HEAP - N
 
     // If thread was sleeping and get too far behind on updating of m_executionCounter
     // Then we make m_executionCounter 4 quantums above m_GlobalExecutionCounter;
-    void BringExecCounterToDate( int iGlobalExecutionCounter, int iDebitForEachRun );
+    void BringExecCounterToDate( int iGlobalExecutionCounter );
 
     void PopEH( CLR_RT_StackFrame* stack, CLR_PMETADATA ip ) { if(m_nestedExceptionsPos) PopEH_Inner( stack, ip ); }
 


### PR DESCRIPTION
## Description
- Remove unused parameter.

## Motivation and Context
- From the description the execution counter adjustment used to be done with the debit for each run. Currently is computed using the ThreadPriority::System_Highest, making this parameter useless.
- Closes  nanoFramework/Home#339.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>