### PR TITLE
Rework NativeInit for SPI

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -231,7 +231,7 @@ void GetSPIConfig(int busIndex, CLR_RT_HeapBlock* config, SPIConfig* llConfig, b
     }
 
     // compute baud rate of SPI peripheral according to the requested frequency
-    llConfig->cr1 |= ComputeBaudRate(busIndex, config[ SpiConnectionSettings::FIELD___clockFrequency ].NumericByRef().s4, (int32_t&)actualFrequency);
+    llConfig->cr1 |= ComputeBaudRate(busIndex, config[ SpiConnectionSettings::FIELD___clockFrequency ].NumericByRef().s4, actualFrequency);
 
     // set data transfer length according to SPI connection settings and...
     // ... buffer data size. Have to use the shortest one.
@@ -665,103 +665,111 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeTransfer
 HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___VOID( CLR_RT_StackFrame& stack )
 {
     NANOCLR_HEADER();
+
+    uint8_t busIndex;
+    NF_PAL_SPI* palSpi = NULL;
+    int32_t actualFrequency = 0;
+    CLR_RT_HeapBlock* pConfig;
+    
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+    
+    // get a pointer to the managed spi connectionSettings object instance
+    pConfig = pThis[ FIELD___connectionSettings ].Dereference();
+    
+    // get bus index
+    // this is coded with a multiplication, need to perform and int division to get the number
+    // see the comments in the SpiDevice() constructor in managed code for details
+    busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
+
+    // config GPIO pins used by the SPI peripheral
+    // init the PAL struct for this SPI bus and assign the respective driver
+    // all this occurs if not already done
+    // why do we need this? because several SPIDevice objects can be created associated to the same bus
+    switch (busIndex)
     {
-        NF_PAL_SPI* palSpi = NULL;
-        int32_t actualFrequency;
-        
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
-        
-        // get a pointer to the managed spi connectionSettings object instance
-        CLR_RT_HeapBlock* pConfig = pThis[ FIELD___connectionSettings ].Dereference();
-        
-        // get bus index
-        // this is coded with a multiplication, need to perform and int division to get the number
-        // see the comments in the SpiDevice() constructor in managed code for details
-        uint8_t busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
+      #if STM32_SPI_USE_SPI1
+        case 1:
+            if(SPI1_PAL.Driver == NULL)
+            {
+                ConfigPins_SPI1();
 
-        // config GPIO pins used by the SPI peripheral
-        // init the PAL struct for this SPI bus and assign the respective driver
-        // all this occurs if not already done
-        // why do we need this? because several SPIDevice objects can be created associated to the same bus
-        switch (busIndex)
-        {
-    #if STM32_SPI_USE_SPI1
-            case 1:
-                if(SPI1_PAL.Driver == NULL)
-                {
-                    ConfigPins_SPI1();
+                SPI1_PAL.Driver = &SPID1;
+                palSpi = &SPI1_PAL;
+            }
+            break;
+      #endif
 
-                    SPI1_PAL.Driver = &SPID1;
-                    palSpi = &SPI1_PAL;
-                }
-                break;
-    #endif
-    #if STM32_SPI_USE_SPI2
-            case 2:
-                if(SPI2_PAL.Driver == NULL)
-                {
-                    ConfigPins_SPI2();
-                    
-                    SPI2_PAL.Driver = &SPID2;
-                    palSpi = &SPI2_PAL;
-                }
-                break;
-    #endif
-    #if STM32_SPI_USE_SPI3
-            case 3:
-                if(SPI3_PAL.Driver == NULL)
-                {
-                    ConfigPins_SPI3();
-                    
-                    SPI3_PAL.Driver = &SPID3;
-                    palSpi = &SPI3_PAL;
-                }
-                break;
-    #endif
-    #if STM32_SPI_USE_SPI4
-            case 4:
-                if(SPI4_PAL.Driver == NULL)
-                {
-                    ConfigPins_SPI4();
-                    
-                    SPI4_PAL.Driver = &SPID4;
-                    palSpi = &SPI4_PAL;
-                }
-                break;
-    #endif
-    #if STM32_SPI_USE_SPI5
-            case 5:
-                if(SPI5_PAL.Driver == NULL)
-                {
-                    ConfigPins_SPI5();
-                    
-                    SPI5_PAL.Driver = &SPID5;
-                    palSpi = &SPI5_PAL;
-                }
-                break;
-    #endif
-    #if STM32_SPI_USE_SPI6
-            case 6:
-                if(SPI6_PAL.Driver == NULL)
-                {
-                    ConfigPins_SPI6();
-                    
-                    SPI6_PAL.Driver = &SPID6;
-                    palSpi = &SPI6_PAL;
-                }
-                break;
-    #endif
-            default:
-                // this SPI bus is not valid
-                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-                break;
-        }
+      #if STM32_SPI_USE_SPI2
+        case 2:
+            if(SPI2_PAL.Driver == NULL)
+            {
+                ConfigPins_SPI2();
+                
+                SPI2_PAL.Driver = &SPID2;
+                palSpi = &SPI2_PAL;
+            }
+            break;
+      #endif
 
-        // compute rough estimate on the time to tx/rx a byte (in milliseconds)
-        ComputeBaudRate(busIndex, pConfig[ SpiConnectionSettings::FIELD___clockFrequency ].NumericByRef().s4, (int32_t&)actualFrequency);
-        palSpi->ByteTime = (1.0 / actualFrequency) * 1000;
+      #if STM32_SPI_USE_SPI3
+        case 3:
+            if(SPI3_PAL.Driver == NULL)
+            {
+                ConfigPins_SPI3();
+                
+                SPI3_PAL.Driver = &SPID3;
+                palSpi = &SPI3_PAL;
+            }
+            break;
+      #endif
+
+      #if STM32_SPI_USE_SPI4
+        case 4:
+            if(SPI4_PAL.Driver == NULL)
+            {
+                ConfigPins_SPI4();
+                
+                SPI4_PAL.Driver = &SPID4;
+                palSpi = &SPI4_PAL;
+            }
+            break;
+      #endif
+
+      #if STM32_SPI_USE_SPI5
+        case 5:
+            if(SPI5_PAL.Driver == NULL)
+            {
+                ConfigPins_SPI5();
+                
+                SPI5_PAL.Driver = &SPID5;
+                palSpi = &SPI5_PAL;
+            }
+            break;
+      #endif
+
+      #if STM32_SPI_USE_SPI6
+        case 6:
+            if(SPI6_PAL.Driver == NULL)
+            {
+                ConfigPins_SPI6();
+                
+                SPI6_PAL.Driver = &SPID6;
+                palSpi = &SPI6_PAL;
+            }
+            break;
+      #endif
+
+        default:
+            // this SPI bus is not valid
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+            break;
     }
+
+    // compute rough estimate on the time to tx/rx a byte (in milliseconds)
+    ComputeBaudRate(busIndex, pConfig[ SpiConnectionSettings::FIELD___clockFrequency ].NumericByRef().s4, actualFrequency);
+    palSpi->ByteTime = (1.0 / actualFrequency) * 1000.0;
+
     NANOCLR_NOCLEANUP();
 }
 

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -667,7 +667,7 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___V
     NANOCLR_HEADER();
 
     uint8_t busIndex;
-    NF_PAL_SPI* palSpi = NULL;
+    NF_PAL_SPI* palSpi;
     int32_t actualFrequency = 0;
     CLR_RT_HeapBlock* pConfig;
     


### PR DESCRIPTION
## Description
- Reorganize code in NativeInit.
- Remove casts from calls to ComputeBaudRate.

## Motivation and Context
- Resolves issues with debug session restarting for STM32 targets using SPI.
- For some reason the build in MinSizeRel (most likely optimizations) was causing issues with the code on this function.

## How Has This Been Tested?<!-- (if applicable) -->
- SPI sample. Now either connected or disconnected from VS the target boots properly.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
