### PR TITLE
Improve HAL Initialize/Uninitialize

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_target.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_target.h
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-
 #ifndef _WIN_DEV_ADC_NATIVE_TARGET_H_
 #define _WIN_DEV_ADC_NATIVE_TARGET_H_
 
@@ -12,13 +11,13 @@
 
 typedef struct
 {
-    uint8_t         adcIndex;
-    stm32_gpio_t*   portId;
-    uint8_t         pin;
-    uint32_t        adcChannel;
+    uint8_t adcIndex;
+    stm32_gpio_t *portId;
+    uint8_t pin;
+    uint32_t adcChannel;
 } NF_PAL_ADC_PORT_PIN_CHANNEL;
 
 extern const NF_PAL_ADC_PORT_PIN_CHANNEL AdcPortPinConfig[];
 extern const int AdcChannelCount;
 
-#endif  //_WIN_DEV_ADC_NATIVE_TARGET_H_
+#endif //_WIN_DEV_ADC_NATIVE_TARGET_H_

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_target.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_target.h
@@ -10,13 +10,13 @@
 #include <hal.h>
 #include <win_dev_adc_native.h>
 
-struct NF_PAL_ADC_PORT_PIN_CHANNEL
+typedef struct
 {
     uint8_t         adcIndex;
     stm32_gpio_t*   portId;
     uint8_t         pin;
     uint32_t        adcChannel;
-};
+} NF_PAL_ADC_PORT_PIN_CHANNEL;
 
 extern const NF_PAL_ADC_PORT_PIN_CHANNEL AdcPortPinConfig[];
 extern const int AdcChannelCount;

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -16,30 +16,36 @@ typedef Library_win_dev_i2c_native_Windows_Devices_I2c_I2cConnectionSettings I2c
 // I2C PAL strucs declared in win_dev_i2c_native.h //
 /////////////////////////////////////////////////////
 #if STM32_I2C_USE_I2C1
-    NF_PAL_I2C I2C1_PAL;
+NF_PAL_I2C I2C1_PAL;
 #endif
 #if STM32_I2C_USE_I2C2
-    NF_PAL_I2C I2C2_PAL;
+NF_PAL_I2C I2C2_PAL;
 #endif
 #if STM32_I2C_USE_I2C3
-    NF_PAL_I2C I2C3_PAL;
+NF_PAL_I2C I2C3_PAL;
 #endif
 #if STM32_I2C_USE_I2C4
-    NF_PAL_I2C I2C4_PAL;
+NF_PAL_I2C I2C4_PAL;
 #endif
-
 
 // ChibiOS I2C working thread
 static THD_FUNCTION(I2CWorkingThread, arg)
 {
-    NF_PAL_I2C* palI2c = (NF_PAL_I2C*)arg;
+    NF_PAL_I2C *palI2c = (NF_PAL_I2C *)arg;
     msg_t result;
     int estimatedDurationMiliseconds = palI2c->ByteTime * (palI2c->WriteSize + palI2c->ReadSize + 1);
 
     if (palI2c->ReadSize != 0 && palI2c->WriteSize != 0)
     {
         // this is a Write/Read transaction
-       result = i2cMasterTransmitTimeout(palI2c->Driver, palI2c->Address, palI2c->WriteBuffer, palI2c->WriteSize, palI2c->ReadBuffer, palI2c->ReadSize, TIME_MS2I(estimatedDurationMiliseconds));
+        result = i2cMasterTransmitTimeout(
+            palI2c->Driver,
+            palI2c->Address,
+            palI2c->WriteBuffer,
+            palI2c->WriteSize,
+            palI2c->ReadBuffer,
+            palI2c->ReadSize,
+            TIME_MS2I(estimatedDurationMiliseconds));
     }
     else
     {
@@ -49,7 +55,14 @@ static THD_FUNCTION(I2CWorkingThread, arg)
 
             estimatedDurationMiliseconds = palI2c->ByteTime * (palI2c->WriteSize + 1);
 
-            result = i2cMasterTransmitTimeout(palI2c->Driver, palI2c->Address, palI2c->WriteBuffer, palI2c->WriteSize, NULL, 0, TIME_MS2I(estimatedDurationMiliseconds));
+            result = i2cMasterTransmitTimeout(
+                palI2c->Driver,
+                palI2c->Address,
+                palI2c->WriteBuffer,
+                palI2c->WriteSize,
+                NULL,
+                0,
+                TIME_MS2I(estimatedDurationMiliseconds));
         }
         else
         {
@@ -57,7 +70,12 @@ static THD_FUNCTION(I2CWorkingThread, arg)
 
             estimatedDurationMiliseconds = palI2c->ByteTime * (palI2c->ReadSize + 1);
 
-            result = i2cMasterReceiveTimeout (palI2c->Driver, palI2c->Address, palI2c->ReadBuffer, palI2c->ReadSize, TIME_MS2I(estimatedDurationMiliseconds));
+            result = i2cMasterReceiveTimeout(
+                palI2c->Driver,
+                palI2c->Address,
+                palI2c->ReadBuffer,
+                palI2c->ReadSize,
+                TIME_MS2I(estimatedDurationMiliseconds));
         }
     }
 
@@ -67,20 +85,19 @@ static THD_FUNCTION(I2CWorkingThread, arg)
     chThdExit(result);
 }
 
-void GetI2cConfig(CLR_RT_HeapBlock* managedConfig, I2CConfig* llConfig)
+void GetI2cConfig(CLR_RT_HeapBlock *managedConfig, I2CConfig *llConfig)
 {
-    I2cBusSpeed busSpeed = (I2cBusSpeed)managedConfig[ I2cConnectionSettings::FIELD___busSpeed ].NumericByRef().s4;
+    I2cBusSpeed busSpeed = (I2cBusSpeed)managedConfig[I2cConnectionSettings::FIELD___busSpeed].NumericByRef().s4;
 
-    // set the LL I2C configuration (according to I2C driver version)
-    #if defined(STM32F1XX) || defined(STM32F4XX) || defined(STM32L1XX)
+// set the LL I2C configuration (according to I2C driver version)
+#if defined(STM32F1XX) || defined(STM32F4XX) || defined(STM32L1XX)
 
     llConfig->op_mode = OPMODE_I2C;
     llConfig->clock_speed = busSpeed == I2cBusSpeed_StandardMode ? 100000U : 400000U;
     llConfig->duty_cycle = busSpeed == I2cBusSpeed_StandardMode ? STD_DUTY_CYCLE : FAST_DUTY_CYCLE_2;
 
-    #elif defined(STM32F7XX) || defined(STM32F3XX) || defined(STM32F0XX) || \
-            defined(STM32L0XX) ||  defined(STM32L4XX) || \
-            defined(STM32H7XX) 
+#elif defined(STM32F7XX) || defined(STM32F3XX) || defined(STM32F0XX) || defined(STM32L0XX) || defined(STM32L4XX) ||    \
+    defined(STM32H7XX)
 
     // Standard mode : 100 KHz, Rise time 120 ns, Fall time 25 ns, 54MHz clock source
     // Fast mode : 400 KHz, Rise time 120 ns, Fall time 25 ns, 54MHz clock source
@@ -89,57 +106,62 @@ void GetI2cConfig(CLR_RT_HeapBlock* managedConfig, I2CConfig* llConfig)
     llConfig->cr1 = 0;
     llConfig->cr2 = 0;
 
-    #else
-        #error Your board is unimplemented. Please provide the needed information for the realtime OS as done above!
-    #endif
-
+#else
+#error Your board is unimplemented. Please provide the needed information for the realtime OS as done above!
+#endif
 }
 
 // estimate the time required to perform the I2C transaction
-bool IsLongRunningOperation(uint16_t writeSize, uint16_t readSize, float byteTime, uint32_t& estimatedDurationMiliseconds)
+bool IsLongRunningOperation(
+    uint16_t writeSize,
+    uint16_t readSize,
+    float byteTime,
+    uint32_t &estimatedDurationMiliseconds)
 {
     // add an extra byte to account for the address
     estimatedDurationMiliseconds = byteTime * (writeSize + readSize + 1);
 
-    if(estimatedDurationMiliseconds > CLR_RT_Thread::c_TimeQuantum_Milliseconds)
+    if (estimatedDurationMiliseconds > CLR_RT_Thread::c_TimeQuantum_Milliseconds)
     {
         // total operation time will exceed thread quantum, so this is a long running operation
         return true;
     }
     else
     {
-        return false;        
+        return false;
     }
 }
 
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID( CLR_RT_StackFrame& stack )
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
 
-    NF_PAL_I2C* palI2c = NULL;
-    CLR_RT_HeapBlock* pConfig;
+    NF_PAL_I2C *palI2c = NULL;
+    CLR_RT_HeapBlock *pConfig;
     uint8_t busIndex;
 
     // get a pointer to the managed object instance and check that it's not NULL
-    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
-    
+    CLR_RT_HeapBlock *pThis = stack.This();
+    FAULT_ON_NULL(pThis);
+
     // get a pointer to the managed I2C connectionSettings object instance
-    pConfig = pThis[ FIELD___connectionSettings ].Dereference();
+    pConfig = pThis[FIELD___connectionSettings].Dereference();
 
     // get bus index
     // this is coded with a multiplication, need to perform and int division to get the number
     // see the comments in the I2cDevice() constructor in managed code for details
-    busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
+    busIndex = (uint8_t)(pThis[FIELD___deviceId].NumericByRef().s4 / 1000);
 
     // config GPIO pins used by the I2C peripheral
     // init the PAL struct for this I2C bus and assign the respective driver
     // all this occurs if not already done
