### PR TITLE
Improve GPIO events for ESP32

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
@@ -91,6 +91,19 @@ void DeleteInputState(GPIO_PIN pinNumber)
 		UnlinkInputState(pState);
 }
 
+void Esp_Gpio_fire_event(gpio_input_state* pState)
+{
+	bool actual = CPU_GPIO_GetPinState(pState->pinNumber);  // get current pin state
+	if (actual == pState->expected)
+	{
+		pState->isrPtr(pState->pinNumber, actual, pState->param);
+		if (pState->mode == GPIO_INT_EDGE_BOTH)
+		{ // both edges
+			pState->expected ^= 1; // update expected state
+		}
+	}
+}
+
 //
 // Debounce Handler, called when timer is complete
 //
@@ -99,15 +112,7 @@ void Esp_Gpio_DebounceHandler(TimerHandle_t xTimer)
 	gpio_input_state* pState = (gpio_input_state*)pvTimerGetTimerID(xTimer);
 	if (pState->isrPtr)
 	{
-		bool actual = CPU_GPIO_GetPinState(pState->pinNumber);  // get current pin state
-		if (actual == pState->expected)
-		{
-			pState->isrPtr(pState->pinNumber, actual, pState->param);
-			if (pState->mode == GPIO_INT_EDGE_BOTH)
-			{ // both edges
-				pState->expected ^= 1; // update expected state
-			}
-		}
+		Esp_Gpio_fire_event(pState);
 	}
 
 	pState->waitingDebounce = false;
@@ -211,31 +216,32 @@ static void gpio_isr(void * arg)
 {
 	NATIVE_INTERRUPT_START
 
-	gpio_input_state * pGpio = (gpio_input_state *)arg;;
+	gpio_input_state * pState = (gpio_input_state *)arg;;
 
 	// Ignore any pin changes during debounce
-	if (pGpio->waitingDebounce) return;
+	if (pState->waitingDebounce) return;
 
 	// If user ISR available then call it
-	if (pGpio->isrPtr)
+	if (pState->isrPtr)
 	{
-		if (pGpio->debounceMs > 0)
+		if (pState->debounceMs > 0)
 		{
-			pGpio->waitingDebounce = true;
+			pState->waitingDebounce = true;
 
-			if (pGpio->debounceTimer == 0)
+			if (pState->debounceTimer == 0)
 			{
 				// Create timer if it doesn't already exist for this pin
-				pGpio->debounceTimer = xTimerCreate("debounce", 100, pdFALSE, (void*)pGpio, Esp_Gpio_DebounceHandler);
+				pState->debounceTimer = xTimerCreate("debounce", 100, pdFALSE, (void*)pState, Esp_Gpio_DebounceHandler);
 			}
 
-			// Start Debounce timer
-			xTimerChangePeriodFromISR(pGpio->debounceTimer, pdMS_TO_TICKS(pGpio->debounceMs), pdFALSE);
+			// Start Debounce timer (minimum 1 freeRtos tick(10ms) )
+			int ticks = pdMS_TO_TICKS(pState->debounceMs);
+			if (ticks == 0) ticks = 1;
+			xTimerChangePeriodFromISR(pState->debounceTimer, ticks, pdFALSE);
 		}
 		else
 		{
-			bool PinState = gpio_get_level((gpio_num_t)pGpio->pinNumber) == 1;
-			pGpio->isrPtr(pGpio->pinNumber, PinState, pGpio->param);
+			Esp_Gpio_fire_event(pState);
 		}
 	}
 


### PR DESCRIPTION
## Description
Improves the ESP32 events so that it always toggles between high, low and doesn't fire more than 1 event of same level. This only happened when no de bounce was used. 

Another fix was added to not allow a debounceTimeout of less than 10ms as this can cause an internal exception when it tries to create a Freertos timer of 0 ticks

## Motivation and Context
The main problem for this issue 630 is a combination of not using debounceTimeout and a previous fix that stopped the input Pull up drive mode working.

- Resolves nanoFramework/Home#630

## How Has This Been Tested?<!-- (if applicable) -->`
Tested with modified version of sample program with simple reads of value and gpio events.
Checked drive mode pull up working.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
