### PR TITLE
Remove c_Flags_Patch from CLR_RECORD_ASSEMBLY

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_AppDomain.cpp
+++ b/src/CLR/CorLib/corlib_native_System_AppDomain.cpp
@@ -246,8 +246,6 @@ HRESULT Library_corlib_native_System_AppDomain::GetAssemblies___SZARRAY_SystemRe
     {
         NANOCLR_FOREACH_ASSEMBLY(g_CLR_RT_TypeSystem)
         {
-            if(pASSM->m_header->flags & CLR_RECORD_ASSEMBLY::c_Flags_Patch) continue;
-
             if(pass == 0)
             {
                 count++;

--- a/src/CLR/Include/nanoCLR_Types.h
+++ b/src/CLR/Include/nanoCLR_Types.h
@@ -822,7 +822,6 @@ struct CLR_RECORD_VERSION
 struct CLR_RECORD_ASSEMBLY
 {
     static const CLR_UINT32 c_Flags_NeedReboot = 0x00000001;
-    static const CLR_UINT32 c_Flags_Patch      = 0x00000002;
 
     CLR_UINT8          marker[ 8 ];
     //


### PR DESCRIPTION
## Description
- Remove c_Flags_Patch from CLR_RECORD_ASSEMBLY
- Update code accordingly.
- Improve comments in FindAssembly.

## Motivation and Context
- This flag was inherited from .NETMF and is not used anymore. 
- Exact match of assembly version is not required. We are enforcing only major and minor.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
