### PR TITLE
Rework ESP32 serial implementation

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Include/Esp32_DeviceMapping.h
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Include/Esp32_DeviceMapping.h
@@ -16,6 +16,17 @@
 #define  I2C2_DATA      25
 #define  I2C2_CLOCK     26
 
+// UART defines
+// number of pins required to configure an UART
+enum Esp32SerialPin
+{
+    Esp32SerialPin_Tx,
+    Esp32SerialPin_Rx,
+    Esp32SerialPin_Rts,
+    Esp32SerialPin_Cts,
+    Esp32SerialPin_Max,
+};
+
 enum Esp32_MapDeviceType
 {
     DEV_TYPE_GPIO,
@@ -32,5 +43,6 @@ int  Esp32_GetMappedDevicePins(Esp32_MapDeviceType DevType, int DevNumber, int P
 int  Esp32_GetMappedDevicePinsWithFunction(uint32_t alternateFunction);
 
 void Esp32_SetMappedDevicePins( uint8_t pin, int32_t alternateFunction );
+void Esp32_SetMappedDevicePins( Esp32_MapDeviceType devType, int devNumber, int8_t pinIndex, int ioPinNumber );
 
 #endif //_ESP32_DEVICEMAPPING_

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/Esp32_DeviceMapping.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/Esp32_DeviceMapping.cpp
@@ -20,17 +20,18 @@ int8_t Esp32_SPI_DevicePinMap[2][3] =
 //  Serial 
 //  3 devices COM1,COM2, COM3 ( UART_NUM_0, UART_NUM_1, UART_NUM_2 )
 //  Map pins  Tx, RX, RTS, CTS
-//  Set default direct pins
-int8_t Esp32_SERIAL_DevicePinMap[3][4] = 
+//  Set pins to default for UART_NUM_0
+// others assign as NONE because the default pins can be shared with serial flash and PSRAM
+int8_t Esp32_SERIAL_DevicePinMap[UART_NUM_MAX][Esp32SerialPin_Max] = 
 {
     // COM 1 - pins 1, 3, 19, 22
     {UART_NUM_0_TXD_DIRECT_GPIO_NUM, UART_NUM_0_RXD_DIRECT_GPIO_NUM, UART_NUM_0_RTS_DIRECT_GPIO_NUM, UART_NUM_0_CTS_DIRECT_GPIO_NUM},
     
-    // COM 2 - 10, 9, 6, 11
-    {UART_NUM_1_TXD_DIRECT_GPIO_NUM, UART_NUM_1_RXD_DIRECT_GPIO_NUM, UART_NUM_1_RTS_DIRECT_GPIO_NUM, UART_NUM_1_CTS_DIRECT_GPIO_NUM},
+    // COM 2 - all set to UART_PIN_NO_CHANGE
+    {UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE},
     
-    // COM3 - 17, 16, 8, 7
-    {UART_NUM_2_TXD_DIRECT_GPIO_NUM, UART_NUM_2_RXD_DIRECT_GPIO_NUM, UART_NUM_2_RTS_DIRECT_GPIO_NUM, UART_NUM_2_CTS_DIRECT_GPIO_NUM}
+    // COM3 - all set to UART_PIN_NO_CHANGE
+    {UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE}
  };
 
 // =============================================
@@ -141,6 +142,35 @@ int  Esp32_GetMappedDevicePinsWithFunction(uint32_t alternateFunction)
 	return Esp32_GetMappedDevicePins(deviceType, deviceIndex, pinIndex);
 }
 
+void Esp32_SetMappedDevicePins( Esp32_MapDeviceType deviceType, int devNumber, int8_t pinIndex, int ioPinNumber)
+{
+    if  ( devNumber >= 0)
+    {
+        switch( deviceType )
+        {
+            case DEV_TYPE_SPI:
+                Esp32_SPI_DevicePinMap[devNumber][pinIndex] = ioPinNumber;
+        
+            case DEV_TYPE_I2C:
+                Esp32_I2C_DevicePinMap[devNumber][pinIndex] = ioPinNumber;
+            
+			case DEV_TYPE_SERIAL:
+				Esp32_SERIAL_DevicePinMap[devNumber][pinIndex] = ioPinNumber;
+			
+			case DEV_TYPE_LED_PWM:
+                Esp32_LED_DevicePinMap[devNumber] = ioPinNumber;
+
+			case DEV_TYPE_ADC:
+				Esp32_ADC_DevicePinMap[pinIndex] = ioPinNumber;
+			
+			case DEV_TYPE_DAC:
+				Esp32_DAC_DevicePinMap[pinIndex] = ioPinNumber;
+
+			default:
+                break;
+        };
+    }
+}
 
 // Esp32_SetMappedDevicePins
 //
@@ -179,7 +209,7 @@ void Esp32_SetMappedDevicePins( uint8_t pin, int32_t alternateFunction )
             break;
 
 		case DEV_TYPE_SERIAL:
-			if (deviceIndex <= 2 && mapping <= 3)
+			if (deviceIndex < UART_NUM_MAX && mapping < Esp32SerialPin_Max)
 			{
 				Esp32_SERIAL_DevicePinMap[deviceIndex][mapping] = pin;
 			}

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -228,7 +228,7 @@ void UartTxWorkerTask(void *pvParameters)
 bool IsLongRunningOperation(uint32_t bufferSize, uint32_t baudRate, uint32_t& estimatedDurationMiliseconds)
 {
     // simplifying calculation assuming worst case values for stop bits
-    estimatedDurationMiliseconds = ((8 + 2) * bufferSize) / baudRate;
+    estimatedDurationMiliseconds = ((8 + 2) * bufferSize * 1000) / baudRate;
 
     if(estimatedDurationMiliseconds > CLR_RT_Thread::c_TimeQuantum_Milliseconds)
     {

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -5,13 +5,10 @@
 
 #include <nanoHAL.h>
 #include "win_dev_serial_native_target.h"
-#include "Esp32_DeviceMapping.h"
+#include <Esp32_DeviceMapping.h>
 
-// buffers size
-// tx buffer size: 256 bytes
-#define UART_TX_BUFER_SIZE  256
-// rx buffer size: 256 bytes
-#define UART_RX_BUFER_SIZE  256
+// UART buffer size: 256 bytes
+#define UART_BUFER_SIZE  256
 
 // in UWP the COM ports are named COM1, COM2, COM3. But ESP32 uses internally UART0, UART1, UART2. This maps the port index 1, 2 or 3 to the uart number 0, 1 or 2
 #define PORT_INDEX_TO_UART_NUM(portIndex)	((portIndex) - 1)
@@ -20,90 +17,261 @@
 
 static const char* TAG = "SerialDevice";
 
-static char Esp_Serial_Initialised_Flag[UART_NUM_MAX] = {0, 0, 0};
-static QueueHandle_t Uart_Event_Queue[UART_NUM_MAX];
-static bool Uart_Post_SerialData_Chars_Event[UART_NUM_MAX] = {true, true, true};
-CLR_RT_HeapBlock* Serial_Device_Instance[UART_NUM_MAX];
-static int Uart_writeLength[UART_NUM_MAX];
+static NF_PAL_UART Uart0_PAL;
+static NF_PAL_UART Uart1_PAL;
+static NF_PAL_UART Uart2_PAL;
+
+void UnitializePalUart(NF_PAL_UART* palUart)
+{
+    if(palUart->SerialDevice)
+    {
+        // send the exit signal to the UART event handling queue
+        xQueueSend(palUart->UartEventQueue, (void*)UART_EVENT_MAX, (portTickType)0);
+
+        // free buffers meory
+        platform_free(palUart->RxBuffer);
+        platform_free(palUart->TxBuffer);
+        
+        // null all pointers
+        palUart->RxBuffer = NULL;
+        palUart->TxBuffer = NULL;
+        palUart->SerialDevice = NULL;
+
+        // delete driver
+        uart_driver_delete((uart_port_t)palUart->UartNum);
+
+        // delete task, if any
+        if(palUart->UartEventTask)
+        {
+            vTaskDelete(palUart->UartEventTask);
+        }
+
+        palUart->UartEventTask = NULL;
+
+        Esp32_SetMappedDevicePins( DEV_TYPE_SERIAL, palUart->UartNum, Esp32SerialPin_Tx, UART_PIN_NO_CHANGE);
+        Esp32_SetMappedDevicePins( DEV_TYPE_SERIAL, palUart->UartNum, Esp32SerialPin_Rx, UART_PIN_NO_CHANGE);
+        Esp32_SetMappedDevicePins( DEV_TYPE_SERIAL, palUart->UartNum, Esp32SerialPin_Rts, UART_PIN_NO_CHANGE);
+        Esp32_SetMappedDevicePins( DEV_TYPE_SERIAL, palUart->UartNum, Esp32SerialPin_Cts, UART_PIN_NO_CHANGE);
+    }
+}
 
 void Esp32_Serial_UnitializeAll()
 {
     for (int uart_num = 0; uart_num < UART_NUM_MAX; uart_num++) 
     {
-        if (Esp_Serial_Initialised_Flag[uart_num])
+        // free buffers memory
+        switch (uart_num)
         {
-            // Delete uart driver and send the exit signal to the UART event handling queue
-            uart_driver_delete((uart_port_t)uart_num);
-			xQueueSend(Uart_Event_Queue[uart_num], (void*)UART_EVENT_MAX, (portTickType)0);
-			Uart_Post_SerialData_Chars_Event[uart_num] = false;
-			Serial_Device_Instance[uart_num] = NULL;
-            Esp_Serial_Initialised_Flag[uart_num] = 0;
+            case UART_NUM_0:
+                UnitializePalUart(&Uart0_PAL);
+                break;
+
+            case UART_NUM_1:
+                UnitializePalUart(&Uart1_PAL);
+                break;
+
+            case UART_NUM_2:
+                UnitializePalUart(&Uart2_PAL);
+                break;
+
+            // can't even happen
+            default:
+                break;
         }
     }
 }
 
-static void uart_event_task(void *pvParameters)
+void uart_event_task(void *pvParameters)
 {
-    int uart_num = (int)pvParameters;
+    // get PAL UART from task parameters
+    NF_PAL_UART* palUart = (NF_PAL_UART*)pvParameters;
+
     uart_event_t event;
     bool run = true;
-	
+    bool readData;
+    int32_t watchCharPos;
+    int32_t readCount;
+    size_t bufferedSize;
+    uint8_t* buffer;
+
+    ESP_LOGI( TAG, "Start UART event task");
+
 	while(run)
 	{
+        ESP_LOGI( TAG, "Waiting UART EVT");
+
         // Waiting for UART event.
-        if(xQueueReceive(Uart_Event_Queue[uart_num], (void*)&event, (portTickType)portMAX_DELAY)) {
-            switch(event.type) {
-                // Data received
+        if( xQueueReceive(
+                palUart->UartEventQueue,
+                &event, 
+                (portTickType)portMAX_DELAY))
+        {
+            ESP_LOGI( TAG, "UART EVT %d", event.type);
+
+            // reset vars
+            readData = false;
+            watchCharPos = -1;
+
+            // deal with event type
+            switch(event.type)
+            {
                 case UART_DATA:
-					// only if no one is reading the chars already and only if an event handler is attached
-					if (Uart_Post_SerialData_Chars_Event[uart_num] && Serial_Device_Instance[uart_num][Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::FIELD___callbacksDataReceivedEvent].Dereference() != NULL)
-					{
-						// post a managed event with the port index and the chars event code; uart_num + 1 because UART0 maps to COM1
-						PostManagedEvent(EVENT_SERIAL, 0, UART_NUM_TO_PORT_INDEX(uart_num), SerialData_Chars);
-						// supress the event for the following chars; prevents spamming with the SerialData_Chars event
-						// the flag will be reset if NativeRead will be called
-						Uart_Post_SerialData_Chars_Event[uart_num] = false;
-					}
+                    // set flag
+                    readData = true;
                     break;
-				// Pattern detection used for the WatchChar
+                
                 case UART_PATTERN_DET:
-					// only if an event handler is attached
-					if (Serial_Device_Instance[uart_num][Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::FIELD___callbacksDataReceivedEvent].Dereference() != NULL)
-					{
-						// post a managed event with the port index and the watch char event code; uart_num + 1 because UART0 maps to COM1
-						PostManagedEvent(EVENT_SERIAL, 0, UART_NUM_TO_PORT_INDEX(uart_num), SerialData_WatchChar);
-					}
-					break;
-				// signal to end the task (UART_EVENT_MAX used)
-				case UART_EVENT_MAX:
-					run = false;
-					break;
-                // Others
+                    // Pattern detection used for the WatchChar
+                    watchCharPos = uart_pattern_get_pos(palUart->UartNum);
+
+                    // set flag
+                    readData = true;
+                    break;
+
+                case UART_FIFO_OVF:
+                case UART_BUFFER_FULL:
+                    uart_flush_input(palUart->UartNum);
+                    xQueueReset(palUart->UartEventQueue);
+                    break;
+
+                case UART_EVENT_MAX:
+                    // signal to end the task (UART_EVENT_MAX used)
+                    run = false;
+                    break;
+
                 default:
                     break;
             }
+
+            if(readData)
+            {
+                // get how many chars are buffered on RX FIFO
+                uart_get_buffered_data_len(palUart->UartNum, &bufferedSize);
+
+                if(bufferedSize > 0)
+                {
+                    // alloc buffer to read RX FIFO
+                    buffer = (uint8_t*)platform_malloc(bufferedSize);
+
+                    // sanity check
+                    if(buffer)
+                    {
+                        // try to read RX FIFO
+                        readCount = uart_read_bytes(palUart->UartNum, buffer, bufferedSize, 1);
+
+                        // push to UART RX buffer
+                        palUart->RxRingBuffer.Push(buffer, readCount);
+
+                        // free buffer
+                        platform_free(buffer);
+
+                        // is there a read operation going on?
+                        if(palUart->RxBytesToRead > 0)
+                        {
+                            // yes
+                            // check if the requested bytes are available in the buffer...
+                            //... or if the watch char was received
+                            if( (palUart->RxRingBuffer.Length() >= palUart->RxBytesToRead) ||
+                                (watchCharPos > -1))
+                            {
+                                // reset Rx bytes to read count
+                                palUart->RxBytesToRead = 0;
+
+                                // fire event for Rx buffer complete
+                                Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
+                            }
+                        }
+                        else
+                        {
+                            // no read operation ongoing, so fire an event
+                        
+                            // post a managed event with the port index and event code (check if there is a watch char in the buffer or just any char)
+                            //  check if callbacks are registered so this is called only if there is anyone listening otherwise don't bother
+                            if( palUart->SerialDevice[ Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::FIELD___callbacksDataReceivedEvent ].Dereference() != NULL )
+                            {
+                                PostManagedEvent( 
+                                    EVENT_SERIAL, 
+                                    0, 
+                                    UART_NUM_TO_PORT_INDEX(palUart->UartNum), 
+                                    (watchCharPos > -1) ? SerialData_WatchChar : SerialData_Chars );
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
-	vQueueDelete(Uart_Event_Queue[uart_num]);
+
     vTaskDelete(NULL);
+}
+
+void UartTxWorkerTask(void *pvParameters)
+{
+    // get PAL UART from task parameters
+    NF_PAL_UART* palUart = (NF_PAL_UART*)pvParameters;
+
+    // Write data directly to UART FIFO
+    // by design: don't bother checking the return value
+    uart_write_bytes( palUart->UartNum, (const char*)palUart->TxRingBuffer.Reader(), palUart->TxOngoingCount);
+
+    // pop elements from ring buffer, just pop
+    palUart->TxRingBuffer.Pop(palUart->TxOngoingCount);
+
+    // set event flag for COM OUT
+    Events_Set( SYSTEM_EVENT_FLAG_COM_OUT );
+
+    // delete task
+    vTaskDelete(NULL);
+}
+
+// estimate the time required to perform the TX transaction
+bool IsLongRunningOperation(uint32_t bufferSize, uint32_t baudRate, uint32_t& estimatedDurationMiliseconds)
+{
+    // simplifying calculation assuming worst case values for stop bits
+    estimatedDurationMiliseconds = ((8 + 2) * bufferSize) / baudRate;
+
+    if(estimatedDurationMiliseconds > CLR_RT_Thread::c_TimeQuantum_Milliseconds)
+    {
+        // total operation time will exceed thread quantum, so this is a long running operation
+        return true;
+    }
+    else
+    {
+        return false;        
+    }
 }
 
 HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::NativeDispose___VOID( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
-    {
-		// get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
 
-		// Get Uart number for serial device
-        uart_port_t uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
-		// uninstall the driver and send the exit signal to the UART event handling queue
-        uart_driver_delete(uart_num);
-		xQueueSend(Uart_Event_Queue[uart_num], (void*)UART_EVENT_MAX, (portTickType)portMAX_DELAY);
-		Uart_Post_SerialData_Chars_Event[uart_num] = false;
-		Serial_Device_Instance[uart_num] = NULL;
-        Esp_Serial_Initialised_Flag[uart_num] = 0;
-   }
+    uart_port_t uart_num;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+
+    // Get Uart number for serial device
+    uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
+    
+    switch (uart_num)
+    {
+        case UART_NUM_0:
+            UnitializePalUart(&Uart0_PAL);
+            break;
+
+        case UART_NUM_1:
+            UnitializePalUart(&Uart1_PAL);
+            break;
+
+        case UART_NUM_2:
+            UnitializePalUart(&Uart2_PAL);
+            break;
+
+        // can't even happen
+        default:
+            break;
+    }
+
     NANOCLR_NOCLEANUP();
 }
 
@@ -113,53 +281,101 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
 HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::NativeInit___VOID( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
+
+    char task_name[16];
+    uart_port_t uart_num;
+    esp_err_t esp_err;
+
+    NF_PAL_UART* palUart;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+
+    // Get Uart number for serial device
+    uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
+    if ( uart_num > UART_NUM_2 || uart_num < 0 )
     {
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
-
-        // Get Uart number for serial device
-        uart_port_t uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
-        if ( uart_num > UART_NUM_2 || uart_num < 0 )
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-        }
-
-        // call the configure and abort if not OK
-        HRESULT res = NativeConfig___VOID(stack);
-        if (res != S_OK)
-        {
-            NANOCLR_SET_AND_LEAVE(res);
-        }
-
-        // Install driver
-        esp_err_t esp_err = uart_driver_install(uart_num, 
-                                                UART_RX_BUFER_SIZE, 			// rx_buffer_size, 
-                                                UART_TX_BUFER_SIZE, 			// tx_buffer_size, not buffered
-                                                20,                  			// queue_size
-                                                &Uart_Event_Queue[uart_num],    // QueueHandle_t *uart_queue ( none for now )
-                                                0                   			// intr_alloc_flags
-                                                );
-        if ( esp_err != ESP_OK )
-        {
-            ESP_LOGE( TAG, "Failed to install uart driver");
-            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-        }   
-        
-		// receive the SerialData_Chars events and store the SerialDevice instance
-		Uart_Post_SerialData_Chars_Event[uart_num] = true;
-		Serial_Device_Instance[uart_num] = pThis;
-		
-		// Create a task to handle UART event from ISR
-		char task_name[16];
-		sprintf(task_name, "uart%d_events", uart_num);
-		xTaskCreate(uart_event_task, task_name, 2048, (void*)uart_num, 12, NULL);
-	
-        // Ensure driver gets unitialized during soft reboot
-        HAL_AddSoftRebootHandler(Esp32_Serial_UnitializeAll);
-        Esp_Serial_Initialised_Flag[uart_num] = 1;
-
-		Uart_writeLength[uart_num] = 0;
+        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
     }
+
+    // call the configure and abort if not OK
+    NANOCLR_CHECK_HRESULT( NativeConfig___VOID(stack) );
+
+    switch(uart_num)
+    {
+        case UART_NUM_0:
+            // set UART PAL
+            palUart = &Uart0_PAL;
+            break;
+
+        case UART_NUM_1:
+            // set UART PAL
+            palUart = &Uart1_PAL;
+            break;
+
+        case UART_NUM_2:
+            // set UART PAL
+            palUart = &Uart2_PAL;
+            break;
+
+        default:
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+    }
+
+    // alloc buffers memory
+    palUart->TxBuffer = (uint8_t*)platform_malloc(UART_BUFER_SIZE);
+    palUart->RxBuffer = (uint8_t*)platform_malloc(UART_BUFER_SIZE);
+
+    // sanity check
+    if( palUart->TxBuffer == NULL ||
+        palUart->RxBuffer == NULL)
+    {
+        NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
+    }
+
+    // init buffers
+    palUart->TxRingBuffer.Initialize( palUart->TxBuffer, UART_BUFER_SIZE );
+    palUart->RxRingBuffer.Initialize( palUart->RxBuffer, UART_BUFER_SIZE );
+
+    // set/reset all the rest
+    palUart->SerialDevice = stack.This();
+    palUart->UartNum = uart_num;
+    palUart->TxOngoingCount = 0; 
+    palUart->RxBytesToRead = 0; 
+
+    // Install driver
+    esp_err = uart_driver_install(  uart_num, 
+                                    UART_BUFER_SIZE, 			    // rx_buffer_size, 
+                                    0, 			                    // tx_buffer_size, not buffered
+                                    20,                  			// queue_size
+                                    &(palUart->UartEventQueue),     // QueueHandle_t *uart_queue ( none for now )
+                                    0                               // intr_alloc_flags
+                                    );
+    if ( esp_err != ESP_OK )
+    {
+        ESP_LOGE( TAG, "Failed to install uart driver");
+        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+    }
+
+    // Create a task to handle UART event from ISR
+    sprintf(task_name, "uart%d_events", uart_num);
+    if( xTaskCreatePinnedToCore(
+            uart_event_task,
+            task_name,
+            2048,
+            palUart,
+            12,
+            &(palUart->UartEventTask),
+            1
+        ) != pdPASS )
+    {
+        ESP_LOGE( TAG, "Failed to start UART events task");
+        NANOCLR_SET_AND_LEAVE(CLR_E_FAIL); 
+    }
+
+    // Ensure driver gets unitialized during soft reboot
+    HAL_AddSoftRebootHandler(Esp32_Serial_UnitializeAll);
+
     NANOCLR_NOCLEANUP(); 
 }
 
@@ -183,19 +399,28 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         }
 
         // setup configuration
-        // data bits / baud rate
-        uart_config.baud_rate  = (uart_word_length_t)pThis[ FIELD___baudRate ].NumericByRef().s4;      //baudrate
+        // baud rate
+        uart_config.baud_rate  = (uint32_t)pThis[ FIELD___baudRate ].NumericByRef().s4;
 
-        switch( pThis[ FIELD___dataBits ].NumericByRef().s4 )      //data bit mode
+        // data bits
+        switch( (uint16_t)pThis[ FIELD___dataBits ].NumericByRef().s4 )
         {
             case 5:
-                uart_config.data_bits = UART_DATA_5_BITS; break;
+                uart_config.data_bits = UART_DATA_5_BITS;
+                break;
+
             case 6:
-                uart_config.data_bits = UART_DATA_6_BITS; break;
+                uart_config.data_bits = UART_DATA_6_BITS; 
+                break;
+
             case 7:
-                uart_config.data_bits = UART_DATA_7_BITS; break;
+                uart_config.data_bits = UART_DATA_7_BITS;
+                break;
+
             case 8:
-                uart_config.data_bits = UART_DATA_8_BITS; break;
+                uart_config.data_bits = UART_DATA_8_BITS;
+                break;
+
             default:
                 NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
         }
@@ -205,13 +430,15 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         {
             default:
             case SerialParity_None :
-                uart_config.parity = UART_PARITY_DISABLE ;                       
+                uart_config.parity = UART_PARITY_DISABLE;                       
                 break;
+
             case SerialParity_Even :
-                uart_config.parity = UART_PARITY_EVEN ;                       
+                uart_config.parity = UART_PARITY_EVEN;                       
                 break;
+
             case SerialParity_Odd :
-                uart_config.parity = UART_PARITY_ODD ;                       
+                uart_config.parity = UART_PARITY_ODD;                       
                 break;
         }
  
@@ -222,58 +449,78 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
             case SerialStopBitCount_One :
                 uart_config.stop_bits = UART_STOP_BITS_1;                       
                 break;
+
             case SerialStopBitCount_OnePointFive :
                 uart_config.stop_bits = UART_STOP_BITS_1_5;
                 break;
+
             case SerialStopBitCount_Two :
                 uart_config.stop_bits = UART_STOP_BITS_2;
                 break;
         }
 
-	   uart_config.rx_flow_ctrl_thresh = 0;
+        uart_config.rx_flow_ctrl_thresh = 120;
 
-	   bool EnableXonXoff = false;
-	   switch ((SerialHandshake)pThis[ FIELD___handshake ].NumericByRef().s4)
+        bool EnableXonXoff = false;
+        switch ((SerialHandshake)pThis[ FIELD___handshake ].NumericByRef().s4)
         {
            default:
             case SerialHandshake_None :
-                uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;                      
+                uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;                    
                 break;
+
            case SerialHandshake_RequestToSend :
                 uart_config.flow_ctrl = UART_HW_FLOWCTRL_RTS ;                      
 				uart_config.rx_flow_ctrl_thresh = 122;
 				break;
-         
-         case SerialHandshake_RequestToSendXOnXOff :
+            
+            case SerialHandshake_RequestToSendXOnXOff :
                 uart_config.flow_ctrl = UART_HW_FLOWCTRL_RTS ;     
-				uart_config.rx_flow_ctrl_thresh = 122;
-				EnableXonXoff = true;
+                uart_config.rx_flow_ctrl_thresh = 122;
+                EnableXonXoff = true;
                 break;
 
-         case SerialHandshake_XOnXOff :
+            case SerialHandshake_XOnXOff :
                 EnableXonXoff = true;                 
                 break;
         }
 
-       uart_param_config(uart_num, &uart_config);
+        if( uart_param_config(uart_num, &uart_config) != ESP_OK )
+        {
+           ESP_LOGE( TAG, "Failed to set UART parameters configuration");
+           NANOCLR_SET_AND_LEAVE(CLR_E_FAIL); 
+        }
 
-       if ( EnableXonXoff )
-            uart_set_sw_flow_ctrl(uart_num, true, 20, 40);
+        if ( EnableXonXoff )
+        {
+           uart_set_sw_flow_ctrl(uart_num, true, 20, 40);
+        }
 
-	   // Map to currently assigned pins
-	   int txPin  = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, 0); 
-	   int rxPin  = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, 1);
-	   int rtsPin = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, 2);
-	   int ctsPin = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, 3);
+        // Map to currently assigned pins
+        int txPin  = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, Esp32SerialPin_Tx); 
+        int rxPin  = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, Esp32SerialPin_Rx);
+        int rtsPin = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, Esp32SerialPin_Rts);
+        int ctsPin = Esp32_GetMappedDevicePins(DEV_TYPE_SERIAL, uart_num, Esp32SerialPin_Cts);
 
-       // Don't use RTS/CTS if no hardware handshake enabled
-       if ( uart_config.flow_ctrl == UART_HW_FLOWCTRL_DISABLE )
-       {
-           rtsPin = UART_PIN_NO_CHANGE;
-           ctsPin = UART_PIN_NO_CHANGE;
-       }
+        // check if TX, RX pins have been previously set
+        if( txPin == UART_PIN_NO_CHANGE ||
+            rxPin == UART_PIN_NO_CHANGE)
+        {
+            NANOCLR_SET_AND_LEAVE(CLR_E_PIN_UNAVAILABLE);
+        }
 
-       uart_set_pin(uart_num, txPin, rxPin, rtsPin, ctsPin);
+        // Don't use RTS/CTS if no hardware handshake enabled
+        if ( uart_config.flow_ctrl == UART_HW_FLOWCTRL_DISABLE )
+        {
+            rtsPin = UART_PIN_NO_CHANGE;
+            ctsPin = UART_PIN_NO_CHANGE;
+        }
+
+        if( uart_set_pin(uart_num, txPin, rxPin, rtsPin, ctsPin) != ESP_OK ) 
+        {
+            ESP_LOGE( TAG, "Failed to set UART pins");
+            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL); 
+        }    
 
         // null pointers and vars
         pThis = NULL;
@@ -288,6 +535,8 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
 {
     NANOCLR_HEADER();
     {
+        NF_PAL_UART* palUart = NULL;
+
         uint8_t* data;
         size_t length = 0;
 
@@ -311,9 +560,35 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         // Get Uart number for serial device
         uart_port_t uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
  
+        // get pointer to PAL UART 
+        switch (uart_num)
+        {
+            case UART_NUM_0:
+                palUart = &Uart0_PAL;
+                break;
 
-        // Write data to ring bufferand start sending
-        size_t bytesWritten = uart_write_bytes( uart_num, (const char*)data, length);
+            case UART_NUM_1:
+                palUart = &Uart1_PAL;
+                break;
+
+            case UART_NUM_2:
+                palUart = &Uart2_PAL;
+                break;
+
+            // can't even happen
+            default:
+                break;
+        }
+
+        // check if there is enough room in the buffer
+        if(palUart->TxRingBuffer.Capacity() - palUart->TxRingBuffer.Length() < length)
+        {
+            // not enough room in the buffer
+             NANOCLR_SET_AND_LEAVE(CLR_E_BUFFER_TOO_SMALL);
+        }
+
+        // push data to buffer
+        size_t bytesWritten = palUart->TxRingBuffer.Push(data, length);
 
         // check if all requested bytes were written
         if(bytesWritten != length)
@@ -322,14 +597,11 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
             NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
         }
         
-		Uart_writeLength[uart_num] += bytesWritten;
-
-        // // need to update the _unstoredBufferLength field in the SerialDeviceOutputStream
-        // // get pointer to outputStream field
-        // CLR_RT_HeapBlock* outputStream = pThis[Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::FIELD___outputStream].Dereference();
-        
-        // // get pointer to _unstoredBufferLength field and udpate field value
-        // outputStream[Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDeviceOutputStream::FIELD___unstoredBufferLength].NumericByRef().s4 = palUart->TxRingBuffer.Length();
+        // need to update the _unstoredBufferLength field in the SerialDeviceOutputStream
+        // get pointer to outputStream field
+        CLR_RT_HeapBlock* outputStream = pThis[ FIELD___outputStream ].Dereference();
+        // get pointer to _unstoredBufferLength field and udpate field value
+        outputStream[Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDeviceOutputStream::FIELD___unstoredBufferLength].NumericByRef().s4 = palUart->TxRingBuffer.Length();
 
         // null pointers and vars
         pThis = NULL;
@@ -343,192 +615,429 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
 HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::NativeStore___U4( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
+
+    NF_PAL_UART* palUart = NULL;
+
+    bool isLongRunningOperation = false;
+    uint32_t estimatedDurationMiliseconds;
+    size_t length = 0;
+    uart_port_t uart_num;
+
+    int64_t*  timeoutTicks;
+    bool eventResult = true;
+    bool txOk = false;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+
+    if(pThis[ FIELD___disposed ].NumericByRef().u1 != 0)
     {
-
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
-
-        if(pThis[ FIELD___disposed ].NumericByRef().u1 != 0)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
-        }
-
-        // Get Uart number for serial device
-        uart_port_t uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
-
-        // get value for writetimeout
-        // the way to access this it's somewhat convoluted but it is what it is
-        // get pointer to the field
-        CLR_RT_HeapBlock* timeout = &pThis[ Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::FIELD___writeTimeout ];
-
-        // now get a pointer to the actual value
-        int64_t* timeoutTicks = Library_corlib_native_System_TimeSpan::GetValuePtr( *timeout );
-
-        // now get the value in ticks and convert it to milliseconds
-        int64_t timeoutMillisecondsValue = *timeoutTicks / TIME_CONVERSION__TICKUNITS;
-
-        // Wait for max. writetimeout timespan for data to be sent
-        esp_err_t esp_err = uart_wait_tx_done( uart_num,  (TickType_t) timeoutMillisecondsValue / portTICK_PERIOD_MS);
-        if (esp_err == ESP_ERR_TIMEOUT)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_TIMEOUT);
-        }
-        else if (esp_err != ESP_OK)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-        }
-
-        // return how many bytes were send to the UART
-        stack.SetResult_U4(Uart_writeLength[uart_num]);
-
-		Uart_writeLength[uart_num] = 0;
-
-        // null pointers and vars
-        pThis = NULL;
+        NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
     }
