### PR TITLE
Fix fatFS install command when spaces in path

### DIFF
--- a/CMake/FatFS.CMakeLists.cmake.in
+++ b/CMake/FatFS.CMakeLists.cmake.in
@@ -19,7 +19,7 @@ ExternalProject_Add(
     GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
     TIMEOUT 10
     LOG_DOWNLOAD 1
-    INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
+    INSTALL_COMMAND "${CMAKE_COMMAND}" -E remove "${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h"
 
     # Disable all other steps
     CONFIGURE_COMMAND ""

--- a/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
+++ b/targets/CMSIS-OS/ChibiOS/CMakeLists.txt
@@ -271,7 +271,7 @@ if(NF_FEATURE_HAS_SDCARD OR NF_FEATURE_HAS_USB_MSD)
             GIT_SHALLOW 1   # download only the tip of the branch, not the complete history
             TIMEOUT 10
             LOG_DOWNLOAD 1
-            INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
+            INSTALL_COMMAND "${CMAKE_COMMAND}" -E remove "${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h"
 
             # Disable all other steps
             CONFIGURE_COMMAND ""
@@ -302,7 +302,7 @@ if(NF_FEATURE_HAS_SDCARD OR NF_FEATURE_HAS_USB_MSD)
             FatFS
             PREFIX FatFS
             SOURCE_DIR ${CMAKE_BINARY_DIR}/FatFS_Source
-            INSTALL_COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h
+            INSTALL_COMMAND "${CMAKE_COMMAND}" -E remove "${PROJECT_BINARY_DIR}/FatFS_Source/source/ffconf.h"
 
             # Disable all other steps
             CONFIGURE_COMMAND ""


### PR DESCRIPTION
## Description
On computers where there is a space in the directory structure for either the cmake command or the build directory, the installation of FatFS can fail.


## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