-    // why do we need to check if this is already done? because several I2cDevice objects can be created associated to the same bus just using different addresses
+    // why do we need to check if this is already done? because several I2cDevice objects can be created associated to
+    // the same bus just using different addresses
     switch (busIndex)
     {
 #if STM32_I2C_USE_I2C1
         case 1:
-            if(I2C1_PAL.Driver == NULL)
+            if (I2C1_PAL.Driver == NULL)
             {
                 ConfigPins_I2C1();
 
@@ -150,7 +172,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
 #endif
 #if STM32_I2C_USE_I2C2
         case 2:
-            if(I2C2_PAL.Driver == NULL)
+            if (I2C2_PAL.Driver == NULL)
             {
                 ConfigPins_I2C2();
 
@@ -161,7 +183,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
 #endif
 #if STM32_I2C_USE_I2C3
         case 3:
-            if(I2C3_PAL.Driver == NULL)
+            if (I2C3_PAL.Driver == NULL)
             {
                 ConfigPins_I2C3();
 
@@ -172,7 +194,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
 #endif
 #if STM32_I2C_USE_I2C4
         case 4:
-            if(I2C4_PAL.Driver == NULL)
+            if (I2C4_PAL.Driver == NULL)
             {
                 ConfigPins_I2C4();
 
@@ -192,7 +214,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
     GetI2cConfig(pConfig, &palI2c->Configuration);
 
     // compute rough estimate on the time to tx/rx a byte (in milliseconds)
-    if((I2cBusSpeed)pConfig[ I2cConnectionSettings::FIELD___busSpeed ].NumericByRef().s4 == I2cBusSpeed_StandardMode)
+    if ((I2cBusSpeed)pConfig[I2cConnectionSettings::FIELD___busSpeed].NumericByRef().s4 == I2cBusSpeed_StandardMode)
     {
         // 100kbit/s: this is roughly 0.10ms per byte, give or take
         palI2c->ByteTime = 0.1;
@@ -206,7 +228,8 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose___VOID__BOOLEAN( CLR_RT_StackFrame& stack )
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose___VOID__BOOLEAN(
+    CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
 
@@ -214,56 +237,57 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose_
     bool disposeController = false;
 
     // get a pointer to the managed object instance and check that it's not NULL
-    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+    CLR_RT_HeapBlock *pThis = stack.This();
+    FAULT_ON_NULL(pThis);
 
     // get disposeController
     disposeController = (bool)stack.Arg0().NumericByRef().u1;
 
-    if(disposeController)
+    if (disposeController)
     {
         // get bus index
         // this is coded with a multiplication, need to perform and int division to get the number
         // see the comments in the I2cDevice() constructor in managed code for details
-        busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
+        busIndex = (uint8_t)(pThis[FIELD___deviceId].NumericByRef().s4 / 1000);
 
         // get the driver for the I2C bus
         switch (busIndex)
         {
-          #if STM32_I2C_USE_I2C1
-            case 1 :
+#if STM32_I2C_USE_I2C1
+            case 1:
                 // deactivates the I2C peripheral
                 i2cStop(&I2CD1);
                 // nulls driver
                 I2C1_PAL.Driver = NULL;
                 break;
-          #endif
+#endif
 
-          #if STM32_I2C_USE_I2C2
-            case 2 :
+#if STM32_I2C_USE_I2C2
+            case 2:
                 // deactivates the I2C peripheral
                 i2cStop(&I2CD2);
                 // nulls driver
                 I2C2_PAL.Driver = NULL;
                 break;
-          #endif
+#endif
 
-          #if STM32_I2C_USE_I2C3
-            case 3 :
+#if STM32_I2C_USE_I2C3
+            case 3:
                 // deactivates the I2C peripheral
                 i2cStop(&I2CD3);
                 // nulls driver
                 I2C3_PAL.Driver = NULL;
                 break;
-          #endif
+#endif
 
-          #if STM32_I2C_USE_I2C4
-            case 4 :
+#if STM32_I2C_USE_I2C4
+            case 4:
                 // deactivates the I2C peripheral
                 i2cStop(&I2CD4);
                 // nulls driver
                 I2C4_PAL.Driver = NULL;
                 break;
-          #endif
+#endif
 
             default:
                 // the requested I2C bus is not valid
@@ -275,58 +299,60 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose_
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1( CLR_RT_StackFrame& stack )
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::
+    NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
     {
         uint8_t busIndex;
-        NF_PAL_I2C* palI2c = NULL;
+        NF_PAL_I2C *palI2c = NULL;
         bool isLongRunningOperation = false;
         msg_t transactionResult = MSG_OK;
 
-        CLR_RT_HeapBlock    hbTimeout;
-        CLR_INT64*          timeout;
-        bool                eventResult = true;
-        uint32_t            estimatedDurationMiliseconds;
+        CLR_RT_HeapBlock hbTimeout;
+        CLR_INT64 *timeout;
+        bool eventResult = true;
+        uint32_t estimatedDurationMiliseconds;
 
-        CLR_RT_HeapBlock_Array* writeBuffer;
-        CLR_RT_HeapBlock_Array* readBuffer;
-        CLR_RT_HeapBlock*       result;
+        CLR_RT_HeapBlock_Array *writeBuffer;
+        CLR_RT_HeapBlock_Array *readBuffer;
+        CLR_RT_HeapBlock *result;
 
         // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+        CLR_RT_HeapBlock *pThis = stack.This();
+        FAULT_ON_NULL(pThis);
 
         // get pointer to connection settings field
-        CLR_RT_HeapBlock* connectionSettings = pThis[ FIELD___connectionSettings ].Dereference();
+        CLR_RT_HeapBlock *connectionSettings = pThis[FIELD___connectionSettings].Dereference();
 
         // get bus index
         // this is coded with a multiplication, need to perform and int division to get the number
         // see the comments in the I2cDevice() constructor in managed code for details
-        busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
+        busIndex = (uint8_t)(pThis[FIELD___deviceId].NumericByRef().s4 / 1000);
 
         // get the driver for the I2C bus
         switch (busIndex)
         {
-    #if STM32_I2C_USE_I2C1
-            case 1 :
+#if STM32_I2C_USE_I2C1
+            case 1:
                 palI2c = &I2C1_PAL;
                 break;
-    #endif
-    #if STM32_I2C_USE_I2C2
-            case 2 :
+#endif
+#if STM32_I2C_USE_I2C2
+            case 2:
                 palI2c = &I2C2_PAL;
                 break;
-    #endif
-    #if STM32_I2C_USE_I2C3
-            case 3 :
+#endif
+#if STM32_I2C_USE_I2C3
+            case 3:
                 palI2c = &I2C3_PAL;
                 break;
-    #endif
-    #if STM32_I2C_USE_I2C4
-            case 4 :
+#endif
+#if STM32_I2C_USE_I2C4
+            case 4:
                 palI2c = &I2C4_PAL;
                 break;
-    #endif
+#endif
             default:
                 // the requested I2C bus is not valid
                 NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
@@ -359,35 +385,43 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
         }
 
         // check if this is a long running operation
-        isLongRunningOperation = IsLongRunningOperation(palI2c->WriteSize, palI2c->ReadSize, palI2c->ByteTime, (uint32_t&)estimatedDurationMiliseconds);
+        isLongRunningOperation = IsLongRunningOperation(
+            palI2c->WriteSize,
+            palI2c->ReadSize,
+            palI2c->ByteTime,
+            (uint32_t &)estimatedDurationMiliseconds);
 
-        if(isLongRunningOperation)
+        if (isLongRunningOperation)
         {
-            // if this is a long running operation, set a timeout equal to the estimated transaction duration in milliseconds
-            // this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() below
+            // if this is a long running operation, set a timeout equal to the estimated transaction duration in
+            // milliseconds this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() below
             hbTimeout.SetInteger((CLR_INT64)estimatedDurationMiliseconds * TIME_CONVERSION__TO_MILLISECONDS);
 
-            NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks( hbTimeout, timeout ));
-            
+            NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
+
             // protect the buffers from GC so DMA can find them where they are supposed to be
-            CLR_RT_ProtectFromGC gcWriteBuffer( *writeBuffer );
-            CLR_RT_ProtectFromGC gcReadBuffer( *readBuffer );
+            CLR_RT_ProtectFromGC gcWriteBuffer(*writeBuffer);
+            CLR_RT_ProtectFromGC gcReadBuffer(*readBuffer);
         }
 
         // this is going to be used to check for the right event in case of simultaneous I2C transaction
-        if(!isLongRunningOperation || stack.m_customState == 1)
+        if (!isLongRunningOperation || stack.m_customState == 1)
         {
             // get slave address from connection settings field
-            palI2c->Address = (i2caddr_t)connectionSettings[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cConnectionSettings::FIELD___slaveAddress].NumericByRef().s4;
+            palI2c->Address =
+                (i2caddr_t)connectionSettings
+                    [Library_win_dev_i2c_native_Windows_Devices_I2c_I2cConnectionSettings::FIELD___slaveAddress]
+                        .NumericByRef()
+                        .s4;
 
             // when using I2Cv1 driver the address needs to be loaded in the I2C driver struct
-    #if defined(STM32F1XX) || defined(STM32F4XX) || defined(STM32L1XX)
+#if defined(STM32F1XX) || defined(STM32F4XX) || defined(STM32L1XX)
             palI2c->Driver->addr = palI2c->Address;
-    #endif
+#endif
 
             if (writeBuffer != NULL)
             {
-                palI2c->WriteBuffer = (uint8_t*)writeBuffer->GetFirstElement();
+                palI2c->WriteBuffer = (uint8_t *)writeBuffer->GetFirstElement();
 
                 // flush DMA buffer to ensure cache coherency
                 // (only required for Cortex-M7)
@@ -396,29 +430,34 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
 
             if (readBuffer != NULL)
             {
-                palI2c->ReadBuffer = (uint8_t*)readBuffer->GetFirstElement();
+                palI2c->ReadBuffer = (uint8_t *)readBuffer->GetFirstElement();
             }
-            
+
             // because the bus access is shared, acquire the appropriate bus
             i2cAcquireBus(palI2c->Driver);
             i2cStart(palI2c->Driver, &palI2c->Configuration);
         }
 
-        if(isLongRunningOperation)
+        if (isLongRunningOperation)
         {
             // this is a long running operation and hasn't started yet
             // perform I2C transaction using driver's ASYNC API which is launching a thread to perform it
-            if(stack.m_customState == 1)
+            if (stack.m_customState == 1)
             {
                 // spawn working thread to perform the I2C transaction
-                palI2c->WorkingThread = chThdCreateFromHeap(NULL, THD_WORKING_AREA_SIZE(256),
-                                            "I2CWT", NORMALPRIO, I2CWorkingThread, palI2c);
+                palI2c->WorkingThread = chThdCreateFromHeap(
+                    NULL,
+                    THD_WORKING_AREA_SIZE(256),
+                    "I2CWT",
+                    NORMALPRIO,
+                    I2CWorkingThread,
+                    palI2c);
 
-                if(palI2c->WorkingThread == NULL)
+                if (palI2c->WorkingThread == NULL)
                 {
                     NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
                 }
-                
+
                 // bump custom state
                 stack.m_customState = 2;
             }
@@ -431,48 +470,71 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
             if (palI2c->ReadSize != 0 && palI2c->WriteSize != 0)
             {
                 // this is a Write/Read transaction
-                transactionResult = i2cMasterTransmitTimeout(palI2c->Driver, palI2c->Address, palI2c->WriteBuffer, palI2c->WriteSize, palI2c->ReadBuffer, palI2c->ReadSize, TIME_MS2I(20));
+                transactionResult = i2cMasterTransmitTimeout(
+                    palI2c->Driver,
+                    palI2c->Address,
+                    palI2c->WriteBuffer,
+                    palI2c->WriteSize,
+                    palI2c->ReadBuffer,
+                    palI2c->ReadSize,
+                    TIME_MS2I(20));
             }
             else
             {
                 if (palI2c->ReadSize == 0)
                 {
                     // this is Write only transaction
-                    transactionResult = i2cMasterTransmitTimeout(palI2c->Driver, palI2c->Address, palI2c->WriteBuffer, palI2c->WriteSize, NULL, 0, TIME_MS2I(20));
+                    transactionResult = i2cMasterTransmitTimeout(
+                        palI2c->Driver,
+                        palI2c->Address,
+                        palI2c->WriteBuffer,
+                        palI2c->WriteSize,
+                        NULL,
+                        0,
+                        TIME_MS2I(20));
                 }
                 else
                 {
                     // this is a Read only transaction
-                    transactionResult = i2cMasterReceiveTimeout (palI2c->Driver, palI2c->Address, palI2c->ReadBuffer, palI2c->ReadSize, TIME_MS2I(20));
+                    transactionResult = i2cMasterReceiveTimeout(
+                        palI2c->Driver,
+                        palI2c->Address,
+                        palI2c->ReadBuffer,
+                        palI2c->ReadSize,
+                        TIME_MS2I(20));
                 }
             }
-        }    
+        }
 
-        while(eventResult)
+        while (eventResult)
         {
-            if(!isLongRunningOperation)
+            if (!isLongRunningOperation)
             {
                 // this is not a long running operation so nothing to do here
                 break;
             }
 
-            if(palI2c->WorkingThread->state == CH_STATE_FINAL)
+            if (palI2c->WorkingThread->state == CH_STATE_FINAL)
             {
                 // I2C working thread is now complete
                 break;
             }
 
             // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
-            NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents( stack.m_owningThread, *timeout, CLR_RT_ExecutionEngine::c_Event_I2cMaster, eventResult ));
+            NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents(
+                stack.m_owningThread,
+                *timeout,
+                CLR_RT_ExecutionEngine::c_Event_I2cMaster,
+                eventResult));
         }
 
-        if(isLongRunningOperation)
+        if (isLongRunningOperation)
         {
             // pop timeout heap block from stack
             stack.PopValue();
         }
 
-        if(eventResult || !isLongRunningOperation)
+        if (eventResult || !isLongRunningOperation)
         {
             // event occurred
             // OR this is NOT a long running operation
@@ -480,14 +542,18 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
             i2cReleaseBus(palI2c->Driver);
 
             // create the return object (I2cTransferResult)
-            // only at this point we are sure that there will be a return from this thread so it's OK to use the managed stack
-            CLR_RT_HeapBlock& top = stack.PushValueAndClear();
-            NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
-            result = top.Dereference(); FAULT_ON_NULL(result);
+            // only at this point we are sure that there will be a return from this thread so it's OK to use the managed
+            // stack
+            CLR_RT_HeapBlock &top = stack.PushValueAndClear();
+            NANOCLR_CHECK_HRESULT(
+                g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+            result = top.Dereference();
+            FAULT_ON_NULL(result);
 
-            if(isLongRunningOperation)
+            if (isLongRunningOperation)
             {
-                // ChibiOS requirement: need to call chThdWait for I2C working thread in order to have it's memory released to the heap, otherwise it won't be returned
+                // ChibiOS requirement: need to call chThdWait for I2C working thread in order to have it's memory
+                // released to the heap, otherwise it won't be returned
                 transactionResult = chThdWait(palI2c->WorkingThread);
             }
 
@@ -496,43 +562,49 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
             {
                 // error in transaction
                 int errors = i2cGetErrors(palI2c->Driver);
-                
+
                 // figure out what was the error and set the status field
-                switch(errors)
+                switch (errors)
                 {
                     case I2C_ACK_FAILURE:
-                        result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status ].SetInteger((CLR_UINT32)I2cTransferStatus_SlaveAddressNotAcknowledged);
+                        result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status]
+                            .SetInteger((CLR_UINT32)I2cTransferStatus_SlaveAddressNotAcknowledged);
                         break;
 
                     case I2C_TIMEOUT:
-                        result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status ].SetInteger((CLR_UINT32)I2cTransferStatus_ClockStretchTimeout);
+                        result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status]
+                            .SetInteger((CLR_UINT32)I2cTransferStatus_ClockStretchTimeout);
                         break;
 
                     default:
-                        result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status ].SetInteger((CLR_UINT32)I2cTransferStatus_UnknownError);
+                        result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status]
+                            .SetInteger((CLR_UINT32)I2cTransferStatus_UnknownError);
                 }
 
-                // set the bytes transferred count to 0 because we don't have a way to know how many bytes were actually sent/received
-                result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___bytesTransferred ].SetInteger(0);
+                // set the bytes transferred count to 0 because we don't have a way to know how many bytes were actually
+                // sent/received
+                result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___bytesTransferred]
+                    .SetInteger(0);
             }
             else
             {
                 // successfull transaction
                 // set the result field
-                result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status ].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
+                result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status].SetInteger(
+                    (CLR_UINT32)I2cTransferStatus_FullTransfer);
 
                 // set the bytes transferred field