+
+    // Get Uart number for serial device
+    uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
+
+    // get pointer to PAL UART 
+    switch (uart_num)
+    {
+        case UART_NUM_0:
+            palUart = &Uart0_PAL;
+            break;
+
+        case UART_NUM_1:
+            palUart = &Uart1_PAL;
+            break;
+
+        case UART_NUM_2:
+            palUart = &Uart2_PAL;
+            break;
+
+        // can't even happen
+        default:
+            break;
+    }
+
+    // check if this is a long running operation
+    isLongRunningOperation = IsLongRunningOperation(
+        palUart->TxRingBuffer.Length(), 
+        (uint32_t)pThis[ FIELD___baudRate ].NumericByRef().s4, 
+        (uint32_t&)estimatedDurationMiliseconds);
+
+    // check if there is anything the buffer
+    if(palUart->TxRingBuffer.Length() > 0)
+    {
+        // check if there is a TX operation ongoing
+        if(palUart->TxOngoingCount == 0)
+        {
+            // OK to Tx
+            txOk = true;
+        }
+        else
+        {
+            // need to wait for the ongoing operation to complete before starting a new one
+        }
+    }
+
+    if(txOk)
+    {
+        // optimize buffer for sequential reading
+        palUart->TxRingBuffer.OptimizeSequence();
+
+        // get data length available in the buffer
+        length = palUart->TxRingBuffer.Length();
+
+        if(isLongRunningOperation)
+        {
+            // setup timeout
+            NANOCLR_CHECK_HRESULT( stack.SetupTimeoutFromTimeSpan(pThis[ FIELD___writeTimeout ], timeoutTicks ) );
+
+            // this is a long running operation and hasn't started yet
+            // perform operation by launching a thread to
+            if(stack.m_customState == 1)
+            {
+                // push to the stack how many bytes bytes where buffered for Tx
+                stack.PushValueI4(length);
+
+                // set TX count
+                palUart->TxOngoingCount = length;
+
+                // Create a task to handle UART event from ISR
+                char task_name[16];
+                sprintf(task_name, "uart%d_tx", uart_num);
+                
+                if( xTaskCreate(
+                        UartTxWorkerTask,
+                        task_name,
+                        2048,
+                        palUart,
+                        12,
+                        NULL) != pdPASS )
+                {
+                    ESP_LOGE( TAG, "Failed to start UART TX task");
+                    NANOCLR_SET_AND_LEAVE(CLR_E_FAIL); 
+                }
+
+                // bump custom state so the read value above is pushed only once
+                stack.m_customState = 2;
+            }
+        }
+        else
+        {
+            // this is NOT a long running operation
+            // perform TX operation right away
+
+            // Write data to ring buffer to start sending
+            // by design: don't bother checking the return value
+            uart_write_bytes( uart_num, (const char*)palUart->TxRingBuffer.Reader(), length);
+            
+            // pop data that was written to FIFO
+            // pop elements from ring buffer, just pop
+            palUart->TxRingBuffer.Pop(length);
+        }
+    }
+
+    while(eventResult)
+    {
+        if(!isLongRunningOperation)
+        {
+            // this is not a long running operation so nothing to do here
+            break;
+        }
+
+        // non-blocking wait allowing other threads to run while we wait for the Tx operation to complete
+        NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents( stack.m_owningThread, *timeoutTicks, CLR_RT_ExecutionEngine::c_Event_SerialPortOut, eventResult ));
+
+        if(eventResult)
+        {
+            // event occurred
+            // get from the eval stack how many bytes were buffered to Tx
+            length = stack.m_evalStack[1].NumericByRef().s4;
+
+            // reset Tx ongoing count
+            palUart->TxOngoingCount = 0;
+
+            // done here
+            break;
+        }
+        else
+        {
+            NANOCLR_SET_AND_LEAVE( CLR_E_TIMEOUT );
+        }
+    }
+
+    if(isLongRunningOperation)
+    {
+        // pop length heap block from stack
+        stack.PopValue();
+
+        // pop timeout heap block from stack
+        stack.PopValue();
+    }
+
+    stack.SetResult_U4(length);
+
+    // null pointers and vars
+    pThis = NULL;
+
     NANOCLR_NOCLEANUP();
 }
 
