### PR TITLE
Work wireless config ESP32

### DIFF
--- a/src/DeviceInterfaces/System.Net/sys_net_native.h
+++ b/src/DeviceInterfaces/System.Net/sys_net_native.h
@@ -14,16 +14,46 @@
 #include <nanoHAL_time.h>
 #include <corlib_native.h>
 
-// MOVED TO src\PAL\Include\nanoPAL_Sockets.h for convinience
-// typedef enum __nfpack NetworkInterface_UpdateOperation
+// MOVED TO src\HAL\Include\nanoHAL_Network.h for convinience
+// typedef enum __nfpack AddressMode
 // {
-//     NetworkInterface_UpdateOperation_Invalid = 0,
-//     NetworkInterface_UpdateOperation_Dns = 1,
-//     NetworkInterface_UpdateOperation_Dhcp = 2,
-//     NetworkInterface_UpdateOperation_DhcpRenew = 4,
-//     NetworkInterface_UpdateOperation_DhcpRelease = 8,
-//     NetworkInterface_UpdateOperation_Mac = 16,
-// } NetworkInterface_UpdateOperation;
+//     AddressMode_Invalid = 0,
+//     AddressMode_DHCP = 1,
+//     AddressMode_Static = 2,
+//     AddressMode_AutoIP = 3,
+// } AddressMode;
+
+// MOVED TO src\HAL\Include\nanoHAL_Network.h for convinience
+// typedef enum __nfpack AuthenticationType
+// {
+//     AuthenticationType_None = 0,
+//     AuthenticationType_EAP = 1,
+//     AuthenticationType_PEAP = 2,
+//     AuthenticationType_WCN = 3,
+//     AuthenticationType_Open = 4,
+//     AuthenticationType_Shared = 5,
+//     AuthenticationType_WEP = 6,
+//     AuthenticationType_WPA = 7,
+//     AuthenticationType_WPA2 = 8,
+// } AuthenticationType;
+
+// MOVED TO src\HAL\Include\nanoHAL_Network.h for convinience
+// typedef enum __nfpack EncryptionType
+// {
+//     EncryptionType_None = 0,
+//     EncryptionType_WEP = 1,
+//     EncryptionType_WPA = 2,
+//     EncryptionType_WPA2 = 3,
+//     EncryptionType_WPA_PSK = 4,
+//     EncryptionType_WPA2_PSK = 5,
+//     EncryptionType_Certificate = 6,
+// } EncryptionType;
+
+// MOVED TO src\PAL\Include\nanoPAL_Sockets.h for convinience
+// typedef enum __nfpack NetworkChange_NetworkEvents
+// {
+//     NetworkChange_NetworkEvents_NetworkAvailable = 1,
+// } NetworkChange_NetworkEvents;
 
 // MOVED TO src\PAL\Include\nanoPAL_Sockets.h for convinience
 // typedef enum __nfpack NetworkChange_NetworkEventType
@@ -35,10 +65,54 @@
 // } NetworkChange_NetworkEventType;
 
 // MOVED TO src\PAL\Include\nanoPAL_Sockets.h for convinience
-// typedef enum __nfpack NetworkChange_NetworkEvents
+// typedef enum __nfpack NetworkInterface_UpdateOperation
 // {
