### PR TITLE
Add SetupTimeoutFromTimeSpan

### DIFF
--- a/src/CLR/Core/CLR_RT_StackFrame.cpp
+++ b/src/CLR/Core/CLR_RT_StackFrame.cpp
@@ -1148,6 +1148,34 @@ HRESULT CLR_RT_StackFrame::SetupTimeoutFromTicks( CLR_RT_HeapBlock& input, CLR_I
     NANOCLR_NOCLEANUP();
 }
 
+// input HeapBlock is TimeSpan
+HRESULT CLR_RT_StackFrame::SetupTimeoutFromTimeSpan( CLR_RT_HeapBlock& inputTimeSpan, CLR_INT64*& output )
+{
+    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_HEADER();
+
+    if(m_customState == 0)
+    {
+        CLR_RT_HeapBlock& ref = PushValueAndClear();
+        CLR_INT64         timeExpire;
+
+		CLR_INT64* debounceValue = Library_corlib_native_System_TimeSpan::GetValuePtr( inputTimeSpan ); FAULT_ON_NULL(debounceValue);
+
+        //
+        // Initialize timeout and save it on the stack.
+        //
+        NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.InitTimeout( timeExpire, *debounceValue ));
+
+        ref.SetInteger( timeExpire );
+
+        m_customState = 1;
+    }
+
+    output = (CLR_INT64*)&m_evalStack[ 0 ].NumericByRef().s8;
+
+    NANOCLR_NOCLEANUP();
+}
+
 //--//
 
 void CLR_RT_StackFrame::Relocate()

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -1926,6 +1926,7 @@ struct CLR_RT_StackFrame : public CLR_RT_HeapBlock_Node // EVENT HEAP - NO RELOC
     HRESULT SetResult_String ( const char*            val                   );
 
     HRESULT SetupTimeoutFromTicks( CLR_RT_HeapBlock& input, CLR_INT64*& output );
+    HRESULT SetupTimeoutFromTimeSpan( CLR_RT_HeapBlock& inputTimeSpan, CLR_INT64*& output );
 
     void ConvertResultToBoolean();
     void NegateResult          ();

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -631,7 +631,6 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
 
     size_t length = 0;
 
-    CLR_RT_HeapBlock* writeTimeout;
     int64_t*  timeoutTicks;
     bool eventResult = true;
     bool txOk = false;
@@ -689,11 +688,8 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
 #endif
     }
 
-    // get value for _readtimeout field (pointer!)
-    writeTimeout = &pThis[ Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::FIELD___writeTimeout ];
-
-    // setup timeout
-    NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(*writeTimeout, timeoutTicks));
+    // setup timeout from _writetTimeout field
+    NANOCLR_CHECK_HRESULT( stack.SetupTimeoutFromTimeSpan(pThis[ FIELD___writeTimeout ], timeoutTicks) );
 
     // push dummy length value onto the eval stack
     // this is going to be used to store how many bytes where buffered to Tx
@@ -795,7 +791,6 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
 
     InputStreamOptions options = InputStreamOptions_None;
 
-    CLR_RT_HeapBlock* readTimeout;
     int64_t*  timeoutTicks;
     bool eventResult = true;
 
@@ -867,11 +862,8 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
 #endif
     }
 
-    // get value for _readtimeout field (pointer!)
-    readTimeout = &pThis[ Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::FIELD___readTimeout ];
-
     // setup timeout from the _readtimeout heap block
-    NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks( *readTimeout, timeoutTicks ));
+    NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTimeSpan( pThis[ FIELD___readTimeout ], timeoutTicks ));
 
     // figure out what's available in the Rx ring buffer
     if(palUart->RxRingBuffer.Length() >= count)

--- a/targets/FreeRTOS/NXP/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/FreeRTOS/NXP/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -397,7 +397,6 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
 
     size_t length = 0;
 
-    CLR_RT_HeapBlock *writeTimeout;
     int64_t *timeoutTicks;
     bool eventResult = true;
     bool txOk = false;
@@ -428,11 +427,8 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
     rx_size = palUart->RxRingBuffer.Length();
     palUart->RxRingBuffer.Pop(rx_size);
 
-    // get value for _readtimeout field (pointer!) 
-    writeTimeout = &pThis[Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::FIELD___writeTimeout];
-
-    // setup timeout 
-    NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(*writeTimeout, timeoutTicks));
+    // setup timeout from _writeTimeout field
+    NANOCLR_CHECK_HRESULT( stack.SetupTimeoutFromTimeSpan(pThis[ FIELD___writeTimeout ], timeoutTicks) );
 
     // push dummy length value onto the eval stack
     // this is going to be used to store how many bytes where buffered to Tx 
@@ -517,7 +513,6 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
     FAULT_ON_NULL(pThis);
     int64_t *timeoutTicks;
     InputStreamOptions options = InputStreamOptions_None;
-    CLR_RT_HeapBlock *readTimeout;
 
     bool eventResult = true;
 
@@ -561,9 +556,8 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
     // TODO: Implement transfer options. 
     options = (InputStreamOptions)stack.Arg3().NumericByRef().s4;
 
-    // Set up timeout. 
-    readTimeout = &pThis[Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::FIELD___readTimeout];
-    NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(*readTimeout, timeoutTicks));
+    // setup timeout from _readTimeout field
+    NANOCLR_CHECK_HRESULT( stack.SetupTimeoutFromTimeSpan(pThis[ FIELD___readTimeout ], timeoutTicks));
 
     // Check what's avaliable in Rx ring buffer 
     if (palUart->RxRingBuffer.Length() >= count) 


### PR DESCRIPTION
## Description
- Add new function SetupTimeoutFromTimeSpanSimplifies allowing setting a timeout on the stack frame from a TimeSpan field.
- Replace calls to SetupTimeoutFromTicks where appropriate.

## Motivation and Context
- Simplifies setting a timeout on the stack frame from a TimeSpan field.

## How Has This Been Tested?<!-- (if applicable) -->
- SerialCommunication sample.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