-
-HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::NativeRead___U4__SZARRAY_U1__I4__I4( CLR_RT_StackFrame& stack )
+HRESULT IRAM_ATTR Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::NativeRead___U4__SZARRAY_U1__I4__I4( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
+
+    CLR_RT_HeapBlock_Array* dataBuffer;
+    NF_PAL_UART* palUart = NULL;
+
+    uint8_t* data;
+    size_t dataLength = 0;
+
+    size_t count = 0;
+    size_t bytesRead = 0;
+    size_t bytesToRead = 0;
+
+    InputStreamOptions options = InputStreamOptions_None;
+    uart_port_t uart_num;
+
+    int64_t*  timeoutTicks;
+    bool eventResult = true;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+
+    if(pThis[ FIELD___disposed ].NumericByRef().u1 != 0)
     {
-        uint8_t* data;
-        size_t dataLength = 0;
+        NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
+    }
 
-        size_t count = 0;
-        int    bytesRead = 0;
-        size_t toRead = 0;
+    // dereference the data buffer from the argument
+    dataBuffer = stack.Arg1().DereferenceArray();
 
-        InputStreamOptions options = InputStreamOptions_None;
+    // get a the pointer to the array by using the first element of the array
+    data = dataBuffer->GetFirstElement();
 
-        CLR_RT_HeapBlock* timeout;
-        int64_t*  timeoutTicks;
-        int64_t  timeoutMillisecondsValue;
+    // get the length of the data buffer
+    dataLength =  dataBuffer->m_numOfElements;
 
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+    // get how many bytes are requested to read
+    count = stack.Arg2().NumericByRef().s4;
 
-        if(pThis[ FIELD___disposed ].NumericByRef().u1 != 0)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
-        }
+    // get the InputStreamOptions option
+    options = (InputStreamOptions)stack.Arg3().NumericByRef().s4;
 
