### PR TITLE
ESP32 Serial Native-store hang fix

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_target.h
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_target.h
@@ -25,6 +25,7 @@ typedef struct
     uint8_t *               RxBuffer;
     uint16_t                RxBytesToRead;
 
+    bool                    IsLongRunning;
 } NF_PAL_UART;
 
 #endif //_WIN_DEV_SERIAL_NATIVE_TARGET_H_


### PR DESCRIPTION
## Description

- Fixes a problem with LongRunning  operations
When using LongRunning it would hang in the Native-store method due to the LongRunning variable not being true the next time around as the buffer length was now shorter due to characters being sent.
Now stores LongRunning bool in NF_PAL_UART structure which is only initialized first time through.

- Fix an issue where the pin assignment were reset when COM port closed and reopened

- Fix a config problem if Xon/Xoff is used.

## Motivation and Context


## How Has This Been Tested?<!-- (if applicable) -->
Tested with my current project which failed straight away with serial at 9600 and longer strings.

There may still be a issue in this area as i did have a stop after running for a while but it also may be unrelated. I will be doing further testing. This PR fixes main problem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