-                result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___bytesTransferred ].SetInteger((CLR_UINT32)(palI2c->WriteSize + palI2c->ReadSize));
+                result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___bytesTransferred]
+                    .SetInteger((CLR_UINT32)(palI2c->WriteSize + palI2c->ReadSize));
             }
-        
-            if(palI2c->ReadSize > 0)
+
+            if (palI2c->ReadSize > 0)
             {
                 // invalidate cache over read buffer to ensure that content from DMA is read
                 // (only required for Cortex-M7)
                 cacheBufferInvalidate(palI2c->ReadBuffer, palI2c->ReadSize);
             }
         }
-
     }
     NANOCLR_NOCLEANUP();
 }

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_target.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_target.h
@@ -9,47 +9,53 @@
 #include <win_dev_i2c_native.h>
 #include <hal.h>
 
-// struct representing the I2C 
+// struct representing the I2C
 typedef struct NF_PAL_I2C_
 {
-    I2CDriver*  Driver;
-    I2CConfig   Configuration;
-    thread_t*   WorkingThread;
-    i2caddr_t   Address;
+    I2CDriver *Driver;
+    I2CConfig Configuration;
+    thread_t *WorkingThread;
+    i2caddr_t Address;
     float ByteTime;
 
-    uint8_t* WriteBuffer;
-    uint8_t  WriteSize;
+    uint8_t *WriteBuffer;
+    uint8_t WriteSize;
 
-    uint8_t* ReadBuffer;
-    uint8_t  ReadSize;
+    uint8_t *ReadBuffer;
+    uint8_t ReadSize;
 } NF_PAL_I2C;
 
 ///////////////////////////////////////////
 // declaration of the the I2C PAL strucs //
 ///////////////////////////////////////////
 #if STM32_I2C_USE_I2C1
-    extern NF_PAL_I2C I2C1_PAL;
+extern NF_PAL_I2C I2C1_PAL;
 #endif
 #if STM32_I2C_USE_I2C2
-    extern NF_PAL_I2C I2C2_PAL;
+extern NF_PAL_I2C I2C2_PAL;
 #endif
 #if STM32_I2C_USE_I2C3
-    extern NF_PAL_I2C I2C3_PAL;
+extern NF_PAL_I2C I2C3_PAL;
 #endif
 #if STM32_I2C_USE_I2C4
-    extern NF_PAL_I2C I2C4_PAL;
+extern NF_PAL_I2C I2C4_PAL;
 #endif
-
 
 // the following macro defines a function that configures the GPIO pins for a STM32 I2C peripheral
 // it gets called in the Windows_Devices_I2c_I2cDevice::NativeInit function
 // this is required because the I2C peripherals can use multiple GPIO configuration combinations
-#define I2C_CONFIG_PINS(num, gpio_port_scl, gpio_port_sda, scl_pin, sda_pin, alternate_function) void ConfigPins_I2C##num() \
-{ \
-    palSetPadMode(gpio_port_scl, scl_pin, (PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_OTYPE_OPENDRAIN) ); \
-    palSetPadMode(gpio_port_sda, sda_pin, (PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_OTYPE_OPENDRAIN)); \
-}
+#define I2C_CONFIG_PINS(num, gpio_port_scl, gpio_port_sda, scl_pin, sda_pin, alternate_function)                       \
+    void ConfigPins_I2C##num()                                                                                         \
+    {                                                                                                                  \
+        palSetPadMode(                                                                                                 \
+            gpio_port_scl,                                                                                             \
+            scl_pin,                                                                                                   \
+            (PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_OTYPE_OPENDRAIN));          \
+        palSetPadMode(                                                                                                 \
+            gpio_port_sda,                                                                                             \
+            sda_pin,                                                                                                   \
+            (PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_OTYPE_OPENDRAIN));          \
+    }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // when an I2C is defined the declarations below will have the real function/configuration //
@@ -60,4 +66,4 @@ void ConfigPins_I2C2();
 void ConfigPins_I2C3();
 void ConfigPins_I2C4();
 
-#endif  //_WIN_DEV_I2C_NATIVE_TARGET_H_
+#endif //_WIN_DEV_I2C_NATIVE_TARGET_H_

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_target.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_target.h
@@ -10,7 +10,7 @@
 #include <hal.h>
 
 // struct representing the I2C 
-struct NF_PAL_I2C
+typedef struct NF_PAL_I2C_
 {
     I2CDriver*  Driver;
     I2CConfig   Configuration;
@@ -23,7 +23,7 @@ struct NF_PAL_I2C
 
     uint8_t* ReadBuffer;
     uint8_t  ReadSize;
-};
+} NF_PAL_I2C;
 
 ///////////////////////////////////////////
 // declaration of the the I2C PAL strucs //

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_target.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_target.h
@@ -10,62 +10,63 @@
 #include <win_dev_serial_native.h>
 #include <hal.h>
 
-// struct representing the UART 
+// struct representing the UART
 typedef struct
 {
-    UARTDriver* UartDriver;
+    UARTDriver *UartDriver;
     UARTConfig Uart_cfg;
 
     HAL_RingBuffer<uint8_t> TxRingBuffer;
-    uint8_t* TxBuffer;
+    uint8_t *TxBuffer;
     uint16_t TxOngoingCount;
 
     HAL_RingBuffer<uint8_t> RxRingBuffer;
-    uint8_t* RxBuffer;
+    uint8_t *RxBuffer;
     uint16_t RxBytesToRead;
 
     uint8_t WatchChar;
 } NF_PAL_UART;
 
-
 ////////////////////////////////////////////
 // declaration of the the UART PAL strucs //
 ////////////////////////////////////////////
 #if NF_SERIAL_COMM_STM32_UART_USE_USART1
-    extern NF_PAL_UART Uart1_PAL;
+extern NF_PAL_UART Uart1_PAL;
 #endif
 #if NF_SERIAL_COMM_STM32_UART_USE_USART2
-    extern NF_PAL_UART Uart2_PAL;
+extern NF_PAL_UART Uart2_PAL;
 #endif
 #if NF_SERIAL_COMM_STM32_UART_USE_USART3
-    extern NF_PAL_UART Uart3_PAL;
+extern NF_PAL_UART Uart3_PAL;
 #endif
 #if NF_SERIAL_COMM_STM32_UART_USE_UART4
-    extern NF_PAL_UART Uart4_PAL;
+extern NF_PAL_UART Uart4_PAL;
 #endif
 #if NF_SERIAL_COMM_STM32_UART_USE_UART5
-    extern NF_PAL_UART Uart5_PAL;
+extern NF_PAL_UART Uart5_PAL;
 #endif
 #if NF_SERIAL_COMM_STM32_UART_USE_USART6
-    extern NF_PAL_UART Uart6_PAL;
+extern NF_PAL_UART Uart6_PAL;
 #endif
 #if NF_SERIAL_COMM_STM32_UART_USE_UART7
-    extern NF_PAL_UART Uart7_PAL;
+extern NF_PAL_UART Uart7_PAL;
 #endif
 #if NF_SERIAL_COMM_STM32_UART_USE_UART8
-    extern NF_PAL_UART Uart8_PAL;
+extern NF_PAL_UART Uart8_PAL;
 #endif
 
 // the following macro defines a function that configures the GPIO pins for a STM32 UART/USART
 // it gets called in the Windows_Devices_SerialCommunication_SerialDevice::NativeConfig function
 // this is required because the UART/USART peripherals can use multiple GPIO configuration combinations
-#define UART_CONFIG_PINS(num, gpio_port_tx, gpio_port_rx, tx_pin, rx_pin, alternate_function) void ConfigPins_UART##num() { \
-    palSetPadMode(gpio_port_tx, tx_pin, PAL_MODE_ALTERNATE(alternate_function)); \
-    palSetPadMode(gpio_port_rx, rx_pin, PAL_MODE_ALTERNATE(alternate_function)); \
+#define UART_CONFIG_PINS(num, gpio_port_tx, gpio_port_rx, tx_pin, rx_pin, alternate_function)                          \
+    void ConfigPins_UART##num()                                                                                        \
+    {                                                                                                                  \
+        palSetPadMode(gpio_port_tx, tx_pin, PAL_MODE_ALTERNATE(alternate_function));                                   \
+        palSetPadMode(gpio_port_rx, rx_pin, PAL_MODE_ALTERNATE(alternate_function));                                   \
     }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-// when a UART/USART is defined the declarations below will have the real function/configuration 
+// when a UART/USART is defined the declarations below will have the real function/configuration
 // in the target folder @ target_windows_devices_serialcommunication_config.cpp
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void ConfigPins_UART1();
@@ -76,7 +77,6 @@ void ConfigPins_UART5();
 void ConfigPins_UART6();
 void ConfigPins_UART7();
 void ConfigPins_UART8();
-
 
 /////////////////////////////////////
 // UART Tx buffers                 //
@@ -91,7 +91,6 @@ extern uint8_t Uart6_TxBuffer[];
 extern uint8_t Uart7_TxBuffer[];
 extern uint8_t Uart8_TxBuffer[];
 
-
 /////////////////////////////////////
 // UART Rx buffers                 //
 // these live in the target folder //
@@ -105,54 +104,56 @@ extern uint8_t Uart6_RxBuffer[];
 extern uint8_t Uart7_RxBuffer[];
 extern uint8_t Uart8_RxBuffer[];
 