-        // dereference the data buffer from the argument
-        CLR_RT_HeapBlock_Array* dataBuffer = stack.Arg1().DereferenceArray();
+    // Get Uart number for serial device
+    uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
+    
+    // get pointer to PAL UART 
+    switch (uart_num)
+    {
+        case UART_NUM_0:
+            palUart = &Uart0_PAL;
+            break;
 
-        // get a the pointer to the array by using the first element of the array
-        data = dataBuffer->GetFirstElement();
+        case UART_NUM_1:
+            palUart = &Uart1_PAL;
+            break;
 
-        // get the length of the data buffer
-        dataLength =  dataBuffer->m_numOfElements;
+        case UART_NUM_2:
+            palUart = &Uart2_PAL;
+            break;
 
-        // get how many bytes are requested to read
-        count = stack.Arg2().NumericByRef().s4;
+        // can't even happen
+        default:
+            break;
+    }
 
-        // get the InputStreamOptions option
-        options = (InputStreamOptions)stack.Arg3().NumericByRef().s4;
+    // setup timeout from the _readtimeout heap block
+    NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTimeSpan( pThis[ FIELD___readTimeout ], timeoutTicks ));
 
-       // Get Uart number for serial device
-        uart_port_t uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
+    // figure out what's available in the Rx ring buffer
+    if(palUart->RxRingBuffer.Length() >= count)
+    {
+        // read from Rx ring buffer
+        bytesToRead = count;
 
-        // Bytes requested to read
-        toRead = count;
-        
         // is the read ahead option enabled?
         if(options == InputStreamOptions_ReadAhead)
         {
             // yes
             // check how many bytes we can store in the buffer argument
-            size_t bufferedLength = 0;
-            uart_get_buffered_data_len(uart_num, &bufferedLength);
-
-            if(dataLength < bufferedLength )
+            if(dataLength < palUart->RxRingBuffer.Length())
             {
                 // read as many bytes has the buffer can hold
-                toRead = dataLength;
+                bytesToRead = dataLength;
             }
             else
             {
                 // read everything that's available in the ring buffer
-                toRead = bufferedLength;
+                bytesToRead = palUart->RxRingBuffer.Length();
             }
         }
 
-        // get value for readtimeout
-        // the way to access this it's somewhat convoluted but it is what it is
-        // get pointer to the field
-        timeout = &pThis[ Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::FIELD___readTimeout ];
-
-        // now get a pointer to the actual value
-        timeoutTicks = Library_corlib_native_System_TimeSpan::GetValuePtr( *timeout );
-
-        // now get the value in ticks and convert it to miliseconds
-        timeoutMillisecondsValue = *timeoutTicks / TIME_CONVERSION__TICKUNITS;
-
-		// suppress the SerialData_Chars event during the reading of the chars; prevents spamming with the SerialData_Chars event
-		Uart_Post_SerialData_Chars_Event[uart_num] = false;
-        bytesRead = uart_read_bytes(uart_num, data, toRead, timeoutMillisecondsValue / portTICK_RATE_MS);
-		Uart_Post_SerialData_Chars_Event[uart_num] = true;
-		
-        if ( bytesRead < 0 )
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
-        }
- 
-        // return how many bytes were read from the Rx buffer and/or UART
-        stack.SetResult_U4(bytesRead);
+        // we have enough bytes, skip wait for event
+        eventResult = false;
+               
+        // clear event by getting it
+        Events_Get(SYSTEM_EVENT_FLAG_COM_IN);
     }
