### PR TITLE
Fix System.Network declarations

### DIFF
--- a/src/DeviceInterfaces/System.Net/sys_net_native.h
+++ b/src/DeviceInterfaces/System.Net/sys_net_native.h
@@ -14,6 +14,32 @@
 #include <nanoHAL_time.h>
 #include <corlib_native.h>
 
+// MOVED TO src\PAL\Include\nanoPAL_Sockets.h for convinience
+// typedef enum __nfpack NetworkInterface_UpdateOperation
+// {
+//     NetworkInterface_UpdateOperation_Invalid = 0,
+//     NetworkInterface_UpdateOperation_Dns = 1,
+//     NetworkInterface_UpdateOperation_Dhcp = 2,
+//     NetworkInterface_UpdateOperation_DhcpRenew = 4,
+//     NetworkInterface_UpdateOperation_DhcpRelease = 8,
+//     NetworkInterface_UpdateOperation_Mac = 16,
+// } NetworkInterface_UpdateOperation;
+
+// MOVED TO src\PAL\Include\nanoPAL_Sockets.h for convinience
+// typedef enum __nfpack NetworkChange_NetworkEventType
+// {
+//     NetworkChange_NetworkEventType_Invalid = 0,
+//     NetworkChange_NetworkEventType_AvailabilityChanged = 1,
+//     NetworkChange_NetworkEventType_AddressChanged = 2,
+//     NetworkChange_NetworkEventType_APStationChanged = 3,
+// } NetworkChange_NetworkEventType;
+
+// MOVED TO src\PAL\Include\nanoPAL_Sockets.h for convinience
+// typedef enum __nfpack NetworkChange_NetworkEvents
+// {
+//     NetworkChange_NetworkEvents_NetworkAvailable = 1,
+// } NetworkChange_NetworkEvents;
+
 struct Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface
 {
     static const int FIELD___interfaceIndex = 1;
@@ -103,11 +129,11 @@ struct Library_sys_net_native_System_Net_NetworkInformation_NetworkChange
 
 struct Library_sys_net_native_System_Net_NetworkInformation_NetworkChange__NetworkEvent
 {
-    static const int FIELD__EventType = 1;
-    static const int FIELD__Flags = 2;
-    static const int FIELD__Index = 3;
-    static const int FIELD__Data = 4;
-    static const int FIELD__Time = 5;
+    static const int FIELD__EventType = 3;
+    static const int FIELD__Flags = 4;
+    static const int FIELD__Index = 5;
+    static const int FIELD__Data = 6;
+    static const int FIELD__Time = 7;
 
     //--//
 
@@ -301,7 +327,7 @@ struct Library_sys_net_native_System_Net_Sockets_NetworkStream
 
 struct Library_sys_net_native_System_Net_Sockets_SocketException
 {
-    static const int FIELD___errorCode = 1;
+    static const int FIELD___errorCode = 5;
 
     //--//
 

--- a/src/PAL/COM/sockets/sockets_lwip.cpp
+++ b/src/PAL/COM/sockets/sockets_lwip.cpp
@@ -147,11 +147,11 @@ HRESULT SOCK_CONFIGURATION_UpdateAdapterConfiguration(HAL_Configuration_NetworkI
     HRESULT hr = S_OK;
     bool success = FALSE;
 
-    const uint32_t c_reInitFlag =   UpdateOperation_Dhcp      | 
-                                    UpdateOperation_DhcpRenew | 
-                                    UpdateOperation_Mac;
+    const uint32_t c_reInitFlag =   NetworkInterface_UpdateOperation_Dhcp      | 
+                                    NetworkInterface_UpdateOperation_DhcpRenew | 
+                                    NetworkInterface_UpdateOperation_Mac;
 
-    const uint32_t c_uninitFlag = c_reInitFlag | UpdateOperation_DhcpRelease;
+    const uint32_t c_uninitFlag = c_reInitFlag | NetworkInterface_UpdateOperation_DhcpRelease;
 
     if(0 != (updateFlags & c_uninitFlag))
     {

--- a/src/PAL/Include/nanoPAL_Sockets.h
+++ b/src/PAL/Include/nanoPAL_Sockets.h
@@ -359,15 +359,15 @@ typedef struct SOCK_timeval {
 // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.NetworkInterface.UpdateOperation (in managed code) !!! //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-enum UpdateOperation
+typedef enum __nfpack NetworkInterface_UpdateOperation
 {
-    UpdateOperation_Invalid =       0x00,
-    UpdateOperation_Dns =           0x01,
-    UpdateOperation_Dhcp =          0x02,
-    UpdateOperation_DhcpRenew =     0x04,
-    UpdateOperation_DhcpRelease =   0x08,
-    UpdateOperation_Mac =           0x10,
-};
+    NetworkInterface_UpdateOperation_Invalid = 0,
+    NetworkInterface_UpdateOperation_Dns = 1,
+    NetworkInterface_UpdateOperation_Dhcp = 2,
+    NetworkInterface_UpdateOperation_DhcpRenew = 4,
+    NetworkInterface_UpdateOperation_DhcpRelease = 8,
+    NetworkInterface_UpdateOperation_Mac = 16,
+} NetworkInterface_UpdateOperation;
 
 #define SOCK_NETWORKCONFIGURATION_INTERFACETYPE_UNKNOWN        0
 #define SOCK_NETWORKCONFIGURATION_INTERFACETYPE_ETHERNET       6
@@ -528,13 +528,13 @@ void Network_Interface_Deauth_Station(uint16_t index);
 // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.NetworkChange.NetworkEventType (in managed code) !!! //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-enum NetworkEventType
+typedef enum __nfpack NetworkChange_NetworkEventType
 {
-    NetworkEventType_Invalid = 0,
-    NetworkEventType_AvailabilityChanged = 1,
-    NetworkEventType_AddressChanged = 2,
-    NetworkEventType_APClientChanged = 3,
-};
+    NetworkChange_NetworkEventType_Invalid = 0,
+    NetworkChange_NetworkEventType_AvailabilityChanged = 1,
+    NetworkChange_NetworkEventType_AddressChanged = 2,
+    NetworkChange_NetworkEventType_APStationChanged = 3,
+} NetworkChange_NetworkEventType;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // !!! KEEP IN SYNC WITH Windows.Devices.WiFi.WiFiEventType (in managed code) !!! //
@@ -550,11 +550,11 @@ enum WiFiEventType
 // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.NetworkChange.NetworkEventFlags (in managed code) !!! //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-enum NetworkEventFlags
+typedef enum __nfpack NetworkChange_NetworkEvents
 {
-    NetworkEventFlags_NetworkNOTAvailable = 0x00,
-    NetworkEventFlags_NetworkAvailable = 0x01,
-};
+    NetworkChange_NetworkEvents_NetworkNOTAvailable = 0,
+    NetworkChange_NetworkEvents_NetworkAvailable = 1,
+} NetworkChange_NetworkEvents;
 
 void Network_PostEvent(unsigned int eventType, unsigned int flags, unsigned int index);
 

--- a/src/PAL/Lwip/lwIP_Sockets.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets.cpp
@@ -59,21 +59,21 @@ void LWIP_SOCKETS_Driver::PostAddressChanged(void* arg)
 {
     (void)arg;
 
-	Network_PostEvent(NetworkEventType_AddressChanged, 0, 0);
+	Network_PostEvent(NetworkChange_NetworkEventType_AddressChanged, 0, 0);
 }
 
 void LWIP_SOCKETS_Driver::PostAvailabilityOn(void* arg)
 {
     (void)arg;
 
-	Network_PostEvent(NetworkEventType_AvailabilityChanged, NetworkEventFlags_NetworkAvailable, 0);
+	Network_PostEvent(NetworkChange_NetworkEventType_AvailabilityChanged, NetworkChange_NetworkEvents_NetworkAvailable, 0);
 }
 
 void LWIP_SOCKETS_Driver::PostAvailabilityOff(void* arg)
 {
     (void)arg;
 
-	Network_PostEvent(NetworkEventType_AvailabilityChanged, NetworkEventFlags_NetworkNOTAvailable, 0);
+	Network_PostEvent(NetworkChange_NetworkEventType_AvailabilityChanged, NetworkChange_NetworkEvents_NetworkNOTAvailable, 0);
 }
 
 #if LWIP_NETIF_LINK_CALLBACK == 1
@@ -190,7 +190,7 @@ bool LWIP_SOCKETS_Driver::Initialize()
 
  		g_LWIP_SOCKETS_Driver.m_interfaces[i].m_interfaceNumber = interfaceNumber;
 
- 		UpdateAdapterConfiguration(i, (UpdateOperation_Dhcp | UpdateOperation_Dns), &networkConfiguration);
+ 		UpdateAdapterConfiguration(i, (NetworkInterface_UpdateOperation_Dhcp | NetworkInterface_UpdateOperation_Dns), &networkConfiguration);
 
  		networkInterface = netif_find_interface(interfaceNumber);
 
@@ -918,7 +918,7 @@ HRESULT LWIP_SOCKETS_Driver::UpdateAdapterConfiguration( uint32_t interfaceIndex
 
 #if LWIP_DNS
     // when using DHCP do not use the static settings
-    if(0 != (updateFlags & UpdateOperation_Dns))
+    if(0 != (updateFlags & NetworkInterface_UpdateOperation_Dns))
     {
         // FIXME IPV6
         if(config->AutomaticDNS == 0)
@@ -945,7 +945,7 @@ HRESULT LWIP_SOCKETS_Driver::UpdateAdapterConfiguration( uint32_t interfaceIndex
 #endif
 
 #if LWIP_DHCP
-    if(0 != (updateFlags & UpdateOperation_Dhcp))
+    if(0 != (updateFlags & NetworkInterface_UpdateOperation_Dhcp))
     {
         if(enableDHCP)
         {
@@ -986,22 +986,22 @@ HRESULT LWIP_SOCKETS_Driver::UpdateAdapterConfiguration( uint32_t interfaceIndex
         // also it's NOT possible to renew & release on the same pass, so adding an extra else-if for that
         // just in case it's request from the managed code
 
-        if(0 != (updateFlags & UpdateOperation_DhcpRelease))
+        if(0 != (updateFlags & NetworkInterface_UpdateOperation_DhcpRelease))
         {
             dhcp_release(networkInterface);
         }
-        else if(0 != (updateFlags & UpdateOperation_DhcpRenew))
+        else if(0 != (updateFlags & NetworkInterface_UpdateOperation_DhcpRenew))
         {
             dhcp_renew(networkInterface);
         }
-        else if(0 != (updateFlags & (UpdateOperation_DhcpRelease | UpdateOperation_DhcpRenew)) )
+        else if(0 != (updateFlags & (NetworkInterface_UpdateOperation_DhcpRelease | NetworkInterface_UpdateOperation_DhcpRenew)) )
         {
             return CLR_E_INVALID_PARAMETER;
         }
     }
 #endif
 
-    if(0 != (updateFlags & UpdateOperation_Mac))
+    if(0 != (updateFlags & NetworkInterface_UpdateOperation_Mac))
     {
         memcpy(networkInterface->hwaddr, config->MacAddress, NETIF_MAX_HWADDR_LEN);
         networkInterface->hwaddr_len = NETIF_MAX_HWADDR_LEN;

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/targetHAL_Network.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/targetHAL_Network.cpp
@@ -34,17 +34,17 @@ __nfweak void InitialiseEthernet()
 
 static void PostAddressChanged(uint netIndex)
 {
-	Network_PostEvent(NetworkEventType_AddressChanged, 0, netIndex);
+	Network_PostEvent(NetworkChange_NetworkEventType_AddressChanged, 0, netIndex);
 }
 
 static void PostAvailabilityOn(uint netIndex)
 {
-	Network_PostEvent(NetworkEventType_AvailabilityChanged, 1, netIndex);
+	Network_PostEvent(NetworkChange_NetworkEventType_AvailabilityChanged, 1, netIndex);
 }
 
 static void PostAvailabilityOff(uint netIndex)
 {
-	Network_PostEvent(NetworkEventType_AvailabilityChanged, 0, netIndex);
+	Network_PostEvent(NetworkChange_NetworkEventType_AvailabilityChanged, 0, netIndex);
 }
 
 static void PostScanComplete(uint netIndex)
@@ -54,7 +54,7 @@ static void PostScanComplete(uint netIndex)
 
 static void PostAPStationChanged(uint connect, uint netInfo)
 {
-	Network_PostEvent(NetworkEventType_APClientChanged, connect, netInfo);
+	Network_PostEvent(NetworkChange_NetworkEventType_APStationChanged, connect, netInfo);
 }
 
 static void initialize_sntp()

--- a/targets/TI-SimpleLink/common/simplelink_sockets.cpp
+++ b/targets/TI-SimpleLink/common/simplelink_sockets.cpp
@@ -26,21 +26,21 @@ void PostAddressChanged(void* arg)
 {
     (void)arg;
 
-	Network_PostEvent(NetworkEventType_AddressChanged, 0, 0);
+	Network_PostEvent(NetworkChange_NetworkEventType_AddressChanged, 0, 0);
 }
 
 void PostAvailabilityOn(void* arg)
 {
     (void)arg;
 
-	Network_PostEvent(NetworkEventType_AvailabilityChanged, NetworkEventFlags_NetworkAvailable, 0);
+	Network_PostEvent(NetworkChange_NetworkEventType_AvailabilityChanged, NetworkChange_NetworkEvents_NetworkAvailable, 0);
 }
 
 void PostAvailabilityOff(void* arg)
 {
     (void)arg;
 
-	Network_PostEvent(NetworkEventType_AvailabilityChanged, NetworkEventFlags_NetworkNOTAvailable, 0);
+	Network_PostEvent(NetworkChange_NetworkEventType_AvailabilityChanged, NetworkChange_NetworkEvents_NetworkNOTAvailable, 0);
 }
 
 void Link_callback(bool linkUp)

--- a/targets/TI-SimpleLink/common/simplelink_sockets_functions.cpp
+++ b/targets/TI-SimpleLink/common/simplelink_sockets_functions.cpp
@@ -78,7 +78,7 @@ HRESULT HAL_SOCK_CONFIGURATION_UpdateAdapterConfiguration(HAL_Configuration_Netw
     if (sl_NetCfgGet(SL_NETCFG_IPV4_STA_ADDR_MODE, &configOptions, &ipLen, (uint8_t *)&ipV4) >= 0)
     {
         // when using DHCP do not use the static settings
-        if(0 != (updateFlags & UpdateOperation_Dns))
+        if(0 != (updateFlags & NetworkInterface_UpdateOperation_Dns))
         {
             // FIXME IPV6
             if(config->AutomaticDNS == 0)
@@ -99,7 +99,7 @@ HRESULT HAL_SOCK_CONFIGURATION_UpdateAdapterConfiguration(HAL_Configuration_Netw
             }
         }
 
-        if(0 != (updateFlags & UpdateOperation_Dhcp))
+        if(0 != (updateFlags & NetworkInterface_UpdateOperation_Dhcp))
         {
             if(enableDHCP)
             {
@@ -129,21 +129,21 @@ HRESULT HAL_SOCK_CONFIGURATION_UpdateAdapterConfiguration(HAL_Configuration_Netw
 
         if(enableDHCP)
         {
-            if(0 != (updateFlags & UpdateOperation_DhcpRelease))
+            if(0 != (updateFlags & NetworkInterface_UpdateOperation_DhcpRelease))
             {
                 sl_NetCfgSet(SL_NETCFG_IPV4_STA_ADDR_MODE, SL_NETCFG_ADDR_RELEASE_IP_SET, 0, 0); 
             }
-            else if(0 != (updateFlags & UpdateOperation_DhcpRenew))
+            else if(0 != (updateFlags & NetworkInterface_UpdateOperation_DhcpRenew))
             {
                 //dhcp_renew(networkInterface);
             }
-            else if(0 != (updateFlags & (UpdateOperation_DhcpRelease | UpdateOperation_DhcpRenew)) )
+            else if(0 != (updateFlags & (NetworkInterface_UpdateOperation_DhcpRelease | NetworkInterface_UpdateOperation_DhcpRenew)) )
             {
                 return CLR_E_INVALID_PARAMETER;
             }
         }
 
-        if(0 != (updateFlags & UpdateOperation_Mac))
+        if(0 != (updateFlags & NetworkInterface_UpdateOperation_Mac))
         {
             uint8_t macAddress[SL_MAC_ADDR_LEN];
 

--- a/targets/TI-SimpleLink/common/sockets_simplelink.cpp
+++ b/targets/TI-SimpleLink/common/sockets_simplelink.cpp
@@ -848,11 +848,11 @@ HRESULT SOCK_CONFIGURATION_UpdateAdapterConfiguration(HAL_Configuration_NetworkI
     HRESULT hr = S_OK;
     bool success = FALSE;
 
-    const uint32_t c_reInitFlag =   UpdateOperation_Dhcp      | 
-                                    UpdateOperation_DhcpRenew | 
-                                    UpdateOperation_Mac;
+    const uint32_t c_reInitFlag =   NetworkInterface_UpdateOperation_Dhcp      | 
+                                    NetworkInterface_UpdateOperation_DhcpRenew | 
+                                    NetworkInterface_UpdateOperation_Mac;
 
-    const uint32_t c_uninitFlag = c_reInitFlag | UpdateOperation_DhcpRelease;
+    const uint32_t c_uninitFlag = c_reInitFlag | NetworkInterface_UpdateOperation_DhcpRelease;
 
     if(0 != (updateFlags & c_uninitFlag))
     {


### PR DESCRIPTION
## Description
- Field index on derived classes was wrong.
- Enums replaced with exported ones from managed code.
- Following the previous one: NetworkEventFlags enum renamed to NetworkEvents.
- Fixed naming of NetworkEventType_APClientChanged, is now NetworkEventType_APStationChanged.

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
- HTTP request sample running successfully on a STM32F769I.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
