### PR TITLE
Fix race condition with debugger on soft reboot

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -124,6 +124,8 @@ HRESULT CLR_DBG_Debugger::DeleteInstance()
     // free debugger
     platform_free(g_CLR_DBG_Debugger);
 
+    g_CLR_DBG_Debugger = NULL;
+
     NANOCLR_NOCLEANUP_NOLABEL();
 }
 

--- a/src/CLR/Messaging/Messaging.cpp
+++ b/src/CLR/Messaging/Messaging.cpp
@@ -391,6 +391,11 @@ bool CLR_Messaging::ProcessPayload( WP_Message* msg )
 // wrapper function for CLR_Messaging::ProcessPayload(
 extern "C" int CLR_Messaging_ProcessPayload(WP_Message* msg)
 {
+    if (g_CLR_DBG_Debugger == NULL)
+    {
+        return false;
+    }
+    
     bool retValue = g_CLR_DBG_Debugger->m_messaging->ProcessPayload(msg);
     return retValue;
 }


### PR DESCRIPTION
## Description
- NULL g_CLR_DBG_Debugger pointer after it is free’d with platform_free.
- Add check for NULL pointer in Messaging.
- Fix proposed by @patrick-haldi .

## Motivation and Context
- Closes nanoFramework/Home#603.
- Resolves nanoFramework/Home#600.
- Resolves nanoFramework/Home#590.
- Resolves nanoFramework/Home#584.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
