### PR TITLE
Rework CPU GPIO for TI SimpleLink

### DIFF
--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/TI_CC1352R1_LAUNCHXL.syscfg
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/TI_CC1352R1_LAUNCHXL.syscfg
@@ -13,12 +13,6 @@ const DMA      = scripting.addModule("/ti/drivers/DMA");
 const RTOS     = scripting.addModule("/ti/drivers/RTOS");
 const UART     = scripting.addModule("/ti/drivers/UART", {}, false);
 const UART1    = UART.addInstance();
-const Button   = scripting.addModule("/ti/drivers/apps/Button", {}, false);
-const Button1  = Button.addInstance();
-const Button2  = Button.addInstance();
-const LED      = scripting.addModule("/ti/drivers/apps/LED", {}, false);
-const LED1     = LED.addInstance();
-const LED2     = LED.addInstance();
 const easylink = scripting.addModule("/ti/easylink/easylink");
 
 /**
@@ -27,28 +21,11 @@ const easylink = scripting.addModule("/ti/easylink/easylink");
 CCFG.forceVddr          = true;
 CCFG.ccfgTemplate.$name = "ti_devices_CCFGTemplate0";
 
-UART1.$name               = "UART0";
 UART1.$hardware           = system.deviceData.board.components.XDS110UART;
+UART1.$name               = "UART0";
 UART1.txPinInstance.$name = "CONFIG_PIN_0";
 UART1.rxPinInstance.$name = "CONFIG_PIN_1";
-
-Button1.$hardware                 = system.deviceData.board.components["BTN-1"];
-Button1.$name                     = "CONFIG_BUTTON_1";
-Button1.gpioPin.$name             = "CONFIG_GPIO_0";
-Button1.gpioPin.pinInstance.$name = "CONFIG_PIN_4";
-
-Button2.$hardware                 = system.deviceData.board.components["BTN-2"];
-Button2.$name                     = "CONFIG_BUTTON_2";
-Button2.gpioPin.$name             = "CONFIG_GPIO_1";
-Button2.gpioPin.pinInstance.$name = "CONFIG_PIN_5";
-
-LED1.$hardware                 = system.deviceData.board.components.LED_RED;
-LED1.$name                     = "CONFIG_GPIO_RLED";
-LED1.gpioPin.pinInstance.$name = "CONFIG_PIN_2";
-
-LED2.$name                     = "CONFIG_GPIO_GLED";
-LED2.$hardware                 = system.deviceData.board.components.LED_GREEN;
-LED2.gpioPin.pinInstance.$name = "CONFIG_PIN_3";
+UART1.uart.$assign        = "UART0";
 
 easylink.EasyLink_Phy_5kbpsSlLr                                    = true;
 easylink.defaultPhy                                                = "EasyLink_Phy_5kbpsSlLr";
@@ -65,10 +42,5 @@ easylink.radioConfigEasylinkPhy200kbps2gfsk.codeExportConfig.$name = "ti_devices
  * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
  * re-solve from scratch.
  */
-UART1.uart.$suggestSolution              = "UART0";
-UART1.uart.txPin.$suggestSolution        = "boosterpack.4";
-UART1.uart.rxPin.$suggestSolution        = "boosterpack.3";
-Button1.gpioPin.gpioPin.$suggestSolution = "boosterpack.13";
-Button2.gpioPin.gpioPin.$suggestSolution = "boosterpack.12";
-LED1.gpioPin.gpioPin.$suggestSolution    = "boosterpack.39";
-LED2.gpioPin.gpioPin.$suggestSolution    = "boosterpack.40";
+UART1.uart.txPin.$suggestSolution = "boosterpack.4";
+UART1.uart.rxPin.$suggestSolution = "boosterpack.3";

--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/nanoCLR/main.c
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/nanoCLR/main.c
@@ -14,6 +14,7 @@
 
 // board Header files
 #include <ti_drivers_config.h>
+#include <ti/drivers/gpio/GPIOCC26XX.h>
 
 //////////////////////////////
 
@@ -24,6 +25,22 @@ Task_Handle receiverHandle;
 Task_Handle clrHandle;
 
 CLR_SETTINGS clrSettings;
+
+// this define has to match the one in cpu_gpio.cpp
+#define GPIO_MAX_PINS      16
+
+// these are declared in cpu_gpio.cpp
+extern GPIO_PinConfig gpioPinConfigs[GPIO_MAX_PINS];
+extern GPIO_CallbackFxn gpioCallbackFunctions[GPIO_MAX_PINS];
+
+// this has to be define in a C file, otherwise the linker can't replace the weak one declared in the SDK driver library
+const GPIOCC26XX_Config GPIOCC26XX_config = {
+    .pinConfigs = (GPIO_PinConfig *)gpioPinConfigs,
+    .callbacks = (GPIO_CallbackFxn *)gpioCallbackFunctions,
+    .numberOfPinConfigs = GPIO_MAX_PINS,
+    .numberOfCallbacks = GPIO_MAX_PINS,
+    .intPriority = (~0)
+};
 
 extern void ReceiverThread(UArg arg0, UArg arg1);
 extern void CLRStartupThread(UArg arg0, UArg arg1);
@@ -69,10 +86,6 @@ int main(void)
     GPIO_init();
     UART_init();
     ConfigUART();
-
-    // Switch off all LEDs on board
-    GPIO_write(CONFIG_GPIO_RLED, CONFIG_LED_OFF);
-    GPIO_write(CONFIG_GPIO_GLED, CONFIG_LED_OFF);
 
     BIOS_start();
 

--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/nanoCLR/main.c
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/nanoCLR/main.c
@@ -27,7 +27,7 @@ Task_Handle clrHandle;
 CLR_SETTINGS clrSettings;
 
 // this define has to match the one in cpu_gpio.cpp
-#define GPIO_MAX_PINS      16
+#define GPIO_MAX_PINS 16
 
 // these are declared in cpu_gpio.cpp
 extern GPIO_PinConfig gpioPinConfigs[GPIO_MAX_PINS];
@@ -39,8 +39,7 @@ const GPIOCC26XX_Config GPIOCC26XX_config = {
     .callbacks = (GPIO_CallbackFxn *)gpioCallbackFunctions,
     .numberOfPinConfigs = GPIO_MAX_PINS,
     .numberOfCallbacks = GPIO_MAX_PINS,
-    .intPriority = (~0)
-};
+    .intPriority = (~0)};
 
 extern void ReceiverThread(UArg arg0, UArg arg1);
 extern void CLRStartupThread(UArg arg0, UArg arg1);

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
@@ -12,29 +12,29 @@
 #include <ti/drivers/gpio/GPIOCC26XX.h>
 #include <ti/drivers/PIN.h>
 
-#define GPIO_MAX_PINS      16
-#define TOTAL_GPIO_PORTS   ((GPIO_MAX_PINS + 15) / 16)
+#define GPIO_MAX_PINS    16
+#define TOTAL_GPIO_PORTS ((GPIO_MAX_PINS + 15) / 16)
 
-#define EMPTY_PIN  0xFFFF
+#define EMPTY_PIN 0xFFFF
 
 // Array of Pin configurations
 GPIO_PinConfig gpioPinConfigs[] = {
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
-	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+    GPIO_DO_NOT_CONFIG | EMPTY_PIN,
 };
 
 // Array of callback function pointers
