### PR TITLE
Fix float point comparisons

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -5,6 +5,7 @@
 //
 #include "Core.h"
 #include <nanoHAL.h>
+#include <nanoPAL_NativeDouble.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -1336,15 +1337,90 @@ CLR_INT32 CLR_RT_HeapBlock::Compare_Values( const CLR_RT_HeapBlock& left, const 
     #if !defined(NANOCLR_EMULATED_FLOATINGPOINT)
 
             case DATATYPE_R4:
-                if(left.NumericByRefConst().r4 > right.NumericByRefConst().r4) return  1;
-                if(left.NumericByRefConst().r4 < right.NumericByRefConst().r4) return -1;
-                /************************************************************/ return  0;
+
+                // deal with special cases: 
+                // return 0 if the numbers are unordered (either or both are NaN)
+                // this is post processed in interpreter so '1' will turn into '0'
+                if(
+                    __isnand(left.NumericByRefConst().r4) ||
+                    __isnand(right.NumericByRefConst().r4))
+                {
+                    return 1;
+                }
+
+                // The infinite values are equal to themselves.
+                // this is post processed in interpreter so '0' will turn into '1'
+                else if(
+                    __isinfd(left.NumericByRefConst().r4) &&
+                    __isinfd(right.NumericByRefConst().r4))
+                {
+                    return 0;
+                }
+                // all the rest now
+                else
+                {
+                    if(
+                        isgreater(
+                            left.NumericByRefConst().r4, 
+                            right.NumericByRefConst().r4))
+                    {
+                        return  1;
+                    }
+                    else if(
+                        isless(
+                            left.NumericByRefConst().r4, 
+                            right.NumericByRefConst().r4))
+                    {
+                        return -1;
+                    }
+                    else
+                    {
+                        return  0;
+                    }
+                }
 
             case DATATYPE_R8:
 
-                if(left.NumericByRefConst().r8 > right.NumericByRefConst().r8) return  1;
-                if(left.NumericByRefConst().r8 < right.NumericByRefConst().r8) return -1;
-                /************************************************************/ return  0;
+                // deal with special cases: 
+                // return 0 if the numbers are unordered (either or both are NaN)
+                // this is post processed in interpreter so '1' will turn into '0'
+                if(
+                    __isnand((double)left.NumericByRefConst().r8) ||
+                    __isnand((double)right.NumericByRefConst().r8))
+                {
+                    return 1;
+                }
+
+                // The infinite values are equal to themselves.
+                // this is post processed in interpreter so '0' will turn into '1'
+                else if(
+                    __isinfd((double)left.NumericByRefConst().r8) &&
+                    __isinfd((double)right.NumericByRefConst().r8))
+                {
+                    return 0;
+                }
+                // all the rest now
+                else
+                {
+                    if(
+                        isgreater(
+                            (double)left.NumericByRefConst().r8,
+                            (double)right.NumericByRefConst().r8))
+                    {
+                        return  1;
+                    }
+                    else if(
+                        isless(
+                            (double)left.NumericByRefConst().r8,
+                            (double)right.NumericByRefConst().r8))
+                    {
+                        return -1;
+                    }
+                    else
+                    {
+                        return  0;
+                    }
+                }
 
     #else
             case DATATYPE_R4      :

--- a/src/PAL/Double/nanoPAL_NativeDouble.cpp
+++ b/src/PAL/Double/nanoPAL_NativeDouble.cpp
@@ -7,52 +7,6 @@
 #include "stdafx.h"
 #include "nanoPAL_NativeDouble.h"
 
-#include <math.h>
-
-#ifdef WIN32
-#include <float.h>
-
-#define __isnand        _isnan
-#define __isinfd(x)    (!_finite(x))
-
-inline int __signbitd(double x)
-{
-  unsigned char *ptr = (unsigned char*) &x;
-  return (*(ptr + (sizeof(double) - 1)) & 0x80) != 0;
-}
-
-#define rint(x)         floor((x) + 0.5) 
-#define remainder(x,y) ((x) - ((y) * rint((x) / (y))))
-
-#define isgreater(param0,param1) (param0 > param1)
-#define isless(param0,param1)    (param0 < param1)
-
-#elif defined(__GNUC__)
-
-#if !defined( isgreater )
-#define isgreater   __builtin_isgreater
-#endif
-
-#if !defined( isless )
-#define isless      __builtin_isless
-#endif
-
-#if !defined( __isnand )
-#define __isnand    __builtin_isnan
-#endif
-
-#if !defined( __isinfd )
-#define __isinfd    __builtin_isinf
-#endif
-
-#if !defined( __signbitd )
-#define __signbitd  __builtin_signbit
-#endif
-
-#endif
-
-
-
 using namespace System;
 // Summary:
 //     Compares this instance to a specified double-precision floating-point number

--- a/src/PAL/Include/nanoPAL_NativeDouble.h
+++ b/src/PAL/Include/nanoPAL_NativeDouble.h
@@ -8,6 +8,50 @@
 
 #include <nanoHAL.h>
 
+#include <math.h>
+
+#ifdef WIN32
+#include <float.h>
+
+#define __isnand        _isnan
+#define __isinfd(x)    (!_finite(x))
+
+inline int __signbitd(double x)
+{
+  unsigned char *ptr = (unsigned char*) &x;
+  return (*(ptr + (sizeof(double) - 1)) & 0x80) != 0;
+}
+
+#define rint(x)         floor((x) + 0.5) 
+#define remainder(x,y) ((x) - ((y) * rint((x) / (y))))
+
+#define isgreater(param0,param1) (param0 > param1)
+#define isless(param0,param1)    (param0 < param1)
+
+#elif defined(__GNUC__)
+
+#if !defined( isgreater )
+#define isgreater   __builtin_isgreater
+#endif
+
+#if !defined( isless )
+#define isless      __builtin_isless
+#endif
+
+#if !defined( __isnand )
+#define __isnand    __builtin_isnan
+#endif
+
+#if !defined( __isinfd )
+#define __isinfd    __builtin_isinf
+#endif
+
+#if !defined( __signbitd )
+#define __signbitd  __builtin_signbit
+#endif
+
+#endif
+
 namespace System
 {
     struct Double


### PR DESCRIPTION
## Description
- ceq IL instruction wasn't properly implemented to deal with NAN and infinite values.
- Rework code to use ISO C99 floating-point macros for FP comparisons.
- Move declarations of native double to header to allow reuse on the new comparison code.

## Motivation and Context
- Resolves nanoFramework/Home#577.

## How Has This Been Tested?<!-- (if applicable) -->
- Sample code from issue.
- Other random FP comparisons.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