-
 // the following macro defines a function that initializes an UART struct
 // it gets called in the Windows_Devices_SerialCommunication_SerialDevice::NativeInit function
 
 #if defined(STM32F7XX) || defined(STM32F0XX)
 
 // STM32F7 and STM32F0 use UART driver v2
-#define UART_INIT(num, tx_buffer_size, rx_buffer_size) void Init_UART##num() { \
-    Uart##num##_PAL.Uart_cfg.txend2_cb = NULL; \
-    Uart##num##_PAL.Uart_cfg.rxend_cb = NULL; \
-    Uart##num##_PAL.Uart_cfg.rxerr_cb = NULL; \
-    Uart##num##_PAL.Uart_cfg.timeout_cb =  NULL; \
-    Uart##num##_PAL.Uart_cfg.timeout = 0; \
-    Uart##num##_PAL.Uart_cfg.speed = 9600; \
-    Uart##num##_PAL.Uart_cfg.cr1 = 0; \
-    Uart##num##_PAL.Uart_cfg.cr2 = 0; \
-    Uart##num##_PAL.Uart_cfg.cr3 = 0; \
-    Uart##num##_PAL.TxBuffer = Uart##num##_TxBuffer; \
-    Uart##num##_PAL.TxRingBuffer.Initialize( Uart##num##_PAL.TxBuffer, tx_buffer_size); \
-    Uart##num##_PAL.TxOngoingCount = 0; \
-    Uart##num##_PAL.RxBuffer = Uart##num##_RxBuffer; \
-    Uart##num##_PAL.RxRingBuffer.Initialize( Uart##num##_PAL.RxBuffer, rx_buffer_size); \
-    Uart##num##_PAL.WatchChar = 0; \
-}
+#define UART_INIT(num, tx_buffer_size, rx_buffer_size)                                                                 \
+    void Init_UART##num()                                                                                              \
+    {                                                                                                                  \
+        Uart##num##_PAL.Uart_cfg.txend2_cb = NULL;                                                                     \
+        Uart##num##_PAL.Uart_cfg.rxend_cb = NULL;                                                                      \
+        Uart##num##_PAL.Uart_cfg.rxerr_cb = NULL;                                                                      \
+        Uart##num##_PAL.Uart_cfg.timeout_cb = NULL;                                                                    \
+        Uart##num##_PAL.Uart_cfg.timeout = 0;                                                                          \
+        Uart##num##_PAL.Uart_cfg.speed = 9600;                                                                         \
+        Uart##num##_PAL.Uart_cfg.cr1 = 0;                                                                              \
+        Uart##num##_PAL.Uart_cfg.cr2 = 0;                                                                              \
+        Uart##num##_PAL.Uart_cfg.cr3 = 0;                                                                              \
+        Uart##num##_PAL.TxBuffer = Uart##num##_TxBuffer;                                                               \
+        Uart##num##_PAL.TxRingBuffer.Initialize(Uart##num##_PAL.TxBuffer, tx_buffer_size);                             \
+        Uart##num##_PAL.TxOngoingCount = 0;                                                                            \
+        Uart##num##_PAL.RxBuffer = Uart##num##_RxBuffer;                                                               \
+        Uart##num##_PAL.RxRingBuffer.Initialize(Uart##num##_PAL.RxBuffer, rx_buffer_size);                             \
+        Uart##num##_PAL.WatchChar = 0;                                                                                 \
+    }
 
 #else
 
 // all other STM32F use UART driver v1 which has a different UARTConfig struct
-#define UART_INIT(num, tx_buffer_size, rx_buffer_size) void Init_UART##num() { \
-    Uart##num##_PAL.Uart_cfg.txend2_cb = NULL; \
-    Uart##num##_PAL.Uart_cfg.rxend_cb = NULL; \
-    Uart##num##_PAL.Uart_cfg.rxerr_cb = NULL; \
-    Uart##num##_PAL.Uart_cfg.speed = 9600; \
-    Uart##num##_PAL.Uart_cfg.cr1 = 0; \
-    Uart##num##_PAL.Uart_cfg.cr2 = 0; \
-    Uart##num##_PAL.Uart_cfg.cr3 = 0; \
-    Uart##num##_PAL.TxBuffer = Uart##num##_TxBuffer; \
-    Uart##num##_PAL.TxRingBuffer.Initialize( Uart##num##_PAL.TxBuffer, tx_buffer_size); \
-    Uart##num##_PAL.TxOngoingCount = 0; \
-    Uart##num##_PAL.RxBuffer = Uart##num##_RxBuffer; \
-    Uart##num##_PAL.RxRingBuffer.Initialize( Uart##num##_PAL.RxBuffer, rx_buffer_size); \
-    Uart##num##_PAL.WatchChar = 0; \
-}
+#define UART_INIT(num, tx_buffer_size, rx_buffer_size)                                                                 \
+    void Init_UART##num()                                                                                              \
+    {                                                                                                                  \
+        Uart##num##_PAL.Uart_cfg.txend2_cb = NULL;                                                                     \
+        Uart##num##_PAL.Uart_cfg.rxend_cb = NULL;                                                                      \
+        Uart##num##_PAL.Uart_cfg.rxerr_cb = NULL;                                                                      \
+        Uart##num##_PAL.Uart_cfg.speed = 9600;                                                                         \
+        Uart##num##_PAL.Uart_cfg.cr1 = 0;                                                                              \
+        Uart##num##_PAL.Uart_cfg.cr2 = 0;                                                                              \
+        Uart##num##_PAL.Uart_cfg.cr3 = 0;                                                                              \
+        Uart##num##_PAL.TxBuffer = Uart##num##_TxBuffer;                                                               \
+        Uart##num##_PAL.TxRingBuffer.Initialize(Uart##num##_PAL.TxBuffer, tx_buffer_size);                             \
+        Uart##num##_PAL.TxOngoingCount = 0;                                                                            \
+        Uart##num##_PAL.RxBuffer = Uart##num##_RxBuffer;                                                               \
+        Uart##num##_PAL.RxRingBuffer.Initialize(Uart##num##_PAL.RxBuffer, rx_buffer_size);                             \
+        Uart##num##_PAL.WatchChar = 0;                                                                                 \
+    }
 
 #endif
 
-
-// when a UART/USART is defined the declarations below will have the real function/configuration 
+// when a UART/USART is defined the declarations below will have the real function/configuration
 // in the target folder @ target_windows_devices_serialcommunication_config.cpp
 void Init_UART1();
 void Init_UART2();
@@ -163,12 +164,15 @@ void Init_UART6();
 void Init_UART7();
 void Init_UART8();
 
-
 // the following macro defines a function that un initializes an UART struct
 // it gets called in the Windows_Devices_SerialCommunication_SerialDevice::NativeDispose function
-#define UART_UNINIT(num) void UnInit_UART##num() { return; }
+#define UART_UNINIT(num)                                                                                               \
+    void UnInit_UART##num()                                                                                            \
+    {                                                                                                                  \
+        return;                                                                                                        \
+    }
 
-// when a UART/USART is defined the declarations below will have the real function/configuration 
+// when a UART/USART is defined the declarations below will have the real function/configuration
 // in the target folder @ target_windows_devices_serialcommunication_config.cpp
 void UnInit_UART1();
 void UnInit_UART2();
@@ -179,4 +183,4 @@ void UnInit_UART6();
 void UnInit_UART7();
 void UnInit_UART8();
 
-#endif  //_WIN_DEV_SERIAL_NATIVE_TARGET_H_
+#endif //_WIN_DEV_SERIAL_NATIVE_TARGET_H_

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_target.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_target.h
@@ -11,7 +11,7 @@
 #include <hal.h>
 
 // struct representing the UART 
-struct NF_PAL_UART
+typedef struct
 {
     UARTDriver* UartDriver;
     UARTConfig Uart_cfg;
@@ -25,7 +25,7 @@ struct NF_PAL_UART
     uint16_t RxBytesToRead;
 
     uint8_t WatchChar;
-};
+} NF_PAL_UART;
 
 
 ////////////////////////////////////////////

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_Windows_Devices_Spi_SpiDevice.cpp
@@ -796,6 +796,7 @@ HRESULT Library_win_dev_spi_native_Windows_Devices_Spi_SpiDevice::NativeInit___V
         busIndex,
         pConfig[SpiConnectionSettings::FIELD___clockFrequency].NumericByRef().s4,
         actualFrequency);
+
     palSpi->ByteTime = (1.0 / actualFrequency) * 1000.0;
 
     NANOCLR_NOCLEANUP();

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_target.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_target.h
@@ -11,7 +11,7 @@
 #include <hal.h>
 
 // struct representing the SPI 
-struct NF_PAL_SPI
+typedef struct
 {
     SPIDriver*  Driver;
     SPIConfig   Configuration;
@@ -23,7 +23,7 @@ struct NF_PAL_SPI
 
     uint8_t* ReadBuffer;
     uint16_t ReadSize;
-};
+} NF_PAL_SPI;
 
 ///////////////////////////////////////////
 // declaration of the the SPI PAL strucs //

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_target.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_target.h
@@ -3,25 +3,24 @@
 // See LICENSE file in the project root for full license information.
 //
 
-
 #ifndef _WIN_DEV_SPI_NATIVE_TARGET_H_
 #define _WIN_DEV_SPI_NATIVE_TARGET_H_
 
 #include <win_dev_spi_native.h>
 #include <hal.h>
 
-// struct representing the SPI 
+// struct representing the SPI
 typedef struct
 {
-    SPIDriver*  Driver;
-    SPIConfig   Configuration;
+    SPIDriver *Driver;
+    SPIConfig Configuration;
     float ByteTime;
     bool SequentialTxRx;
 
-    uint8_t* WriteBuffer;
+    uint8_t *WriteBuffer;
     uint16_t WriteSize;
 
-    uint8_t* ReadBuffer;
+    uint8_t *ReadBuffer;
     uint16_t ReadSize;
 } NF_PAL_SPI;
 
@@ -29,39 +28,54 @@ typedef struct
 // declaration of the the SPI PAL strucs //
 ///////////////////////////////////////////
 #if STM32_SPI_USE_SPI1
-    extern NF_PAL_SPI SPI1_PAL;
+extern NF_PAL_SPI SPI1_PAL;
 #endif
 #if STM32_SPI_USE_SPI2
-    extern NF_PAL_SPI SPI2_PAL;
+extern NF_PAL_SPI SPI2_PAL;
 #endif
 #if STM32_SPI_USE_SPI3
-    extern NF_PAL_SPI SPI3_PAL;
+extern NF_PAL_SPI SPI3_PAL;
 #endif
 #if STM32_SPI_USE_SPI4
-    extern NF_PAL_SPI SPI4_PAL;
+extern NF_PAL_SPI SPI4_PAL;
 #endif
 #if STM32_SPI_USE_SPI5
-    extern NF_PAL_SPI SPI5_PAL;
+extern NF_PAL_SPI SPI5_PAL;
 #endif
 #if STM32_SPI_USE_SPI6
-    extern NF_PAL_SPI SPI6_PAL;
+extern NF_PAL_SPI SPI6_PAL;
 #endif
 
 // the following macro defines a function that configures the GPIO pins for an STM32 SPI peripheral
 // it gets called in the Windows_Devices_SPi_SPiDevice::NativeInit function
 // this is required because the SPI peripherals can use multiple GPIO configuration combinations