@@ -43,161 +43,161 @@ GPIO_CallbackFxn gpioCallbackFunctions[GPIO_MAX_PINS];
 // Gpio input state structure
 struct gpio_input_state : public HAL_DblLinkedNode<gpio_input_state>
 {
-	// Pin number
-	GPIO_PIN 		pinNumber;
+    // Pin number
+    GPIO_PIN pinNumber;
 
-	// pin config index
-	uint8_t			pinConfigIndex;
-	
-	// debounce timer for this Pin
-	Clock_Handle 	debounceTimer;			
-	
-	// poniter to user ISR or null
-	GPIO_INTERRUPT_SERVICE_ROUTINE isrPtr;
-		
-	// debounce millsecs, no debonce=0
-	uint32_t 		debounceMs;             
-	
-	// interrupt mode
-	uint8_t  		mode;                   
+    // pin config index
+    uint8_t pinConfigIndex;
 
-	// param to user IRS call
-	void *   		param; 
+    // debounce timer for this Pin
+    Clock_Handle debounceTimer;
 
-	// expected state for debounce handler
-	bool     		expected;               
-	
-	// flag for waiting for debounce timer to complete
-	bool     		waitingDebounce;	    
+    // poniter to user ISR or null
+    GPIO_INTERRUPT_SERVICE_ROUTINE isrPtr;
+
+    // debounce millsecs, no debonce=0
+    uint32_t debounceMs;
+
+    // interrupt mode
+    uint8_t mode;
+
+    // param to user IRS call
+    void *param;
+
+    // expected state for debounce handler
+    bool expected;
+
+    // flag for waiting for debounce timer to complete
+    bool waitingDebounce;
 };
 
 // Double Linked list for GPIO input status
 static HAL_DblLinkedList<gpio_input_state> gpioInputList;
 
 // Array of bits for saving reserved state
-static uint16_t pinReserved[TOTAL_GPIO_PORTS];      
+static uint16_t pinReserved[TOTAL_GPIO_PORTS];
 
 // Get pointer to gpio_input_state for GPIO pin
 // return NULL if not found
-gpio_input_state* GetInputState(GPIO_PIN pinNumber)
+gpio_input_state *GetInputState(GPIO_PIN pinNumber)
 {
-	gpio_input_state* pState = gpioInputList.FirstNode();
-	
-	while (pState->Next() != NULL)
-	{
-		if (pState->pinNumber == pinNumber) 
-		{
-			return pState;
-		}
+    gpio_input_state *pState = gpioInputList.FirstNode();
 
-		pState = pState->Next();
-	}
+    while (pState->Next() != NULL)
+    {
+        if (pState->pinNumber == pinNumber)
+        {
+            return pState;
+        }
 
-	return NULL;
+        pState = pState->Next();
+    }
+
+    return NULL;
 }
 
 // find a free slot in the pin config array
 int8_t FindFreePinConfig()
 {
-	for(uint8_t index = 0; index < GPIO_MAX_PINS; index++)
-	{
-		if((uint16_t)gpioPinConfigs[index] == EMPTY_PIN)
-		{
-			// found a free slot!
-			return index;
-		}
-	}
+    for (uint8_t index = 0; index < GPIO_MAX_PINS; index++)
+    {
+        if ((uint16_t)gpioPinConfigs[index] == EMPTY_PIN)
+        {
+            // found a free slot!
+            return index;
+        }
+    }
 
-	return -1;
+    return -1;
 }
 
 // find a pin number in the pin config array
 int8_t FindPinConfig(GPIO_PIN pinNumber)
 {
-	for(uint8_t index = 0; index < GPIO_MAX_PINS; index++)
-	{
-		if((uint8_t)gpioPinConfigs[index] == pinNumber)
-		{
-			// found a free slot!
-			return index;
-		}
-	}
+    for (uint8_t index = 0; index < GPIO_MAX_PINS; index++)
+    {
+        if ((uint8_t)gpioPinConfigs[index] == pinNumber)
+        {
+            // found a free slot!
+            return index;
+        }
+    }
 
-	return -1;
+    return -1;
 }
 
 // Allocate a new gpio_input_state and add to end of list
 // if already exist then just return current ptr
-gpio_input_state* AllocateGpioInputState(GPIO_PIN pinNumber)
+gpio_input_state *AllocateGpioInputState(GPIO_PIN pinNumber)
 {
-	gpio_input_state * pState = GetInputState(pinNumber);
+    gpio_input_state *pState = GetInputState(pinNumber);
 
-	if (pState == NULL)
-	{
-		// no input state for this GPIO
-		// check if there is room at the pinf config array
-		uint8_t index = FindFreePinConfig();
+    if (pState == NULL)
+    {
+        // no input state for this GPIO
+        // check if there is room at the pinf config array
+        uint8_t index = FindFreePinConfig();
 
-		if(index >= 0)
-		{
-			// found a free slot!
-			pState = (gpio_input_state *)platform_malloc(sizeof(gpio_input_state));
-	
-			// sanity check
-			if(pState != NULL)
-			{
-				memset(pState, 0, sizeof(gpio_input_state));
-				
-				// store the pin number
-				pState->pinNumber = pinNumber;
+        if (index >= 0)
+        {
+            // found a free slot!
+            pState = (gpio_input_state *)platform_malloc(sizeof(gpio_input_state));
 
-				// store the index of the pin config
-				pState->pinConfigIndex = index;
+            // sanity check
+            if (pState != NULL)
+            {
+                memset(pState, 0, sizeof(gpio_input_state));
 
-				gpioInputList.LinkAtBack(pState);
+                // store the pin number
+                pState->pinNumber = pinNumber;
 
-				// set the pin number in the config array
-				gpioPinConfigs[index] = pinNumber | GPIO_CFG_IN_NOPULL | GPIO_CFG_IN_INT_NONE;
-			}
-		}
-	}
+                // store the index of the pin config
+                pState->pinConfigIndex = index;
 
-	return pState;
+                gpioInputList.LinkAtBack(pState);
+
+                // set the pin number in the config array
+                gpioPinConfigs[index] = pinNumber | GPIO_CFG_IN_NOPULL | GPIO_CFG_IN_INT_NONE;
+            }
+        }
+    }
+
+    return pState;
 }
 
-void UnlinkInputState(gpio_input_state* pState)
+void UnlinkInputState(gpio_input_state *pState)
 {
-	if (pState->debounceTimer != 0)
-	{
-		Clock_delete(&pState->debounceTimer);
-	}
+    if (pState->debounceTimer != 0)
+    {
+        Clock_delete(&pState->debounceTimer);
+    }
 
-	// Remove interrupt associated with pin
-	// it's OK to do always this, no matter if interrupts are enabled or not
-	GPIO_disableInt(pState->pinConfigIndex);
+    // Remove interrupt associated with pin
+    // it's OK to do always this, no matter if interrupts are enabled or not
+    GPIO_disableInt(pState->pinConfigIndex);
 
-	// remove callback
-	gpioCallbackFunctions[pState->pinConfigIndex] = NULL;
+    // remove callback
+    gpioCallbackFunctions[pState->pinConfigIndex] = NULL;
 
-	// clear pin config
-	gpioPinConfigs[pState->pinConfigIndex] = GPIO_DO_NOT_CONFIG | EMPTY_PIN;
+    // clear pin config
+    gpioPinConfigs[pState->pinConfigIndex] = GPIO_DO_NOT_CONFIG | EMPTY_PIN;
 
-	// unlink from list
-	pState->Unlink();
+    // unlink from list
+    pState->Unlink();
 
-	// free memory
-	platform_free(pState);
+    // free memory
+    platform_free(pState);
 }
 
 // Delete gpio_input_state from array and tidy up ( Timer & ISR handler )
 void DeleteGpioInputState(GPIO_PIN pinNumber)
 {
-	gpio_input_state* pState = GetInputState(pinNumber);
+    gpio_input_state *pState = GetInputState(pinNumber);
 
-	if (pState)
-	{
-		UnlinkInputState(pState);
-	}
+    if (pState)
+    {
+        UnlinkInputState(pState);
+    }
 }
 
 //
