### PR TITLE
Fix UART timeouts configuration

### DIFF
--- a/targets/TI-SimpleLink/nanoCLR/targetPAL.c
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL.c
@@ -6,6 +6,7 @@
 #include <ti/drivers/UART.h>
 #include <board.h>
 #include <ti/drivers/dpl/SemaphoreP.h>
+#include <ti/drivers/dpl/ClockP.h>
 
 extern UART_Handle uart;
 
@@ -17,6 +18,9 @@ SemaphoreP_Handle uartMutex;
 // The clean alternative would be to add the GCC attribute used in those functions, but that's not our code to touch.
 
 void dummyFunction(void) __attribute__((used));
+
+// UART operations timeout 
+#define UART_TIMEOUT_MILLISECONDS       500000
 
 // Never called.
 void dummyFunction(void) {
@@ -35,7 +39,9 @@ void ConfigUART()
     uartParams.writeDataMode = UART_DATA_BINARY;
     uartParams.readDataMode = UART_DATA_BINARY;
     uartParams.readEcho = UART_ECHO_OFF;
-    uartParams.baudRate = 921600;
+    uartParams.baudRate = 115200;
+    uartParams.readTimeout   = UART_TIMEOUT_MILLISECONDS / ClockP_tickPeriod; // Default tick period is 10us
+    uartParams.writeTimeout   = UART_TIMEOUT_MILLISECONDS / ClockP_tickPeriod; // Default tick period is 10us
 
     uart = UART_open(Board_UART0, &uartParams);
 

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL.c
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL.c
@@ -6,7 +6,7 @@
 #include <ti/drivers/UART.h>
 #include <board.h>
 #include <ti/drivers/dpl/SemaphoreP.h>
-#include <ti/drivers/dpl/ClockP.h>
+#include <ti/sysbios/knl/Clock.h>
 
 extern UART_Handle uart;
 
@@ -40,9 +40,9 @@ void ConfigUART()
     uartParams.writeDataMode = UART_DATA_BINARY;
     uartParams.readDataMode = UART_DATA_BINARY;
     uartParams.readEcho = UART_ECHO_OFF;
-    uartParams.baudRate = 115200;
-    uartParams.readTimeout = UART_TIMEOUT_MILLISECONDS / ClockP_tickPeriod;  // Default tick period is 10us
-    uartParams.writeTimeout = UART_TIMEOUT_MILLISECONDS / ClockP_tickPeriod; // Default tick period is 10us
+    uartParams.baudRate = 921600;
+    uartParams.readTimeout   = UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod;
+    uartParams.writeTimeout   = UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod;
 
     uart = UART_open(Board_UART0, &uartParams);
 

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL.c
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL.c
@@ -41,8 +41,8 @@ void ConfigUART()
     uartParams.readDataMode = UART_DATA_BINARY;
     uartParams.readEcho = UART_ECHO_OFF;
     uartParams.baudRate = 921600;
-    uartParams.readTimeout   = UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod;
-    uartParams.writeTimeout   = UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod;
+    uartParams.readTimeout = UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod;
+    uartParams.writeTimeout = UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod;
 
     uart = UART_open(Board_UART0, &uartParams);
 

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL.c
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL.c
@@ -19,11 +19,12 @@ SemaphoreP_Handle uartMutex;
 
 void dummyFunction(void) __attribute__((used));
 
-// UART operations timeout 
-#define UART_TIMEOUT_MILLISECONDS       500000
+// UART operations timeout
+#define UART_TIMEOUT_MILLISECONDS 500000
 
 // Never called.
-void dummyFunction(void) {
+void dummyFunction(void)
+{
     vTaskSwitchContext();
     localProgramStart();
 }
@@ -40,33 +41,35 @@ void ConfigUART()
     uartParams.readDataMode = UART_DATA_BINARY;
     uartParams.readEcho = UART_ECHO_OFF;
     uartParams.baudRate = 115200;
-    uartParams.readTimeout   = UART_TIMEOUT_MILLISECONDS / ClockP_tickPeriod; // Default tick period is 10us
-    uartParams.writeTimeout   = UART_TIMEOUT_MILLISECONDS / ClockP_tickPeriod; // Default tick period is 10us
+    uartParams.readTimeout = UART_TIMEOUT_MILLISECONDS / ClockP_tickPeriod;  // Default tick period is 10us
+    uartParams.writeTimeout = UART_TIMEOUT_MILLISECONDS / ClockP_tickPeriod; // Default tick period is 10us
 
     uart = UART_open(Board_UART0, &uartParams);
 
     if (uart == NULL)
     {
         // UART_open() failed
-        while (1);
+        while (1)
+            ;
     }
 
     uartMutex = SemaphoreP_createBinary(1);
     if (uartMutex == NULL)
     {
         // failed to create semaphore
-        while (1);
-    }    
+        while (1)
+            ;
+    }
 }
 
 void __error__(char *pcFilename, unsigned long ulLine)
 {
-  //
-  // Something horrible happened! You need to look
-  // at file "pcFilename" at line "ulLine" to see
-  // what error is being reported.
-  //
-  while(1)
-  {
-  }
+    //
+    // Something horrible happened! You need to look
+    // at file "pcFilename" at line "ulLine" to see
+    // what error is being reported.
+    //
+    while (1)
+    {
+    }
 }


### PR DESCRIPTION
## Description
- Add RX & TX timeout to UART config. Default to 500ms.

## Motivation and Context
- Required for the last SDK when using UART_MODE_BLOCKING, otherwise the call would block "forever".

## How Has This Been Tested?<!-- (if applicable) -->
- VS target detection.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