-#define SPI_CONFIG_PINS(num, gpio_port_sck, sck_pin, gpio_port_miso, miso_pin, gpio_port_mosi, mosi_pin, alternate_function) void ConfigPins_SPI##num() \
-{ \
-    palSetPadMode(gpio_port_sck, sck_pin, \
-                    (PAL_MODE_ALTERNATE(alternate_function) | \
-                    PAL_STM32_OSPEED_HIGHEST | PAL_STM32_PUPDR_FLOATING | PAL_STM32_OTYPE_PUSHPULL) ); \
-    palSetPadMode(gpio_port_miso, miso_pin, \
-                    (PAL_MODE_ALTERNATE(alternate_function) | \
-                    PAL_STM32_OSPEED_HIGHEST | PAL_STM32_PUPDR_FLOATING | PAL_STM32_OTYPE_PUSHPULL) ); \
-    palSetPadMode(gpio_port_mosi, mosi_pin, \
-                    (PAL_MODE_ALTERNATE(alternate_function) | \
-                    PAL_STM32_OSPEED_HIGHEST | PAL_STM32_PUPDR_FLOATING | PAL_STM32_OTYPE_PUSHPULL) ); \
-} 
+#define SPI_CONFIG_PINS(                                                                                               \
+    num,                                                                                                               \
+    gpio_port_sck,                                                                                                     \
+    sck_pin,                                                                                                           \
+    gpio_port_miso,                                                                                                    \
+    miso_pin,                                                                                                          \
+    gpio_port_mosi,                                                                                                    \
+    mosi_pin,                                                                                                          \
+    alternate_function)                                                                                                \
+    void ConfigPins_SPI##num()                                                                                         \
+    {                                                                                                                  \
+        palSetPadMode(                                                                                                 \
+            gpio_port_sck,                                                                                             \
+            sck_pin,                                                                                                   \
+            (PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_PUPDR_FLOATING |            \
+             PAL_STM32_OTYPE_PUSHPULL));                                                                               \
+        palSetPadMode(                                                                                                 \
+            gpio_port_miso,                                                                                            \
+            miso_pin,                                                                                                  \
+            (PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_PUPDR_FLOATING |            \
+             PAL_STM32_OTYPE_PUSHPULL));                                                                               \
+        palSetPadMode(                                                                                                 \
+            gpio_port_mosi,                                                                                            \
+            mosi_pin,                                                                                                  \
+            (PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_PUPDR_FLOATING |            \
+             PAL_STM32_OTYPE_PUSHPULL));                                                                               \
+    }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // when an SPI is defined the declarations below will have the real function/configuration //
@@ -74,4 +88,4 @@ void ConfigPins_SPI4();
 void ConfigPins_SPI5();
 void ConfigPins_SPI6();
 
-#endif  //_WIN_DEV_SPI_NATIVE_TARGET_H_
+#endif //_WIN_DEV_SPI_NATIVE_TARGET_H_

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Devices.Can/nf_devices_can_native_target.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Devices.Can/nf_devices_can_native_target.h
@@ -13,7 +13,7 @@
 
 
 // struct representing the CAN 
-struct NF_PAL_CAN
+typedef struct
 {
     CANDriver*  Driver;
     CANConfig   Configuration;
@@ -21,7 +21,7 @@ struct NF_PAL_CAN
 
     HAL_RingBuffer<CANRxFrame> MsgRingBuffer;
     CANRxFrame* MsgBuffer;
-};
+} NF_PAL_CAN;
 
 ///////////////////////////////////////////
 // declaration of the CAN PAL strucs     //

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Devices.Can/nf_devices_can_native_target.h
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/nanoFramework.Devices.Can/nf_devices_can_native_target.h
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-
 #ifndef _NF_DEVICES_CAN_NATIVE_TARGET_H_
 #define _NF_DEVICES_CAN_NATIVE_TARGET_H_
 
@@ -11,48 +10,55 @@
 #include "target_nf_devices_can_config.h"
 #include <nf_devices_can_native.h>
 
-
-// struct representing the CAN 
+// struct representing the CAN
 typedef struct
 {
-    CANDriver*  Driver;
-    CANConfig   Configuration;
-    thread_t*   ReceiverThread;
+    CANDriver *Driver;
+    CANConfig Configuration;
+    thread_t *ReceiverThread;
 
     HAL_RingBuffer<CANRxFrame> MsgRingBuffer;
-    CANRxFrame* MsgBuffer;
+    CANRxFrame *MsgBuffer;
 } NF_PAL_CAN;
 
 ///////////////////////////////////////////
 // declaration of the CAN PAL strucs     //
 ///////////////////////////////////////////
 #if STM32_CAN_USE_CAN1
-    extern NF_PAL_CAN Can1_PAL;
+extern NF_PAL_CAN Can1_PAL;
 #endif
 #if STM32_CAN_USE_CAN2
-    extern NF_PAL_CAN Can2_PAL;
+extern NF_PAL_CAN Can2_PAL;
 #endif
 #if STM32_CAN_USE_CAN3
-    extern NF_PAL_CAN Can3_PAL;
+extern NF_PAL_CAN Can3_PAL;
 #endif
 
 // the following macro defines a function that configures the GPIO pins for a STM32 CAN
-// it gets called in the can_lld_start function// this is required because the CAN peripherals can use multiple GPIO configuration combinations
-#define CAN_CONFIG_PINS(num, gpio_port_tx, gpio_port_rx, tx_pin, rx_pin, alternate_function) void ConfigPins_CAN##num() { \
-    palSetPadMode(gpio_port_tx, tx_pin, PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OTYPE_PUSHPULL \
-    | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_MODE_ALTERNATE); \
-    palSetPadMode(gpio_port_rx, rx_pin, PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OTYPE_PUSHPULL \
-    | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_MODE_ALTERNATE); \
-}
+// it gets called in the can_lld_start function// this is required because the CAN peripherals can use multiple GPIO
+// configuration combinations
+#define CAN_CONFIG_PINS(num, gpio_port_tx, gpio_port_rx, tx_pin, rx_pin, alternate_function)                           \
+    void ConfigPins_CAN##num()                                                                                         \
+    {                                                                                                                  \
+        palSetPadMode(                                                                                                 \
+            gpio_port_tx,                                                                                              \
+            tx_pin,                                                                                                    \
+            PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OTYPE_PUSHPULL | PAL_STM32_OSPEED_HIGHEST |             \
+                PAL_STM32_MODE_ALTERNATE);                                                                             \
+        palSetPadMode(                                                                                                 \
+            gpio_port_rx,                                                                                              \
+            rx_pin,                                                                                                    \
+            PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OTYPE_PUSHPULL | PAL_STM32_OSPEED_HIGHEST |             \
+                PAL_STM32_MODE_ALTERNATE);                                                                             \
+    }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// when a CAN is defined the declarations below will have the real function/configuration 
+// when a CAN is defined the declarations below will have the real function/configuration
 // in the target folder @ target_nf_devices_can_config.cpp
 ///////////////////////////////////////////////////////////////////////////////////////////
 void ConfigPins_CAN1();
 void ConfigPins_CAN2();
 void ConfigPins_CAN3();
-
 
 /////////////////////////////////////
 // CAN Msg buffers                 //
@@ -62,16 +68,18 @@ extern CANRxFrame Can1_MsgBuffer[];
 extern CANRxFrame Can2_MsgBuffer[];
 extern CANRxFrame Can3_MsgBuffer[];
 
-// 
-#define CAN_INIT(num, buffer_size) void Init_Can##num() { \
-    Can##num##_PAL.MsgBuffer = Can##num##_MsgBuffer; \
-    Can##num##_PAL.MsgRingBuffer.Initialize( Can##num##_PAL.MsgBuffer, buffer_size); \
-}
+//
+#define CAN_INIT(num, buffer_size)                                                                                     \
+    void Init_Can##num()                                                                                               \
+    {                                                                                                                  \
+        Can##num##_PAL.MsgBuffer = Can##num##_MsgBuffer;                                                               \
+        Can##num##_PAL.MsgRingBuffer.Initialize(Can##num##_PAL.MsgBuffer, buffer_size);                                \
+    }
 
-// when a CAN is defined the declarations below will have the real function/configuration 
+// when a CAN is defined the declarations below will have the real function/configuration
 // in the target folder @ target_nf_devices_can_config.cpp
 void Init_Can1();
 void Init_Can2();
 void Init_Can3();
 
-#endif  //_NF_DEVICES_CAN_NATIVE_TARGET_H_
+#endif //_NF_DEVICES_CAN_NATIVE_TARGET_H_

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL.cpp
@@ -12,6 +12,20 @@
 #include <nanoPAL_BlockStorage.h>
 #include <nanoHAL_ConfigurationManager.h>
 
+#if (HAL_USE_CAN == TRUE)
+#include <nf_devices_can_native_target.h>
+#endif
+#if (HAL_USE_I2C == TRUE)
+#include <win_dev_i2c_native_target.h>
+#endif
+#if (HAL_USE_SPI == TRUE)
+#include <win_dev_spi_native_target.h>
+#endif
+#if (HAL_USE_UART == TRUE)
+#include "win_dev_serial_native_target.h"
+#endif
+
+
 // global mutex protecting the internal state of the interpreter, including event flags
 //mutex_t interpreterGlobalMutex;
 
@@ -59,6 +73,89 @@ void nanoHAL_Initialize()
 
     // no PAL events required until now
     //PalEvent_Initialize();
+
+#if (HAL_USE_CAN == TRUE)
+
+    #if STM32_CAN_USE_CAN1
+    Can1_PAL.Driver = NULL;
+    #endif
+    #if STM32_CAN_USE_CAN2
+    Can2_PAL.Driver = NULL;
+    #endif
+    #if STM32_CAN_USE_CAN3
+    Can3_PAL.Driver = NULL;
+    #endif
+
+#endif
+
+#if (HAL_USE_I2C == TRUE)
+
+    #if STM32_I2C_USE_I2C1
+    I2C1_PAL.Driver = NULL;
+    #endif
+    #if STM32_I2C_USE_I2C2
+    I2C2_PAL.Driver = NULL;
+    #endif
+    #if STM32_I2C_USE_I2C3
+    I2C3_PAL.Driver = NULL;
+    #endif
+    #if STM32_I2C_USE_I2C4
+    I2C4_PAL.Driver = NULL;
+    #endif
+
+#endif
+
+#if (HAL_USE_SPI == TRUE)
+
+    #if STM32_SPI_USE_SPI1
+    SPI1_PAL.Driver = NULL;
+    #endif
+    #if STM32_SPI_USE_SPI2
+    SPI2_PAL.Driver = NULL;
+    #endif
+    #if STM32_SPI_USE_SPI3
+    SPI3_PAL.Driver = NULL;
+    #endif
+    #if STM32_SPI_USE_SPI4
+    SPI4_PAL.Driver = NULL;
+    #endif
+    #if STM32_SPI_USE_SPI5
+    SPI5_PAL.Driver = NULL;
+    #endif
+    #if STM32_SPI_USE_SPI6
+    SPI6_PAL.Driver = NULL;
+    #endif
+
+#endif
+
+#if (HAL_USE_UART == TRUE)
+
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
+    Uart1_PAL.UartDriver = NULL;
+    #endif
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
+    Uart2_PAL.UartDriver = NULL;
+    #endif
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
+    Uart3_PAL.UartDriver = NULL;
+    #endif
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
+    Uart4_PAL.UartDriver = NULL;
+    #endif
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
+    Uart5_PAL.UartDriver = NULL;
+    #endif
+    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
+    Uart6_PAL.UartDriver = NULL;
+    #endif
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
+    Uart7_PAL.UartDriver = NULL;
+    #endif
+    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
+    Uart8_PAL.UartDriver = NULL;
+    #endif
+
+#endif
 	
 	// Initialise Network Stack
     Network_Initialize();
@@ -91,26 +188,20 @@ void nanoHAL_Uninitialize()
 
     BlockStorageList_UnInitializeDevices();
 
-    // need to be sure that all mutexes for drivers that use them are released
-#if (HAL_USE_SPI == TRUE)
+    // need to be sure that:
+    // - all mutexes for drivers that use them are released
+    // - all drivers are stopped
 
-    #if STM32_SPI_USE_SPI1
-    spiReleaseBus(&SPID1);
+#if (HAL_USE_CAN == TRUE)
+
+    #if STM32_CAN_USE_CAN1
+    canStop(&CAND1);
     #endif