@@ -207,261 +207,271 @@ static void debounceTimer_Callback(UArg arg)
 {
     int16_t index = (int16_t)arg;
 
-	gpio_input_state * pState = GetInputState(index);
+    gpio_input_state *pState = GetInputState(index);
 
-	if (pState)
-	{
-		if (pState->isrPtr)
-		{
-			// get current pin state
-			bool actual = CPU_GPIO_GetPinState(pState->pinNumber);
-			if (actual == pState->expected)
-			{
-				pState->isrPtr(pState->pinNumber, actual, pState->param);
+    if (pState)
+    {
+        if (pState->isrPtr)
+        {
+            // get current pin state
+            bool actual = CPU_GPIO_GetPinState(pState->pinNumber);
+            if (actual == pState->expected)
+            {
+                pState->isrPtr(pState->pinNumber, actual, pState->param);
 
-				if (pState->mode == GPIO_INT_EDGE_BOTH)
-				{
-					// both edges
-					// update expected state
-					pState->expected ^= 1;
-				}
-			}
-		}
-	}
+                if (pState->mode == GPIO_INT_EDGE_BOTH)
+                {
+                    // both edges
+                    // update expected state
+                    pState->expected ^= 1;
+                }
+            }
+        }
+    }
 
-	pState->waitingDebounce = false;
+    pState->waitingDebounce = false;
 }
 
 // Gpio event callback
 static void GpioEventCallback(uint_least8_t index)
 {
-	NATIVE_INTERRUPT_START
+    NATIVE_INTERRUPT_START
 
-	gpio_input_state* pState = GetInputState(index);
+    gpio_input_state *pState = GetInputState(index);
 
-	// Any pin set up here ?
-	if (pState != NULL)
-	{
-		// Ignore any pin changes during debounce timeout
-		if (!pState->waitingDebounce)
-		{
-			// If calling ISR available then call it
-			if (pState->isrPtr)
-			{
-				// Debounce time set ?
-				if (pState->debounceMs > 0)
-				{
-					// Yes, set up debounce timer
-					pState->waitingDebounce = true;
+    // Any pin set up here ?
+    if (pState != NULL)
+    {
+        // Ignore any pin changes during debounce timeout
+        if (!pState->waitingDebounce)
+        {
+            // If calling ISR available then call it
+            if (pState->isrPtr)
+            {
+                // Debounce time set ?
+                if (pState->debounceMs > 0)
+                {
+                    // Yes, set up debounce timer
+                    pState->waitingDebounce = true;
 
-					// Timer created yet ?
-					if (pState->debounceTimer == 0)
-					{
-						// setup timer
-						Clock_Params params;
+                    // Timer created yet ?
+                    if (pState->debounceTimer == 0)
+                    {
+                        // setup timer
+                        Clock_Params params;
 
-						Clock_Params_init(&params);
-						params.arg = (UArg)index;
-						params.startFlag = false;
-						params.period = 0;
+                        Clock_Params_init(&params);
+                        params.arg = (UArg)index;
+                        params.startFlag = false;
+                        params.period = 0;
 
-						// Create and start timer
-						pState->debounceTimer = Clock_create(debounceTimer_Callback, pState->debounceMs / Clock_tickPeriod, &params, Error_IGNORE);
-					}
-					else
-					{
-						// timer already exists
-						// set timeout
-						Clock_setTimeout(pState->debounceTimer, pState->debounceMs / Clock_tickPeriod);
-					}
+                        // Create and start timer
+                        pState->debounceTimer = Clock_create(
+                            debounceTimer_Callback,
+                            pState->debounceMs / Clock_tickPeriod,
+                            &params,
+                            Error_IGNORE);
+                    }
+                    else
+                    {
+                        // timer already exists
+                        // set timeout
+                        Clock_setTimeout(pState->debounceTimer, pState->debounceMs / Clock_tickPeriod);
+                    }
 
-					// start timer
-					Clock_start(pState->debounceTimer);
-				}
-				else
-				{
-					// No debounce so just call ISR with current pin state
-					uint_fast8_t pinState = GPIO_read(pState->pinConfigIndex);
-					pState->isrPtr(pState->pinNumber, pinState, pState->param);
-				}
-			}
-		}
-	}
+                    // start timer
+                    Clock_start(pState->debounceTimer);
+                }
+                else
+                {
+                    // No debounce so just call ISR with current pin state
+                    uint_fast8_t pinState = GPIO_read(pState->pinConfigIndex);
+                    pState->isrPtr(pState->pinNumber, pinState, pState->param);
+                }
+            }
+        }
+    }
 
-	NATIVE_INTERRUPT_END
+    NATIVE_INTERRUPT_END
 }
 
 bool CPU_GPIO_Initialize()
 {
-	// Initialise Double linked list for input pin states
-	gpioInputList.Initialize();
+    // Initialise Double linked list for input pin states
+    gpioInputList.Initialize();
 
-	// clear GPIO pin configs
-	for(uint8_t index = 0; index < GPIO_MAX_PINS; index++)
-	{
-		gpioPinConfigs[index] == GPIO_DO_NOT_CONFIG | EMPTY_PIN;
-	}
+    // clear GPIO pin configs
+    for (uint8_t index = 0; index < GPIO_MAX_PINS; index++)
+    {
+        gpioPinConfigs[index] == GPIO_DO_NOT_CONFIG | EMPTY_PIN;
+    }
 
-	// clear callbacks
-	memset(gpioCallbackFunctions, 0, sizeof(gpioCallbackFunctions));
-	
-	// Make sure all pins are not reserved
-	memset(pinReserved, 0, sizeof(pinReserved));
-	
-	return true;
+    // clear callbacks
+    memset(gpioCallbackFunctions, 0, sizeof(gpioCallbackFunctions));
+
+    // Make sure all pins are not reserved
+    memset(pinReserved, 0, sizeof(pinReserved));
+
+    return true;
 }
 
 bool CPU_GPIO_Uninitialize()
 {
-	NANOCLR_FOREACH_NODE(gpio_input_state, pGpio, gpioInputList)
-	{
-		UnlinkInputState(pGpio);
-	}
-	NANOCLR_FOREACH_NODE_END();
+    NANOCLR_FOREACH_NODE(gpio_input_state, pGpio, gpioInputList)
+    {
+        UnlinkInputState(pGpio);
+    }
+    NANOCLR_FOREACH_NODE_END();
 
-	return true;
+    return true;
 }
 
 // Set/reset reserved state of pin
 bool CPU_GPIO_ReservePin(GPIO_PIN pinNumber, bool fReserve)
 {
-	// Check if valid pin number 0 - 15
-	// TODO get this define from the SDK as the number is wrong 
-	// for CC13x2 there are 32 possible GPIO pins
-	if ( pinNumber >= GPIO_MAX_PINS )
-	{
-		return false;
-	}
+    // Check if valid pin number 0 - 15
+    // TODO get this define from the SDK as the number is wrong
+    // for CC13x2 there are 32 possible GPIO pins
+    if (pinNumber >= GPIO_MAX_PINS)
+    {
+        return false;
+    }
 
-	int port = pinNumber >> 4, bit = 1 << (pinNumber & 0x0F);
+    int port = pinNumber >> 4, bit = 1 << (pinNumber & 0x0F);
 
-	GLOBAL_LOCK();
+    GLOBAL_LOCK();
 
-	if (fReserve)
-	{
-		if (pinReserved[port] & bit)
-		{
-			GLOBAL_UNLOCK();
-			return false; // already reserved
-		}
+    if (fReserve)
+    {
+        if (pinReserved[port] & bit)
+        {
+            GLOBAL_UNLOCK();
+            return false; // already reserved
+        }
 
-		pinReserved[port] |= bit;
-	}
-	else
-	{
-		pinReserved[port] &= ~bit;
-	}
+        pinReserved[port] |= bit;
+    }
+    else
+    {
+        pinReserved[port] &= ~bit;
+    }
 
-	GLOBAL_UNLOCK();
-	return true;
+    GLOBAL_UNLOCK();
+    return true;
 }
 
 // Return if Pin is reserved
 bool CPU_GPIO_PinIsBusy(GPIO_PIN pin)
 {
-	int port = pin >> 4, sh = pin & 0x0F;
-	return (pinReserved[port] >> sh) & 1;
+    int port = pin >> 4, sh = pin & 0x0F;
+    return (pinReserved[port] >> sh) & 1;
 }
 
 // Return maximum number of pins
 int32_t CPU_GPIO_GetPinCount()
 {
-	return GPIO_MAX_PINS;
+    return GPIO_MAX_PINS;
 }
 
 // Get current state of pin
 GpioPinValue CPU_GPIO_GetPinState(GPIO_PIN pinNumber)
 {
-	// get index of pin in config array
-	uint8_t index = FindPinConfig(pinNumber);
+    // get index of pin in config array
+    uint8_t index = FindPinConfig(pinNumber);
 
-	if(index >= 0)
-	{
-		return (GpioPinValue)GPIO_read(index);
-	}
+    if (index >= 0)
+    {
+        return (GpioPinValue)GPIO_read(index);
+    }
 }
 
 // Set Pin state
 void CPU_GPIO_SetPinState(GPIO_PIN pinNumber, GpioPinValue pinState)
 {
-	// get index of pin in config array
-	uint8_t index = FindPinConfig(pinNumber);
+    // get index of pin in config array
+    uint8_t index = FindPinConfig(pinNumber);
 
-	if(index >= 0)
-	{
-		GPIO_write(index, pinState);
-	}
+    if (index >= 0)
+    {
+        GPIO_write(index, pinState);
+    }
 }
 
 // Toggle pin state
 void CPU_GPIO_TogglePinState(GPIO_PIN pinNumber)
 {
-	uint8_t index = FindPinConfig(pinNumber);
+    uint8_t index = FindPinConfig(pinNumber);
 
-	if(index >= 0)
-	{
-		GPIO_toggle(index);
-	}
+    if (index >= 0)
+    {
+        GPIO_toggle(index);
+    }
 }
 
 // Enable gpio pin for input