+    else
+    {
+        if(stack.m_customState == 1)
+        {
+            // not enough bytes available, have to read from UART
+            palUart->RxBytesToRead = count;
+            
+            // clear event by getting it
+            Events_Get(SYSTEM_EVENT_FLAG_COM_IN);
+
+            // don't read anything from the buffer yet
+            bytesToRead = 0;
+        }  
+    }
+
+    while(eventResult)
+    {
+        if(stack.m_customState == 1)
+        {
+            if(bytesToRead > 0)
+            {
+                // enough bytes available
+                eventResult = false;
+            }
+            else
+            {
+                // need to read from the UART
+                // update custom state
+                stack.m_customState = 2;
+            }
+        }
+        else
+        {
+            // wait for event
+            NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeoutTicks, CLR_RT_ExecutionEngine::c_Event_SerialPortIn, eventResult));
+
+            if(!eventResult)
+            {
+                // event timeout
+
+                // compute how many bytes to read 
+                // considering the InputStreamOptions read ahead option
+                if(options == InputStreamOptions_ReadAhead)
+                {
+                    // yes
+                    // check how many bytes we can store in the buffer argument
+                    if(dataLength < palUart->RxRingBuffer.Length())
+                    {
+                        // read as many bytes has the buffer can hold
+                        bytesToRead = dataLength;
+                    }
+                    else
+                    {
+                        // read everything that's available in the ring buffer
+                        bytesToRead = palUart->RxRingBuffer.Length();
+                    }
+                }
+                else
+                {
+                    // take InputStreamOptions_Partial as default and read requested quantity or what's available
+                    bytesToRead = count;
+
+                    if(count > palUart->RxRingBuffer.Length())
+                    {
+                        // need to adjust because there aren't enough bytes available
+                        bytesToRead = palUart->RxRingBuffer.Length();
+                    }
+                }
+            }
+        }
+    }
+
+    if(bytesToRead > 0)
+    {
+        // pop the requested bytes from the ring buffer
+        bytesRead = palUart->RxRingBuffer.Pop(data, bytesToRead);
+    }
+
+    // pop timeout heap block from stack
+    stack.PopValue();
+
+    // return how many bytes were read
+    stack.SetResult_U4(bytesRead);
+
     NANOCLR_NOCLEANUP();
 }
 
 HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::NativeSetWatchChar___VOID( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
-	{
-		// get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
 
-        if(pThis[ FIELD___disposed ].NumericByRef().u1 != 0)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
-        }
-		
-		// Get Uart number for serial device
-        uart_port_t uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
-		
-		// Get the watch char
-        uint8_t watchChar = (uint8_t)pThis[ FIELD___watchChar ].NumericByRef().u1;
-		
-		// Enable pattern detection for the serial device
-		uart_enable_pattern_det_intr(uart_num, watchChar, 1, 10000, 10, 10);
-	}
+    uart_port_t uart_num;
+    uint8_t watchChar;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+
+    if(pThis[ FIELD___disposed ].NumericByRef().u1 != 0)
+    {
+        NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
+    }
+    
+    // Get Uart number for serial device
+    uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
+    
+    // Get the watch char
+    watchChar = (uint8_t)pThis[ FIELD___watchChar ].NumericByRef().u1;
+    
+    // Enable pattern detection for the serial device
+    uart_enable_pattern_det_intr(uart_num, watchChar, 1, 10000, 10, 10);
+    //Reset the pattern queue length to record at most 10 pattern positions.
+    uart_pattern_queue_reset(uart_num, 10);
+
     NANOCLR_NOCLEANUP();
 }
 
 HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::get_BytesToRead___U4( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
-	{
-		// get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
 
-        if(pThis[ FIELD___disposed ].NumericByRef().u1 != 0)
-        {
-            NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
-        }
-		
-		// Get Uart number for serial device
-        uart_port_t uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
-		
-		// check how many bytes are in the buffer
-        size_t bufferedLength = 0;
-        uart_get_buffered_data_len(uart_num, &bufferedLength);
-		
-		// return how many bytes can be read from the Rx buffer
-        stack.SetResult_U4(bufferedLength);
-	}
+    NF_PAL_UART* palUart = NULL;
+    uart_port_t uart_num;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+
+    if(pThis[ FIELD___disposed ].NumericByRef().u1 != 0)
+    {
+        NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
+    }
+    
+    // Get Uart number for serial device
+    uart_num = (uart_port_t)PORT_INDEX_TO_UART_NUM(pThis[ FIELD___portIndex ].NumericByRef().s4);
+    
+    // get pointer to PAL UART 
+    switch (uart_num)
+    {
+        case UART_NUM_0:
+            palUart = &Uart0_PAL;
+            break;
+
+        case UART_NUM_1:
+            palUart = &Uart1_PAL;
+            break;
+
+        case UART_NUM_2:
+            palUart = &Uart2_PAL;
+            break;
+
+        // can't even happen
+        default:
+            break;
+    }
+
+    // return how many bytes can be read from the Rx buffer
+    stack.SetResult_U4(palUart->RxRingBuffer.Length());
+
 	NANOCLR_NOCLEANUP();
 }
 