-    #if STM32_SPI_USE_SPI2
-    spiReleaseBus(&SPID2);
+    #if STM32_CAN_USE_CAN2
+    canStop(&CAND2);
     #endif
-    #if STM32_SPI_USE_SPI3
-    spiReleaseBus(&SPID3);
-    #endif
-    #if STM32_SPI_USE_SPI4
-    spiReleaseBus(&SPID4);
-    #endif
-    #if STM32_SPI_USE_SPI5
-    spiReleaseBus(&SPID5);
-    #endif
-    #if STM32_SPI_USE_SPI6
-    spiReleaseBus(&SPID6);
+    #if STM32_CAN_USE_CAN3
+    canStop(&CAND3);
     #endif
 
 #endif
@@ -119,15 +210,49 @@ void nanoHAL_Uninitialize()
 
     #if STM32_I2C_USE_I2C1
     i2cReleaseBus(&I2CD1);
+    i2cStop(&I2CD1);
     #endif
     #if STM32_I2C_USE_I2C2
     i2cReleaseBus(&I2CD2);
+    i2cStop(&I2CD2);
     #endif
     #if STM32_I2C_USE_I2C3
     i2cReleaseBus(&I2CD3);
+    i2cStop(&I2CD3);
     #endif
     #if STM32_I2C_USE_I2C4
     i2cReleaseBus(&I2CD4);
+    i2cStop(&I2CD4);
+    #endif
+
+#endif
+
+#if (HAL_USE_SPI == TRUE)
+
+    #if STM32_SPI_USE_SPI1
+    spiReleaseBus(&SPID1);
+    spiStop(&SPID1);
+    #endif
+    #if STM32_SPI_USE_SPI2
+    spiReleaseBus(&SPID2);
+    spiStop(&SPID2);
+    #endif
+    #if STM32_SPI_USE_SPI3
+    spiReleaseBus(&SPID3);
+    spiStop(&SPID3);
+    SPI3_PAL.Driver = NULL;
+    #endif
+    #if STM32_SPI_USE_SPI4
+    spiReleaseBus(&SPID4);
+    spiStop(&SPID4);
+    #endif
+    #if STM32_SPI_USE_SPI5
+    spiReleaseBus(&SPID5);
+    spiStop(&SPID5);
+    #endif
+    #if STM32_SPI_USE_SPI6
+    spiReleaseBus(&SPID6);
+    spiStop(&SPID6);
     #endif
 
 #endif
@@ -136,27 +261,35 @@ void nanoHAL_Uninitialize()
 
     #if NF_SERIAL_COMM_STM32_UART_USE_USART1
     uartReleaseBus(&UARTD1);
+    uartStop(&UARTD1);
     #endif
     #if NF_SERIAL_COMM_STM32_UART_USE_USART2
     uartReleaseBus(&UARTD2);
+    uartStop(&UARTD2);
     #endif
     #if NF_SERIAL_COMM_STM32_UART_USE_USART3
     uartReleaseBus(&UARTD3);
+    uartStop(&UARTD3);
     #endif
     #if NF_SERIAL_COMM_STM32_UART_USE_UART4
     uartReleaseBus(&UARTD4);
+    uartStop(&UARTD4);
     #endif
     #if NF_SERIAL_COMM_STM32_UART_USE_UART5
     uartReleaseBus(&UARTD5);
+    uartStop(&UARTD5);
     #endif
     #if NF_SERIAL_COMM_STM32_UART_USE_USART6
     uartReleaseBus(&UARTD6);
+    uartStop(&UARTD6);
     #endif
     #if NF_SERIAL_COMM_STM32_UART_USE_UART7
     uartReleaseBus(&UARTD7);
+    uartStop(&UARTD7);
     #endif
     #if NF_SERIAL_COMM_STM32_UART_USE_UART8
     uartReleaseBus(&UARTD8);
+    uartStop(&UARTD8);
     #endif
 
 #endif

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/targetHAL.cpp
@@ -25,13 +25,14 @@
 #include "win_dev_serial_native_target.h"
 #endif
 
-
 // global mutex protecting the internal state of the interpreter, including event flags
-//mutex_t interpreterGlobalMutex;
+// mutex_t interpreterGlobalMutex;
 