-bool CPU_GPIO_EnableInputPin(GPIO_PIN pinNumber, CLR_UINT64 debounceTimeMilliseconds, GPIO_INTERRUPT_SERVICE_ROUTINE pin_ISR, void* isr_Param, GPIO_INT_EDGE intEdge, GpioPinDriveMode driveMode)
+bool CPU_GPIO_EnableInputPin(
+    GPIO_PIN pinNumber,
+    CLR_UINT64 debounceTimeMilliseconds,
+    GPIO_INTERRUPT_SERVICE_ROUTINE pin_ISR,
+    void *isr_Param,
+    GPIO_INT_EDGE intEdge,
+    GpioPinDriveMode driveMode)
 {
-	gpio_input_state* pState;
+    gpio_input_state *pState;
 
-	// Check Input drive mode
-	if (driveMode >= (int)GpioPinDriveMode_Output)
-	{
-		return false;
-	}
+    // Check Input drive mode
+    if (driveMode >= (int)GpioPinDriveMode_Output)
+    {
+        return false;
+    }
 
-	pState = AllocateGpioInputState(pinNumber);
+    pState = AllocateGpioInputState(pinNumber);
 
-	if (!CPU_GPIO_SetDriveMode(pState->pinConfigIndex, driveMode))
-	{
-		return false;
-	}
+    if (!CPU_GPIO_SetDriveMode(pState->pinConfigIndex, driveMode))
+    {
+        return false;
+    }
 
-	// Link ISR ptr supplied and not already set up
-	// CPU_GPIO_EnableInputPin could be called a 2nd time with changed parameters
-	if ( (pin_ISR != NULL) && (pState->isrPtr == NULL))
-	{
-		// get current config
-		GPIO_PinConfig currentPinConfig;
-		GPIO_getConfig(pState->pinConfigIndex, &currentPinConfig);
+    // Link ISR ptr supplied and not already set up
+    // CPU_GPIO_EnableInputPin could be called a 2nd time with changed parameters
+    if ((pin_ISR != NULL) && (pState->isrPtr == NULL))
+    {
+        // get current config
+        GPIO_PinConfig currentPinConfig;
+        GPIO_getConfig(pState->pinConfigIndex, &currentPinConfig);
 
-		// set interrupt on both edges
-		GPIO_setConfig(pState->pinConfigIndex, currentPinConfig | GPIO_CFG_IN_INT_BOTH_EDGES );
-		GPIO_setCallback(pState->pinConfigIndex, GpioEventCallback);
-	}
+        // set interrupt on both edges
+        GPIO_setConfig(pState->pinConfigIndex, currentPinConfig | GPIO_CFG_IN_INT_BOTH_EDGES);
+        GPIO_setCallback(pState->pinConfigIndex, GpioEventCallback);
+    }
 
-	pState->isrPtr = pin_ISR;
-	pState->mode = intEdge;
-	pState->param = (void *)isr_Param;
-	pState->debounceMs = (uint32_t)(debounceTimeMilliseconds);
+    pState->isrPtr = pin_ISR;
+    pState->mode = intEdge;
+    pState->param = (void *)isr_Param;
+    pState->debounceMs = (uint32_t)(debounceTimeMilliseconds);
 
-	switch (intEdge)
-	{
-		case GPIO_INT_EDGE_LOW:
-		case GPIO_INT_LEVEL_LOW:
-			pState->expected = false;
-			break;
+    switch (intEdge)
+    {
+        case GPIO_INT_EDGE_LOW:
+        case GPIO_INT_LEVEL_LOW:
+            pState->expected = false;
+            break;
 
-		case GPIO_INT_EDGE_HIGH:
-		case GPIO_INT_LEVEL_HIGH:
-			pState->expected = true;
-			break;
+        case GPIO_INT_EDGE_HIGH:
+        case GPIO_INT_LEVEL_HIGH:
+            pState->expected = true;
+            break;
 
-		case GPIO_INT_EDGE_BOTH:
-			// Use inverse of current pin state  
-			pState->expected = !CPU_GPIO_GetPinState(pinNumber);  
-			break;
+        case GPIO_INT_EDGE_BOTH:
+            // Use inverse of current pin state
+            pState->expected = !CPU_GPIO_GetPinState(pinNumber);
+            break;
 
-		default:
-			break;
-	}
+        default:
+            break;
+    }
 
-	return true;
+    return true;
 }
 
 // Enable an output pin
