### PR TITLE
Fix inclusion of Interop assemblies through CMake build option

### DIFF
--- a/.vscode/cmake-variants.TEMPLATE.json
+++ b/.vscode/cmake-variants.TEMPLATE.json
@@ -74,10 +74,7 @@
           "NF_FEATURE_USE_SPIFFS": "OFF-default-ON-to-enable-support-for-SPI-flash-file-system",
           "NF_PLATFORM_NO_CLR_TRACE": "OFF-default-ON-to-disable-all-trace-on-CLR",
           "NF_CLR_NO_IL_INLINE": "OFF-default-ON-to-disable-CLR-IL-inlining",
-          "NF_INTEROP_ASSEMBLIES": [
-            "Assembly1-Namespace",
-            "Assembly2-Namespace"
-          ],
+          "NF_INTEROP_ASSEMBLIES": "assembly-namespaces-separated-by-whitespace-leave-empty-to-NOT-include-any-interop-assemblies",
           "NF_NETWORKING_SNTP": "ON-default-to-add-SNTP-client-requires-networking",
           "NF_SECURITY_MBEDTLS": "OFF-default-ON-to-add-network-security-from-mbedTLS",
           "MBEDTLS_SOURCE": "<path-to-mbedtls-source-mind-the-forward-slashes>",

--- a/CMake/Modules/NF_NativeAssemblies.cmake
+++ b/CMake/Modules/NF_NativeAssemblies.cmake
@@ -320,8 +320,13 @@ macro(ParseInteropAssemblies)
     # check if there are any Interop assemblies to be added
     if(NF_INTEROP_ASSEMBLIES)
 
+        # need to split define containing assembly namespaces
+        # for Windows buids this is a string with the namespaces separated by an whitespace
+        # e.g.: "NF_INTEROP_ASSEMBLIES": "Assembly1_Namespace Assembly2_Namespace"
+        separate_arguments(INTEROP_ASSEMBLIES_LIST NATIVE_COMMAND ${NF_INTEROP_ASSEMBLIES})
+
         # loop through each Interop assembly and add it to the build
-        foreach(assembly ${NF_INTEROP_ASSEMBLIES})
+        foreach(assembly ${INTEROP_ASSEMBLIES_LIST})
             PerformSettingsForInteropEntry(${assembly})
         endforeach()
        

--- a/CMakeSettings.SAMPLE.json
+++ b/CMakeSettings.SAMPLE.json
@@ -160,8 +160,8 @@
         },
         {
           "name": "NF_INTEROP_ASSEMBLIES",
-          "value": "False",
-          "type": "BOOL"
+          "value": "Assembly1_Namespace Assembly2_Namespace",
+          "type": "STRING"
         },
         {
           "name": "NF_NETWORKING_SNTP",
@@ -420,8 +420,8 @@
         },
         {
           "name": "NF_INTEROP_ASSEMBLIES",
-          "value": "OFF",
-          "type": "BOOL"
+          "value": "Assembly1_Namespace Assembly2_Namespace",
+          "type": "STRING"
         },
         {
           "name": "NF_NETWORKING_SNTP",

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -141,7 +141,7 @@
         },
         {
           "name": "NF_INTEROP_ASSEMBLIES",
-          "value": "OFF"
+          "value": ""
         },
         {
           "name": "NF_NETWORKING_SNTP",
@@ -367,8 +367,8 @@
           "value": "OFF"
         },
         {
-          "name": "NF_INTEROP_ASSEMBLIES:BOOL", //OFF-default-ON-to-disable-CLR-IL-inlining
-          "value": "OFF"
+          "name": "NF_INTEROP_ASSEMBLIES:STRING", //empty-to-NOT-include-any-interop-assemblies
+          "value": ""
         },
         {
           "name": "NF_NETWORKING_SNTP:BOOL", //ON-default-to-add-SNTP-client-requires-networking


### PR DESCRIPTION
## Description
- CMake option is now a string and namespaces are separated by whitespace.
- Add code to split by whitespace.
- Update templates and VS cmake-settings.json too.

## Motivation and Context
- Resolves nanoFramework/Home#580.

## How Has This Been Tested?<!-- (if applicable) -->
- Running a test build defining 2 Interop assemblies.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