-// because nanoHAL_Initialize/Uninitialize needs to be called in both C and C++ we need a proxy to allow it to be called in 'C'
-extern "C" {
-    
+// because nanoHAL_Initialize/Uninitialize needs to be called in both C and C++ we need a proxy to allow it to be called
+// in 'C'
+extern "C"
+{
+
     void nanoHAL_Initialize_C()
     {
         nanoHAL_Initialize();
@@ -46,10 +47,10 @@ extern "C" {
 void nanoHAL_Initialize()
 {
     // initialize global mutex
-    //chMtxObjectInit(&interpreterGlobalMutex);
+    // chMtxObjectInit(&interpreterGlobalMutex);
 
     HAL_CONTINUATION::InitializeList();
-    HAL_COMPLETION  ::InitializeList();
+    HAL_COMPLETION ::InitializeList();
 
     BlockStorageList_Initialize();
 
@@ -59,10 +60,10 @@ void nanoHAL_Initialize()
     BlockStorageList_InitializeDevices();
 
     // clear managed heap region
-    unsigned char* heapStart = NULL;
-    unsigned int heapSize  = 0;
+    unsigned char *heapStart = NULL;
+    unsigned int heapSize = 0;
 
-    ::HeapLocation( heapStart, heapSize );
+    ::HeapLocation(heapStart, heapSize);
     memset(heapStart, 0, heapSize);
 
     ConfigurationManager_Initialize();
@@ -72,99 +73,99 @@ void nanoHAL_Initialize()
     CPU_GPIO_Initialize();
 
     // no PAL events required until now
-    //PalEvent_Initialize();
+    // PalEvent_Initialize();
 
 #if (HAL_USE_CAN == TRUE)
 
-    #if STM32_CAN_USE_CAN1
+#if STM32_CAN_USE_CAN1
     Can1_PAL.Driver = NULL;
-    #endif
-    #if STM32_CAN_USE_CAN2
+#endif
+#if STM32_CAN_USE_CAN2
     Can2_PAL.Driver = NULL;
-    #endif
-    #if STM32_CAN_USE_CAN3
+#endif
+#if STM32_CAN_USE_CAN3
     Can3_PAL.Driver = NULL;
-    #endif
+#endif
 
 #endif
 
 #if (HAL_USE_I2C == TRUE)
 
-    #if STM32_I2C_USE_I2C1
+#if STM32_I2C_USE_I2C1
     I2C1_PAL.Driver = NULL;
-    #endif
-    #if STM32_I2C_USE_I2C2
+#endif
+#if STM32_I2C_USE_I2C2
     I2C2_PAL.Driver = NULL;
-    #endif
-    #if STM32_I2C_USE_I2C3
+#endif
+#if STM32_I2C_USE_I2C3
     I2C3_PAL.Driver = NULL;
-    #endif
-    #if STM32_I2C_USE_I2C4
+#endif
+#if STM32_I2C_USE_I2C4
     I2C4_PAL.Driver = NULL;
-    #endif
+#endif
 
 #endif
 
 #if (HAL_USE_SPI == TRUE)
 
-    #if STM32_SPI_USE_SPI1
+#if STM32_SPI_USE_SPI1
     SPI1_PAL.Driver = NULL;
-    #endif
-    #if STM32_SPI_USE_SPI2
+#endif
+#if STM32_SPI_USE_SPI2
     SPI2_PAL.Driver = NULL;
-    #endif
-    #if STM32_SPI_USE_SPI3
+#endif
+#if STM32_SPI_USE_SPI3
     SPI3_PAL.Driver = NULL;
-    #endif
-    #if STM32_SPI_USE_SPI4
+#endif
+#if STM32_SPI_USE_SPI4
     SPI4_PAL.Driver = NULL;
-    #endif
-    #if STM32_SPI_USE_SPI5
+#endif
+#if STM32_SPI_USE_SPI5
     SPI5_PAL.Driver = NULL;
-    #endif
-    #if STM32_SPI_USE_SPI6
+#endif
+#if STM32_SPI_USE_SPI6
     SPI6_PAL.Driver = NULL;
-    #endif
+#endif
 
 #endif
 
 #if (HAL_USE_UART == TRUE)
 
-    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
+#if NF_SERIAL_COMM_STM32_UART_USE_USART1
     Uart1_PAL.UartDriver = NULL;
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_USART2
     Uart2_PAL.UartDriver = NULL;
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_USART3
     Uart3_PAL.UartDriver = NULL;
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_UART4
     Uart4_PAL.UartDriver = NULL;
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_UART5
     Uart5_PAL.UartDriver = NULL;
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_USART6
     Uart6_PAL.UartDriver = NULL;
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_UART7
     Uart7_PAL.UartDriver = NULL;
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_UART8
     Uart8_PAL.UartDriver = NULL;
-    #endif
+#endif
 
 #endif
-	
-	// Initialise Network Stack
+
+    // Initialise Network Stack
     Network_Initialize();
 }
 
 void nanoHAL_Uninitialize()
 {
     // release the global mutex, just in case it's locked somewhere
-    //chMtxUnlock(&interpreterGlobalMutex);
+    // chMtxUnlock(&interpreterGlobalMutex);
 
     // TODO check for s_rebootHandlers
     // for(int i = 0; i< ARRAYSIZE(s_rebootHandlers); i++)
@@ -177,14 +178,14 @@ void nanoHAL_Uninitialize()
     //     {
     //         break;
     //     }
-    // }   
+    // }
 
     SOCKETS_CloseConnections();
 
-  #if !defined(HAL_REDUCESIZE)
+#if !defined(HAL_REDUCESIZE)
     // TODO need to call this but it's preventing the debug session from starting
-    //Network_Uninitialize();
-  #endif
+    // Network_Uninitialize();
+#endif
 
     BlockStorageList_UnInitializeDevices();
 
@@ -194,112 +195,112 @@ void nanoHAL_Uninitialize()
 
 #if (HAL_USE_CAN == TRUE)
 
-    #if STM32_CAN_USE_CAN1
+#if STM32_CAN_USE_CAN1
     canStop(&CAND1);
-    #endif
-    #if STM32_CAN_USE_CAN2
+#endif
+#if STM32_CAN_USE_CAN2
     canStop(&CAND2);
-    #endif
-    #if STM32_CAN_USE_CAN3
+#endif
+#if STM32_CAN_USE_CAN3
     canStop(&CAND3);
-    #endif
+#endif
 
 #endif
 
 #if (HAL_USE_I2C == TRUE)
 
-    #if STM32_I2C_USE_I2C1
+#if STM32_I2C_USE_I2C1
     i2cReleaseBus(&I2CD1);
     i2cStop(&I2CD1);
-    #endif
-    #if STM32_I2C_USE_I2C2
+#endif
+#if STM32_I2C_USE_I2C2
     i2cReleaseBus(&I2CD2);
     i2cStop(&I2CD2);
-    #endif
-    #if STM32_I2C_USE_I2C3
+#endif
+#if STM32_I2C_USE_I2C3
     i2cReleaseBus(&I2CD3);
     i2cStop(&I2CD3);
-    #endif
-    #if STM32_I2C_USE_I2C4
+#endif
+#if STM32_I2C_USE_I2C4
     i2cReleaseBus(&I2CD4);
     i2cStop(&I2CD4);
-    #endif
+#endif
 
 #endif
 
 #if (HAL_USE_SPI == TRUE)
 
-    #if STM32_SPI_USE_SPI1
+#if STM32_SPI_USE_SPI1
     spiReleaseBus(&SPID1);
     spiStop(&SPID1);
-    #endif
-    #if STM32_SPI_USE_SPI2
+#endif
+#if STM32_SPI_USE_SPI2
     spiReleaseBus(&SPID2);
     spiStop(&SPID2);
-    #endif
-    #if STM32_SPI_USE_SPI3
+#endif
+#if STM32_SPI_USE_SPI3
     spiReleaseBus(&SPID3);
     spiStop(&SPID3);
     SPI3_PAL.Driver = NULL;
-    #endif
-    #if STM32_SPI_USE_SPI4
+#endif
+#if STM32_SPI_USE_SPI4
     spiReleaseBus(&SPID4);
     spiStop(&SPID4);
-    #endif
-    #if STM32_SPI_USE_SPI5
+#endif
+#if STM32_SPI_USE_SPI5
     spiReleaseBus(&SPID5);
     spiStop(&SPID5);
-    #endif
-    #if STM32_SPI_USE_SPI6
+#endif
+#if STM32_SPI_USE_SPI6
     spiReleaseBus(&SPID6);
     spiStop(&SPID6);
-    #endif
+#endif
 
 #endif
 
 #if (HAL_USE_UART == TRUE)
 
-    #if NF_SERIAL_COMM_STM32_UART_USE_USART1
+#if NF_SERIAL_COMM_STM32_UART_USE_USART1
     uartReleaseBus(&UARTD1);
     uartStop(&UARTD1);
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_USART2
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_USART2
     uartReleaseBus(&UARTD2);
     uartStop(&UARTD2);
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_USART3
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_USART3
     uartReleaseBus(&UARTD3);
     uartStop(&UARTD3);
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_UART4
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_UART4
     uartReleaseBus(&UARTD4);
     uartStop(&UARTD4);
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_UART5
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_UART5
     uartReleaseBus(&UARTD5);
     uartStop(&UARTD5);
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_USART6
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_USART6
     uartReleaseBus(&UARTD6);
     uartStop(&UARTD6);
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_UART7
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_UART7
     uartReleaseBus(&UARTD7);
     uartStop(&UARTD7);
-    #endif
-    #if NF_SERIAL_COMM_STM32_UART_USE_UART8
+#endif
+#if NF_SERIAL_COMM_STM32_UART_USE_UART8
     uartReleaseBus(&UARTD8);
     uartStop(&UARTD8);
-    #endif
+#endif
 
 #endif
 
     CPU_GPIO_Uninitialize();
 
     Events_Uninitialize();
-    
+
     HAL_CONTINUATION::Uninitialize();
-    HAL_COMPLETION  ::Uninitialize();
+    HAL_COMPLETION ::Uninitialize();
 }
 
 volatile int32_t SystemStates[SYSTEM_STATE_TOTAL_STATES];
@@ -332,18 +333,18 @@ void SystemState_Clear(SYSTEM_STATE_type state)
 {
     GLOBAL_LOCK();
 
-    SystemState_ClearNoLock(state );
+    SystemState_ClearNoLock(state);
 
     GLOBAL_UNLOCK();
 }
 
 bool SystemState_Query(SYSTEM_STATE_type state)
 {
-	bool systemStateCopy = false;
+    bool systemStateCopy = false;
     GLOBAL_LOCK();
 
     systemStateCopy = SystemState_QueryNoLock(state);
-    
+
     GLOBAL_UNLOCK();
 
     return systemStateCopy;

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -75,7 +75,6 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose_
     NANOCLR_HEADER();
 
     uint8_t busIndex;
-    NF_PAL_I2C* palI2c = NULL;
     bool disposeController = false;
 
     // get a pointer to the managed object instance and check that it's not NULL
@@ -96,7 +95,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose_
         {
             case 1:
                 // deactivates the I2C peripheral
-                I2C_close(palI2c->i2c);
+                I2C_close(I2C1_PAL.i2c);
                 I2C1_PAL.i2c == NULL;
                 break;
 

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -23,31 +23,33 @@ void HostI2C_CallbackFxn(I2C_Handle handle, I2C_Transaction *transaction, bool t
     NATIVE_INTERRUPT_END
 }
 
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID( CLR_RT_StackFrame& stack )
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___VOID(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
     {
-        NF_PAL_I2C* palI2c = NULL;
+        NF_PAL_I2C *palI2c = NULL;
 
         // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
-       
+        CLR_RT_HeapBlock *pThis = stack.This();
+        FAULT_ON_NULL(pThis);
+
         // get a pointer to the managed I2C connectionSettings object instance
-        CLR_RT_HeapBlock* pConfig = pThis[ FIELD___connectionSettings ].Dereference();
+        CLR_RT_HeapBlock *pConfig = pThis[FIELD___connectionSettings].Dereference();
 
         // get bus index
         // this is coded with a multiplication, need to perform and int division to get the number
         // see the comments in the I2cDevice() constructor in managed code for details
-        uint8_t busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
+        uint8_t busIndex = (uint8_t)(pThis[FIELD___deviceId].NumericByRef().s4 / 1000);
 
         // config GPIO pins used by the I2C peripheral
         // init the PAL struct for this I2C bus and assign the respective driver
         // all this occurs if not already done
-        // why do we need to check if this is already done? because several I2cDevice objects can be created associated to the same bus just using different addresses
+        // why do we need to check if this is already done? because several I2cDevice objects can be created associated
+        // to the same bus just using different addresses
         switch (busIndex)
         {
             case 1:
-                if(I2C1_PAL.i2c == NULL)
+                if (I2C1_PAL.i2c == NULL)
                 {
                     palI2c = &I2C1_PAL;
                 }
@@ -61,16 +63,22 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeInit___V
 
         // Create I2C for usage
         I2C_Params_init(&palI2c->i2cParams);
-        palI2c->i2cParams.bitRate = (I2cBusSpeed)pConfig[ I2cConnectionSettings::FIELD___busSpeed ].NumericByRef().s4 == I2cBusSpeed_StandardMode ? I2C_100kHz : I2C_400kHz;
+        palI2c->i2cParams.bitRate =
+            (I2cBusSpeed)pConfig[I2cConnectionSettings::FIELD___busSpeed].NumericByRef().s4 == I2cBusSpeed_StandardMode
+                ? I2C_100kHz
+                : I2C_400kHz;
         palI2c->i2cParams.transferMode = I2C_MODE_CALLBACK;
         palI2c->i2cParams.transferCallbackFxn = HostI2C_CallbackFxn;
-        palI2c->i2c = I2C_open(Board_I2C0, &palI2c->i2cParams); FAULT_ON_NULL(palI2c->i2c);
-        palI2c->i2cTransaction.slaveAddress = (I2cBusSpeed)pConfig[ I2cConnectionSettings::FIELD___slaveAddress ].NumericByRef().s4;
+        palI2c->i2c = I2C_open(Board_I2C0, &palI2c->i2cParams);
+        FAULT_ON_NULL(palI2c->i2c);
+        palI2c->i2cTransaction.slaveAddress =
+            (I2cBusSpeed)pConfig[I2cConnectionSettings::FIELD___slaveAddress].NumericByRef().s4;
     }
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose___VOID__BOOLEAN( CLR_RT_StackFrame& stack )
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose___VOID__BOOLEAN(
+    CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
 
@@ -78,17 +86,18 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose_
     bool disposeController = false;
 
     // get a pointer to the managed object instance and check that it's not NULL
-    CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+    CLR_RT_HeapBlock *pThis = stack.This();
+    FAULT_ON_NULL(pThis);
 
     // get disposeController
     disposeController = (bool)stack.Arg0().NumericByRef().u1;
 
-    if(disposeController)
+    if (disposeController)
     {
         // get bus index
         // this is coded with a multiplication, need to perform and int division to get the number
         // see the comments in the I2cDevice() constructor in managed code for details
-        busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
+        busIndex = (uint8_t)(pThis[FIELD___deviceId].NumericByRef().s4 / 1000);
 
         // get the driver for the I2C bus
         switch (busIndex)
@@ -104,30 +113,31 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeDispose_
                 NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
                 break;
         }
-
     }
 
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1( CLR_RT_StackFrame& stack )
+HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::
+    NativeTransmit___WindowsDevicesI2cI2cTransferResult__SZARRAY_U1__SZARRAY_U1(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
     {
         uint8_t busIndex;
-        NF_PAL_I2C* palI2c = NULL;
+        NF_PAL_I2C *palI2c = NULL;
 
-        CLR_RT_HeapBlock    hbTimeout;
-        CLR_INT64*          timeout;
-        bool                eventResult = true;
-        uint32_t            estimatedDurationMiliseconds;
+        CLR_RT_HeapBlock hbTimeout;
+        CLR_INT64 *timeout;
+        bool eventResult = true;
+        uint32_t estimatedDurationMiliseconds;
 
-        CLR_RT_HeapBlock_Array* writeBuffer;
-        CLR_RT_HeapBlock_Array* readBuffer;
-        CLR_RT_HeapBlock*       result;
+        CLR_RT_HeapBlock_Array *writeBuffer;
+        CLR_RT_HeapBlock_Array *readBuffer;
+        CLR_RT_HeapBlock *result;
 
         // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
+        CLR_RT_HeapBlock *pThis = stack.This();
+        FAULT_ON_NULL(pThis);
 
         // // get pointer to connection settings field
         // CLR_RT_HeapBlock* connectionSettings = pThis[ FIELD___connectionSettings ].Dereference();
@@ -135,12 +145,12 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
         // get bus index
         // this is coded with a multiplication, need to perform and int division to get the number
         // see the comments in the I2cDevice() constructor in managed code for details
-        busIndex = (uint8_t)(pThis[ FIELD___deviceId ].NumericByRef().s4 / 1000);
+        busIndex = (uint8_t)(pThis[FIELD___deviceId].NumericByRef().s4 / 1000);
 
         // get the driver for the I2C bus
         switch (busIndex)
         {
-            case 1 :
+            case 1:
                 palI2c = &I2C1_PAL;
                 break;
             default:
@@ -179,52 +189,61 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
         // !! need to cast to CLR_INT64 otherwise it wont setup a proper timeout infinite
         hbTimeout.SetInteger((CLR_INT64)-1);
 
-        NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks( hbTimeout, timeout ));
-        
+        NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
+
         // protect the buffers from GC so DMA can find them where they are supposed to be
-        CLR_RT_ProtectFromGC gcWriteBuffer( *writeBuffer );
-        CLR_RT_ProtectFromGC gcReadBuffer( *readBuffer );
+        CLR_RT_ProtectFromGC gcWriteBuffer(*writeBuffer);
+        CLR_RT_ProtectFromGC gcReadBuffer(*readBuffer);
 
         if (writeBuffer != NULL)
         {
-            palI2c->i2cTransaction.writeBuf = (uint8_t*)writeBuffer->GetFirstElement();
+            palI2c->i2cTransaction.writeBuf = (uint8_t *)writeBuffer->GetFirstElement();
         }
 
         if (readBuffer != NULL)
         {
-            palI2c->i2cTransaction.readBuf = (uint8_t*)readBuffer->GetFirstElement();
+            palI2c->i2cTransaction.readBuf = (uint8_t *)readBuffer->GetFirstElement();
         }
-        
+
         // perform I2C transaction using driver's callback which will set the appropriate event on completion
-        if(stack.m_customState == 1)
+        if (stack.m_customState == 1)
         {
             I2C_transfer(palI2c->i2c, &palI2c->i2cTransaction);
-            
+
             // bump custom state
             stack.m_customState = 2;
         }
 
-        while(eventResult)
+        while (eventResult)
         {
             // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
-            NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents( stack.m_owningThread, *timeout, CLR_RT_ExecutionEngine::c_Event_I2cMaster, eventResult ));
+            NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.WaitEvents(
+                stack.m_owningThread,
+                *timeout,
+                CLR_RT_ExecutionEngine::c_Event_I2cMaster,
+                eventResult));
 
-            if(eventResult)
+            if (eventResult)
             {
                 // event occurred
 
                 // create the return object (I2cTransferResult)
-                // only at this point we are sure that there will be a return from this thread so it's OK to use the managed stack
-                CLR_RT_HeapBlock& top = stack.PushValueAndClear();
-                NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
-                result = top.Dereference(); FAULT_ON_NULL(result);
+                // only at this point we are sure that there will be a return from this thread so it's OK to use the
+                // managed stack
+                CLR_RT_HeapBlock &top = stack.PushValueAndClear();
+                NANOCLR_CHECK_HRESULT(
+                    g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+                result = top.Dereference();
+                FAULT_ON_NULL(result);
 
                 // successfull transaction
                 // set the result field
-                result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status ].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
+                result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status].SetInteger(
+                    (CLR_UINT32)I2cTransferStatus_FullTransfer);
 
                 // set the bytes transferred field
-                result[ Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___bytesTransferred ].SetInteger((CLR_UINT32)(palI2c->i2cTransaction.writeCount + palI2c->i2cTransaction.readCount));
+                result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___bytesTransferred]
+                    .SetInteger((CLR_UINT32)(palI2c->i2cTransaction.writeCount + palI2c->i2cTransaction.readCount));
 
                 // done here
                 break;
@@ -237,7 +256,6 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
 
         // pop timeout heap block from stack
         stack.PopValue();
-
     }
     NANOCLR_NOCLEANUP();
 }

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_target.h
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_target.h
@@ -10,11 +10,11 @@
 #include "Board.h"
 #include <ti/drivers/I2C.h>
 
-// struct representing the I2C 
+// struct representing the I2C
 typedef struct
 {
-    I2C_Handle      i2c;
-    I2C_Params      i2cParams;
+    I2C_Handle i2c;
+    I2C_Params i2cParams;
     I2C_Transaction i2cTransaction;
 } NF_PAL_I2C;
 
@@ -23,4 +23,4 @@ typedef struct
 ///////////////////////////////////////////
 extern NF_PAL_I2C I2C1_PAL;
 
-#endif  //_WIN_DEV_I2C_NATIVE_TARGET_H_
+#endif //_WIN_DEV_I2C_NATIVE_TARGET_H_

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_target.h
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_target.h
@@ -11,12 +11,12 @@
 #include <ti/drivers/I2C.h>
 
 // struct representing the I2C 
-struct NF_PAL_I2C
+typedef struct
 {
     I2C_Handle      i2c;
     I2C_Params      i2cParams;
     I2C_Transaction i2cTransaction;
-};
+} NF_PAL_I2C;
 
 ///////////////////////////////////////////
 // declaration of the the I2C PAL strucs //

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_target.h
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_target.h
@@ -12,13 +12,13 @@
 #include <ti/drivers/SPI.h>
 
 // struct representing the SPI 
-struct NF_PAL_SPI
+typedef struct
 {
     SPI_Handle          masterSpi;
     SPI_Params          spiParams;
     SPI_Transaction*    transactions;
     uint8_t             transactionCount;
-};
+} NF_PAL_SPI;
 
 ///////////////////////////////////////////
 // declaration of the the SPI PAL strucs //

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_target.h
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.Spi/win_dev_spi_native_target.h
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-
 #ifndef _WIN_DEV_SPI_NATIVE_TARGET_H_
 #define _WIN_DEV_SPI_NATIVE_TARGET_H_
 
@@ -11,13 +10,13 @@
 #include "Board.h"
 #include <ti/drivers/SPI.h>
 
-// struct representing the SPI 
+// struct representing the SPI
 typedef struct
 {
-    SPI_Handle          masterSpi;
-    SPI_Params          spiParams;
-    SPI_Transaction*    transactions;
-    uint8_t             transactionCount;
+    SPI_Handle masterSpi;
+    SPI_Params spiParams;
+    SPI_Transaction *transactions;
+    uint8_t transactionCount;
 } NF_PAL_SPI;
 
 ///////////////////////////////////////////
@@ -25,4 +24,4 @@ typedef struct
 ///////////////////////////////////////////
 extern NF_PAL_SPI SPI1_PAL;
 
-#endif  //_WIN_DEV_SPI_NATIVE_TARGET_H_
+#endif //_WIN_DEV_SPI_NATIVE_TARGET_H_

--- a/targets/TI-SimpleLink/nanoCLR/targetHAL.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/targetHAL.cpp
@@ -23,32 +23,35 @@
 //
 //  Reboot handlers clean up on reboot
 //
-static ON_SOFT_REBOOT_HANDLER s_rebootHandlers[16] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
+static ON_SOFT_REBOOT_HANDLER s_rebootHandlers[16] =
+    {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
 void HAL_AddSoftRebootHandler(ON_SOFT_REBOOT_HANDLER handler)
 {
-    for(unsigned int i=0; i<ARRAYSIZE(s_rebootHandlers); i++)
+    for (unsigned int i = 0; i < ARRAYSIZE(s_rebootHandlers); i++)
     {
-        if(s_rebootHandlers[i] == NULL)
+        if (s_rebootHandlers[i] == NULL)
         {
             s_rebootHandlers[i] = handler;
             return;
         }
-        else if(s_rebootHandlers[i] == handler)
+        else if (s_rebootHandlers[i] == handler)
         {
             return;
         }
     }
 }
 
-// because nanoHAL_Initialize/Uninitialize needs to be called in both C and C++ we need a proxy to allow it to be called in 'C'
-extern "C" {
-    
+// because nanoHAL_Initialize/Uninitialize needs to be called in both C and C++ we need a proxy to allow it to be called
+// in 'C'
+extern "C"
+{
+
     void nanoHAL_Initialize_C()
     {
         nanoHAL_Initialize();
     }
-    
+
     void nanoHAL_Uninitialize_C()
     {
         nanoHAL_Uninitialize();
@@ -58,7 +61,7 @@ extern "C" {
 void nanoHAL_Initialize()
 {
     HAL_CONTINUATION::InitializeList();
-    HAL_COMPLETION  ::InitializeList();
+    HAL_COMPLETION ::InitializeList();
 
     BlockStorageList_Initialize();
 
@@ -68,10 +71,10 @@ void nanoHAL_Initialize()
     BlockStorageList_InitializeDevices();
 
     // clear managed heap region
-    unsigned char* heapStart = NULL;
-    unsigned int heapSize  = 0;
+    unsigned char *heapStart = NULL;
+    unsigned int heapSize = 0;
 
-    ::HeapLocation( heapStart, heapSize );
+    ::HeapLocation(heapStart, heapSize);
     memset(heapStart, 0, heapSize);
 
     ConfigurationManager_Initialize();
@@ -81,7 +84,7 @@ void nanoHAL_Initialize()
     CPU_GPIO_Initialize();
 
     // no PAL events required until now
-    //PalEvent_Initialize();
+    // PalEvent_Initialize();
 
 #if (HAL_USE_I2C == TRUE)
     I2C1_PAL.i2c = NULL;
@@ -91,19 +94,19 @@ void nanoHAL_Initialize()
     SPI1_PAL.masterSpi = NULL;
 #endif
 
-	// Init Networking
-	Network_Initialize();
-    
-	// Start Network Debugger
-   // SOCKETS_DbgInitialize( 0 );
+    // Init Networking
+    Network_Initialize();
+
+    // Start Network Debugger
+    // SOCKETS_DbgInitialize( 0 );
 }
 
 void nanoHAL_Uninitialize()
 {
     // check for s_rebootHandlers
-    for(unsigned int i = 0; i< ARRAYSIZE(s_rebootHandlers); i++)
+    for (unsigned int i = 0; i < ARRAYSIZE(s_rebootHandlers); i++)
     {
-        if(s_rebootHandlers[i] != NULL)
+        if (s_rebootHandlers[i] != NULL)
         {
             s_rebootHandlers[i]();
         }
@@ -111,14 +114,14 @@ void nanoHAL_Uninitialize()
         {
             break;
         }
-    }   
-    
+    }
+
     BlockStorageList_UnInitializeDevices();
 
-    //PalEvent_Uninitialize();
+    // PalEvent_Uninitialize();
 
     // TODO need to call this but it's preventing the debug session from starting
-    //Network_Uninitialize();
+    // Network_Uninitialize();
 
     CPU_GPIO_Uninitialize();
 
@@ -133,9 +136,8 @@ void nanoHAL_Uninitialize()
     Events_Uninitialize();
 
     HAL_CONTINUATION::Uninitialize();
-    HAL_COMPLETION  ::Uninitialize();
+    HAL_COMPLETION ::Uninitialize();
 }
-
 
 volatile int32_t SystemStates[SYSTEM_STATE_TOTAL_STATES];
 
@@ -167,7 +169,7 @@ void SystemState_Clear(SYSTEM_STATE_type state)
 {
     GLOBAL_LOCK();
 
-    SystemState_ClearNoLock(state );
+    SystemState_ClearNoLock(state);
 
     GLOBAL_UNLOCK();
 }
@@ -177,7 +179,7 @@ bool SystemState_Query(SYSTEM_STATE_type state)
     GLOBAL_LOCK();
 
     bool systemStateCopy = SystemState_QueryNoLock(state);
-    
+
     GLOBAL_UNLOCK();
 
     return systemStateCopy;

--- a/targets/TI-SimpleLink/nanoCLR/targetHAL.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/targetHAL.cpp
@@ -11,6 +11,15 @@
 #include <nanoHAL_ConfigurationManager.h>
 // #include <FreeRTOS.h>
 
+#if (HAL_USE_I2C == TRUE)
+#include <ti/drivers/I2C.h>
+#include <win_dev_i2c_native_target.h>
+#endif
+#if (HAL_USE_SPI == TRUE)
+#include <ti/drivers/SPI.h>
+#include <win_dev_spi_native_target.h>
+#endif
+
 //
 //  Reboot handlers clean up on reboot
 //
@@ -73,7 +82,15 @@ void nanoHAL_Initialize()
 
     // no PAL events required until now
     //PalEvent_Initialize();
-	
+
+#if (HAL_USE_I2C == TRUE)
+    I2C1_PAL.i2c = NULL;
+#endif
+
+#if (HAL_USE_SPI == TRUE)
+    SPI1_PAL.masterSpi = NULL;
+#endif
+
 	// Init Networking
 	Network_Initialize();
     
@@ -104,6 +121,14 @@ void nanoHAL_Uninitialize()
     //Network_Uninitialize();
 
     CPU_GPIO_Uninitialize();
+
+#if (HAL_USE_I2C == TRUE)
+    I2C_close(I2C1_PAL.i2c);
+#endif
+
+#if (HAL_USE_SPI == TRUE)
+    SPI_close(SPI1_PAL.masterSpi);
+#endif
 
     Events_Uninitialize();
 

--- a/targets/TI-SimpleLink/nanoCLR/target_platform.h.in
+++ b/targets/TI-SimpleLink/nanoCLR/target_platform.h.in
@@ -14,4 +14,10 @@
 // enable SNTP app
 #define SL_APP_SNTP         @NF_NETWORKING_SNTP@
 
+// enable I2C
+#define HAL_USE_I2C @API_Windows.Devices.I2c@
+
+// enable SPI
+#define HAL_USE_SPI @API_Windows.Devices.Spi@
+
 #endif /* _TARGET_TI_SIMPLELINK_NANOCLR_H_ */


### PR DESCRIPTION
## Description
- Add code to stop and release buses and drivers during nanoHAL_Uninitialize.
- Add code to init control structs of several drivers during nanoHAL_Initialize.
- Change declarations of control structs of several drivers to use typedef instead of plain structs.
- Add HAL options to TI SimpleLink to expose I2C and SPI inclusion to be able to properly manage the code in nanoHAL Init/Uninit.

## Motivation and Context
- Stopping and disposing of drivers is executed on call of NativeDispose. This doesn't always happen (specially on CLR reboot on which the RTOS is not restarted, except on devices that don't have soft reboot), which leads to drivers being wrongly left active/locked and their control structs initialized.
- Similar situation with the control structs of some drivers on CLR restart, which where NOT being reset/initialized causing the issues on the code ahead that uses them in a invalid state.
- Resolves nanoFramework/Home#627.
- Resolves nanoFramework/Home#626.

## How Has This Been Tested?<!-- (if applicable) -->
- I2C and SPI samples with STM32F429, STM32F091.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