@@ -471,61 +481,61 @@ bool CPU_GPIO_EnableInputPin(GPIO_PIN pinNumber, CLR_UINT64 debounceTimeMillisec
 // driveMode    -   Drive mode and resistors
 // return       -   True if succesful, false invalid pin, pin not putput, invalid drive mode for ouptput
 //
-bool  CPU_GPIO_EnableOutputPin(GPIO_PIN pinNumber, GpioPinValue InitialState, GpioPinDriveMode driveMode)
+bool CPU_GPIO_EnableOutputPin(GPIO_PIN pinNumber, GpioPinValue InitialState, GpioPinDriveMode driveMode)
 {
-	// check is output drive mode
-	if (driveMode < (int)GpioPinDriveMode_Output)
-	{
-		return false;
-	}
+    // check is output drive mode
+    if (driveMode < (int)GpioPinDriveMode_Output)
+    {
+        return false;
+    }
 
-	// If this is currently an input pin then clean up
-	DeleteGpioInputState(pinNumber);
+    // If this is currently an input pin then clean up
+    DeleteGpioInputState(pinNumber);
 
-	// get free slot in pin config array
-	uint8_t index = FindFreePinConfig();
+    // get free slot in pin config array
+    uint8_t index = FindFreePinConfig();
 
-	if(index >= 0)
-	{
-		// found a free slot!
-		
-		// set the pin number in the config array
-		gpioPinConfigs[index] = pinNumber | PIN_GPIO_OUTPUT_EN;
+    if (index >= 0)
+    {
+        // found a free slot!
 
-		if (CPU_GPIO_SetDriveMode(index, driveMode) == false)
-		{
-			return false;
-		}
+        // set the pin number in the config array
+        gpioPinConfigs[index] = pinNumber | PIN_GPIO_OUTPUT_EN;
 
-		CPU_GPIO_SetPinState(pinNumber, InitialState);
+        if (CPU_GPIO_SetDriveMode(index, driveMode) == false)
+        {
+            return false;
+        }
 
-		return true;
-	}
+        CPU_GPIO_SetPinState(pinNumber, InitialState);
 
-	return false;
+        return true;
+    }
+
+    return false;
 }
 
 void CPU_GPIO_DisablePin(GPIO_PIN pinNumber, GpioPinDriveMode driveMode, uint32_t alternateFunction)
 {
-	GLOBAL_LOCK();
+    GLOBAL_LOCK();
 
-	uint8_t index = FindPinConfig(pinNumber);
+    uint8_t index = FindPinConfig(pinNumber);
 
-	if(index >= 0)
-	{
-		DeleteGpioInputState(pinNumber);
+    if (index >= 0)
+    {
+        DeleteGpioInputState(pinNumber);
 
-		CPU_GPIO_SetDriveMode(index, driveMode);
+        CPU_GPIO_SetDriveMode(index, driveMode);
 
-		if (alternateFunction)
-		{
-			GPIO_setConfig(index, alternateFunction);
-		}
+        if (alternateFunction)
+        {
+            GPIO_setConfig(index, alternateFunction);
+        }
 
-		GLOBAL_UNLOCK();
+        GLOBAL_UNLOCK();
 
-		CPU_GPIO_ReservePin(pinNumber, false);
-	}
+        CPU_GPIO_ReservePin(pinNumber, false);
+    }
 }
 
 // Set drive mode
@@ -571,46 +581,43 @@ bool CPU_GPIO_SetDriveMode(GPIO_PIN pinNumber, GpioPinDriveMode driveMode)
             return false;
     }
 
-	return true;
+    return true;
 }
 
 bool CPU_GPIO_DriveModeSupported(GPIO_PIN pinNumber, GpioPinDriveMode driveMode)
 {
-	(void)pinNumber;
+    (void)pinNumber;
 
-	bool driveModeSupported = false;
+    bool driveModeSupported = false;
 
-	// check if the requested drive mode is supported by SimpleLink
-	if ((driveMode == GpioPinDriveMode_Input) ||
-		(driveMode == GpioPinDriveMode_InputPullDown) ||
-		(driveMode == GpioPinDriveMode_InputPullUp) ||
-		(driveMode == GpioPinDriveMode_Output) ||
-		(driveMode == GpioPinDriveMode_OutputOpenDrain) ||
-		(driveMode == GpioPinDriveMode_OutputOpenDrainPullUp) ||
-		(driveMode == GpioPinDriveMode_OutputOpenSourcePullDown))
-	{
-		driveModeSupported = true;
-	}
+    // check if the requested drive mode is supported by SimpleLink
+    if ((driveMode == GpioPinDriveMode_Input) || (driveMode == GpioPinDriveMode_InputPullDown) ||
+        (driveMode == GpioPinDriveMode_InputPullUp) || (driveMode == GpioPinDriveMode_Output) ||
+        (driveMode == GpioPinDriveMode_OutputOpenDrain) || (driveMode == GpioPinDriveMode_OutputOpenDrainPullUp) ||
+        (driveMode == GpioPinDriveMode_OutputOpenSourcePullDown))
+    {
+        driveModeSupported = true;
+    }
 
-	return driveModeSupported;
+    return driveModeSupported;
 }
 
 uint32_t CPU_GPIO_GetPinDebounce(GPIO_PIN pinNumber)
 {
-	gpio_input_state* pState = GetInputState(pinNumber);
+    gpio_input_state *pState = GetInputState(pinNumber);
 
-	_ASSERTE(pState == NULL);
+    _ASSERTE(pState == NULL);
 
-	return pState->debounceMs;
+    return pState->debounceMs;
 }
 
 bool CPU_GPIO_SetPinDebounce(GPIO_PIN pinNumber, CLR_UINT64 debounceTimeMilliseconds)
 {
-	gpio_input_state* pState = GetInputState(pinNumber);
+    gpio_input_state *pState = GetInputState(pinNumber);
 
-	_ASSERTE(pState == NULL);
+    _ASSERTE(pState == NULL);
 
-	pState->debounceMs = (uint32_t)(debounceTimeMilliseconds);
+    pState->debounceMs = (uint32_t)(debounceTimeMilliseconds);
 
-	return true;
+    return true;
 }

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
@@ -9,66 +9,194 @@
 
 #include <ti/sysbios/knl/Clock.h>
 #include <xdc/runtime/Error.h>
+#include <ti/drivers/gpio/GPIOCC26XX.h>
+#include <ti/drivers/PIN.h>
 
 #define GPIO_MAX_PINS      16
 #define TOTAL_GPIO_PORTS   ((GPIO_MAX_PINS + 15) / 16)
 
