### PR TITLE
Fix target name ORGPAL_PALTHREE on cmake-variants

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ORGPAL_PALTHREE/cmake-variants.json
+++ b/targets/CMSIS-OS/ChibiOS/ORGPAL_PALTHREE/cmake-variants.json
@@ -22,8 +22,8 @@
   "linkage": {
     "default": "",
     "choices": {
-      "ST_STM32F769I_DISCOVERY": {
-        "short": "ST_STM32F769I_DISCOVERY",
+      "ORGPAL_PALTHREE": {
+        "short": "ORGPAL_PALTHREE",
         "settings": {
           "BUILD_VERSION": "0.9.99.999",
           "CMAKE_TOOLCHAIN_FILE": "CMake/toolchain.arm-none-eabi.cmake",
@@ -32,7 +32,7 @@
           "RTOS": "CHIBIOS",
           "TARGET_SERIES": "STM32F7xx",
           "CHIBIOS_SOURCE": "",
-          "CHIBIOS_BOARD": "ST_STM32F769I_DISCOVERY",
+          "CHIBIOS_BOARD": "ORGPAL_PALTHREE",
           "CHIBIOS_CONTRIB_REQUIRED": "OFF",
           "CHIBIOS_CONTRIB_SOURCE": "",
           "STM32_CUBE_PACKAGE_REQUIRED": "ON",


### PR DESCRIPTION
## Description
- Target was wrong.

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
