### PR TITLE
Fix create Process failed error on ESP32 build

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/CMakeLists.txt
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/CMakeLists.txt
@@ -79,6 +79,9 @@ if(USE_SECURITY_MBEDTLS_OPTION)
     add_dependencies(NetworkLib mbedTLS)
 endif()
 
+# Add Library for all NanoFramework Api
+add_library(NanoApiLib STATIC ${TARGET_NANO_APIS_SOURCES} )
+
 #######################
 # nanoCLR executable
 
@@ -102,9 +105,6 @@ add_executable(
     ${NF_CoreCLR_SOURCES}
     ${NF_Debugger_SOURCES}
     ${NF_Diagnostics_SOURCES}
-  
-    # # sources for nanoFramework APIs
-    ${TARGET_NANO_APIS_SOURCES}
 )
 
 # Add link flags
@@ -113,6 +113,8 @@ set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_F
 if(USE_SECURITY_MBEDTLS_OPTION)
     add_dependencies(${NANOCLR_PROJECT_NAME}.elf NetworkLib)
 endif()
+
+add_dependencies(${NANOCLR_PROJECT_NAME}.elf NanoApiLib)
 
 #message( "project libs:${PROJECT_LINK_LIBS} " )
 set(LIBPATHSAVE "")
@@ -166,10 +168,11 @@ foreach( IDF_libraries ${PROJECT_LINK_LIBS} )
 
 endforeach( IDF_libraries )
 
-
 if(USE_NETWORKING_OPTION)
     set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_FLAGS " -L${CMAKE_CURRENT_BINARY_DIR} -lNetworkLib " )
 endif()
+
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_FLAGS " -Wl,--whole-archive  -L${CMAKE_CURRENT_BINARY_DIR} -lNanoApiLib -Wl,--no-whole-archive " )
 
 set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_FLAGS " -lgcc -lstdc++ -lgcov -Wl,--end-group -Wl,-EL  ")
 
@@ -225,8 +228,22 @@ if(USE_NETWORKING_OPTION)
     set_target_properties(NetworkLib PROPERTIES COMPILE_FLAGS " -w " )
 endif()
 
+ target_include_directories(NanoApiLib PUBLIC
+    # directories for nanoFramework libraries
+    ${CMAKE_CURRENT_BINARY_DIR}/nanoCLR
+    ${NF_CoreCLR_INCLUDE_DIRS}
+
+    ${TARGET_ESP32_IDF_INCLUDES}
+
+    # includes for nanoFramework APIs
+    ${TARGET_NANO_APIS_INCLUDES}
+)
+
 # set platform for NanoClr
 target_compile_definitions(${NANOCLR_PROJECT_NAME}.elf PUBLIC "-DPLATFORM_ESP32 " )
+
+# set platform for NanoApiLib
+target_compile_definitions(NanoApiLib PUBLIC "-DPLATFORM_ESP32 " )
 
 # build types that have debugging capabilities AND are NOT RTM have to have the define 'NANOCLR_ENABLE_SOURCELEVELDEBUGGING'
 if((NOT NF_BUILD_RTM) OR NF_FEATURE_DEBUGGER)


### PR DESCRIPTION
## Description

When builds causes the GCC link command line to be greater than 32k you will get the error:-

**Create Process failed : No such file.**

In the latest builds this is now appearing.  Especially if all features are included. i.e. Graphic and new generic SPI code.

This is now fixed by putting all the nanoFramework API sources in to a separate library which is then linked in with main nanoClr.

## How Has This Been Tested?<!-- (if applicable) -->

Tested by building and running some test programs to check it linked ok.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