+#define EMPTY_PIN  0xFFFF
+
+// Array of Pin configurations
+GPIO_PinConfig gpioPinConfigs[] = {
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+	GPIO_DO_NOT_CONFIG | EMPTY_PIN,
+};
+
+// Array of callback function pointers
+GPIO_CallbackFxn gpioCallbackFunctions[GPIO_MAX_PINS];
+
 // Gpio input state structure
 struct gpio_input_state : public HAL_DblLinkedNode<gpio_input_state>
 {
-	GPIO_PIN 		pinNumber;              // Pin number
-	Clock_Handle 	debounceTimer;			// debounce timer for this Pin
-	GPIO_INTERRUPT_SERVICE_ROUTINE isrPtr;	// Ptr to user ISR or null
-	uint32_t 		debounceMs;             // debounce Millsecs, no debonce=0
-	uint8_t  		mode;                   // Interrupt mode
-	void *   		param;                  // Param to user isr call
-	bool     		expected;               // Expected state for debounce handler
-	bool     		waitingDebounce;	    // True if waiting for debounce timer to complete
+	// Pin number
+	GPIO_PIN 		pinNumber;
+
+	// pin config index
+	uint8_t			pinConfigIndex;
+	
+	// debounce timer for this Pin
+	Clock_Handle 	debounceTimer;			
+	
+	// poniter to user ISR or null
+	GPIO_INTERRUPT_SERVICE_ROUTINE isrPtr;
+		
+	// debounce millsecs, no debonce=0
+	uint32_t 		debounceMs;             
+	
+	// interrupt mode
+	uint8_t  		mode;                   
+
+	// param to user IRS call
+	void *   		param; 
+
+	// expected state for debounce handler
+	bool     		expected;               
+	
+	// flag for waiting for debounce timer to complete
+	bool     		waitingDebounce;	    
 };
 
-// Array holds pointers to gpio_input_state for active input pins
-static gpio_input_state * gpioInputState[GPIO_MAX_PINS];
+// Double Linked list for GPIO input status
+static HAL_DblLinkedList<gpio_input_state> gpioInputList;
 
 // Array of bits for saving reserved state
 static uint16_t pinReserved[TOTAL_GPIO_PORTS];      
 
-// Allocate a new gpio_input_state and update gpioInputState array
-// if already exist then just return current ptr
-gpio_input_state * AllocateGpioInputState(GPIO_PIN pinNumber)
+// Get pointer to gpio_input_state for GPIO pin
+// return NULL if not found
+gpio_input_state* GetInputState(GPIO_PIN pinNumber)
 {
-	gpio_input_state * ptr = gpioInputState[pinNumber];
-	if (ptr == NULL)
+	gpio_input_state* pState = gpioInputList.FirstNode();
+	
+	while (pState->Next() != NULL)
 	{
-		ptr = (gpio_input_state *)platform_malloc(sizeof(gpio_input_state));
-		memset(ptr, 0, sizeof(gpio_input_state));
+		if (pState->pinNumber == pinNumber) 
+		{
+			return pState;
+		}
 
-		ptr->pinNumber = pinNumber;
-		gpioInputState[pinNumber] = ptr;
+		pState = pState->Next();
 	}
-	return ptr;
+
+	return NULL;
+}
+
+// find a free slot in the pin config array
+int8_t FindFreePinConfig()
+{
+	for(uint8_t index = 0; index < GPIO_MAX_PINS; index++)
+	{
+		if((uint16_t)gpioPinConfigs[index] == EMPTY_PIN)
+		{
+			// found a free slot!
+			return index;
+		}
+	}
+
+	return -1;
+}
+
+// find a pin number in the pin config array
+int8_t FindPinConfig(GPIO_PIN pinNumber)
+{
+	for(uint8_t index = 0; index < GPIO_MAX_PINS; index++)
+	{
+		if((uint8_t)gpioPinConfigs[index] == pinNumber)
+		{
+			// found a free slot!
+			return index;
+		}
+	}
+
+	return -1;
+}
+
+// Allocate a new gpio_input_state and add to end of list
+// if already exist then just return current ptr
+gpio_input_state* AllocateGpioInputState(GPIO_PIN pinNumber)
+{
+	gpio_input_state * pState = GetInputState(pinNumber);
+
+	if (pState == NULL)
+	{
+		// no input state for this GPIO
+		// check if there is room at the pinf config array
+		uint8_t index = FindFreePinConfig();
+
+		if(index >= 0)
+		{
+			// found a free slot!
+			pState = (gpio_input_state *)platform_malloc(sizeof(gpio_input_state));
+	
+			// sanity check
+			if(pState != NULL)
+			{
+				memset(pState, 0, sizeof(gpio_input_state));
+				
+				// store the pin number
+				pState->pinNumber = pinNumber;
+
+				// store the index of the pin config
+				pState->pinConfigIndex = index;
+
+				gpioInputList.LinkAtBack(pState);
+
+				// set the pin number in the config array
+				gpioPinConfigs[index] = pinNumber | GPIO_CFG_IN_NOPULL | GPIO_CFG_IN_INT_NONE;
+			}
+		}
+	}
+
+	return pState;
+}
+
+void UnlinkInputState(gpio_input_state* pState)
+{
+	if (pState->debounceTimer != 0)
+	{
+		Clock_delete(&pState->debounceTimer);
+	}
+
+	// Remove interrupt associated with pin
+	// it's OK to do always this, no matter if interrupts are enabled or not
+	GPIO_disableInt(pState->pinConfigIndex);
+
+	// remove callback
+	gpioCallbackFunctions[pState->pinConfigIndex] = NULL;
+
+	// clear pin config
+	gpioPinConfigs[pState->pinConfigIndex] = GPIO_DO_NOT_CONFIG | EMPTY_PIN;
+
+	// unlink from list
+	pState->Unlink();
+
+	// free memory
+	platform_free(pState);
 }
 
 // Delete gpio_input_state from array and tidy up ( Timer & ISR handler )
 void DeleteGpioInputState(GPIO_PIN pinNumber)
 {
-	if (pinNumber < GPIO_MAX_PINS) 
+	gpio_input_state* pState = GetInputState(pinNumber);
+
+	if (pState)
 	{
-		gpio_input_state * pState =  gpioInputState[pinNumber];
-		if ( pState )
-		{	
-			if (pState->debounceTimer != 0)
-			{
-				Clock_delete(&pState->debounceTimer);
-			}
-
-			// Remove interrupt associated with pin
-			// it's OK to do always this, no matter if interrupts are enabled or not
-			GPIO_disableInt(pState->pinNumber);
-
-			platform_free(pState);
-			
-			gpioInputState[pinNumber]  = NULL;
-		}
+		UnlinkInputState(pState);
 	}
 }
 