-//     NetworkChange_NetworkEvents_NetworkAvailable = 1,
-// } NetworkChange_NetworkEvents;
+//     NetworkInterface_UpdateOperation_Invalid = 0,
+//     NetworkInterface_UpdateOperation_Dns = 1,
+//     NetworkInterface_UpdateOperation_Dhcp = 2,
+//     NetworkInterface_UpdateOperation_DhcpRenew = 4,
+//     NetworkInterface_UpdateOperation_DhcpRelease = 8,
+//     NetworkInterface_UpdateOperation_Mac = 16,
+// } NetworkInterface_UpdateOperation;
+
+// MOVED TO src\HAL\Include\nanoHAL_Network.h for convinience
+// typedef enum __nfpack NetworkInterfaceType
+// {
+//     NetworkInterfaceType_Unknown = 1,
+//     NetworkInterfaceType_Ethernet = 6,
+//     NetworkInterfaceType_Wireless80211 = 71,
+//     NetworkInterfaceType_WirelessAP = 72,
+// } NetworkInterfaceType;
+
+// MOVED TO src\HAL\Include\nanoHAL_Network.h for convinience
+// typedef enum __nfpack RadioType
+// {
+//     RadioType_NotSpecified = 0,
+//     RadioType__802_11a = 1,
+//     RadioType__802_11b = 2,
+//     RadioType__802_11g = 4,
+//     RadioType__802_11n = 8,
+// } RadioType;
+
+// MOVED TO src\HAL\Include\nanoHAL_Network.h for convinience
+// typedef enum __nfpack Wireless80211Configuration_ConfigurationOptions
+// {
+//     Wireless80211Configuration_ConfigurationOptions_None = 0,
+//     Wireless80211Configuration_ConfigurationOptions_Disable = 1,
+//     Wireless80211Configuration_ConfigurationOptions_Enable = 2,
+//     Wireless80211Configuration_ConfigurationOptions_AutoConnect = 6,
+//     Wireless80211Configuration_ConfigurationOptions_SmartConfig = 10,
+// } Wireless80211Configuration_ConfigurationOptions;
+
+// MOVED TO src\HAL\Include\nanoHAL_Network.h for convinience
+// typedef enum __nfpack WirelessAPConfiguration_ConfigurationOptions
+// {
+//     WirelessAPConfiguration_ConfigurationOptions_None = 0,
+//     WirelessAPConfiguration_ConfigurationOptions_Disable = 1,
+//     WirelessAPConfiguration_ConfigurationOptions_Enable = 2,
+//     WirelessAPConfiguration_ConfigurationOptions_AutoStart = 6,
+//     WirelessAPConfiguration_ConfigurationOptions_HiddenSSID = 8,
+// } WirelessAPConfiguration_ConfigurationOptions;
 
 struct Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface
 {

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_Wireless80211Configuration.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_Wireless80211Configuration.cpp
@@ -46,7 +46,7 @@ HRESULT Library_sys_net_native_System_Net_NetworkInformation_Wireless80211Config
     pConfig[FIELD___authentication].SetInteger((CLR_UINT32)config.Authentication);
     pConfig[FIELD___encryption].SetInteger((CLR_UINT32)config.Encryption);
     pConfig[FIELD___radio].SetInteger((CLR_UINT32)config.Radio);
-    pConfig[FIELD___options].SetInteger((CLR_UINT8)config.Flags);
+    pConfig[FIELD___options].SetInteger((CLR_UINT8)config.Options);
 
     // the following ones are strings so a simple assignment isn't enough, need to create a managed string instance and copy over 
     // make sure the terminators are there
@@ -79,7 +79,7 @@ HRESULT Library_sys_net_native_System_Net_NetworkInformation_Wireless80211Config
     config.Authentication = (AuthenticationType)pConfig[FIELD___authentication].NumericByRef().u4;
     config.Encryption = (EncryptionType)pConfig[FIELD___encryption].NumericByRef().u4;
     config.Radio = (RadioType)pConfig[FIELD___radio].NumericByRef().u4;
-    config.Flags = (uint8_t)pConfig[FIELD___options].NumericByRef().u1;
+    config.Options = (Wireless80211Configuration_ConfigurationOptions)pConfig[FIELD___options].NumericByRef().u1;
  
     // the following ones are strings
     // make sure the terminators are there

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_WirelessAPConfiguration.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_WirelessAPConfiguration.cpp
@@ -56,7 +56,7 @@ HRESULT Library_sys_net_native_System_Net_NetworkInformation_WirelessAPConfigura
     pConfig[FIELD___apAuthentication].SetInteger((CLR_UINT32)config.Authentication);
     pConfig[FIELD___apEncryption].SetInteger((CLR_UINT32)config.Encryption);
     pConfig[FIELD___apRadio].SetInteger((CLR_UINT32)config.Radio);
-    pConfig[FIELD___options].SetInteger((CLR_UINT8)config.Flags);
+    pConfig[FIELD___options].SetInteger((CLR_UINT8)config.Options);
     pConfig[FIELD___apChannel].SetInteger((CLR_UINT8)config.Channel);
     pConfig[FIELD___apMaxConnections].SetInteger((CLR_UINT8)config.MaxConnections);
  
@@ -99,7 +99,7 @@ HRESULT Library_sys_net_native_System_Net_NetworkInformation_WirelessAPConfigura
     config.Authentication = (AuthenticationType)pConfig[FIELD___apAuthentication].NumericByRef().u4;
     config.Encryption = (EncryptionType)pConfig[FIELD___apEncryption].NumericByRef().u4;
     config.Radio = (RadioType)pConfig[FIELD___apRadio].NumericByRef().u4;
-    config.Flags = (uint8_t)pConfig[FIELD___options].NumericByRef().u1;
+    config.Options = (WirelessAPConfiguration_ConfigurationOptions)pConfig[FIELD___options].NumericByRef().u1;
     config.Channel = (uint8_t)pConfig[FIELD___apChannel].NumericByRef().u1;
     config.MaxConnections = (uint8_t)pConfig[FIELD___apMaxConnections].NumericByRef().u1;
 

--- a/src/HAL/Include/nanoHAL_Network.h
+++ b/src/HAL/Include/nanoHAL_Network.h
@@ -50,11 +50,37 @@ static const unsigned char c_MARKER_CONFIGURATION_X509CAROOTBUNDLE_V1[] = "XB1";
 // Description: network interface type 
 typedef enum __nfpack NetworkInterfaceType
 {
-    NetworkInterfaceType_Unknown        = 1,
-    NetworkInterfaceType_Ethernet       = 6,
-    NetworkInterfaceType_Wireless80211  = 71,
-    NetworkInterfaceType_WirelessAP     = 72,
-}NetworkInterfaceType;
+    NetworkInterfaceType_Unknown = 1,
+    NetworkInterfaceType_Ethernet = 6,
+    NetworkInterfaceType_Wireless80211 = 71,
+    NetworkInterfaceType_WirelessAP = 72,
+} NetworkInterfaceType;
+
+typedef enum __nfpack Wireless80211Configuration_ConfigurationOptions
+{
+    Wireless80211Configuration_ConfigurationOptions_None = 0,
+    // DISABLE Station or AP
+    Wireless80211Configuration_ConfigurationOptions_Disable = 1,
+    // Enable Station or AP ( Wifi component started & memory allocated )
+    Wireless80211Configuration_ConfigurationOptions_Enable = 2,
+    // Wireless station automatically connects on CLR start
+    Wireless80211Configuration_ConfigurationOptions_AutoConnect = 4 | Wireless80211Configuration_ConfigurationOptions_Enable,
+    // Enable Smart config
+    Wireless80211Configuration_ConfigurationOptions_SmartConfig = 8 | Wireless80211Configuration_ConfigurationOptions_Enable,
+} Wireless80211Configuration_ConfigurationOptions;
+
+typedef enum __nfpack WirelessAPConfiguration_ConfigurationOptions
+{
+    WirelessAPConfiguration_ConfigurationOptions_None = 0,
+    // DISABLE Wireless AP
+    WirelessAPConfiguration_ConfigurationOptions_Disable = 1,
+    // Enable Wireless AP ( Wifi component started & memory allocated )
+    WirelessAPConfiguration_ConfigurationOptions_Enable = 2,
+    // Wireless AP automatically starts on CLR start
+    WirelessAPConfiguration_ConfigurationOptions_AutoStart = 4 | WirelessAPConfiguration_ConfigurationOptions_Enable,
+    // Wireless AP uses hidden SSID
+    WirelessAPConfiguration_ConfigurationOptions_HiddenSSID = 8,
+} WirelessAPConfiguration_ConfigurationOptions;
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.AddressMode (in managed code) !!! //
@@ -64,15 +90,15 @@ typedef enum __nfpack NetworkInterfaceType
 // Description: Startup network IP assigning modes
 typedef enum __nfpack AddressMode
 {
-    AddressMode_DHCP       = 0x01,
-    AddressMode_Static     = 0x02,
+    AddressMode_Invalid = 0,
+    AddressMode_DHCP = 1,
+    AddressMode_Static = 2,
 
     ////////////////////////////////////////
     // for this option to be valid 
     // LWIP_AUTOIP (lwIP option) has to be defined
-    AddressMode_AutoIP     = 0x03
-    
-}AddressMode;
+    AddressMode_AutoIP = 3,
+} AddressMode;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.AuthenticationType (in managed code) !!! //
@@ -82,17 +108,16 @@ typedef enum __nfpack AddressMode
 // Description: authentication used in wireless network
 typedef enum __nfpack AuthenticationType
 {
-    AuthenticationType_None     = 0x00,
-    AuthenticationType_EAP      = 0x01,
-    AuthenticationType_PEAP     = 0x02,
-    AuthenticationType_WCN      = 0x03,
-    AuthenticationType_Open     = 0x04,
-    AuthenticationType_Shared   = 0x05,
-    AuthenticationType_WEP      = 0x06,
-    AuthenticationType_WPA      = 0x07,
-    AuthenticationType_WPA2     = 0x08,
-    
-}AuthenticationType;
+    AuthenticationType_None = 0,
+    AuthenticationType_EAP = 1,
+    AuthenticationType_PEAP = 2,
+    AuthenticationType_WCN = 3,
+    AuthenticationType_Open = 4,
+    AuthenticationType_Shared = 5,
+    AuthenticationType_WEP = 6,
+    AuthenticationType_WPA = 7,
+    AuthenticationType_WPA2 = 8,
+} AuthenticationType;
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.EncryptionType (in managed code) !!! //
@@ -102,15 +127,14 @@ typedef enum __nfpack AuthenticationType
 // Description: encryption used in wireless network
 typedef enum __nfpack EncryptionType
 {
-    EncryptionType_None         = 0x00,
-    EncryptionType_WEP          = 0x01,
-    EncryptionType_WPA          = 0x02,
-    EncryptionType_WPA2         = 0x03,
-    EncryptionType_WPA_PSK      = 0x04,
-    EncryptionType_WPA2_PSK     = 0x05,
-    EncryptionType_Certificate  = 0x06,
-    
-}EncryptionType;
+    EncryptionType_None = 0,
+    EncryptionType_WEP = 1,
+    EncryptionType_WPA = 2,
+    EncryptionType_WPA2 = 3,
+    EncryptionType_WPA_PSK = 4,
+    EncryptionType_WPA2_PSK = 5,
+    EncryptionType_Certificate = 6,
+} EncryptionType;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.RadioType (in managed code) !!! //
@@ -120,12 +144,12 @@ typedef enum __nfpack EncryptionType
 // Description: type of radio that the wireless network uses
 typedef enum __nfpack RadioType
 {
-    RadioType_NotSpecified  = 0x00,
-    RadioType_802_11a       = 0x01,
-    RadioType_802_11b       = 0x02,
-    RadioType_802_11g       = 0x03,
-    RadioType_802_11n       = 0x04,
-}RadioType;
+    RadioType_NotSpecified = 0,
+    RadioType__802_11a = 1,
+    RadioType__802_11b = 2,
+    RadioType__802_11g = 4,
+    RadioType__802_11n = 8,
+} RadioType;
 
 typedef struct __nfpack HAL_Configuration_NetworkInterface {
 
@@ -183,22 +207,6 @@ typedef struct __nfpack HAL_Configuration_NetworkInterface {
 
 } HAL_Configuration_NetworkInterface;
 
-typedef enum __nfpack WirelessFlags
-{
-    WirelessFlags_None          = 0x00,
-    WirelessFlags_Enable        = 0x01,     // Enable Station or AP ( Wifi component started & memory allocated )
-    WirelessFlags_Auto          = 0x02,     // Wireless station automatically connects on CLR start
-    WirelessFlags_SmartConfig   = 0x04      // Enable Smart config
-} WirelessFlags;
-
-typedef enum __nfpack WirelessAPFlags
-{
-    WirelessAPFlags_None          = 0x00,
-    WirelessAPFlags_Enable        = 0x01,     // Enable Wireless AP ( Wifi component started & memory allocated )
-    WirelessAPFlags_Auto          = 0x02,     // Wireless AP automatically starts on CLR start
-    WirelessAPFlags_Hidden_SSID   = 0x04,     // Wireless AP uses hidden SSID
-} WirelessAPFlags;
-
 typedef struct __nfpack HAL_Configuration_Wireless80211 {
 
     // this is the marker placeholder for this configuration block
@@ -222,8 +230,8 @@ typedef struct __nfpack HAL_Configuration_Wireless80211 {
     // Network password
     uint8_t Password[64];
 
-    // Wireless Flags, depends if wireless Station
-    uint8_t Flags;
+    // Wireless options (flags), depends if wireless Station
+    Wireless80211Configuration_ConfigurationOptions Options;
 
      // Rssi, station only
 
@@ -252,8 +260,8 @@ typedef struct __nfpack HAL_Configuration_WirelessAP {
     // Network password
     uint8_t Password[64];
 
-    // Wireless Flags for AP
-    uint8_t Flags;
+    // Wireless options for AP (flags)
+    WirelessAPConfiguration_ConfigurationOptions Options;
 
     // channel used for AP
     uint8_t Channel; 

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Target_Network.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Target_Network.cpp
@@ -125,15 +125,21 @@ int  Network_Interface_Connect(int configIndex, const char * ssid, const char * 
 
     if ( GetWirelessConfig(configIndex,  & pWireless) == false )  return SOCK_SOCKET_ERROR;
     
-    pWireless->Flags = WirelessFlags_Enable;
+    pWireless->Options = Wireless80211Configuration_ConfigurationOptions_Enable;
 
     if ( options & NETWORK_CONNECT_RECONNECT)
     {
-        pWireless->Flags |= WirelessFlags_Auto;
+        // need this stupid cast because the current gcc version with ESP32 IDF is not happy with the simple sintax '|='
+        pWireless->Options = 
+            (Wireless80211Configuration_ConfigurationOptions)
+            (pWireless->Options | Wireless80211Configuration_ConfigurationOptions_AutoConnect);
     }
     else
     {
-        pWireless->Flags ^= WirelessFlags_Auto;
+        // need this stupid cast because the current gcc version with ESP32 IDF is not happy with the simple sintax '^='
+        pWireless->Options = 
+            (Wireless80211Configuration_ConfigurationOptions)
+            (pWireless->Options ^ Wireless80211Configuration_ConfigurationOptions_AutoConnect);
     }
 
     // Update Wireless structure with new SSID and passphase

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetHAL_ConfigurationManager.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/targetHAL_ConfigurationManager.cpp
@@ -321,7 +321,11 @@ void InitialiseWirelessDefaultConfig(HAL_Configuration_Wireless80211 * pconfig, 
 	// Set default to Auto Connect + Enable + WirelessFlags_SmartConfig so station can be started by default
 	// Once smart config has run will start up automatically and reconnect of disconnected
 	// Application will have to disable wifi to save power etc
-	pconfig->Flags = (WirelessFlags)(WirelessFlags_Auto | WirelessFlags_Enable | WirelessFlags_SmartConfig);
+	pconfig->Options = 
+		(Wireless80211Configuration_ConfigurationOptions)(
+            Wireless80211Configuration_ConfigurationOptions_AutoConnect | 
+            Wireless80211Configuration_ConfigurationOptions_Enable | 
+            Wireless80211Configuration_ConfigurationOptions_SmartConfig);
 }
 
 //  Default initialisation of wireless config blocks for ESP32 targets
@@ -339,12 +343,12 @@ void InitialiseWirelessAPDefaultConfig(HAL_Configuration_WirelessAP * pconfig, u
 
 	pconfig->Authentication = AuthenticationType_WPA2;
 	pconfig->Encryption = EncryptionType_WPA2;
-	pconfig->Radio = RadioType_802_11n;
+	pconfig->Radio = RadioType__802_11n;
 	pconfig->Channel = 11;
 	pconfig->MaxConnections = 4;
 
 	// Disable Soft AP (default)
-	pconfig->Flags = WirelessAPFlags_None;
+	pconfig->Options = WirelessAPConfiguration_ConfigurationOptions_Disable;
 }
 
 //  Default initialisation of Network interface config blocks for ESP32 targets


### PR DESCRIPTION
## Description
- Update system.net declaration to use generated enums.
- Rework code accordingly.
- Rename Flags to Options on wireless config HAL structs to match managed class.
- Rework code to to use new enum options to disable wireless station and AP.
- Minor changes to code style.

## Motivation and Context
- Fixes storing/retrieving ESP32 config blocks.
- Sync enums in System.Net between managed and native.

## How Has This Been Tested?<!-- (if applicable) -->
- Running SSL sample. 

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