@@ -537,7 +1046,8 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
    NANOCLR_HEADER();
    {
        // declare the device selector string whose max size is "COM1,COM2,COM3" + terminator 
-       char deviceSelectorString[ 15 ] = "COM1,COM2,COM3";
+       // COM1 is being used for VS debug, so it's not available
+       char deviceSelectorString[ 15 ] = "COM2,COM3";
 
        // because the caller is expecting a result to be returned
        // we need set a return result in the stack argument using the appropriate SetResult according to the variable type (a string here)

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_target.h
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_target.h
@@ -8,4 +8,23 @@
 
 #include <win_dev_serial_native.h>
 
+// struct representing the UART 
+typedef struct
+{
+    uart_port_t UartNum;
+    TaskHandle_t UartEventTask;
+    QueueHandle_t UartEventQueue;
+
+    CLR_RT_HeapBlock* SerialDevice;
+
+    HAL_RingBuffer<uint8_t> TxRingBuffer;
+    uint8_t* TxBuffer;
+    uint16_t TxOngoingCount;
+
+    HAL_RingBuffer<uint8_t> RxRingBuffer;
+    uint8_t* RxBuffer;
+    uint16_t RxBytesToRead;
+
+} NF_PAL_UART;
+
 #endif  //_WIN_DEV_SERIAL_NATIVE_TARGET_H_


### PR DESCRIPTION
## Description
- Add new function Esp32_SetMappedDevicePins.
- Add new enum with serial pins indexes.
- Replace "magic numbers" in serial gpio arrays with defines and enums.
- Add NF_PAL_UART struct to ESP32 serial device.
- Rework Store and Read implementations to properly handle timeout and non blocking execution.
- Fix get_BytesToRead to return count of elements in the input stream buffer.
- Remove COM1 from the available UARTS.

## Motivation and Context
- Fixes issues with using default UART GPIOs that are shared with serial flash and PSRAM.
- Addresses nanoFramework/Home#610.
- Addresses nanoFramework/Home#612.


## How Has This Been Tested?<!-- (if applicable) -->
- Serial sample. Latest version adjusted to work with ESP32.
- TX is working. 
- RX is failing.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