@@ -79,21 +207,24 @@ static void debounceTimer_Callback(UArg arg)
 {
     int16_t index = (int16_t)arg;
 
-	gpio_input_state * pState = gpioInputState[index];
+	gpio_input_state * pState = GetInputState(index);
 
-	if (pState->isrPtr)
+	if (pState)
 	{
-		// get current pin state
-		bool actual = CPU_GPIO_GetPinState(pState->pinNumber);
-		if (actual == pState->expected)
+		if (pState->isrPtr)
 		{
-			pState->isrPtr(pState->pinNumber, actual, pState->param);
-
-			if (pState->mode == GPIO_INT_EDGE_BOTH)
+			// get current pin state
+			bool actual = CPU_GPIO_GetPinState(pState->pinNumber);
+			if (actual == pState->expected)
 			{
-				// both edges
-				// update expected state
-				pState->expected ^= 1;
+				pState->isrPtr(pState->pinNumber, actual, pState->param);
+
+				if (pState->mode == GPIO_INT_EDGE_BOTH)
+				{
+					// both edges
+					// update expected state
+					pState->expected ^= 1;
+				}
 			}
 		}
 	}
@@ -106,7 +237,7 @@ static void GpioEventCallback(uint_least8_t index)
 {
 	NATIVE_INTERRUPT_START
 
-	gpio_input_state * pState = gpioInputState[index];
+	gpio_input_state* pState = GetInputState(index);
 
 	// Any pin set up here ?
 	if (pState != NULL)
@@ -150,7 +281,7 @@ static void GpioEventCallback(uint_least8_t index)
 				else
 				{
 					// No debounce so just call ISR with current pin state
-					uint_fast8_t pinState = GPIO_read(pState->pinNumber);
+					uint_fast8_t pinState = GPIO_read(pState->pinConfigIndex);
 					pState->isrPtr(pState->pinNumber, pinState, pState->param);
 				}
 			}
@@ -160,35 +291,50 @@ static void GpioEventCallback(uint_least8_t index)
 	NATIVE_INTERRUPT_END
 }
 
-bool   CPU_GPIO_Initialize()
+bool CPU_GPIO_Initialize()
 {
-	// set gpioState ptrs to NULL
-	memset(gpioInputState, 0, sizeof(gpioInputState));
+	// Initialise Double linked list for input pin states
+	gpioInputList.Initialize();
 
+	// clear GPIO pin configs
+	for(uint8_t index = 0; index < GPIO_MAX_PINS; index++)
+	{
+		gpioPinConfigs[index] == GPIO_DO_NOT_CONFIG | EMPTY_PIN;
+	}
+
+	// clear callbacks
+	memset(gpioCallbackFunctions, 0, sizeof(gpioCallbackFunctions));
+	
 	// Make sure all pins are not reserved
 	memset(pinReserved, 0, sizeof(pinReserved));
 	
 	return true;
 }
 
-bool   CPU_GPIO_Uninitialize()
+bool CPU_GPIO_Uninitialize()
 {
-	// Clean up input list
-	for(int index; index < GPIO_MAX_PINS; index++)
+	NANOCLR_FOREACH_NODE(gpio_input_state, pGpio, gpioInputList)
 	{
-		DeleteGpioInputState(index);
+		UnlinkInputState(pGpio);
 	}
+	NANOCLR_FOREACH_NODE_END();
 
 	return true;
 }
 
 // Set/reset reserved state of pin
