### PR TITLE
Work on boot and debugger

### DIFF
--- a/src/CLR/Debugger/Debugger_stub.cpp
+++ b/src/CLR/Debugger/Debugger_stub.cpp
@@ -7,6 +7,10 @@
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+__nfweak void CLR_DBG_Debugger::Debugger_Discovery()
+{
+    NATIVE_PROFILE_CLR_DEBUGGER();
+}
 
 __nfweak void CLR_DBG_Debugger::Debugger_WaitForCommands()
 {

--- a/src/CLR/Include/WireProtocol.h
+++ b/src/CLR/Include/WireProtocol.h
@@ -152,6 +152,7 @@ typedef enum Monitor_Ping_Source_Flags
 {
     Monitor_Ping_c_Ping_Source_NanoCLR          = 0x00010000,
     Monitor_Ping_c_Ping_Source_NanoBooter       = 0x00010001,
+    Monitor_Ping_c_Ping_Source_Host             = 0x00010002,
 
     Monitor_Ping_c_Ping_DbgFlag_Stop            = 0x00000001,
     Monitor_Ping_c_Ping_DbgFlag_AppExit         = 0x00000004,

--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -1021,6 +1021,7 @@ struct CLR_DBG_Debugger
 
     //--//
 
+    static void Debugger_Discovery();
     static void Debugger_WaitForCommands();
 
     static HRESULT CreateInstance();

--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -57,6 +57,8 @@ struct Settings
         CLR_Debug::Printf( "Started Hardware.\r\n" );
 #endif
 
+        CLR_DBG_Debugger::Debugger_Discovery();
+
         m_fInitialized = true;
 
         NANOCLR_NOCLEANUP();
@@ -111,9 +113,8 @@ struct Settings
         CLR_EE_DBG_CLR(StateResolutionFailed);
 
 #if !defined(BUILD_RTM)
-        CLR_Debug::Printf( "Create TS.\r\n" );
+        CLR_Debug::Printf( "Create Type System.\r\n" );
 #endif
-        //NANOCLR_CHECK_HRESULT(LoadKnownAssemblies( (char*)&__deployment_start__, (char*)&__deployment_end__ ));
 
 #if !defined(BUILD_RTM)
         CLR_Debug::Printf( "Loading Deployment Assemblies.\r\n" );
@@ -282,10 +283,6 @@ struct Settings
             // we have good Assembly 
             CLR_RT_Assembly* assm;
 
-#if !defined(BUILD_RTM)            
-            CLR_Debug::Printf( "Attaching deployed file.\r\n" );
-#endif
-            
             // Creates instance of assembly, sets pointer to native functions, links to g_CLR_RT_TypeSystem 
             if (FAILED(LoadAssembly(header, assm)))
             {
@@ -383,7 +380,6 @@ void ClrStartup(CLR_SETTINGS params)
 #if !defined(BUILD_RTM)
         CLR_Debug::Printf( "Starting...\r\n" );
 #endif
-
 
         HRESULT hr;
 

--- a/targets/os/win32/nanoCLR/CLRStartup.cpp
+++ b/targets/os/win32/nanoCLR/CLRStartup.cpp
@@ -71,13 +71,13 @@ struct Settings
         CLR_Debug::Printf( "Started Hardware.\r\n" );
 #endif
 
-        m_fInitialized = true;
+        CLR_DBG_Debugger::Debugger_Discovery();
 
+        m_fInitialized = true;
 
         NANOCLR_NOCLEANUP();
     }
 
-    
     HRESULT LoadAssembly( const CLR_RECORD_ASSEMBLY* header, CLR_RT_Assembly*& assm )
     {   
         NANOCLR_HEADER();
@@ -95,7 +95,7 @@ struct Settings
             // First verify that check sum in assembly object matches hardcoded check sum. 
             if ( assm->m_header->nativeMethodsChecksum != pNativeAssmData->m_checkSum )
             {
-                CLR_Debug::Printf("***********************************************************************\r\n");
+                CLR_Debug::Printf("\r\n\r\n***********************************************************************\r\n");
                 CLR_Debug::Printf("*                                                                     *\r\n");
                 CLR_Debug::Printf("* ERROR!!!!  Firmware version does not match managed code version!!!! *\r\n");
                 CLR_Debug::Printf("*                                                                     *\r\n");
@@ -193,7 +193,7 @@ struct Settings
 #else     
 
 #if !defined(BUILD_RTM)
-        CLR_Debug::Printf( "Create TS.\r\n" );
+        CLR_Debug::Printf( "Create Type System.\r\n" );
 #endif
 
         NANOCLR_CHECK_HRESULT(LoadKnownAssemblies( nanoCLR_Dat_Start, nanoCLR_Dat_End ));
@@ -359,10 +359,6 @@ struct Settings
             // we have good Assembly 
             CLR_RT_Assembly* assm;
 
-#if !defined(BUILD_RTM)            
-            CLR_Debug::Printf( "Attaching deployed file.\r\n" );
-#endif
-
             // Creates instance of assembly, sets pointer to native functions, links to g_CLR_RT_TypeSystem 
             if (FAILED(LoadAssembly( header, assm ) ))
             {   
@@ -375,7 +371,6 @@ struct Settings
         
         NANOCLR_NOCLEANUP();
     }
-
 
     HRESULT LoadDeploymentAssemblies( unsigned int memoryUsage )
     {
@@ -661,9 +656,10 @@ void ClrStartup( CLR_SETTINGS params )
 
 #if !defined(BUILD_RTM)
         CLR_Debug::Printf( "\r\nnanoCLR (Build %d.%d.%d.%d)\r\n\r\n", VERSION_MAJOR, VERSION_MINOR, VERSION_BUILD, VERSION_REVISION );
+        CLR_Debug::Printf( "\r\n%s\r\n\r\n", OEMSYSTEMINFOSTRING );
 #endif
 
-        CLR_RT_Memory::Reset         ();
+        CLR_RT_Memory::Reset();
         
 #if !defined(BUILD_RTM)
         CLR_Debug::Printf( "Starting...\r\n" );


### PR DESCRIPTION
## Description
- Add Debugger_Discovery to debugger.
- Add call to Debugger_Discovery in CLRStartup.
- Add Ping_Source_Host to Monitor_Ping_Source_Flags enum.
- Remove wrong debug messages from startup.
- Improve debug messages on startup.
- Bring Win32 CLRStartup in sync with native one.

## ⚠️ REQUIRES VS EXTENSION > 2019.2.0/2017.2.0 ⚠️ ##

## Motivation and Context
- Improves boot:
  + boot sequence on VS debug session start.
  + messages output to VS output console.

## How Has This Been Tested?<!-- (if applicable) -->
- VS experimental instance running debug v1.16.0-preview.15.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