-bool   CPU_GPIO_ReservePin(GPIO_PIN pinNumber, bool fReserve)
+bool CPU_GPIO_ReservePin(GPIO_PIN pinNumber, bool fReserve)
 {
 	// Check if valid pin number 0 - 15
-	if ( pinNumber >= GPIO_MAX_PINS ) return false;
+	// TODO get this define from the SDK as the number is wrong 
+	// for CC13x2 there are 32 possible GPIO pins
+	if ( pinNumber >= GPIO_MAX_PINS )
+	{
+		return false;
+	}
 
 	int port = pinNumber >> 4, bit = 1 << (pinNumber & 0x0F);
+
 	GLOBAL_LOCK();
 
 	if (fReserve)
@@ -226,57 +372,67 @@ int32_t CPU_GPIO_GetPinCount()
 // Get current state of pin
 GpioPinValue CPU_GPIO_GetPinState(GPIO_PIN pinNumber)
 {
-	return (GpioPinValue)GPIO_read(pinNumber);
+	// get index of pin in config array
+	uint8_t index = FindPinConfig(pinNumber);
+
+	if(index >= 0)
+	{
+		return (GpioPinValue)GPIO_read(index);
+	}
 }
 
 // Set Pin state
-void CPU_GPIO_SetPinState(GPIO_PIN pinNumber, GpioPinValue PinState)
+void CPU_GPIO_SetPinState(GPIO_PIN pinNumber, GpioPinValue pinState)
 {
-	GPIO_write(pinNumber, PinState);
+	// get index of pin in config array
+	uint8_t index = FindPinConfig(pinNumber);
+
+	if(index >= 0)
+	{
+		GPIO_write(index, pinState);
+	}
 }
 
 // Toggle pin state
 void CPU_GPIO_TogglePinState(GPIO_PIN pinNumber)
 {
-	GPIO_toggle(pinNumber);
+	uint8_t index = FindPinConfig(pinNumber);
+
+	if(index >= 0)
+	{
+		GPIO_toggle(index);
+	}
 }
 
 // Enable gpio pin for input
 bool CPU_GPIO_EnableInputPin(GPIO_PIN pinNumber, CLR_UINT64 debounceTimeMilliseconds, GPIO_INTERRUPT_SERVICE_ROUTINE pin_ISR, void* isr_Param, GPIO_INT_EDGE intEdge, GpioPinDriveMode driveMode)
 {
-	gpio_input_state * pState;
-
-	// Check if valid pin number 0 - 15
-	if ( pinNumber >= GPIO_MAX_PINS ) return false;
+	gpio_input_state* pState;
 
 	// Check Input drive mode
 	if (driveMode >= (int)GpioPinDriveMode_Output)
+	{
 		return false;
-
-	if (!CPU_GPIO_SetDriveMode(pinNumber, driveMode))
-		return false;
+	}
 
 	pState = AllocateGpioInputState(pinNumber);
+
+	if (!CPU_GPIO_SetDriveMode(pState->pinConfigIndex, driveMode))
+	{
+		return false;
+	}
 
 	// Link ISR ptr supplied and not already set up
 	// CPU_GPIO_EnableInputPin could be called a 2nd time with changed parameters
 	if ( (pin_ISR != NULL) && (pState->isrPtr == NULL))
 	{
-           // get current config
-            GPIO_PinConfig currentPinConfig;
-            GPIO_getConfig(pinNumber, &currentPinConfig);
+		// get current config
+		GPIO_PinConfig currentPinConfig;
+		GPIO_getConfig(pState->pinConfigIndex, &currentPinConfig);
 
-            // Map Interrupt edge to Ti-SimpleLink edge definitions
-            // NONE=0, EDGE_LOW=1, EDGE_HIGH=2, EDGE_BOTH=3, LEVEL_HIGH=4, LEVEL_LOW
-            GPIO_PinConfig mapint[6] = 
-				{ GPIO_CFG_IN_INT_NONE, GPIO_CFG_IN_INT_FALLING, GPIO_CFG_IN_INT_RISING, GPIO_CFG_IN_INT_BOTH_EDGES, GPIO_CFG_IN_INT_LOW, GPIO_CFG_IN_INT_HIGH  };
-
-			currentPinConfig = mapint[6] | currentPinConfig;
-
-            // set interrupt on both edges
-            GPIO_setConfig(pinNumber, currentPinConfig | mapint[6] );
-            GPIO_setCallback(pinNumber, GpioEventCallback);
-			
+		// set interrupt on both edges
+		GPIO_setConfig(pState->pinConfigIndex, currentPinConfig | GPIO_CFG_IN_INT_BOTH_EDGES );
+		GPIO_setCallback(pState->pinConfigIndex, GpioEventCallback);
 	}
 
 	pState->isrPtr = pin_ISR;
@@ -297,7 +453,8 @@ bool CPU_GPIO_EnableInputPin(GPIO_PIN pinNumber, CLR_UINT64 debounceTimeMillisec
 			break;
 
 		case GPIO_INT_EDGE_BOTH:
-			pState->expected = !CPU_GPIO_GetPinState(pinNumber);  // Use inverse of current pin state  
+			// Use inverse of current pin state  
+			pState->expected = !CPU_GPIO_GetPinState(pinNumber);  
 			break;
 
 		default:
@@ -316,47 +473,66 @@ bool CPU_GPIO_EnableInputPin(GPIO_PIN pinNumber, CLR_UINT64 debounceTimeMillisec
 //
 bool  CPU_GPIO_EnableOutputPin(GPIO_PIN pinNumber, GpioPinValue InitialState, GpioPinDriveMode driveMode)
 {
-   	// Check if valid pin number 0 - 15
-	if ( pinNumber >= GPIO_MAX_PINS ) return false;
-
 	// check is output drive mode
-	if (driveMode < (int)GpioPinDriveMode_Output) return false;
+	if (driveMode < (int)GpioPinDriveMode_Output)
+	{
+		return false;
+	}
 
 	// If this is currently an input pin then clean up
 	DeleteGpioInputState(pinNumber);
 
-	if (CPU_GPIO_SetDriveMode(pinNumber, driveMode) == false) return false;
+	// get free slot in pin config array
+	uint8_t index = FindFreePinConfig();
 
-	CPU_GPIO_SetPinState(pinNumber, InitialState);
+	if(index >= 0)
+	{
+		// found a free slot!
+		
+		// set the pin number in the config array
+		gpioPinConfigs[index] = pinNumber | PIN_GPIO_OUTPUT_EN;
 
-	return true;
+		if (CPU_GPIO_SetDriveMode(index, driveMode) == false)
+		{
+			return false;
+		}
+
+		CPU_GPIO_SetPinState(pinNumber, InitialState);
+
+		return true;
+	}
+
+	return false;
 }
 
 void CPU_GPIO_DisablePin(GPIO_PIN pinNumber, GpioPinDriveMode driveMode, uint32_t alternateFunction)
 {
 	GLOBAL_LOCK();
-	
-	DeleteGpioInputState(pinNumber);
 
-	CPU_GPIO_SetDriveMode(pinNumber, driveMode);
-	
-	if (alternateFunction)
+	uint8_t index = FindPinConfig(pinNumber);
+
+	if(index >= 0)
 	{
-		GPIO_setConfig(pinNumber, alternateFunction);
+		DeleteGpioInputState(pinNumber);
+
+		CPU_GPIO_SetDriveMode(index, driveMode);
+
+		if (alternateFunction)
+		{
+			GPIO_setConfig(index, alternateFunction);
+		}
+
+		GLOBAL_UNLOCK();
+
+		CPU_GPIO_ReservePin(pinNumber, false);
 	}
-
-	GLOBAL_UNLOCK();
-
-	CPU_GPIO_ReservePin(pinNumber, false);
 }
 
-
-// Validate pin and set drive mode
+// Set drive mode
+// pinNumber is the index of the corresponding PIN config in array
 // return true if ok
 bool CPU_GPIO_SetDriveMode(GPIO_PIN pinNumber, GpioPinDriveMode driveMode)
 {
-	if (pinNumber >= GPIO_MAX_PINS) return false;
-
     // disable interrupt as default
     GPIO_disableInt(pinNumber);
 
@@ -375,7 +551,7 @@ bool CPU_GPIO_SetDriveMode(GPIO_PIN pinNumber, GpioPinDriveMode driveMode)
             break;
 
         case GpioPinDriveMode_Output:
-            GPIO_setConfig(pinNumber, GPIO_CFG_OUT_STD | GPIO_CFG_OUT_LOW);
+            GPIO_setConfig(pinNumber, GPIO_CFG_OUT_STD | GPIO_CFG_OUT_STR_MED | GPIO_CFG_OUT_LOW);
             break;
 
         case GpioPinDriveMode_OutputOpenDrain:
@@ -400,43 +576,41 @@ bool CPU_GPIO_SetDriveMode(GPIO_PIN pinNumber, GpioPinDriveMode driveMode)
 
 bool CPU_GPIO_DriveModeSupported(GPIO_PIN pinNumber, GpioPinDriveMode driveMode)
 {
-        bool driveModeSupported = false;
+	(void)pinNumber;
 
-        // check if the requested drive mode is supported by SimpleLink
-        if ((driveMode == GpioPinDriveMode_Input) ||
-            (driveMode == GpioPinDriveMode_InputPullDown) ||
-            (driveMode == GpioPinDriveMode_InputPullUp) ||
-            (driveMode == GpioPinDriveMode_Output) ||
-            (driveMode == GpioPinDriveMode_OutputOpenDrain) ||
-            (driveMode == GpioPinDriveMode_OutputOpenDrainPullUp) ||
-            (driveMode == GpioPinDriveMode_OutputOpenSourcePullDown))
-        {
-            driveModeSupported = true;
-        }
+	bool driveModeSupported = false;
+
+	// check if the requested drive mode is supported by SimpleLink
+	if ((driveMode == GpioPinDriveMode_Input) ||
+		(driveMode == GpioPinDriveMode_InputPullDown) ||
+		(driveMode == GpioPinDriveMode_InputPullUp) ||
+		(driveMode == GpioPinDriveMode_Output) ||
+		(driveMode == GpioPinDriveMode_OutputOpenDrain) ||
+		(driveMode == GpioPinDriveMode_OutputOpenDrainPullUp) ||
+		(driveMode == GpioPinDriveMode_OutputOpenSourcePullDown))
+	{
+		driveModeSupported = true;
+	}
 
 	return driveModeSupported;
 }
 
 uint32_t CPU_GPIO_GetPinDebounce(GPIO_PIN pinNumber)
 {
-	if (pinNumber >= GPIO_MAX_PINS) return false;
+	gpio_input_state* pState = GetInputState(pinNumber);
 
-	gpio_input_state * ptr = gpioInputState[pinNumber];
-	if (ptr)
-		return ptr->debounceMs;
+	_ASSERTE(pState == NULL);
 
-	return 0;
+	return pState->debounceMs;
 }
 
 bool CPU_GPIO_SetPinDebounce(GPIO_PIN pinNumber, CLR_UINT64 debounceTimeMilliseconds)
 {
-	if (pinNumber >= GPIO_MAX_PINS) return false;
+	gpio_input_state* pState = GetInputState(pinNumber);
 
-	gpio_input_state * ptr = gpioInputState[pinNumber];
-	if (ptr)
-	{
-		ptr->debounceMs = (uint32_t)(debounceTimeMilliseconds);
-		return true;
-	}
-	return false;
+	_ASSERTE(pState == NULL);
+
+	pState->debounceMs = (uint32_t)(debounceTimeMilliseconds);
+
+	return true;
 }


### PR DESCRIPTION
## Description
- Replace GPIO pin number with index.
- Move GPIO declarations from sysconfig generated files to array.
- Replace array with linked list for input pins.
- Update sysconfig project file to remove GPIO declarations and GPIO drivers.

## Motivation and Context
- TI SimpleLink driver uses a fixed array with GPIO declarations and the API uses the index of that array as parameter instead of the GPIO pin number. This is completely different of the "standard" implementation of the CPU GPIO layer. Had to rework almost the layer for the TI to make it work this way.

## How Has This Been Tested?<!-- (if applicable) -->
- Blinky sample.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
