### PR TITLE
Rework Debugger::AccessMemory

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -3118,8 +3118,8 @@ bool CLR_DBG_Debugger::Debugging_Resolve_AppDomain(WP_Message *msg)
     CLR_UINT32 numAssemblies = 0;
     CLR_DBG_Commands::Debugging_Resolve_AppDomain::Reply *cmdReply;
     CLR_UINT8
-        buf[sizeof(CLR_DBG_Commands::Debugging_Resolve_AppDomain::Reply) +
-            sizeof(CLR_RT_Assembly_Index) * CLR_RT_TypeSystem::c_MaxAssemblies];
+    buf[sizeof(CLR_DBG_Commands::Debugging_Resolve_AppDomain::Reply) +
+        sizeof(CLR_RT_Assembly_Index) * CLR_RT_TypeSystem::c_MaxAssemblies];
     size_t count;
     const char *name;
     CLR_RT_Assembly_Index *pAssemblyIndex;

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -12,11 +12,11 @@
 #include "Debugger.h"
 #include <corlib_native.h>
 
-#define __min(a,b) (((a) < (b)) ? (a) : (b))
+#define __min(a, b) (((a) < (b)) ? (a) : (b))
 
 #if 0
-#define TRACE0( msg, ...) debug_printf( msg ) 
-#define TRACE( msg, ...) debug_printf( msg, __VA_ARGS__ ) 
+#define TRACE0(msg, ...) debug_printf(msg)
+#define TRACE(msg, ...)  debug_printf(msg, __VA_ARGS__) 
 char const* const AccessMemoryModeNames[] = {
 "AccessMemory_Check",
 "AccessMemory_Read", 
@@ -24,8 +24,8 @@ char const* const AccessMemoryModeNames[] = {
 "AccessMemory_Erase"
 };
 #else
-#define TRACE0(msg,...)
-#define TRACE(msg,...)
+#define TRACE0(msg, ...)
+#define TRACE(msg, ...)
 #endif
 
 //--//
@@ -33,9 +33,9 @@ char const* const AccessMemoryModeNames[] = {
 extern const CLR_RT_NativeAssemblyData *g_CLR_InteropAssembliesNativeData[];
 extern uint16_t g_CLR_InteropAssembliesCount;
 
-CLR_DBG_Debugger* g_CLR_DBG_Debugger;
+CLR_DBG_Debugger *g_CLR_DBG_Debugger;
 
-BlockStorageDevice* CLR_DBG_Debugger::m_deploymentStorageDevice = NULL;
+BlockStorageDevice *CLR_DBG_Debugger::m_deploymentStorageDevice = NULL;
 
 //--//
 
@@ -44,10 +44,10 @@ void CLR_DBG_Debugger::Debugger_WaitForCommands()
     NATIVE_PROFILE_CLR_DEBUGGER();
 
 #if !defined(BUILD_RTM)
-    CLR_Debug::Printf( "Waiting for debug commands...\r\n" );
+    CLR_Debug::Printf("Waiting for debug commands...\r\n");
 #endif
 
-    while( !CLR_EE_DBG_IS(RebootPending) && !CLR_EE_DBG_IS(ExitPending) )
+    while (!CLR_EE_DBG_IS(RebootPending) && !CLR_EE_DBG_IS(ExitPending))
     {
         g_CLR_RT_ExecutionEngine.DebuggerLoop();
     }
@@ -65,31 +65,35 @@ void CLR_DBG_Debugger::Debugger_Discovery()
     Monitor_Ping_Command cmd;
     cmd.m_source = Monitor_Ping_c_Ping_Source_NanoCLR;
 
-    while(true)
+    while (true)
     {
-        CLR_EE_DBG_EVENT_BROADCAST(CLR_DBG_Commands::c_Monitor_Ping, sizeof(cmd), &cmd, WP_Flags_c_NoCaching | WP_Flags_c_NonCritical);
+        CLR_EE_DBG_EVENT_BROADCAST(
+            CLR_DBG_Commands::c_Monitor_Ping,
+            sizeof(cmd),
+            &cmd,
+            WP_Flags_c_NoCaching | WP_Flags_c_NonCritical);
 
         // if we support soft reboot and the debugger is not stopped then we don't need to connect the debugger
-        if(!CLR_EE_DBG_IS(Stopped) && ::CPU_IsSoftRebootSupported())
+        if (!CLR_EE_DBG_IS(Stopped) && ::CPU_IsSoftRebootSupported())
         {
             break;
         }
 
         g_CLR_RT_ExecutionEngine.DebuggerLoop();
 
-        if(CLR_EE_DBG_IS(Enabled))
+        if (CLR_EE_DBG_IS(Enabled))
         {
             // Debugger on the other side, let's exit the discovery loop.
-            CLR_Debug::Printf( "Debugger found. Resuming boot sequence.\r\n" );
+            CLR_Debug::Printf("Debugger found. Resuming boot sequence.\r\n");
             break;
         }
 
         CLR_INT64 now = HAL_Time_CurrentTime();
 
-        if(expire < now)
+        if (expire < now)
         {
             // no response after timeout...
-            CLR_Debug::Printf( "No debugger found...\r\n" );
+            CLR_Debug::Printf("No debugger found...\r\n");
             break;
         }
     }
@@ -105,18 +109,18 @@ HRESULT CLR_DBG_Debugger::CreateInstance()
     NANOCLR_HEADER();
 
     // alloc memory for debugger
-    g_CLR_DBG_Debugger = (CLR_DBG_Debugger*)platform_malloc(sizeof(CLR_DBG_Debugger));
+    g_CLR_DBG_Debugger = (CLR_DBG_Debugger *)platform_malloc(sizeof(CLR_DBG_Debugger));
 
-    // sanity check...    
+    // sanity check...
     FAULT_ON_NULL(g_CLR_DBG_Debugger);
 
     //... and clear memory
     memset(g_CLR_DBG_Debugger, 0, sizeof(CLR_DBG_Debugger));
 
     // alloc memory for debugger messaging
-    g_CLR_DBG_Debugger->m_messaging = (CLR_Messaging*)platform_malloc(sizeof(CLR_Messaging));
-   
-    // sanity check...    
+    g_CLR_DBG_Debugger->m_messaging = (CLR_Messaging *)platform_malloc(sizeof(CLR_Messaging));
+
+    // sanity check...
     FAULT_ON_NULL(g_CLR_DBG_Debugger->m_messaging);
 
     //... and clear memory
@@ -127,7 +131,7 @@ HRESULT CLR_DBG_Debugger::CreateInstance()
     BlockStorageStream stream;
     memset(&stream, 0, sizeof(BlockStorageStream));
 
-    if (BlockStorageStream_Initialize(&stream, BlockUsage_DEPLOYMENT ))
+    if (BlockStorageStream_Initialize(&stream, BlockUsage_DEPLOYMENT))
     {
         m_deploymentStorageDevice = stream.Device;
     }
@@ -141,14 +145,18 @@ HRESULT CLR_DBG_Debugger::CreateInstance()
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT CLR_DBG_Debugger::Debugger_Initialize( COM_HANDLE port )
+HRESULT CLR_DBG_Debugger::Debugger_Initialize(COM_HANDLE port)
 {
     (void)port;
 
     NATIVE_PROFILE_CLR_DEBUGGER();
     NANOCLR_HEADER();
 
-    m_messaging->Initialize( c_Debugger_Lookup_Request, c_Debugger_Lookup_Request_count, c_Debugger_Lookup_Reply, c_Debugger_Lookup_Reply_count );
+    m_messaging->Initialize(
+        c_Debugger_Lookup_Request,
+        c_Debugger_Lookup_Request_count,
+        c_Debugger_Lookup_Reply,
+        c_Debugger_Lookup_Reply_count);
 
     NANOCLR_NOCLEANUP_NOLABEL();
 }
@@ -187,10 +195,14 @@ void CLR_DBG_Debugger::Debugger_Cleanup()
 //     m_messaging->m_controller.AdvanceState();
 // }
 
-void CLR_DBG_Debugger::BroadcastEvent( unsigned int cmd, unsigned int payloadSize, unsigned char* payload, unsigned int flags )
+void CLR_DBG_Debugger::BroadcastEvent(
+    unsigned int cmd,
+    unsigned int payloadSize,
+    unsigned char *payload,
+    unsigned int flags)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    WP_PrepareAndSendProtocolMessage( cmd, payloadSize, payload, flags );
+    WP_PrepareAndSendProtocolMessage(cmd, payloadSize, payload, flags);
 }
 
 //--//
@@ -199,63 +211,66 @@ void CLR_DBG_Debugger::BroadcastEvent( unsigned int cmd, unsigned int payloadSiz
 
 #if defined(NANOCLR_APPDOMAINS)
 
-CLR_RT_AppDomain* CLR_DBG_Debugger::GetAppDomainFromID( CLR_UINT32 id )
+CLR_RT_AppDomain *CLR_DBG_Debugger::GetAppDomainFromID(CLR_UINT32 id)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     NANOCLR_FOREACH_NODE(CLR_RT_AppDomain, appDomain, g_CLR_RT_ExecutionEngine.m_appDomains)
     {
-        if(appDomain->m_id == id) return appDomain;
+        if (appDomain->m_id == id)
+            return appDomain;
     }
     NANOCLR_FOREACH_NODE_END();
 
     return NULL;
 }
-#endif //NANOCLR_APPDOMAINS
+#endif // NANOCLR_APPDOMAINS
 
-CLR_RT_Thread* CLR_DBG_Debugger::GetThreadFromPid( CLR_INT32 pid )
+CLR_RT_Thread *CLR_DBG_Debugger::GetThreadFromPid(CLR_INT32 pid)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    NANOCLR_FOREACH_NODE(CLR_RT_Thread,th,g_CLR_RT_ExecutionEngine.m_threadsReady)
+    NANOCLR_FOREACH_NODE(CLR_RT_Thread, th, g_CLR_RT_ExecutionEngine.m_threadsReady)
     {
-        if(th->m_pid == pid) return th;
+        if (th->m_pid == pid)
+            return th;
     }
     NANOCLR_FOREACH_NODE_END();
 
-    NANOCLR_FOREACH_NODE(CLR_RT_Thread,th,g_CLR_RT_ExecutionEngine.m_threadsWaiting)
+    NANOCLR_FOREACH_NODE(CLR_RT_Thread, th, g_CLR_RT_ExecutionEngine.m_threadsWaiting)
     {
-        if(th->m_pid == pid) return th;
+        if (th->m_pid == pid)
+            return th;
     }
     NANOCLR_FOREACH_NODE_END();
 
     return NULL;
 }
 
-HRESULT CLR_DBG_Debugger::CreateListOfThreads( CLR_DBG_Commands::Debugging_Thread_List::Reply*& cmdReply, int& totLen )
+HRESULT CLR_DBG_Debugger::CreateListOfThreads(CLR_DBG_Commands::Debugging_Thread_List::Reply *&cmdReply, int &totLen)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     NANOCLR_HEADER();
 
-    CLR_UINT32* pidDst;
-    int         num;
+    CLR_UINT32 *pidDst;
+    int num;
 
-    num = g_CLR_RT_ExecutionEngine.m_threadsReady  .NumOfNodes() +
-          g_CLR_RT_ExecutionEngine.m_threadsWaiting.NumOfNodes();
+    num = g_CLR_RT_ExecutionEngine.m_threadsReady.NumOfNodes() + g_CLR_RT_ExecutionEngine.m_threadsWaiting.NumOfNodes();
 
-    totLen = sizeof(*cmdReply) + (num-1) * sizeof(CLR_UINT32);
+    totLen = sizeof(*cmdReply) + (num - 1) * sizeof(CLR_UINT32);
 
-    cmdReply = (CLR_DBG_Commands::Debugging_Thread_List::Reply*)CLR_RT_Memory::Allocate_And_Erase( totLen, true ); CHECK_ALLOCATION(cmdReply);
+    cmdReply = (CLR_DBG_Commands::Debugging_Thread_List::Reply *)CLR_RT_Memory::Allocate_And_Erase(totLen, true);
+    CHECK_ALLOCATION(cmdReply);
 
     cmdReply->m_num = num;
 
     pidDst = cmdReply->m_pids;
 
-    NANOCLR_FOREACH_NODE(CLR_RT_Thread,thSrc,g_CLR_RT_ExecutionEngine.m_threadsReady)
+    NANOCLR_FOREACH_NODE(CLR_RT_Thread, thSrc, g_CLR_RT_ExecutionEngine.m_threadsReady)
     {
         *pidDst++ = thSrc->m_pid;
     }
     NANOCLR_FOREACH_NODE_END();
 
-    NANOCLR_FOREACH_NODE(CLR_RT_Thread,thSrc,g_CLR_RT_ExecutionEngine.m_threadsWaiting)
+    NANOCLR_FOREACH_NODE(CLR_RT_Thread, thSrc, g_CLR_RT_ExecutionEngine.m_threadsWaiting)
     {
         *pidDst++ = thSrc->m_pid;
     }
@@ -264,57 +279,61 @@ HRESULT CLR_DBG_Debugger::CreateListOfThreads( CLR_DBG_Commands::Debugging_Threa
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT CLR_DBG_Debugger::CreateListOfCalls( CLR_INT32 pid, CLR_DBG_Commands::Debugging_Thread_Stack::Reply*& cmdReply, int& totLen )
+HRESULT CLR_DBG_Debugger::CreateListOfCalls(
+    CLR_INT32 pid,
+    CLR_DBG_Commands::Debugging_Thread_Stack::Reply *&cmdReply,
+    int &totLen)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     NANOCLR_HEADER();
 
-    CLR_RT_Thread* th = GetThreadFromPid( pid ); FAULT_ON_NULL(th);
+    CLR_RT_Thread *th = GetThreadFromPid(pid);
+    FAULT_ON_NULL(th);
 
-    for(int pass=0; pass<2; pass++)
+    for (int pass = 0; pass < 2; pass++)
     {
         int num = 0;
 
-        NANOCLR_FOREACH_NODE(CLR_RT_StackFrame,call,th->m_stackFrames)
+        NANOCLR_FOREACH_NODE(CLR_RT_StackFrame, call, th->m_stackFrames)
         {
-            if(pass == 1)
+            if (pass == 1)
             {
                 int tmp = num;
-                
+
 #ifndef CLR_NO_IL_INLINE
-                if(call->m_inlineFrame)
+                if (call->m_inlineFrame)
                 {
-                    CLR_DBG_Commands::Debugging_Thread_Stack::Reply::Call& dst = cmdReply->m_data[ tmp++ ];
-                    
-                    dst.m_md =              call->m_inlineFrame->m_frame.m_call;
+                    CLR_DBG_Commands::Debugging_Thread_Stack::Reply::Call &dst = cmdReply->m_data[tmp++];
+
+                    dst.m_md = call->m_inlineFrame->m_frame.m_call;
                     dst.m_IP = (CLR_UINT32)(call->m_inlineFrame->m_frame.m_IP - call->m_inlineFrame->m_frame.m_IPStart);
 #if defined(NANOCLR_APPDOMAINS)
                     dst.m_appDomainID = call->m_appDomain->m_id;
-                    dst.m_flags       = call->m_flags;
+                    dst.m_flags = call->m_flags;
 #endif
                 }
 #endif
-                CLR_DBG_Commands::Debugging_Thread_Stack::Reply::Call& dst = cmdReply->m_data[ tmp ];
+                CLR_DBG_Commands::Debugging_Thread_Stack::Reply::Call &dst = cmdReply->m_data[tmp];
 
-                dst.m_md =              call->m_call;
+                dst.m_md = call->m_call;
                 dst.m_IP = (CLR_UINT32)(call->m_IP - call->m_IPstart);
 
-                if(dst.m_IP && call != th->CurrentFrame())
+                if (dst.m_IP && call != th->CurrentFrame())
                 {
-                    //With the exception of when the IP is 0, for a breakpoint on Push,
-                    //The call->m_IP is the next instruction to execute, not the currently executing one.
-                    //For non-leaf frames, this will return the IP within the call.
+                    // With the exception of when the IP is 0, for a breakpoint on Push,
+                    // The call->m_IP is the next instruction to execute, not the currently executing one.
+                    // For non-leaf frames, this will return the IP within the call.
                     dst.m_IP--;
                 }
 
 #if defined(NANOCLR_APPDOMAINS)
                 dst.m_appDomainID = call->m_appDomain->m_id;
-                dst.m_flags       = call->m_flags;
+                dst.m_flags = call->m_flags;
 #endif
             }
 
 #ifndef CLR_NO_IL_INLINE
-            if(call->m_inlineFrame)
+            if (call->m_inlineFrame)
             {
                 num++;
             }
@@ -324,15 +343,18 @@ HRESULT CLR_DBG_Debugger::CreateListOfCalls( CLR_INT32 pid, CLR_DBG_Commands::De
         }
         NANOCLR_FOREACH_NODE_END();
 
-        if(pass == 0)
+        if (pass == 0)
         {
-            totLen = sizeof(*cmdReply) + (num-1) * sizeof(CLR_DBG_Commands::Debugging_Thread_Stack::Reply::Call);
+            totLen = sizeof(*cmdReply) + (num - 1) * sizeof(CLR_DBG_Commands::Debugging_Thread_Stack::Reply::Call);
 
-            cmdReply = (CLR_DBG_Commands::Debugging_Thread_Stack::Reply*)CLR_RT_Memory::Allocate_And_Erase( totLen, CLR_RT_HeapBlock::HB_CompactOnFailure ); CHECK_ALLOCATION(cmdReply);
+            cmdReply = (CLR_DBG_Commands::Debugging_Thread_Stack::Reply *)CLR_RT_Memory::Allocate_And_Erase(
+                totLen,
+                CLR_RT_HeapBlock::HB_CompactOnFailure);
+            CHECK_ALLOCATION(cmdReply);
 
-            cmdReply->m_num    = num;
+            cmdReply->m_num = num;
             cmdReply->m_status = th->m_status;
-            cmdReply->m_flags  = th->m_flags;
+            cmdReply->m_flags = th->m_flags;
         }
     }
 
@@ -343,7 +365,7 @@ HRESULT CLR_DBG_Debugger::CreateListOfCalls( CLR_INT32 pid, CLR_DBG_Commands::De
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-bool CLR_DBG_Debugger::Monitor_Ping( WP_Message* msg)
+bool CLR_DBG_Debugger::Monitor_Ping(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     bool fStopOnBoot = true;
@@ -351,59 +373,61 @@ bool CLR_DBG_Debugger::Monitor_Ping( WP_Message* msg)
     //
     // There's someone on the other side!!
     //
-    CLR_EE_DBG_SET( Enabled );
+    CLR_EE_DBG_SET(Enabled);
 
-    if((msg->m_header.m_flags & WP_Flags_c_Reply      ) == 0)
+    if ((msg->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
         Monitor_Ping_Reply cmdReply;
-        Monitor_Ping_Command *cmd = (Monitor_Ping_Command*)msg->m_payload;
+        Monitor_Ping_Command *cmd = (Monitor_Ping_Command *)msg->m_payload;
 
         // default is to stop the debugger (backwards compatibility)
         fStopOnBoot = (cmd != NULL) && (cmd->m_dbg_flags & Monitor_Ping_c_Ping_DbgFlag_Stop);
 
-        cmdReply.m_source    = Monitor_Ping_c_Ping_Source_NanoCLR;
+        cmdReply.m_source = Monitor_Ping_c_Ping_Source_NanoCLR;
 
         cmdReply.m_dbg_flags = CLR_EE_DBG_IS(StateProgramExited) != 0 ? Monitor_Ping_c_Ping_DbgFlag_AppExit : 0;
 
-        #if defined(WP_IMPLEMENTS_CRC32)
+#if defined(WP_IMPLEMENTS_CRC32)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_Ping_WPFlag_SupportsCRC32;
-        #endif
-     
-        // Wire Protocol packet size 
-      #if (WP_PACKET_SIZE == 512)
-        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0512;
-      #elif (WP_PACKET_SIZE == 256)
-        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0256;
-      #elif (WP_PACKET_SIZE == 128)
-        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0128;
-      #elif (WP_PACKET_SIZE == 1024)
-        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_1024;
-      #endif
+#endif
 
-        WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+        // Wire Protocol packet size
+#if (WP_PACKET_SIZE == 512)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0512;
+#elif (WP_PACKET_SIZE == 256)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0256;
+#elif (WP_PACKET_SIZE == 128)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0128;
+#elif (WP_PACKET_SIZE == 1024)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_1024;
+#endif
+
+        WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
     }
     else
     {
-        Monitor_Ping_Reply *cmdReply = (Monitor_Ping_Reply*)msg->m_payload;
+        Monitor_Ping_Reply *cmdReply = (Monitor_Ping_Reply *)msg->m_payload;
 
         // default is to stop the debugger (backwards compatibility)
         fStopOnBoot = (cmdReply != NULL) && (cmdReply->m_dbg_flags & Monitor_Ping_c_Ping_DbgFlag_Stop);
     }
 
-    if(CLR_EE_DBG_IS_MASK(StateInitialize, StateMask))
+    if (CLR_EE_DBG_IS_MASK(StateInitialize, StateMask))
     {
-        if(fStopOnBoot) CLR_EE_DBG_SET(Stopped);
-        else            CLR_EE_DBG_CLR(Stopped);
+        if (fStopOnBoot)
+            CLR_EE_DBG_SET(Stopped);
+        else
+            CLR_EE_DBG_CLR(Stopped);
     }
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Monitor_FlashSectorMap( WP_Message* msg)
+bool CLR_DBG_Debugger::Monitor_FlashSectorMap(WP_Message *msg)
 {
-	NATIVE_PROFILE_CLR_DEBUGGER();
+    NATIVE_PROFILE_CLR_DEBUGGER();
 
-    if((msg->m_header.m_flags & WP_Flags_c_Reply) == 0)
+    if ((msg->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
         struct Flash_BlockRegionInfo
         {
@@ -421,59 +445,62 @@ bool CLR_DBG_Debugger::Monitor_FlashSectorMap( WP_Message* msg)
         unsigned int numDevices = BlockStorageList_GetNumDevices();
 
         // get an array of pointer to all the storage devices in the list and then request the device info
-        BlockStorageDevice** devices = (BlockStorageDevice**) platform_malloc(numDevices * sizeof(BlockStorageDevice*));
-        DeviceBlockInfo** deviceInfos = (DeviceBlockInfo**) platform_malloc(numDevices * sizeof(DeviceBlockInfo*));
+        BlockStorageDevice **devices =
+            (BlockStorageDevice **)platform_malloc(numDevices * sizeof(BlockStorageDevice *));
+        DeviceBlockInfo **deviceInfos = (DeviceBlockInfo **)platform_malloc(numDevices * sizeof(DeviceBlockInfo *));
 
-        for(unsigned int i = 0; i < numDevices; i++)
+        for (unsigned int i = 0; i < numDevices; i++)
         {
-            if(i == 0)
+            if (i == 0)
             {
                 devices[i] = BlockStorageList_GetFirstDevice();
-            } 
+            }
             else
             {
-                devices[i] = BlockStorageList_GetNextDevice(devices[i-1]);
+                devices[i] = BlockStorageList_GetNextDevice(devices[i - 1]);
             }
             // sanity check
-            if(devices[i] == NULL)
+            if (devices[i] == NULL)
             {
-                WP_ReplyToCommand( msg, true, false, NULL, 0 );
+                WP_ReplyToCommand(msg, true, false, NULL, 0);
                 return false;
             }
             deviceInfos[i] = BlockStorageDevice_GetDeviceInfo(devices[i]);
         }
-	    
-        for(int cnt = 0; cnt < 2; cnt++)
-        {
-            if(cnt == 1)
-            {
-                pData = (struct Flash_BlockRegionInfo*)platform_malloc(rangeCount * sizeof(struct Flash_BlockRegionInfo));
 
-                if(pData == NULL)
+        for (int cnt = 0; cnt < 2; cnt++)
+        {
+            if (cnt == 1)
+            {
+                pData =
+                    (struct Flash_BlockRegionInfo *)platform_malloc(rangeCount * sizeof(struct Flash_BlockRegionInfo));
+
+                if (pData == NULL)
                 {
-                    WP_ReplyToCommand( msg, true, false, NULL, 0 );
+                    WP_ReplyToCommand(msg, true, false, NULL, 0);
                     return false;
                 }
             }
-            for(unsigned int i = 0; i < numDevices; i++)
+            for (unsigned int i = 0; i < numDevices; i++)
             {
-                for(unsigned int j = 0; j < deviceInfos[i]->NumRegions;  j++)
+                for (unsigned int j = 0; j < deviceInfos[i]->NumRegions; j++)
                 {
-                    const BlockRegionInfo* pRegion = &deviceInfos[i]->Regions[ j ];
+                    const BlockRegionInfo *pRegion = &deviceInfos[i]->Regions[j];
 
-                    for(unsigned int k = 0; k < pRegion->NumBlockRanges; k++)
+                    for (unsigned int k = 0; k < pRegion->NumBlockRanges; k++)
                     {
 
-                        if(cnt == 0)
+                        if (cnt == 0)
                         {
                             rangeCount++;
                         }
                         else
                         {
-                            pData[ rangeIndex ].StartAddress  = BlockRegionInfo_BlockAddress(pRegion, pRegion->BlockRanges[ k ].StartBlock);
-                            pData[ rangeIndex ].NumBlocks = BlockRange_GetBlockCount(pRegion->BlockRanges[k]);
-                            pData[ rangeIndex ].BytesPerBlock = pRegion->BytesPerBlock;
-                            pData[ rangeIndex ].Usage  = pRegion->BlockRanges[ k ].RangeType & BlockRange_USAGE_MASK;
+                            pData[rangeIndex].StartAddress =
+                                BlockRegionInfo_BlockAddress(pRegion, pRegion->BlockRanges[k].StartBlock);
+                            pData[rangeIndex].NumBlocks = BlockRange_GetBlockCount(pRegion->BlockRanges[k]);
+                            pData[rangeIndex].BytesPerBlock = pRegion->BytesPerBlock;
+                            pData[rangeIndex].Usage = pRegion->BlockRanges[k].RangeType & BlockRange_USAGE_MASK;
                             rangeIndex++;
                         }
                     }
@@ -481,8 +508,7 @@ bool CLR_DBG_Debugger::Monitor_FlashSectorMap( WP_Message* msg)
             }
         }
 
-
-        WP_ReplyToCommand( msg, true, false, (void*)pData, rangeCount * sizeof (struct Flash_BlockRegionInfo) );
+        WP_ReplyToCommand(msg, true, false, (void *)pData, rangeCount * sizeof(struct Flash_BlockRegionInfo));
 
         platform_free(pData);
         platform_free(devices);
@@ -490,46 +516,39 @@ bool CLR_DBG_Debugger::Monitor_FlashSectorMap( WP_Message* msg)
     }
 
     return true;
-
 }
 
 //--//
 
-
-
-
-
-
-
-bool CLR_DBG_Debugger::CheckPermission( ByteAddress address, int mode )
+bool CLR_DBG_Debugger::CheckPermission(ByteAddress address, int mode)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    bool   hasPermission = false;
+    bool hasPermission = false;
     unsigned int regionIndex, rangeIndex;
 
-	BlockStorageDevice_FindRegionFromAddress(m_deploymentStorageDevice, address, &regionIndex, &rangeIndex);
-    const BlockRange& range =  BlockStorageDevice_GetDeviceInfo(m_deploymentStorageDevice)->Regions[ regionIndex ].BlockRanges[ rangeIndex ];
+    BlockStorageDevice_FindRegionFromAddress(m_deploymentStorageDevice, address, &regionIndex, &rangeIndex);
+    const BlockRange &range =
+        BlockStorageDevice_GetDeviceInfo(m_deploymentStorageDevice)->Regions[regionIndex].BlockRanges[rangeIndex];
 
-
-    switch(mode)
+    switch (mode)
     {
         case AccessMemory_Check:
             hasPermission = true;
             break;
         case AccessMemory_Read:
 #if defined(BUILD_RTM)
-            if(!DebuggerPort_IsUsingSsl(HalSystemConfig.DebuggerPort))
+            if (!DebuggerPort_IsUsingSsl(HalSystemConfig.DebuggerPort))
                 break;
 #endif
-            switch(range.RangeType)
+            switch (range.RangeType)
             {
-                case BlockRange_BLOCKTYPE_CONFIG:         // fall through
-                case BlockRange_BLOCKTYPE_BOOTSTRAP:      // fall through
-                case BlockRange_BLOCKTYPE_CODE:           // fall through
-                case BlockRange_BLOCKTYPE_DIRTYBIT:       // fall through
-                case BlockRange_BLOCKTYPE_DEPLOYMENT:     // fall through
-                case BlockRange_BLOCKTYPE_FILESYSTEM:     // fall through
-                case BlockRange_BLOCKTYPE_STORAGE_A:      // fall through
+                case BlockRange_BLOCKTYPE_CONFIG:     // fall through
+                case BlockRange_BLOCKTYPE_BOOTSTRAP:  // fall through
+                case BlockRange_BLOCKTYPE_CODE:       // fall through
+                case BlockRange_BLOCKTYPE_DIRTYBIT:   // fall through
+                case BlockRange_BLOCKTYPE_DEPLOYMENT: // fall through
+                case BlockRange_BLOCKTYPE_FILESYSTEM: // fall through
+                case BlockRange_BLOCKTYPE_STORAGE_A:  // fall through
                 case BlockRange_BLOCKTYPE_STORAGE_B:
                 case BlockRange_BLOCKTYPE_SIMPLE_A:
                 case BlockRange_BLOCKTYPE_SIMPLE_B:
@@ -541,10 +560,10 @@ bool CLR_DBG_Debugger::CheckPermission( ByteAddress address, int mode )
             break;
         case AccessMemory_Write:
 #if defined(BUILD_RTM)
-            if(!DebuggerPort_IsUsingSsl(HalSystemConfig.DebuggerPort))
+            if (!DebuggerPort_IsUsingSsl(HalSystemConfig.DebuggerPort))
                 break;
 #endif
-            if(BlockRange_IsDeployment(range) || BlockRange_IsConfig(range))
+            if (BlockRange_IsDeployment(range) || BlockRange_IsConfig(range))
             {
                 hasPermission = true;
             }
@@ -555,10 +574,10 @@ bool CLR_DBG_Debugger::CheckPermission( ByteAddress address, int mode )
             break;
         case AccessMemory_Erase:
 #if defined(BUILD_RTM)
-            if(!DebuggerPort_IsUsingSsl(HalSystemConfig.DebuggerPort))
+            if (!DebuggerPort_IsUsingSsl(HalSystemConfig.DebuggerPort))
                 break;
 #endif
-            switch(range.RangeType)
+            switch (range.RangeType)
             {
                 case BlockRange_BLOCKTYPE_DEPLOYMENT:
                 case BlockRange_BLOCKTYPE_FILESYSTEM:
@@ -580,10 +599,15 @@ bool CLR_DBG_Debugger::CheckPermission( ByteAddress address, int mode )
     return hasPermission;
 }
 
-void CLR_DBG_Debugger::AccessMemory( uint32_t location, uint32_t lengthInBytes, uint8_t* buf, uint32_t mode, uint32_t* errorCode )
+void CLR_DBG_Debugger::AccessMemory(
+    uint32_t location,
+    uint32_t lengthInBytes,
+    uint8_t *buf,
+    uint32_t mode,
+    uint32_t *errorCode)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    TRACE("AccessMemory( 0x%08X, 0x%08x, 0x%08X, %s)\n", location, lengthInBytes, buf, AccessMemoryModeNames[mode] );
+    TRACE("AccessMemory( 0x%08X, 0x%08x, 0x%08X, %s)\n", location, lengthInBytes, buf, AccessMemoryModeNames[mode]);
 
     bool proceed = false;
 
@@ -595,47 +619,50 @@ void CLR_DBG_Debugger::AccessMemory( uint32_t location, uint32_t lengthInBytes, 
 
     if (BlockStorageDevice_FindRegionFromAddress(m_deploymentStorageDevice, location, &iRegion, &iRange))
     {
-        const DeviceBlockInfo* deviceInfo = BlockStorageDevice_GetDeviceInfo(m_deploymentStorageDevice);
+        const DeviceBlockInfo *deviceInfo = BlockStorageDevice_GetDeviceInfo(m_deploymentStorageDevice);
 
         // start from the block where the sector sits.
-        ByteAddress    accessAddress    = location;
+        ByteAddress accessAddress = location;
 
-        uint8_t*       bufPtr           = buf;
-        signed int     accessLenInBytes = lengthInBytes;
-        signed int     blockOffset      = BlockRegionInfo_OffsetFromBlock(((BlockRegionInfo*)(&deviceInfo->Regions[iRegion])), accessAddress);
+        uint8_t *bufPtr = buf;
+        signed int accessLenInBytes = lengthInBytes;
+        signed int blockOffset =
+            BlockRegionInfo_OffsetFromBlock(((BlockRegionInfo *)(&deviceInfo->Regions[iRegion])), accessAddress);
 
-        for(;iRegion < deviceInfo->NumRegions; iRegion++)
+        for (; iRegion < deviceInfo->NumRegions; iRegion++)
         {
-            const BlockRegionInfo *pRegion = &deviceInfo->Regions[ iRegion ];
+            const BlockRegionInfo *pRegion = &deviceInfo->Regions[iRegion];
 
-            unsigned int blockIndex       = BlockRegionInfo_BlockIndexFromAddress(pRegion, accessAddress);
-            unsigned int accessMaxLength  = pRegion->BytesPerBlock - blockOffset;
+            unsigned int blockIndex = BlockRegionInfo_BlockIndexFromAddress(pRegion, accessAddress);
+            unsigned int accessMaxLength = pRegion->BytesPerBlock - blockOffset;
 
             blockOffset = 0;
 
-            for(;blockIndex < pRegion->NumBlocks; blockIndex++)
+            for (; blockIndex < pRegion->NumBlocks; blockIndex++)
             {
-                //accessMaxLength =the current largest number of bytes can be read from the block from the address to its block boundary.
+                // accessMaxLength =the current largest number of bytes can be read from the block from the address to
+                // its block boundary.
                 unsigned int NumOfBytes = __min(accessMaxLength, (unsigned int)accessLenInBytes);
 
                 accessMaxLength = pRegion->BytesPerBlock;
 
-                if(blockIndex > pRegion->BlockRanges[ iRange ].EndBlock)
+                if (blockIndex > pRegion->BlockRanges[iRange].EndBlock)
                 {
                     iRange++;
 
-                    if(iRange >= pRegion->NumBlockRanges)
+                    if (iRange >= pRegion->NumBlockRanges)
                     {
                         ASSERT(false);
                         break;
                     }
                 }
 
-                // since AccessMemory_Check is always true and will not break from here, no need to check AccessMemory_Check to free memory.
-                if(!CheckPermission( accessAddress, mode ))
+                // since AccessMemory_Check is always true and will not break from here, no need to check
+                // AccessMemory_Check to free memory.
+                if (!CheckPermission(accessAddress, mode))
                 {
                     TRACE0("=> Permission check failed!\n");
-                    
+
                     // set error code
                     *errorCode = AccessMemoryErrorCode_PermissionDenied;
 
@@ -643,25 +670,25 @@ void CLR_DBG_Debugger::AccessMemory( uint32_t location, uint32_t lengthInBytes, 
                     return;
                 }
 
-                switch(mode)
+                switch (mode)
                 {
                     case AccessMemory_Check:
                     case AccessMemory_Read:
-                        if(deviceInfo->Attribute & MediaAttribute_SupportsXIP)
+                        if (deviceInfo->Attribute & MediaAttribute_SupportsXIP)
                         {
-                            memcpy( (unsigned char*)bufPtr, (const void*)accessAddress, NumOfBytes );
+                            memcpy((unsigned char *)bufPtr, (const void *)accessAddress, NumOfBytes);
                             proceed = true;
                         }
                         else
                         {
                             if (mode == AccessMemory_Check)
                             {
-                                bufPtr = (unsigned char*) CLR_RT_Memory::Allocate( lengthInBytes, true );
+                                bufPtr = (unsigned char *)CLR_RT_Memory::Allocate(lengthInBytes, true);
 
-                                if(!bufPtr)
+                                if (!bufPtr)
                                 {
-                                    TRACE0( "=> Failed to allocate data buffer\n");
-                                                        
+                                    TRACE0("=> Failed to allocate data buffer\n");
+
                                     // set error code
                                     *errorCode = AccessMemoryErrorCode_PermissionDenied;
 
@@ -670,19 +697,28 @@ void CLR_DBG_Debugger::AccessMemory( uint32_t location, uint32_t lengthInBytes, 
                                 }
                             }
 
-                            proceed = BlockStorageDevice_Read(m_deploymentStorageDevice, accessAddress , NumOfBytes, (unsigned char *)bufPtr);
+                            proceed = BlockStorageDevice_Read(
+                                m_deploymentStorageDevice,
+                                accessAddress,
+                                NumOfBytes,
+                                (unsigned char *)bufPtr);
 
                             if (mode == AccessMemory_Check)
                             {
-                                *(unsigned int*)buf = SUPPORT_ComputeCRC( bufPtr, NumOfBytes, *(unsigned int*)buf );
+                                *(unsigned int *)buf = SUPPORT_ComputeCRC(bufPtr, NumOfBytes, *(unsigned int *)buf);
 
-                                CLR_RT_Memory::Release( bufPtr );
+                                CLR_RT_Memory::Release(bufPtr);
                             }
                         }
                         break;
 
                     case AccessMemory_Write:
-                        proceed = BlockStorageDevice_Write(m_deploymentStorageDevice, accessAddress , NumOfBytes, (unsigned char *)bufPtr, false);
+                        proceed = BlockStorageDevice_Write(
+                            m_deploymentStorageDevice,
+                            accessAddress,
+                            NumOfBytes,
+                            (unsigned char *)bufPtr,
+                            false);
                         break;
 
                     case AccessMemory_Erase:
@@ -698,11 +734,11 @@ void CLR_DBG_Debugger::AccessMemory( uint32_t location, uint32_t lengthInBytes, 
                         }
                         break;
 
-                     default:
+                    default:
                         break;
                 }
 
-                if(!proceed)
+                if (!proceed)
                 {
                     return;
                 }
@@ -714,17 +750,17 @@ void CLR_DBG_Debugger::AccessMemory( uint32_t location, uint32_t lengthInBytes, 
                     break;
                 }
 
-                bufPtr        += NumOfBytes;
+                bufPtr += NumOfBytes;
                 accessAddress += NumOfBytes;
             }
 
             blockIndex = 0;
-            iRange     = 0;
+            iRange = 0;
 
-           if ((accessLenInBytes <= 0) || (!proceed))
-           {
-               break;
-           }
+            if ((accessLenInBytes <= 0) || (!proceed))
+            {
+                break;
+            }
         }
     }
     else
@@ -732,60 +768,65 @@ void CLR_DBG_Debugger::AccessMemory( uint32_t location, uint32_t lengthInBytes, 
         //--// RAM write
         ByteAddress sectAddr = location;
 
-      #if defined(_WIN32)
+#if defined(_WIN32)
 
         bool proceed = false;
-        void * temp;
-        temp = (void *) sectAddr;
+        void *temp;
+        temp = (void *)sectAddr;
 
-        switch(mode)
+        switch (mode)
         {
-        case AccessMemory_Check:
-            break;
+            case AccessMemory_Check:
+                break;
 
-        case AccessMemory_Read:
-            proceed = IsBadReadPtr( temp, lengthInBytes ) == false;
-            break;
+            case AccessMemory_Read:
+                proceed = IsBadReadPtr(temp, lengthInBytes) == false;
+                break;
 
-        case AccessMemory_Write:
-            proceed = IsBadWritePtr( temp, lengthInBytes ) == false;
-            break;
+            case AccessMemory_Write:
+                proceed = IsBadWritePtr(temp, lengthInBytes) == false;
+                break;
         }
 
-        if(proceed)
-      #else
+        if (proceed)
+#else
 
-        unsigned int sectAddrEnd     = sectAddr + lengthInBytes;
+        unsigned int sectAddrEnd = sectAddr + lengthInBytes;
         unsigned int ramStartAddress = HalSystemConfig.RAM1.Base;
-        unsigned int ramEndAddress   = ramStartAddress + HalSystemConfig.RAM1.Size ;
+        unsigned int ramEndAddress = ramStartAddress + HalSystemConfig.RAM1.Size;
 
-        if((sectAddr <ramStartAddress) || (sectAddr >=ramEndAddress) || (sectAddrEnd >ramEndAddress) )
+        if ((sectAddr < ramStartAddress) || (sectAddr >= ramEndAddress) || (sectAddrEnd > ramEndAddress))
         {
-            TRACE(" Invalid address %x and range %x Ram Start %x, Ram end %x\r\n", sectAddr, lengthInBytes, ramStartAddress, ramEndAddress);
+            TRACE(
+                " Invalid address %x and range %x Ram Start %x, Ram end %x\r\n",
+                sectAddr,
+                lengthInBytes,
+                ramStartAddress,
+                ramEndAddress);
             return;
         }
         else
-      #endif
+#endif
         {
-            switch(mode)
+            switch (mode)
             {
                 case AccessMemory_Check:
                     break;
 
                 case AccessMemory_Read:
-                    memcpy( buf, (const void*)sectAddr, lengthInBytes );
+                    memcpy(buf, (const void *)sectAddr, lengthInBytes);
                     break;
 
                 case AccessMemory_Write:
-                    unsigned char * memPtr;
-                    memPtr = (unsigned char*)sectAddr;
-                    memcpy( memPtr, buf, lengthInBytes );
+                    unsigned char *memPtr;
+                    memPtr = (unsigned char *)sectAddr;
+                    memcpy(memPtr, buf, lengthInBytes);
                     break;
 
                 case AccessMemory_Erase:
-                    memPtr = (unsigned char*)sectAddr;
-                    if (lengthInBytes !=0)
-                        memset( memPtr, 0xFF, lengthInBytes );
+                    memPtr = (unsigned char *)sectAddr;
+                    if (lengthInBytes != 0)
+                        memset(memPtr, 0xFF, lengthInBytes);
                     break;
 
                 default:
@@ -794,22 +835,22 @@ void CLR_DBG_Debugger::AccessMemory( uint32_t location, uint32_t lengthInBytes, 
         }
     }
 
-    TRACE0( "=> SUCCESS\n");
+    TRACE0("=> SUCCESS\n");
 
     *errorCode = AccessMemoryErrorCode_NoError;
 }
 
-bool CLR_DBG_Debugger::Monitor_ReadMemory( WP_Message* msg)
+bool CLR_DBG_Debugger::Monitor_ReadMemory(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands_Monitor_ReadMemory*       cmd = (CLR_DBG_Commands_Monitor_ReadMemory*)msg->m_payload;
-    uint8_t* buffer;
+    CLR_DBG_Commands_Monitor_ReadMemory *cmd = (CLR_DBG_Commands_Monitor_ReadMemory *)msg->m_payload;
+    uint8_t *buffer;
     uint32_t errorCode;
 
     uint32_t allocationSize = 0;
-    uint32_t len = cmd->length; 
-    
+    uint32_t len = cmd->length;
+
     // adjust length, if bigger than the WP packet size
     if (len > WP_PACKET_SIZE)
     {
@@ -822,17 +863,17 @@ bool CLR_DBG_Debugger::Monitor_ReadMemory( WP_Message* msg)
     allocationSize += len;
 
     // allocate memory
-    buffer = (uint8_t*)platform_malloc(allocationSize);
+    buffer = (uint8_t *)platform_malloc(allocationSize);
 
     // sanity check
-    if(buffer != NULL)
+    if (buffer != NULL)
     {
         // clear allocated memory
         memset(buffer, 0, allocationSize);
 
-        g_CLR_DBG_Debugger->AccessMemory( cmd->address, len, (buffer + sizeof(uint32_t)), AccessMemory_Read, &errorCode );
+        g_CLR_DBG_Debugger->AccessMemory(cmd->address, len, (buffer + sizeof(uint32_t)), AccessMemory_Read, &errorCode);
 
-        WP_ReplyToCommand( msg, true, false, buffer, allocationSize );
+        WP_ReplyToCommand(msg, true, false, buffer, allocationSize);
 
         // free allocated memory
         platform_free(buffer);
@@ -844,58 +885,58 @@ bool CLR_DBG_Debugger::Monitor_ReadMemory( WP_Message* msg)
     return false;
 }
 
-bool CLR_DBG_Debugger::Monitor_WriteMemory( WP_Message* msg)
+bool CLR_DBG_Debugger::Monitor_WriteMemory(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands_Monitor_WriteMemory* cmd = (CLR_DBG_Commands_Monitor_WriteMemory*)msg->m_payload;
+    CLR_DBG_Commands_Monitor_WriteMemory *cmd = (CLR_DBG_Commands_Monitor_WriteMemory *)msg->m_payload;
     CLR_DBG_Commands_Monitor_WriteMemory_Reply cmdReply;
 
-    g_CLR_DBG_Debugger->AccessMemory( cmd->address, cmd->length, cmd->data, AccessMemory_Write, &cmdReply );
+    g_CLR_DBG_Debugger->AccessMemory(cmd->address, cmd->length, cmd->data, AccessMemory_Write, &cmdReply);
 
     WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Monitor_CheckMemory( WP_Message* msg)
+bool CLR_DBG_Debugger::Monitor_CheckMemory(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands_Monitor_CheckMemory*       cmd      = (CLR_DBG_Commands_Monitor_CheckMemory*)msg->m_payload;
-    CLR_DBG_Commands_Monitor_CheckMemory_Reply  cmdReply;
+    CLR_DBG_Commands_Monitor_CheckMemory *cmd = (CLR_DBG_Commands_Monitor_CheckMemory *)msg->m_payload;
+    CLR_DBG_Commands_Monitor_CheckMemory_Reply cmdReply;
     uint32_t errorCode;
 
-    g_CLR_DBG_Debugger->AccessMemory( cmd->address, cmd->length, (unsigned char*)&cmdReply, AccessMemory_Check, &errorCode );
-
-    WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
-
-    return true;
-}
-
-bool CLR_DBG_Debugger::Monitor_EraseMemory( WP_Message* msg)
-{
-    NATIVE_PROFILE_CLR_DEBUGGER();
-
-    CLR_DBG_Commands_Monitor_EraseMemory* cmd = (CLR_DBG_Commands_Monitor_EraseMemory*)msg->m_payload;
-    CLR_DBG_Commands_Monitor_EraseMemory_Reply cmdReply;
-
-    g_CLR_DBG_Debugger->AccessMemory( cmd->address, cmd->length, NULL, AccessMemory_Erase, &cmdReply );
+    g_CLR_DBG_Debugger
+        ->AccessMemory(cmd->address, cmd->length, (unsigned char *)&cmdReply, AccessMemory_Check, &errorCode);
 
     WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Monitor_Execute( WP_Message* msg)
+bool CLR_DBG_Debugger::Monitor_EraseMemory(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
 
-    CLR_DBG_Commands::Monitor_Execute* cmd = (CLR_DBG_Commands::Monitor_Execute*)msg->m_payload;
+    CLR_DBG_Commands_Monitor_EraseMemory *cmd = (CLR_DBG_Commands_Monitor_EraseMemory *)msg->m_payload;
+    CLR_DBG_Commands_Monitor_EraseMemory_Reply cmdReply;
+
+    g_CLR_DBG_Debugger->AccessMemory(cmd->address, cmd->length, NULL, AccessMemory_Erase, &cmdReply);
+
+    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
+
+    return true;
+}
+
+bool CLR_DBG_Debugger::Monitor_Execute(WP_Message *msg)
+{
+    NATIVE_PROFILE_CLR_DEBUGGER();
+
+    CLR_DBG_Commands::Monitor_Execute *cmd = (CLR_DBG_Commands::Monitor_Execute *)msg->m_payload;
 
 #if defined(BUILD_RTM)
-    if(!DebuggerPort_IsUsingSsl(HalSystemConfig.DebuggerPort))
+    if (!DebuggerPort_IsUsingSsl(HalSystemConfig.DebuggerPort))
         return false;
 #endif
 
@@ -906,19 +947,20 @@ bool CLR_DBG_Debugger::Monitor_Execute( WP_Message* msg)
     return true;
 }
 
-bool CLR_DBG_Debugger::Monitor_Reboot( WP_Message* msg)
+bool CLR_DBG_Debugger::Monitor_Reboot(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Monitor_Reboot* cmd = (CLR_DBG_Commands::Monitor_Reboot*)msg->m_payload;
 
-    if(NULL != cmd)
+    CLR_DBG_Commands::Monitor_Reboot *cmd = (CLR_DBG_Commands::Monitor_Reboot *)msg->m_payload;
+
+    if (NULL != cmd)
     {
-        if(CLR_DBG_Commands::Monitor_Reboot::c_EnterBootloader == (cmd->m_flags & CLR_DBG_Commands::Monitor_Reboot::c_EnterBootloader))
+        if (CLR_DBG_Commands::Monitor_Reboot::c_EnterBootloader ==
+            (cmd->m_flags & CLR_DBG_Commands::Monitor_Reboot::c_EnterBootloader))
         {
             WP_ReplyToCommand(msg, true, false, NULL, 0);
 
-            Events_WaitForEvents( 0, 100 ); // give message a little time to be flushed
+            Events_WaitForEvents(0, 100); // give message a little time to be flushed
 
             HAL_EnterBooterMode();
         }
@@ -928,110 +970,121 @@ bool CLR_DBG_Debugger::Monitor_Reboot( WP_Message* msg)
 
     WP_ReplyToCommand(msg, true, false, NULL, 0);
 
-    Events_WaitForEvents( 0, 100 ); // give message a little time to be flushed
+    Events_WaitForEvents(0, 100); // give message a little time to be flushed
 
-    CLR_EE_DBG_SET( RebootPending );
+    CLR_EE_DBG_SET(RebootPending);
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Monitor_MemoryMap( WP_Message* msg)
+bool CLR_DBG_Debugger::Monitor_MemoryMap(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
+
     MemoryMap_Range map[2];
 
     map[0].m_address = HalSystemConfig.RAM1.Base;
-    map[0].m_length  = HalSystemConfig.RAM1.Size;
-    map[0].m_flags   = Monitor_MemoryMap_c_RAM;
+    map[0].m_length = HalSystemConfig.RAM1.Size;
+    map[0].m_flags = Monitor_MemoryMap_c_RAM;
 
     map[1].m_address = HalSystemConfig.FLASH1.Base;
-    map[1].m_length  = HalSystemConfig.FLASH1.Size;
-    map[1].m_flags   = Monitor_MemoryMap_c_FLASH;
+    map[1].m_length = HalSystemConfig.FLASH1.Size;
+    map[1].m_flags = Monitor_MemoryMap_c_FLASH;
 
     WP_ReplyToCommand(msg, true, false, map, sizeof(map));
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Monitor_DeploymentMap( WP_Message* msg)
+bool CLR_DBG_Debugger::Monitor_DeploymentMap(WP_Message *msg)
 {
     (void)msg;
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Monitor_QueryConfiguration( WP_Message* message)
+bool CLR_DBG_Debugger::Monitor_QueryConfiguration(WP_Message *message)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    bool success     = false;
+    bool success = false;
 
     // include handling of configuration block only if feature is available
-  #if (HAS_CONFIG_BLOCK == TRUE)
+#if (HAS_CONFIG_BLOCK == TRUE)
 
-    Monitor_QueryConfiguration_Command *cmd = (Monitor_QueryConfiguration_Command*)message->m_payload;
-    int size          = 0;
+    Monitor_QueryConfiguration_Command *cmd = (Monitor_QueryConfiguration_Command *)message->m_payload;
+    int size = 0;
     int sizeOfBlock = 0;
 
-    HAL_Configuration_NetworkInterface* configNetworkInterface;
-    HAL_Configuration_Wireless80211* configWireless80211NetworkInterface;
-    HAL_Configuration_X509CaRootBundle* x509Certificate;
+    HAL_Configuration_NetworkInterface *configNetworkInterface;
+    HAL_Configuration_Wireless80211 *configWireless80211NetworkInterface;
+    HAL_Configuration_X509CaRootBundle *x509Certificate;
 
-    switch((DeviceConfigurationOption)cmd->Configuration)
+    switch ((DeviceConfigurationOption)cmd->Configuration)
     {
         case DeviceConfigurationOption_Network:
 
-            configNetworkInterface = (HAL_Configuration_NetworkInterface*)platform_malloc(sizeof(HAL_Configuration_NetworkInterface));
+            configNetworkInterface =
+                (HAL_Configuration_NetworkInterface *)platform_malloc(sizeof(HAL_Configuration_NetworkInterface));
             memset(configNetworkInterface, 0, sizeof(HAL_Configuration_NetworkInterface));
 
-            if(ConfigurationManager_GetConfigurationBlock(configNetworkInterface, (DeviceConfigurationOption)cmd->Configuration, cmd->BlockIndex) == true)
+            if (ConfigurationManager_GetConfigurationBlock(
+                    configNetworkInterface,
+                    (DeviceConfigurationOption)cmd->Configuration,
+                    cmd->BlockIndex) == true)
             {
                 size = sizeof(HAL_Configuration_NetworkInterface);
                 success = true;
 
-                WP_ReplyToCommand( message, success, false, (uint8_t*)configNetworkInterface, size );
-            }            
+                WP_ReplyToCommand(message, success, false, (uint8_t *)configNetworkInterface, size);
+            }
             platform_free(configNetworkInterface);
             break;
 
         case DeviceConfigurationOption_Wireless80211Network:
 
-            configWireless80211NetworkInterface = (HAL_Configuration_Wireless80211*)platform_malloc(sizeof(HAL_Configuration_Wireless80211));
+            configWireless80211NetworkInterface =
+                (HAL_Configuration_Wireless80211 *)platform_malloc(sizeof(HAL_Configuration_Wireless80211));
             memset(configWireless80211NetworkInterface, 0, sizeof(HAL_Configuration_Wireless80211));
 
-            if(ConfigurationManager_GetConfigurationBlock(configWireless80211NetworkInterface, (DeviceConfigurationOption)cmd->Configuration, cmd->BlockIndex) == true)
+            if (ConfigurationManager_GetConfigurationBlock(
+                    configWireless80211NetworkInterface,
+                    (DeviceConfigurationOption)cmd->Configuration,
+                    cmd->BlockIndex) == true)
             {
                 size = sizeof(HAL_Configuration_Wireless80211);
                 success = true;
 
-                WP_ReplyToCommand( message, success, false, (uint8_t*)configWireless80211NetworkInterface, size );
+                WP_ReplyToCommand(message, success, false, (uint8_t *)configWireless80211NetworkInterface, size);
             }
             platform_free(configWireless80211NetworkInterface);
             break;
-    
+
         case DeviceConfigurationOption_X509CaRootBundle:
 
-            if(g_TargetConfiguration.CertificateStore->Count > cmd->BlockIndex )
+            if (g_TargetConfiguration.CertificateStore->Count > cmd->BlockIndex)
             {
                 // because X509 certificate has a variable length need to compute the block size in two steps
                 sizeOfBlock = offsetof(HAL_Configuration_X509CaRootBundle, Certificate);
                 sizeOfBlock += g_TargetConfiguration.CertificateStore->Certificates[cmd->BlockIndex]->CertificateSize;
             }
 
-            x509Certificate = (HAL_Configuration_X509CaRootBundle*)platform_malloc(sizeOfBlock);
+            x509Certificate = (HAL_Configuration_X509CaRootBundle *)platform_malloc(sizeOfBlock);
             memset(x509Certificate, 0, sizeof(sizeOfBlock));
 
-            if(ConfigurationManager_GetConfigurationBlock(x509Certificate, (DeviceConfigurationOption)cmd->Configuration, cmd->BlockIndex) == true)
+            if (ConfigurationManager_GetConfigurationBlock(
+                    x509Certificate,
+                    (DeviceConfigurationOption)cmd->Configuration,
+                    cmd->BlockIndex) == true)
             {
                 size = sizeOfBlock;
                 success = true;
 
-                WP_ReplyToCommand( message, success, false, (uint8_t*)x509Certificate, size );
+                WP_ReplyToCommand(message, success, false, (uint8_t *)x509Certificate, size);
             }
             platform_free(x509Certificate);
             break;
-    
+
         case DeviceConfigurationOption_WirelessNetworkAP:
             // TODO missing implementation for now
             break;
@@ -1040,44 +1093,50 @@ bool CLR_DBG_Debugger::Monitor_QueryConfiguration( WP_Message* message)
             break;
     }
 
-    if(!success)
+    if (!success)
     {
-        WP_ReplyToCommand( message, success, false, NULL, size );
+        WP_ReplyToCommand(message, success, false, NULL, size);
     }
 
-  #else
+#else
 
     (void)message;
 
-  #endif // (HAS_CONFIG_BLOCK == TRUE)
+#endif // (HAS_CONFIG_BLOCK == TRUE)
 
     return success;
 }
 
-bool CLR_DBG_Debugger::Monitor_UpdateConfiguration(WP_Message* message)
+bool CLR_DBG_Debugger::Monitor_UpdateConfiguration(WP_Message *message)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
     bool success = false;
 
     // include handling of configuration block only if feature is available
-  #if (HAS_CONFIG_BLOCK == TRUE)
+#if (HAS_CONFIG_BLOCK == TRUE)
 
-    Monitor_UpdateConfiguration_Command* cmd = (Monitor_UpdateConfiguration_Command*)message->m_payload;
+    Monitor_UpdateConfiguration_Command *cmd = (Monitor_UpdateConfiguration_Command *)message->m_payload;
     Monitor_UpdateConfiguration_Reply cmdReply;
 
-    switch((DeviceConfigurationOption)cmd->Configuration)
+    switch ((DeviceConfigurationOption)cmd->Configuration)
     {
         case DeviceConfigurationOption_Network:
         case DeviceConfigurationOption_Wireless80211Network:
         case DeviceConfigurationOption_X509CaRootBundle:
         case DeviceConfigurationOption_All:
-            if(ConfigurationManager_StoreConfigurationBlock(cmd->Data, (DeviceConfigurationOption)cmd->Configuration, cmd->BlockIndex, cmd->Length, cmd->Offset, cmd->Done) == true)
+            if (ConfigurationManager_StoreConfigurationBlock(
+                    cmd->Data,
+                    (DeviceConfigurationOption)cmd->Configuration,
+                    cmd->BlockIndex,
+                    cmd->Length,
+                    cmd->Offset,
+                    cmd->Done) == true)
             {
                 cmdReply.ErrorCode = 0;
                 success = true;
             }
-            else 
+            else
             {
                 cmdReply.ErrorCode = 100;
             }
@@ -1089,50 +1148,51 @@ bool CLR_DBG_Debugger::Monitor_UpdateConfiguration(WP_Message* message)
 
     WP_ReplyToCommand(message, success, false, &cmdReply, sizeof(cmdReply));
 
-  #else
+#else
 
     (void)message;
 
-  #endif // (HAS_CONFIG_BLOCK == TRUE)
+#endif // (HAS_CONFIG_BLOCK == TRUE)
 
     return success;
 }
 
 //--//
 
-bool CLR_DBG_Debugger::Debugging_Execution_BasePtr( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Execution_BasePtr(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
+
     CLR_DBG_Commands::Debugging_Execution_BasePtr::Reply cmdReply;
 
     cmdReply.m_EE = (CLR_UINT32)(size_t)&g_CLR_RT_ExecutionEngine;
 
-    WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Execution_ChangeConditions( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Execution_ChangeConditions(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Execution_ChangeConditions* cmd = (CLR_DBG_Commands::Debugging_Execution_ChangeConditions*)msg->m_payload;
 
-    g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions |=  cmd->FlagsToSet;
+    CLR_DBG_Commands::Debugging_Execution_ChangeConditions *cmd =
+        (CLR_DBG_Commands::Debugging_Execution_ChangeConditions *)msg->m_payload;
+
+    g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions |= cmd->FlagsToSet;
     g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions &= ~cmd->FlagsToReset;
 
     // updating the debugging execution conditions requires sometime to propagate
     // make sure we allow enough time for that to happen
     OS_DELAY(100);
 
-    if((msg->m_header.m_flags & WP_Flags_c_NonCritical) == 0)
+    if ((msg->m_header.m_flags & WP_Flags_c_NonCritical) == 0)
     {
         CLR_DBG_Commands::Debugging_Execution_ChangeConditions::Reply cmdReply;
 
         cmdReply.CurrentState = g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions;
 
-        WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+        WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
     }
 
     return true;
@@ -1140,95 +1200,100 @@ bool CLR_DBG_Debugger::Debugging_Execution_ChangeConditions( WP_Message* msg)
 
 //--//
 
-static void GetClrReleaseInfo(CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::ClrInfo& clrInfo)
+static void GetClrReleaseInfo(CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::ClrInfo &clrInfo)
 {
-    NFReleaseInfo::Init( 
-        clrInfo.m_clrReleaseInfo, 
-        VERSION_MAJOR, 
-        VERSION_MINOR, 
-        VERSION_BUILD, 
-        VERSION_REVISION, 
-        OEMSYSTEMINFOSTRING, 
+    NFReleaseInfo::Init(
+        clrInfo.m_clrReleaseInfo,
+        VERSION_MAJOR,
+        VERSION_MINOR,
+        VERSION_BUILD,
+        VERSION_REVISION,
+        OEMSYSTEMINFOSTRING,
         ARRAYSIZE(OEMSYSTEMINFOSTRING),
         TARGETNAMESTRING,
         ARRAYSIZE(TARGETNAMESTRING),
         PLATFORMNAMESTRING,
-        ARRAYSIZE(PLATFORMNAMESTRING)
-        );
+        ARRAYSIZE(PLATFORMNAMESTRING));
 
-    if ( g_CLR_RT_TypeSystem.m_assemblyMscorlib &&
-         g_CLR_RT_TypeSystem.m_assemblyMscorlib->m_header)
+    if (g_CLR_RT_TypeSystem.m_assemblyMscorlib && g_CLR_RT_TypeSystem.m_assemblyMscorlib->m_header)
     {
-        const CLR_RECORD_VERSION* mscorlibVer = & (g_CLR_RT_TypeSystem.m_assemblyMscorlib->m_header->version);
-        NFVersion::Init(  clrInfo.m_TargetFrameworkVersion,
-                        mscorlibVer->iMajorVersion, mscorlibVer->iMinorVersion,
-                        mscorlibVer->iBuildNumber, mscorlibVer->iRevisionNumber
-                        );
+        const CLR_RECORD_VERSION *mscorlibVer = &(g_CLR_RT_TypeSystem.m_assemblyMscorlib->m_header->version);
+        NFVersion::Init(
+            clrInfo.m_TargetFrameworkVersion,
+            mscorlibVer->iMajorVersion,
+            mscorlibVer->iMinorVersion,
+            mscorlibVer->iBuildNumber,
+            mscorlibVer->iRevisionNumber);
     }
     else
     {
-        NFVersion::Init( clrInfo.m_TargetFrameworkVersion, 0, 0, 0, 0 );
+        NFVersion::Init(clrInfo.m_TargetFrameworkVersion, 0, 0, 0, 0);
     }
 }
 
-static bool GetInteropNativeAssemblies( uint8_t* &data, int* size, uint32_t startIndex, uint32_t count )
+static bool GetInteropNativeAssemblies(uint8_t *&data, int *size, uint32_t startIndex, uint32_t count)
 {
     uint32_t index = 0;
-    
-    CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::NativeAssemblyDetails* interopNativeAssemblies = NULL;
+
+    CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::NativeAssemblyDetails *interopNativeAssemblies = NULL;
 
     // sanity checks on the requested size
-    // - if 0, adjust to the assemblies count to make the execution backwards compatible 
+    // - if 0, adjust to the assemblies count to make the execution backwards compatible
     // - trim if over the available assembly count
     // (max possible page size is 255)
-    if(startIndex == 0 && count == 0)
+    if (startIndex == 0 && count == 0)
     {
-        // adjust to the assemblies count to make the execution backwards compatible 
+        // adjust to the assemblies count to make the execution backwards compatible
         count = g_CLR_InteropAssembliesCount;
     }
-    else if(count > 255 ||
-            count + startIndex > g_CLR_InteropAssembliesCount)
+    else if (count > 255 || count + startIndex > g_CLR_InteropAssembliesCount)
     {
-        // adjust to the assemblies count so it doesn't overflow 
+        // adjust to the assemblies count so it doesn't overflow
         count = g_CLR_InteropAssembliesCount - startIndex;
     }
 
     // alloc buffer to hold the requested number of assemblies
-    interopNativeAssemblies = (CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::NativeAssemblyDetails*)platform_malloc(sizeof(CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::NativeAssemblyDetails) * count);
+    interopNativeAssemblies =
+        (CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::NativeAssemblyDetails *)platform_malloc(
+            sizeof(CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::NativeAssemblyDetails) * count);
 
     // check for malloc failure
-    if(interopNativeAssemblies == NULL)
+    if (interopNativeAssemblies == NULL)
     {
         return false;
     }
 
     // clear buffer memory
     memset(
-        interopNativeAssemblies, 
-        0, 
+        interopNativeAssemblies,
+        0,
         sizeof(CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::NativeAssemblyDetails) * count);
 
     // fill the array
-    for ( uint32_t i = 0; i < g_CLR_InteropAssembliesCount; i++ )
+    for (uint32_t i = 0; i < g_CLR_InteropAssembliesCount; i++)
     {
         // check if the assembly at this position it's on the requested range
-        if( i >= startIndex &&
-            i < (startIndex + count))
+        if (i >= startIndex && i < (startIndex + count))
         {
             interopNativeAssemblies[index].CheckSum = g_CLR_InteropAssembliesNativeData[i]->m_checkSum;
-            hal_strcpy_s((char*)interopNativeAssemblies[index].AssemblyName, ARRAYSIZE(interopNativeAssemblies[index].AssemblyName), g_CLR_InteropAssembliesNativeData[i]->m_szAssemblyName);
+            hal_strcpy_s(
+                (char *)interopNativeAssemblies[index].AssemblyName,
+                ARRAYSIZE(interopNativeAssemblies[index].AssemblyName),
+                g_CLR_InteropAssembliesNativeData[i]->m_szAssemblyName);
 
-            NFVersion::Init(interopNativeAssemblies[index].Version,
-                        g_CLR_InteropAssembliesNativeData[i]->m_Version.iMajorVersion, g_CLR_InteropAssembliesNativeData[i]->m_Version.iMinorVersion,
-                        g_CLR_InteropAssembliesNativeData[i]->m_Version.iBuildNumber, g_CLR_InteropAssembliesNativeData[i]->m_Version.iRevisionNumber
-                        );
+            NFVersion::Init(
+                interopNativeAssemblies[index].Version,
+                g_CLR_InteropAssembliesNativeData[i]->m_Version.iMajorVersion,
+                g_CLR_InteropAssembliesNativeData[i]->m_Version.iMinorVersion,
+                g_CLR_InteropAssembliesNativeData[i]->m_Version.iBuildNumber,
+                g_CLR_InteropAssembliesNativeData[i]->m_Version.iRevisionNumber);
 
             index++;
         }
     }
 
-    // copy back the buffer 
-    data = (uint8_t*)interopNativeAssemblies;
+    // copy back the buffer
+    data = (uint8_t *)interopNativeAssemblies;
 
     // set buffer size
     *size = (sizeof(CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::NativeAssemblyDetails) * count);
@@ -1238,18 +1303,19 @@ static bool GetInteropNativeAssemblies( uint8_t* &data, int* size, uint32_t star
 
 //--//
 
-bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities* cmd = (CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities*)msg->m_payload;
+
+    CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities *cmd =
+        (CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities *)msg->m_payload;
 
     CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::ReplyUnion reply;
     reply.u_capsFlags = 0;
 
-    CLR_UINT8* data   = NULL;
-    int size          = 0;
-    bool fSuccess     = true;
+    CLR_UINT8 *data = NULL;
+    int size = 0;
+    bool fSuccess = true;
     bool freeAllocFlag = false;
     uint32_t startIndex = 0;
     uint32_t count = 0xFF;
@@ -1257,7 +1323,7 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg
     // set the compiler info string here
 #if defined(__GNUC__)
 #define COMPILER_INFO "GNU ARM GCC"
-    const size_t len = MIN(sizeof(COMPILER_INFO), sizeof(reply.u_SoftwareVersion.CompilerInfo)-1);
+    const size_t len = MIN(sizeof(COMPILER_INFO), sizeof(reply.u_SoftwareVersion.CompilerInfo) - 1);
 #else
 #define COMPILER_INFO "UNKNOWN"
     const size_t len = 0;
@@ -1268,91 +1334,113 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg
     // need to mask the command to get only the lower byte with the command code
     uint32_t cmdCode = 0x000000FF & cmd->m_cmd;
 
-    switch(cmdCode)
+    switch (cmdCode)
     {
         case CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags:
 
 #if !defined(NANOCLR_EMULATED_FLOATINGPOINT)
-            reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_FloatingPoint;
+            reply.u_capsFlags |=
+                CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_FloatingPoint;
 #endif
 
-            reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_ExceptionFilters;
+            reply.u_capsFlags |=
+                CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_ExceptionFilters;
 
             // the current version ONLY suports incremental deployment
-            reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_IncrementalDeployment;
+            reply.u_capsFlags |=
+                CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_IncrementalDeployment;
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-            reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_SourceLevelDebugging;
+            reply.u_capsFlags |=
+                CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_SourceLevelDebugging;
 
-            reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_ThreadCreateEx;
+            reply.u_capsFlags |=
+                CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_ThreadCreateEx;
 #endif
 
 #if defined(NANOCLR_PROFILE_NEW)
-            reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_Profiling;
+            reply.u_capsFlags |=
+                CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_Profiling;
 #if defined(NANOCLR_PROFILE_NEW_CALLS)
-            reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_Profiling_Calls;
+            reply.u_capsFlags |=
+                CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_Profiling_Calls;
 #endif
 #if defined(NANOCLR_PROFILE_NEW_ALLOCATIONS)
-            reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_Profiling_Allocations;
+            reply.u_capsFlags |=
+                CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_Profiling_Allocations;
 #endif
 #endif
 
 #if defined(NANOCLR_APPDOMAINS)
-            reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_AppDomains;
+            reply.u_capsFlags |=
+                CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_AppDomains;
 #endif
 
             if (CPU_IsSoftRebootSupported())
             {
-                reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_SoftReboot;
+                reply.u_capsFlags |=
+                    CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_SoftReboot;
             }
 
             if (::Target_ConfigUpdateRequiresErase())
             {
-                reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_ConfigBlockRequiresErase;
+                reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::
+                    c_CapabilityFlags_ConfigBlockRequiresErase;
             }
 
             if (::Target_HasNanoBooter())
             {
-                reply.u_capsFlags |= CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_HasNanoBooter;
+                reply.u_capsFlags |=
+                    CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_HasNanoBooter;
             }
 
-            reply.u_capsFlags |= (::GetPlatformCapabilities() & 
-                                    ( CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_PlatformCapabiliy_0 |
-                                    CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_PlatformCapabiliy_1));
+            reply.u_capsFlags |=
+                (::GetPlatformCapabilities() &
+                 (CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_PlatformCapabiliy_0 |
+                  CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_PlatformCapabiliy_1));
 
-            reply.u_capsFlags |= (::GetTargetCapabilities() & 
-                                    ( CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_TargetCapabiliy_0 |
-                                    CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_TargetCapabiliy_1));
+            reply.u_capsFlags |=
+                (::GetTargetCapabilities() &
+                 (CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_TargetCapabiliy_0 |
+                  CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_TargetCapabiliy_1));
 
-            data = (CLR_UINT8*)&reply.u_capsFlags;
+            data = (CLR_UINT8 *)&reply.u_capsFlags;
             size = sizeof(reply.u_capsFlags);
             break;
 
         case CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityVersion:
 #if defined(__GNUC__)
-			// this is returning the GNU GCC compiler version in coded format: MAJOR x 10000 + MINOR x 100 + PATCH
+            // this is returning the GNU GCC compiler version in coded format: MAJOR x 10000 + MINOR x 100 + PATCH
             // example: v6.3.1 shows as 6 x 10000 + 3 x 100 + 1 = 60301
             reply.u_SoftwareVersion.CompilerVersion = (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__);
 #else
-			reply.u_SoftwareVersion.CompilerVersion = -1;
+            reply.u_SoftwareVersion.CompilerVersion = -1;
 #endif
 
 #if defined(__DATE__)
-            hal_strncpy_s( reply.u_SoftwareVersion.BuildDate, sizeof(reply.u_SoftwareVersion.BuildDate), __DATE__,  hal_strlen_s(__DATE__) );
+            hal_strncpy_s(
+                reply.u_SoftwareVersion.BuildDate,
+                sizeof(reply.u_SoftwareVersion.BuildDate),
+                __DATE__,
+                hal_strlen_s(__DATE__));
 #else
 #error "__DATE__ with build timestamp needs to be  defined"
 #endif
 
-            hal_strncpy_s( (char*)&reply.u_SoftwareVersion.CompilerInfo[ 0 ], sizeof(reply.u_SoftwareVersion.CompilerInfo), COMPILER_INFO, len );
+            hal_strncpy_s(
+                (char *)&reply.u_SoftwareVersion.CompilerInfo[0],
+                sizeof(reply.u_SoftwareVersion.CompilerInfo),
+                COMPILER_INFO,
+                len);
 
-            data = (CLR_UINT8*)&reply.u_SoftwareVersion;
+            data = (CLR_UINT8 *)&reply.u_SoftwareVersion;
             size = sizeof(reply.u_SoftwareVersion);
             break;
 
         case CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_HalSystemInfo:
-            if(GetHalSystemInfo( reply.u_HalSystemInfo ) == true)
+            if (GetHalSystemInfo(reply.u_HalSystemInfo) == true)
             {
-                data = (CLR_UINT8*)&reply.u_HalSystemInfo;
+                data = (CLR_UINT8 *)&reply.u_HalSystemInfo;
                 size = sizeof(reply.u_HalSystemInfo);
             }
             else
@@ -1363,14 +1451,14 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg
 
         case CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_ClrInfo:
             GetClrReleaseInfo(reply.u_ClrInfo);
-            data = (CLR_UINT8*)&reply.u_ClrInfo;
+            data = (CLR_UINT8 *)&reply.u_ClrInfo;
             size = sizeof(reply.u_ClrInfo);
             break;
 
         case CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_TargetReleaseInfo:
-            if(Target_GetReleaseInfo(reply.u_TargetReleaseInfo) == true)
+            if (Target_GetReleaseInfo(reply.u_TargetReleaseInfo) == true)
             {
-                data = (CLR_UINT8*)&reply.u_TargetReleaseInfo;
+                data = (CLR_UINT8 *)&reply.u_TargetReleaseInfo;
                 size = sizeof(reply.u_TargetReleaseInfo);
             }
             else
@@ -1380,7 +1468,7 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg
             break;
 
         case CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_InteropNativeAssemblies:
-            
+
             // the start index and count are encoded on the MSBytes of the command, like this: 0xCCSSxxxx
             // SS: index of the 1st assembly to list
             // CC: how many assemblies to add to the list
@@ -1392,7 +1480,7 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg
             // now fix the start index by masking the count byte
             startIndex &= 0x000000FF;
 
-            if(GetInteropNativeAssemblies(data, &size, startIndex, count) == true)
+            if (GetInteropNativeAssemblies(data, &size, startIndex, count) == true)
             {
                 // signal need to free memory
                 freeAllocFlag = true;
@@ -1404,10 +1492,10 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg
             break;
 
         case CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_InteropNativeAssembliesCount:
-            // reusing the struct field to return the assemblies count 
+            // reusing the struct field to return the assemblies count
             // because GCC optimizations prevent using the variable directly
             reply.u_capsFlags = g_CLR_InteropAssembliesCount;
-            data = (CLR_UINT8*)&reply.u_capsFlags;
+            data = (CLR_UINT8 *)&reply.u_capsFlags;
             size = sizeof(reply.u_capsFlags);
             break;
 
@@ -1416,10 +1504,10 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg
             break;
     }
 
-    WP_ReplyToCommand( msg, fSuccess, false, data, size );
+    WP_ReplyToCommand(msg, fSuccess, false, data, size);
 
     // check if we need to free data pointer
-    if(freeAllocFlag)
+    if (freeAllocFlag)
     {
         platform_free(data);
     }
@@ -1427,326 +1515,120 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities( WP_Message* msg
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Execution_Allocate( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Execution_Allocate(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Execution_Allocate*       cmd = (CLR_DBG_Commands::Debugging_Execution_Allocate*)msg->m_payload;
+
+    CLR_DBG_Commands::Debugging_Execution_Allocate *cmd =
+        (CLR_DBG_Commands::Debugging_Execution_Allocate *)msg->m_payload;
     CLR_DBG_Commands::Debugging_Execution_Allocate::Reply reply;
 
-    reply.m_address = (CLR_UINT32)(size_t)CLR_RT_Memory::Allocate( cmd->m_size, CLR_RT_HeapBlock::HB_CompactOnFailure );
+    reply.m_address = (CLR_UINT32)(size_t)CLR_RT_Memory::Allocate(cmd->m_size, CLR_RT_HeapBlock::HB_CompactOnFailure);
 
-    if(!reply.m_address) return false;
+    if (!reply.m_address)
+        return false;
 
-    WP_ReplyToCommand( msg, true, false, &reply, sizeof(reply) );
+    WP_ReplyToCommand(msg, true, false, &reply, sizeof(reply));
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_UpgradeToSsl(WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_UpgradeToSsl(WP_Message *msg)
 {
-    
-    CLR_DBG_Commands::Debugging_UpgradeToSsl*       cmd = (CLR_DBG_Commands::Debugging_UpgradeToSsl*)msg->m_payload;
+
+    CLR_DBG_Commands::Debugging_UpgradeToSsl *cmd = (CLR_DBG_Commands::Debugging_UpgradeToSsl *)msg->m_payload;
     CLR_DBG_Commands::Debugging_UpgradeToSsl::Reply reply;
 
-    if(!DebuggerPort_IsSslSupported(HalSystemConfig.DebuggerPort))
+    if (!DebuggerPort_IsSslSupported(HalSystemConfig.DebuggerPort))
     {
         return false;
     }
 
     reply.m_success = 1;
 
-    WP_ReplyToCommand( msg, true, true, &reply, sizeof(reply) );
+    WP_ReplyToCommand(msg, true, true, &reply, sizeof(reply));
 
     Events_WaitForEvents(0, 300);
 
     return true == DebuggerPort_UpgradeToSsl(HalSystemConfig.DebuggerPort, cmd->m_flags);
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
-static bool FillValues( CLR_RT_HeapBlock* ptr, CLR_DBG_Commands::Debugging_Value*& array, size_t num, CLR_RT_HeapBlock* reference, CLR_RT_TypeDef_Instance* pTD )
+static bool FillValues(
+    CLR_RT_HeapBlock *ptr,
+    CLR_DBG_Commands::Debugging_Value *&array,
+    size_t num,
+    CLR_RT_HeapBlock *reference,
+    CLR_RT_TypeDef_Instance *pTD)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    if(!ptr) return true;
+    if (!ptr)
+        return true;
 
-    if(!array || num == 0) return false;
+    if (!array || num == 0)
+        return false;
 
-    CLR_DBG_Commands::Debugging_Value* dst = array++; num--;
-    CLR_RT_TypeDescriptor              desc;
+    CLR_DBG_Commands::Debugging_Value *dst = array++;
+    num--;
+    CLR_RT_TypeDescriptor desc;
 
-    memset( dst, 0, sizeof(*dst) );
+    memset(dst, 0, sizeof(*dst));
 
     dst->m_referenceID = (reference != NULL) ? reference : ptr;
-    dst->m_dt          = ptr->DataType ();
-    dst->m_flags       = ptr->DataFlags();
-    dst->m_size        = ptr->DataSize ();
+    dst->m_dt = ptr->DataType();
+    dst->m_flags = ptr->DataFlags();
+    dst->m_size = ptr->DataSize();
 
-    if(pTD != NULL)
+    if (pTD != NULL)
     {
         dst->m_td = *pTD;
     }
-    else if(SUCCEEDED(desc.InitializeFromObject( *ptr )))
+    else if (SUCCEEDED(desc.InitializeFromObject(*ptr)))
     {
         dst->m_td = desc.m_handlerCls;
     }
 
-    switch(dst->m_dt)
+    switch (dst->m_dt)
     {
-    case DATATYPE_BOOLEAN   :
-    case DATATYPE_I1        :
-    case DATATYPE_U1        :
+        case DATATYPE_BOOLEAN:
+        case DATATYPE_I1:
+        case DATATYPE_U1:
 
-    case DATATYPE_CHAR      :
-    case DATATYPE_I2        :
-    case DATATYPE_U2        :
+        case DATATYPE_CHAR:
+        case DATATYPE_I2:
+        case DATATYPE_U2:
 
-    case DATATYPE_I4        :
-    case DATATYPE_U4        :
-    case DATATYPE_R4        :
+        case DATATYPE_I4:
+        case DATATYPE_U4:
+        case DATATYPE_R4:
 
-    case DATATYPE_I8        :
-    case DATATYPE_U8        :
-    case DATATYPE_R8        :
-    case DATATYPE_DATETIME  :
-    case DATATYPE_TIMESPAN  :
-    case DATATYPE_REFLECTION:
-        //
-        // Primitives or optimized value types.
-        //
-        memcpy( dst->m_builtinValue, (void*)&ptr->NumericByRefConst().u1, 8 );
-        break;
+        case DATATYPE_I8:
+        case DATATYPE_U8:
+        case DATATYPE_R8:
+        case DATATYPE_DATETIME:
+        case DATATYPE_TIMESPAN:
+        case DATATYPE_REFLECTION:
+            //
+            // Primitives or optimized value types.
+            //
+            memcpy(dst->m_builtinValue, (void *)&ptr->NumericByRefConst().u1, 8);
+            break;
 
-    case DATATYPE_STRING:
+        case DATATYPE_STRING:
         {
-            const char* text = ptr->StringText();
+            const char *text = ptr->StringText();
 
-            if(text != NULL)
+            if (text != NULL)
             {
-                dst->m_charsInString =                     text;
-                dst->m_bytesInString = (CLR_UINT32)hal_strlen_s( text );
+                dst->m_charsInString = text;
+                dst->m_bytesInString = (CLR_UINT32)hal_strlen_s(text);
 
-                hal_strncpy_s( (char*)dst->m_builtinValue, ARRAYSIZE(dst->m_builtinValue), text, __min(dst->m_bytesInString, MAXSTRLEN(dst->m_builtinValue)) );
+                hal_strncpy_s(
+                    (char *)dst->m_builtinValue,
+                    ARRAYSIZE(dst->m_builtinValue),
+                    text,
+                    __min(dst->m_bytesInString, MAXSTRLEN(dst->m_builtinValue)));
             }
             else
             {
@@ -1757,111 +1639,114 @@ static bool FillValues( CLR_RT_HeapBlock* ptr, CLR_DBG_Commands::Debugging_Value
         }
         break;
 
+        case DATATYPE_OBJECT:
+        case DATATYPE_BYREF:
+            return FillValues(ptr->Dereference(), array, num, NULL, pTD);
 
-    case DATATYPE_OBJECT:
-    case DATATYPE_BYREF :
-        return FillValues( ptr->Dereference(), array, num, NULL, pTD );
+        case DATATYPE_CLASS:
+        case DATATYPE_VALUETYPE:
+            dst->m_td = ptr->ObjectCls();
+            break;
 
-
-    case DATATYPE_CLASS    :
-    case DATATYPE_VALUETYPE:
-        dst->m_td = ptr->ObjectCls();
-        break;
-
-    case DATATYPE_SZARRAY:
+        case DATATYPE_SZARRAY:
         {
-            CLR_RT_HeapBlock_Array* ptr2 = (CLR_RT_HeapBlock_Array*)ptr;
+            CLR_RT_HeapBlock_Array *ptr2 = (CLR_RT_HeapBlock_Array *)ptr;
 
             dst->m_array_numOfElements = ptr2->m_numOfElements;
-            dst->m_array_depth         = ptr2->ReflectionDataConst().m_levels;
-            dst->m_array_typeIndex     = ptr2->ReflectionDataConst().m_data.m_type;
+            dst->m_array_depth = ptr2->ReflectionDataConst().m_levels;
+            dst->m_array_typeIndex = ptr2->ReflectionDataConst().m_data.m_type;
         }
         break;
 
-    ////////////////////////////////////////
+            ////////////////////////////////////////
 
-    case DATATYPE_WEAKCLASS                  :
-        break;
+        case DATATYPE_WEAKCLASS:
+            break;
 
-    case DATATYPE_ARRAY_BYREF                :
-        dst->m_arrayref_referenceID = ptr->Array     ();
-        dst->m_arrayref_index       = ptr->ArrayIndex();
+        case DATATYPE_ARRAY_BYREF:
+            dst->m_arrayref_referenceID = ptr->Array();
+            dst->m_arrayref_index = ptr->ArrayIndex();
 
-        break;
+            break;
 
-    case DATATYPE_DELEGATE_HEAD              :
-        break;
+        case DATATYPE_DELEGATE_HEAD:
+            break;
 
-    case DATATYPE_DELEGATELIST_HEAD          :
-        break;
+        case DATATYPE_DELEGATELIST_HEAD:
+            break;
 
-    case DATATYPE_FREEBLOCK                  :
-    case DATATYPE_CACHEDBLOCK                :
-    case DATATYPE_ASSEMBLY                   :
-    case DATATYPE_OBJECT_TO_EVENT            :
-    case DATATYPE_BINARY_BLOB_HEAD           :
+        case DATATYPE_FREEBLOCK:
+        case DATATYPE_CACHEDBLOCK:
+        case DATATYPE_ASSEMBLY:
+        case DATATYPE_OBJECT_TO_EVENT:
+        case DATATYPE_BINARY_BLOB_HEAD:
 
-    case DATATYPE_THREAD                     :
-    case DATATYPE_SUBTHREAD                  :
-    case DATATYPE_STACK_FRAME                :
-    case DATATYPE_TIMER_HEAD                 :
-    case DATATYPE_LOCK_HEAD                  :
-    case DATATYPE_LOCK_OWNER_HEAD            :
-    case DATATYPE_LOCK_REQUEST_HEAD          :
-    case DATATYPE_WAIT_FOR_OBJECT_HEAD       :
-    case DATATYPE_FINALIZER_HEAD             :
-    case DATATYPE_MEMORY_STREAM_HEAD         :
-    case DATATYPE_MEMORY_STREAM_DATA         :
+        case DATATYPE_THREAD:
+        case DATATYPE_SUBTHREAD:
+        case DATATYPE_STACK_FRAME:
+        case DATATYPE_TIMER_HEAD:
+        case DATATYPE_LOCK_HEAD:
+        case DATATYPE_LOCK_OWNER_HEAD:
+        case DATATYPE_LOCK_REQUEST_HEAD:
+        case DATATYPE_WAIT_FOR_OBJECT_HEAD:
+        case DATATYPE_FINALIZER_HEAD:
+        case DATATYPE_MEMORY_STREAM_HEAD:
+        case DATATYPE_MEMORY_STREAM_DATA:
 
-    case DATATYPE_SERIALIZER_HEAD            :
-    case DATATYPE_SERIALIZER_DUPLICATE       :
-    case DATATYPE_SERIALIZER_STATE           :
+        case DATATYPE_SERIALIZER_HEAD:
+        case DATATYPE_SERIALIZER_DUPLICATE:
+        case DATATYPE_SERIALIZER_STATE:
 
-    case DATATYPE_ENDPOINT_HEAD              :
+        case DATATYPE_ENDPOINT_HEAD:
 
 #if defined(NANOCLR_APPDOMAINS)
-    case DATATYPE_APPDOMAIN_HEAD             :
-    case DATATYPE_TRANSPARENT_PROXY          :
-    case DATATYPE_APPDOMAIN_ASSEMBLY         :
+        case DATATYPE_APPDOMAIN_HEAD:
+        case DATATYPE_TRANSPARENT_PROXY:
+        case DATATYPE_APPDOMAIN_ASSEMBLY:
 #endif
 
-        break;
+            break;
     }
 
     return true;
 }
 
-bool CLR_DBG_Debugger::GetValue( WP_Message* msg, CLR_RT_HeapBlock* ptr, CLR_RT_HeapBlock* reference, CLR_RT_TypeDef_Instance *pTD )
+bool CLR_DBG_Debugger::GetValue(
+    WP_Message *msg,
+    CLR_RT_HeapBlock *ptr,
+    CLR_RT_HeapBlock *reference,
+    CLR_RT_TypeDef_Instance *pTD)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_DBG_Commands::Debugging_Value  reply[ 4 ];
-    CLR_DBG_Commands::Debugging_Value* array = reply;
+    CLR_DBG_Commands::Debugging_Value reply[4];
+    CLR_DBG_Commands::Debugging_Value *array = reply;
 
-    if(FillValues( ptr, array, ARRAYSIZE(reply), reference, pTD ))
+    if (FillValues(ptr, array, ARRAYSIZE(reply), reference, pTD))
     {
-        WP_ReplyToCommand( msg, true, false, reply, (int)((size_t)array - (size_t)reply) );
+        WP_ReplyToCommand(msg, true, false, reply, (int)((size_t)array - (size_t)reply));
 
         return true;
     }
 
-	WP_ReplyToCommand(msg, false, false, NULL, 0);
+    WP_ReplyToCommand(msg, false, false, NULL, 0);
 
     return false;
 }
 
 //--//
 
-bool CLR_DBG_Debugger::Debugging_Execution_SetCurrentAppDomain( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Execution_SetCurrentAppDomain(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 #if defined(NANOCLR_APPDOMAINS)
-    
-    CLR_DBG_Commands::Debugging_Execution_SetCurrentAppDomain* cmd       = (CLR_DBG_Commands::Debugging_Execution_SetCurrentAppDomain*)msg->m_payload;
-    CLR_RT_AppDomain*                                          appDomain = g_CLR_DBG_Debugger->GetAppDomainFromID( cmd->m_id );
 
-    if(appDomain)
+    CLR_DBG_Commands::Debugging_Execution_SetCurrentAppDomain *cmd =
+        (CLR_DBG_Commands::Debugging_Execution_SetCurrentAppDomain *)msg->m_payload;
+    CLR_RT_AppDomain *appDomain = g_CLR_DBG_Debugger->GetAppDomainFromID(cmd->m_id);
+
+    if (appDomain)
     {
-        g_CLR_RT_ExecutionEngine.SetCurrentAppDomain( appDomain );
+        g_CLR_RT_ExecutionEngine.SetCurrentAppDomain(appDomain);
     }
 
     WP_ReplyToCommand(msg, appDomain != NULL, false, NULL, 0);
@@ -1873,103 +1758,107 @@ bool CLR_DBG_Debugger::Debugging_Execution_SetCurrentAppDomain( WP_Message* msg)
 #endif
 }
 
-bool CLR_DBG_Debugger::Debugging_Execution_Breakpoints( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Execution_Breakpoints(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Execution_Breakpoints* cmd = (CLR_DBG_Commands::Debugging_Execution_Breakpoints*)msg->m_payload;
 
-    g_CLR_RT_ExecutionEngine.InstallBreakpoints( cmd->m_data, (msg->m_header.m_size - sizeof(cmd->m_flags)) / sizeof(CLR_DBG_Commands::Debugging_Execution_BreakpointDef) );
+    CLR_DBG_Commands::Debugging_Execution_Breakpoints *cmd =
+        (CLR_DBG_Commands::Debugging_Execution_Breakpoints *)msg->m_payload;
+
+    g_CLR_RT_ExecutionEngine.InstallBreakpoints(
+        cmd->m_data,
+        (msg->m_header.m_size - sizeof(cmd->m_flags)) / sizeof(CLR_DBG_Commands::Debugging_Execution_BreakpointDef));
 
     WP_ReplyToCommand(msg, true, false, NULL, 0);
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Execution_BreakpointStatus( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Execution_BreakpointStatus(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
+
     CLR_DBG_Commands::Debugging_Execution_BreakpointStatus::Reply reply;
 
-    if(g_CLR_RT_ExecutionEngine.DequeueActiveBreakpoint( reply.m_lastHit ) == false)
+    if (g_CLR_RT_ExecutionEngine.DequeueActiveBreakpoint(reply.m_lastHit) == false)
     {
-        memset( &reply.m_lastHit, 0, sizeof(reply.m_lastHit) );
+        memset(&reply.m_lastHit, 0, sizeof(reply.m_lastHit));
     }
 
-    WP_ReplyToCommand( msg, true, false, &reply, sizeof(reply) );
+    WP_ReplyToCommand(msg, true, false, &reply, sizeof(reply));
 
     return true;
 }
 
 //--//
 
-CLR_RT_Assembly* CLR_DBG_Debugger::IsGoodAssembly( CLR_IDX idxAssm )
+CLR_RT_Assembly *CLR_DBG_Debugger::IsGoodAssembly(CLR_IDX idxAssm)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     NANOCLR_FOREACH_ASSEMBLY(g_CLR_RT_TypeSystem)
     {
-        if(pASSM->m_idx == idxAssm) return pASSM;
+        if (pASSM->m_idx == idxAssm)
+            return pASSM;
     }
     NANOCLR_FOREACH_ASSEMBLY_END();
 
     return NULL;
 }
 
-bool CLR_DBG_Debugger::CheckTypeDef( const CLR_RT_TypeDef_Index& td, CLR_RT_TypeDef_Instance& inst )
+bool CLR_DBG_Debugger::CheckTypeDef(const CLR_RT_TypeDef_Index &td, CLR_RT_TypeDef_Instance &inst)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_RT_Assembly* assm = IsGoodAssembly( td.Assembly() );
+    CLR_RT_Assembly *assm = IsGoodAssembly(td.Assembly());
 
-    if(assm && td.Type() < assm->m_pTablesSize[ TBL_TypeDef ])
+    if (assm && td.Type() < assm->m_pTablesSize[TBL_TypeDef])
     {
-        return inst.InitializeFromIndex( td );
+        return inst.InitializeFromIndex(td);
     }
 
     return false;
 }
 
-bool CLR_DBG_Debugger::CheckFieldDef( const CLR_RT_FieldDef_Index& fd, CLR_RT_FieldDef_Instance& inst )
+bool CLR_DBG_Debugger::CheckFieldDef(const CLR_RT_FieldDef_Index &fd, CLR_RT_FieldDef_Instance &inst)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_RT_Assembly* assm = IsGoodAssembly( fd.Assembly() );
+    CLR_RT_Assembly *assm = IsGoodAssembly(fd.Assembly());
 
-    if(assm && fd.Field() < assm->m_pTablesSize[ TBL_FieldDef ])
+    if (assm && fd.Field() < assm->m_pTablesSize[TBL_FieldDef])
     {
-        return inst.InitializeFromIndex( fd );
+        return inst.InitializeFromIndex(fd);
     }
 
     return false;
 }
 
-bool CLR_DBG_Debugger::CheckMethodDef( const CLR_RT_MethodDef_Index& md, CLR_RT_MethodDef_Instance& inst )
+bool CLR_DBG_Debugger::CheckMethodDef(const CLR_RT_MethodDef_Index &md, CLR_RT_MethodDef_Instance &inst)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_RT_Assembly* assm = IsGoodAssembly( md.Assembly() );
+    CLR_RT_Assembly *assm = IsGoodAssembly(md.Assembly());
 
-    if(assm && md.Method() < assm->m_pTablesSize[ TBL_MethodDef ])
+    if (assm && md.Method() < assm->m_pTablesSize[TBL_MethodDef])
     {
-        return inst.InitializeFromIndex( md );
+        return inst.InitializeFromIndex(md);
     }
 
     return false;
 }
 
-CLR_RT_StackFrame* CLR_DBG_Debugger::CheckStackFrame( CLR_INT32 pid, CLR_UINT32 depth, bool& isInline )
+CLR_RT_StackFrame *CLR_DBG_Debugger::CheckStackFrame(CLR_INT32 pid, CLR_UINT32 depth, bool &isInline)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_RT_Thread* th = GetThreadFromPid( pid );
+    CLR_RT_Thread *th = GetThreadFromPid(pid);
 
     isInline = false;
 
-    if(th)
+    if (th)
     {
-        NANOCLR_FOREACH_NODE(CLR_RT_StackFrame,call,th->m_stackFrames)
+        NANOCLR_FOREACH_NODE(CLR_RT_StackFrame, call, th->m_stackFrames)
         {
 #ifndef CLR_NO_IL_INLINE
-            if(call->m_inlineFrame)
+            if (call->m_inlineFrame)
             {
-                if(depth-- == 0) 
+                if (depth-- == 0)
                 {
                     isInline = true;
                     return call;
@@ -1977,7 +1866,8 @@ CLR_RT_StackFrame* CLR_DBG_Debugger::CheckStackFrame( CLR_INT32 pid, CLR_UINT32 
             }
 #endif
 
-            if(depth-- == 0) return call;
+            if (depth-- == 0)
+                return call;
         }
         NANOCLR_FOREACH_NODE_END();
     }
@@ -1987,21 +1877,22 @@ CLR_RT_StackFrame* CLR_DBG_Debugger::CheckStackFrame( CLR_INT32 pid, CLR_UINT32 
 
 //--//
 
-static HRESULT Debugging_Thread_Create_Helper( CLR_RT_MethodDef_Index& md, CLR_RT_Thread*& th, CLR_INT32 pid )
+static HRESULT Debugging_Thread_Create_Helper(CLR_RT_MethodDef_Index &md, CLR_RT_Thread *&th, CLR_INT32 pid)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock     ref; ref.SetObjectReference( NULL );
-    CLR_RT_ProtectFromGC gc( ref );
-    CLR_RT_Thread*       realThread = (pid != 0) ? CLR_DBG_Debugger::GetThreadFromPid( pid ) : NULL;
+    CLR_RT_HeapBlock ref;
+    ref.SetObjectReference(NULL);
+    CLR_RT_ProtectFromGC gc(ref);
+    CLR_RT_Thread *realThread = (pid != 0) ? CLR_DBG_Debugger::GetThreadFromPid(pid) : NULL;
 
     th = NULL;
 
-    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Delegate::CreateInstance( ref, md, NULL ));
+    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Delegate::CreateInstance(ref, md, NULL));
 
-    NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewThread( th, ref.DereferenceDelegate(), ThreadPriority::Highest, -1 ));
-    
+    NANOCLR_CHECK_HRESULT(
+        g_CLR_RT_ExecutionEngine.NewThread(th, ref.DereferenceDelegate(), ThreadPriority::Highest, -1));
 
     if (realThread)
     {
@@ -2009,19 +1900,20 @@ static HRESULT Debugging_Thread_Create_Helper( CLR_RT_MethodDef_Index& md, CLR_R
     }
 
     {
-        CLR_RT_StackFrame*          stack   = th->CurrentFrame();
-        const CLR_RECORD_METHODDEF* target  = stack->m_call.m_target;
-        CLR_UINT8                   numArgs = target->numArgs;
+        CLR_RT_StackFrame *stack = th->CurrentFrame();
+        const CLR_RECORD_METHODDEF *target = stack->m_call.m_target;
+        CLR_UINT8 numArgs = target->numArgs;
 
-        if(numArgs)
+        if (numArgs)
         {
-            CLR_RT_SignatureParser          parser; parser.Initialize_MethodSignature( stack->m_call.m_assm, target );
+            CLR_RT_SignatureParser parser;
+            parser.Initialize_MethodSignature(stack->m_call.m_assm, target);
             CLR_RT_SignatureParser::Element res;
-            CLR_RT_HeapBlock*               args = stack->m_arguments;
+            CLR_RT_HeapBlock *args = stack->m_arguments;
 
-            if(parser.m_flags & PIMAGE_CEE_CS_CALLCONV_HASTHIS)
+            if (parser.m_flags & PIMAGE_CEE_CS_CALLCONV_HASTHIS)
             {
-                args->SetObjectReference( NULL );
+                args->SetObjectReference(NULL);
 
                 numArgs--;
                 args++;
@@ -2030,7 +1922,7 @@ static HRESULT Debugging_Thread_Create_Helper( CLR_RT_MethodDef_Index& md, CLR_R
             //
             // Skip return value.
             //
-            NANOCLR_CHECK_HRESULT(parser.Advance( res ));
+            NANOCLR_CHECK_HRESULT(parser.Advance(res));
 
             //
             // None of the arguments can be ByRef.
@@ -2038,29 +1930,29 @@ static HRESULT Debugging_Thread_Create_Helper( CLR_RT_MethodDef_Index& md, CLR_R
             {
                 CLR_RT_SignatureParser parser2 = parser;
 
-                for(;parser2.Available() > 0;)
+                for (; parser2.Available() > 0;)
                 {
-                    NANOCLR_CHECK_HRESULT(parser2.Advance( res ));
+                    NANOCLR_CHECK_HRESULT(parser2.Advance(res));
 
-                    if(res.m_fByRef)
+                    if (res.m_fByRef)
                     {
                         NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                     }
                 }
             }
 
-            for(CLR_UINT8 i=0; i<numArgs; i++, args++)
+            for (CLR_UINT8 i = 0; i < numArgs; i++, args++)
             {
-                NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.InitializeReference( *args, parser ));
+                NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.InitializeReference(*args, parser));
             }
         }
     }
 
     NANOCLR_CLEANUP();
 
-    if(FAILED(hr))
+    if (FAILED(hr))
     {
-        if(th)
+        if (th)
         {
             th->Terminate();
             th = NULL;
@@ -2070,15 +1962,15 @@ static HRESULT Debugging_Thread_Create_Helper( CLR_RT_MethodDef_Index& md, CLR_R
     NANOCLR_CLEANUP_END();
 }
 
-bool CLR_DBG_Debugger::Debugging_Thread_CreateEx( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Thread_CreateEx(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Thread_CreateEx*       cmd = (CLR_DBG_Commands::Debugging_Thread_CreateEx*)msg->m_payload;
-    CLR_DBG_Commands::Debugging_Thread_CreateEx::Reply cmdReply;
-    CLR_RT_Thread*                                     th;
 
-    if(SUCCEEDED(Debugging_Thread_Create_Helper( cmd->m_md, th, cmd->m_pid )))
+    CLR_DBG_Commands::Debugging_Thread_CreateEx *cmd = (CLR_DBG_Commands::Debugging_Thread_CreateEx *)msg->m_payload;
+    CLR_DBG_Commands::Debugging_Thread_CreateEx::Reply cmdReply;
+    CLR_RT_Thread *th;
+
+    if (SUCCEEDED(Debugging_Thread_Create_Helper(cmd->m_md, th, cmd->m_pid)))
     {
         th->m_scratchPad = cmd->m_scratchPad;
 
@@ -2089,63 +1981,63 @@ bool CLR_DBG_Debugger::Debugging_Thread_CreateEx( WP_Message* msg)
         cmdReply.m_pid = -1;
     }
 
-    WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Thread_List( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Thread_List(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Thread_List::Reply* cmdReply = NULL;
-    int                                             len      = 0;
 
-    if(FAILED(g_CLR_DBG_Debugger->CreateListOfThreads( cmdReply, len )))
-    {
-        WP_ReplyToCommand( msg, false, false, NULL, 0);
-    }
-    else
-    {
-        WP_ReplyToCommand( msg, true, false, cmdReply, len );
-    }
+    CLR_DBG_Commands::Debugging_Thread_List::Reply *cmdReply = NULL;
+    int len = 0;
 
-    CLR_RT_Memory::Release( cmdReply );
-
-    return true;
-}
-
-bool CLR_DBG_Debugger::Debugging_Thread_Stack( WP_Message* msg)
-{
-    NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Thread_Stack*        cmd      = (CLR_DBG_Commands::Debugging_Thread_Stack*)msg->m_payload;
-    CLR_DBG_Commands::Debugging_Thread_Stack::Reply* cmdReply = NULL;
-    int                                              len      = 0;
-
-    if(FAILED(g_CLR_DBG_Debugger->CreateListOfCalls( cmd->m_pid, cmdReply, len )))
+    if (FAILED(g_CLR_DBG_Debugger->CreateListOfThreads(cmdReply, len)))
     {
         WP_ReplyToCommand(msg, false, false, NULL, 0);
     }
     else
     {
-        WP_ReplyToCommand( msg, true, false, cmdReply, len );
+        WP_ReplyToCommand(msg, true, false, cmdReply, len);
     }
 
-    CLR_RT_Memory::Release( cmdReply );
+    CLR_RT_Memory::Release(cmdReply);
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Thread_Kill( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Thread_Stack(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Thread_Kill*       cmd = (CLR_DBG_Commands::Debugging_Thread_Kill*)msg->m_payload;
-    CLR_DBG_Commands::Debugging_Thread_Kill::Reply cmdReply;
-    CLR_RT_Thread*                                 th  = g_CLR_DBG_Debugger->GetThreadFromPid( cmd->m_pid );
 
-    if(th)
+    CLR_DBG_Commands::Debugging_Thread_Stack *cmd = (CLR_DBG_Commands::Debugging_Thread_Stack *)msg->m_payload;
+    CLR_DBG_Commands::Debugging_Thread_Stack::Reply *cmdReply = NULL;
+    int len = 0;
+
+    if (FAILED(g_CLR_DBG_Debugger->CreateListOfCalls(cmd->m_pid, cmdReply, len)))
+    {
+        WP_ReplyToCommand(msg, false, false, NULL, 0);
+    }
+    else
+    {
+        WP_ReplyToCommand(msg, true, false, cmdReply, len);
+    }
+
+    CLR_RT_Memory::Release(cmdReply);
+
+    return true;
+}
+
+bool CLR_DBG_Debugger::Debugging_Thread_Kill(WP_Message *msg)
+{
+    NATIVE_PROFILE_CLR_DEBUGGER();
+
+    CLR_DBG_Commands::Debugging_Thread_Kill *cmd = (CLR_DBG_Commands::Debugging_Thread_Kill *)msg->m_payload;
+    CLR_DBG_Commands::Debugging_Thread_Kill::Reply cmdReply;
+    CLR_RT_Thread *th = g_CLR_DBG_Debugger->GetThreadFromPid(cmd->m_pid);
+
+    if (th)
     {
         th->Terminate();
 
@@ -2156,19 +2048,19 @@ bool CLR_DBG_Debugger::Debugging_Thread_Kill( WP_Message* msg)
         cmdReply.m_result = 0;
     }
 
-    WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Thread_Suspend( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Thread_Suspend(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Thread_Suspend* cmd = (CLR_DBG_Commands::Debugging_Thread_Suspend*)msg->m_payload;
-    CLR_RT_Thread*                              th  = g_CLR_DBG_Debugger->GetThreadFromPid( cmd->m_pid );
 
-    if(th)
+    CLR_DBG_Commands::Debugging_Thread_Suspend *cmd = (CLR_DBG_Commands::Debugging_Thread_Suspend *)msg->m_payload;
+    CLR_RT_Thread *th = g_CLR_DBG_Debugger->GetThreadFromPid(cmd->m_pid);
+
+    if (th)
     {
         th->Suspend();
     }
@@ -2178,14 +2070,14 @@ bool CLR_DBG_Debugger::Debugging_Thread_Suspend( WP_Message* msg)
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Thread_Resume( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Thread_Resume(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Thread_Resume* cmd = (CLR_DBG_Commands::Debugging_Thread_Resume*)msg->m_payload;
-    CLR_RT_Thread*                             th  = g_CLR_DBG_Debugger->GetThreadFromPid( cmd->m_pid );
 
-    if(th)
+    CLR_DBG_Commands::Debugging_Thread_Resume *cmd = (CLR_DBG_Commands::Debugging_Thread_Resume *)msg->m_payload;
+    CLR_RT_Thread *th = g_CLR_DBG_Debugger->GetThreadFromPid(cmd->m_pid);
+
+    if (th)
     {
         th->Resume();
     }
@@ -2195,125 +2087,135 @@ bool CLR_DBG_Debugger::Debugging_Thread_Resume( WP_Message* msg)
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Thread_Get( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Thread_Get(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_DBG_Debugger*                       dbg  = g_CLR_DBG_Debugger;
-    CLR_DBG_Commands::Debugging_Thread_Get* cmd  = (CLR_DBG_Commands::Debugging_Thread_Get*)msg->m_payload;
-    CLR_RT_Thread*                          th   = dbg->GetThreadFromPid( cmd->m_pid );
-    CLR_RT_HeapBlock*                       pThread;
+    CLR_DBG_Debugger *dbg = g_CLR_DBG_Debugger;
+    CLR_DBG_Commands::Debugging_Thread_Get *cmd = (CLR_DBG_Commands::Debugging_Thread_Get *)msg->m_payload;
+    CLR_RT_Thread *th = dbg->GetThreadFromPid(cmd->m_pid);
+    CLR_RT_HeapBlock *pThread;
     bool fFound = false;
 
-    if(th == NULL) return false;
+    if (th == NULL)
+        return false;
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-    //If we are a thread spawned by the debugger to perform evaluations,
-    //return the thread object that correspond to thread that has focus in debugger.
+    // If we are a thread spawned by the debugger to perform evaluations,
+    // return the thread object that correspond to thread that has focus in debugger.
     th = th->m_realThread;
 #endif //#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
-    //Find an existing managed thread, if it exists
-    //making sure to only return the managed object association with the current appdomain
-    //to prevent leaking of managed Thread objects across AD boundaries.
+    // Find an existing managed thread, if it exists
+    // making sure to only return the managed object association with the current appdomain
+    // to prevent leaking of managed Thread objects across AD boundaries.
 
-    NANOCLR_FOREACH_NODE(CLR_RT_ObjectToEvent_Source,src,th->m_references)
+    NANOCLR_FOREACH_NODE(CLR_RT_ObjectToEvent_Source, src, th->m_references)
     {
-        CLR_RT_HeapBlock* pManagedThread = src->m_objectPtr;
+        CLR_RT_HeapBlock *pManagedThread = src->m_objectPtr;
         _ASSERTE(pManagedThread != NULL);
-        
+
 #if defined(NANOCLR_APPDOMAINS)
         {
-            CLR_RT_ObjectToEvent_Source* appDomainSrc = CLR_RT_ObjectToEvent_Source::ExtractInstance( pManagedThread[ Library_corlib_native_System_Threading_Thread::FIELD___appDomain ] );
+            CLR_RT_ObjectToEvent_Source *appDomainSrc = CLR_RT_ObjectToEvent_Source::ExtractInstance(
+                pManagedThread[Library_corlib_native_System_Threading_Thread::FIELD___appDomain]);
 
-            if(appDomainSrc == NULL) break;
-            
+            if (appDomainSrc == NULL)
+                break;
+
             fFound = (appDomainSrc->m_eventPtr == g_CLR_RT_ExecutionEngine.GetCurrentAppDomain());
         }
 #else
         fFound = true;
 #endif
 
-        if(fFound)
+        if (fFound)
         {
             pThread = pManagedThread;
-            
+
             break;
         }
     }
-    NANOCLR_FOREACH_NODE_END();    
+    NANOCLR_FOREACH_NODE_END();
 
-    if(!fFound)
+    if (!fFound)
     {
-        pThread = (CLR_RT_HeapBlock*)platform_malloc(sizeof(CLR_RT_HeapBlock));
-        
-        //Create the managed thread.
-        //This implies that there is no state in the managed object.  This is not exactly true, as the managed thread 
-        //contains the priority as well as the delegate to start.  However, that state is really just used as a placeholder for
-        //the data before the thread is started.  Once the thread is started, they are copied over to the unmanaged thread object
-        //and no longer used.  The managed object is then used simply as a wrapper for the unmanaged thread.  Therefore, it is safe 
-        //to simply make another managed thread here.
-        if(SUCCEEDED(g_CLR_RT_ExecutionEngine.NewObjectFromIndex( *pThread, g_CLR_RT_WellKnownTypes.m_Thread )))
+        pThread = (CLR_RT_HeapBlock *)platform_malloc(sizeof(CLR_RT_HeapBlock));
+
+        // Create the managed thread.
+        // This implies that there is no state in the managed object.  This is not exactly true, as the managed thread
+        // contains the priority as well as the delegate to start.  However, that state is really just used as a
+        // placeholder for the data before the thread is started.  Once the thread is started, they are copied over to
+        // the unmanaged thread object and no longer used.  The managed object is then used simply as a wrapper for the
+        // unmanaged thread.  Therefore, it is safe to simply make another managed thread here.
+        if (SUCCEEDED(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(*pThread, g_CLR_RT_WellKnownTypes.m_Thread)))
         {
-            CLR_RT_HeapBlock* pRes = pThread->Dereference();
+            CLR_RT_HeapBlock *pRes = pThread->Dereference();
 
             int pri = th->GetThreadPriority();
-            
+
             pRes[Library_corlib_native_System_Threading_Thread::FIELD___priority].NumericByRef().s4 = pri;
 
-            if(SUCCEEDED(CLR_RT_ObjectToEvent_Source::CreateInstance( th, *pRes, pRes[ Library_corlib_native_System_Threading_Thread::FIELD___thread ] )))
+            if (SUCCEEDED(CLR_RT_ObjectToEvent_Source::CreateInstance(
+                    th,
+                    *pRes,
+                    pRes[Library_corlib_native_System_Threading_Thread::FIELD___thread])))
             {
 #if defined(NANOCLR_APPDOMAINS)
-                CLR_RT_ObjectToEvent_Source::CreateInstance( g_CLR_RT_ExecutionEngine.GetCurrentAppDomain(), *pRes, pRes[ Library_corlib_native_System_Threading_Thread::FIELD___appDomain ] );
+                CLR_RT_ObjectToEvent_Source::CreateInstance(
+                    g_CLR_RT_ExecutionEngine.GetCurrentAppDomain(),
+                    *pRes,
+                    pRes[Library_corlib_native_System_Threading_Thread::FIELD___appDomain]);
 #endif
                 fFound = true;
             }
-            
         }
     }
 
-    if(!fFound) return false;
-    
-    return g_CLR_DBG_Debugger->GetValue( msg, pThread, NULL, NULL );
+    if (!fFound)
+        return false;
+
+    return g_CLR_DBG_Debugger->GetValue(msg, pThread, NULL, NULL);
 }
 
-bool CLR_DBG_Debugger::Debugging_Thread_GetException( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Thread_GetException(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Thread_GetException* cmd = (CLR_DBG_Commands::Debugging_Thread_GetException*)msg->m_payload;
-    CLR_RT_Thread*                                   th  = g_CLR_DBG_Debugger->GetThreadFromPid( cmd->m_pid );
-    CLR_RT_HeapBlock*                                blk = NULL;
 
-    if(th)
+    CLR_DBG_Commands::Debugging_Thread_GetException *cmd =
+        (CLR_DBG_Commands::Debugging_Thread_GetException *)msg->m_payload;
+    CLR_RT_Thread *th = g_CLR_DBG_Debugger->GetThreadFromPid(cmd->m_pid);
+    CLR_RT_HeapBlock *blk = NULL;
+
+    if (th)
     {
         blk = &th->m_currentException;
     }
 
-    return g_CLR_DBG_Debugger->GetValue( msg, blk, NULL, NULL );
+    return g_CLR_DBG_Debugger->GetValue(msg, blk, NULL, NULL);
 }
 
-bool CLR_DBG_Debugger::Debugging_Thread_Unwind( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Thread_Unwind(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Thread_Unwind* cmd = (CLR_DBG_Commands::Debugging_Thread_Unwind*)msg->m_payload;
-    CLR_RT_StackFrame*                         call;
-    CLR_RT_Thread*                             th;
-    bool                                       isInline = false;
 
-    if((call = g_CLR_DBG_Debugger->CheckStackFrame( cmd->m_pid, cmd->m_depth, isInline )) != NULL)
+    CLR_DBG_Commands::Debugging_Thread_Unwind *cmd = (CLR_DBG_Commands::Debugging_Thread_Unwind *)msg->m_payload;
+    CLR_RT_StackFrame *call;
+    CLR_RT_Thread *th;
+    bool isInline = false;
+
+    if ((call = g_CLR_DBG_Debugger->CheckStackFrame(cmd->m_pid, cmd->m_depth, isInline)) != NULL)
     {
         _ASSERTE((call->m_flags & CLR_RT_StackFrame::c_MethodKind_Native) == 0);
 
         th = call->m_owningThread;
         _ASSERTE(th->m_nestedExceptionsPos);
 
-        CLR_RT_Thread::UnwindStack& us = th->m_nestedExceptions[ th->m_nestedExceptionsPos - 1 ];
+        CLR_RT_Thread::UnwindStack &us = th->m_nestedExceptions[th->m_nestedExceptionsPos - 1];
         _ASSERTE(th->m_currentException.Dereference() == us.m_exception);
         _ASSERTE(us.m_flags & CLR_RT_Thread::UnwindStack::c_ContinueExceptionHandler);
 
-        us.m_handlerStack  = call;
-        us.m_flags        |= CLR_RT_Thread::UnwindStack::c_MagicCatchForInteceptedException;
+        us.m_handlerStack = call;
+        us.m_flags |= CLR_RT_Thread::UnwindStack::c_MagicCatchForInteceptedException;
 
         us.SetPhase(CLR_RT_Thread::UnwindStack::p_2_RunningFinallys_0);
     }
@@ -2323,70 +2225,70 @@ bool CLR_DBG_Debugger::Debugging_Thread_Unwind( WP_Message* msg)
 
 //--//
 
-bool CLR_DBG_Debugger::Debugging_Stack_Info( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Stack_Info(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Stack_Info*       cmd = (CLR_DBG_Commands::Debugging_Stack_Info*)msg->m_payload;
-    CLR_DBG_Commands::Debugging_Stack_Info::Reply cmdReply;
-    CLR_RT_StackFrame*                            call;
-    bool                                          isInline = false;
 
-    if((call = g_CLR_DBG_Debugger->CheckStackFrame( cmd->m_pid, cmd->m_depth, isInline )) != NULL)
+    CLR_DBG_Commands::Debugging_Stack_Info *cmd = (CLR_DBG_Commands::Debugging_Stack_Info *)msg->m_payload;
+    CLR_DBG_Commands::Debugging_Stack_Info::Reply cmdReply;
+    CLR_RT_StackFrame *call;
+    bool isInline = false;
+
+    if ((call = g_CLR_DBG_Debugger->CheckStackFrame(cmd->m_pid, cmd->m_depth, isInline)) != NULL)
     {
 #ifndef CLR_NO_IL_INLINE
-        if(isInline)
+        if (isInline)
         {
-            cmdReply.m_md               =              call->m_inlineFrame->m_frame.m_call;
-            cmdReply.m_IP               = (CLR_UINT32)(call->m_inlineFrame->m_frame.m_IP - call->m_inlineFrame->m_frame.m_IPStart);
-            cmdReply.m_numOfArguments   =              call->m_inlineFrame->m_frame.m_call.m_target->numArgs;
-            cmdReply.m_numOfLocals      =              call->m_inlineFrame->m_frame.m_call.m_target->numLocals;
+            cmdReply.m_md = call->m_inlineFrame->m_frame.m_call;
+            cmdReply.m_IP = (CLR_UINT32)(call->m_inlineFrame->m_frame.m_IP - call->m_inlineFrame->m_frame.m_IPStart);
+            cmdReply.m_numOfArguments = call->m_inlineFrame->m_frame.m_call.m_target->numArgs;
+            cmdReply.m_numOfLocals = call->m_inlineFrame->m_frame.m_call.m_target->numLocals;
             cmdReply.m_depthOfEvalStack = (CLR_UINT32)(call->m_evalStack - call->m_inlineFrame->m_frame.m_evalStack);
         }
         else
 #endif
         {
-            cmdReply.m_md               =              call->m_call;
-            cmdReply.m_IP               = (CLR_UINT32)(call->m_IP - call->m_IPstart);
-            cmdReply.m_numOfArguments   =              call->m_call.m_target->numArgs;
-            cmdReply.m_numOfLocals      =              call->m_call.m_target->numLocals;
-            cmdReply.m_depthOfEvalStack = (CLR_UINT32) call->TopValuePosition();
+            cmdReply.m_md = call->m_call;
+            cmdReply.m_IP = (CLR_UINT32)(call->m_IP - call->m_IPstart);
+            cmdReply.m_numOfArguments = call->m_call.m_target->numArgs;
+            cmdReply.m_numOfLocals = call->m_call.m_target->numLocals;
+            cmdReply.m_depthOfEvalStack = (CLR_UINT32)call->TopValuePosition();
         }
 
-        WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+        WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
         return true;
     }
 
-	WP_ReplyToCommand(msg, false, false, NULL, 0);
+    WP_ReplyToCommand(msg, false, false, NULL, 0);
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Stack_SetIP( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Stack_SetIP(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Stack_SetIP* cmd = (CLR_DBG_Commands::Debugging_Stack_SetIP*)msg->m_payload;
-    CLR_RT_StackFrame*                       call;
-    bool                                     isInline = false;
 
-    if((call = g_CLR_DBG_Debugger->CheckStackFrame( cmd->m_pid, cmd->m_depth, isInline )) != NULL)
+    CLR_DBG_Commands::Debugging_Stack_SetIP *cmd = (CLR_DBG_Commands::Debugging_Stack_SetIP *)msg->m_payload;
+    CLR_RT_StackFrame *call;
+    bool isInline = false;
+
+    if ((call = g_CLR_DBG_Debugger->CheckStackFrame(cmd->m_pid, cmd->m_depth, isInline)) != NULL)
     {
 #ifndef CLR_NO_IL_INLINE
-        if(isInline)
+        if (isInline)
         {
             WP_ReplyToCommand(msg, false, false, NULL, 0);
 
             return true;
         }
         else
-#endif            
+#endif
         {
-            call->m_IP            = call->m_IPstart   + cmd->m_IP;
-            call->m_evalStackPos  = call->m_evalStack + cmd->m_depthOfEvalStack;
+            call->m_IP = call->m_IPstart + cmd->m_IP;
+            call->m_evalStackPos = call->m_evalStack + cmd->m_depthOfEvalStack;
         }
-        
+
         call->m_flags &= ~CLR_RT_StackFrame::c_InvalidIP;
 
         WP_ReplyToCommand(msg, true, false, NULL, 0);
@@ -2401,55 +2303,56 @@ bool CLR_DBG_Debugger::Debugging_Stack_SetIP( WP_Message* msg)
 
 //--//
 
-static bool IsBlockEnumMaybe( CLR_RT_HeapBlock* blk )
+static bool IsBlockEnumMaybe(CLR_RT_HeapBlock *blk)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     const CLR_UINT32 c_MaskForPrimitive = CLR_RT_DataTypeLookup::c_Integer | CLR_RT_DataTypeLookup::c_Numeric;
 
     CLR_RT_TypeDescriptor desc;
 
-    if(FAILED(desc.InitializeFromObject( *blk ))) return false;
+    if (FAILED(desc.InitializeFromObject(*blk)))
+        return false;
 
-    const CLR_RT_DataTypeLookup& dtl = c_CLR_RT_DataTypeLookup[ desc.m_handlerCls.m_target->dataType ];
+    const CLR_RT_DataTypeLookup &dtl = c_CLR_RT_DataTypeLookup[desc.m_handlerCls.m_target->dataType];
 
     return (dtl.m_flags & c_MaskForPrimitive) == c_MaskForPrimitive;
 }
 
-static bool SetBlockHelper( CLR_RT_HeapBlock* blk, CLR_DataType dt, CLR_UINT8* builtinValue )
+static bool SetBlockHelper(CLR_RT_HeapBlock *blk, CLR_DataType dt, CLR_UINT8 *builtinValue)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     bool fCanAssign = false;
 
-    if(blk)
+    if (blk)
     {
-        CLR_DataType                 dtDst;
-        CLR_RT_HeapBlock             src;
+        CLR_DataType dtDst;
+        CLR_RT_HeapBlock src;
 
         dtDst = blk->DataType();
 
-        src.SetDataId( CLR_RT_HEAPBLOCK_RAW_ID(dt, 0, 1) );
-        memcpy( (void*)&src.NumericByRef().u1, builtinValue, sizeof(CLR_UINT64) );
+        src.SetDataId(CLR_RT_HEAPBLOCK_RAW_ID(dt, 0, 1));
+        memcpy((void *)&src.NumericByRef().u1, builtinValue, sizeof(CLR_UINT64));
 
-        if(dtDst == dt)
+        if (dtDst == dt)
         {
             fCanAssign = true;
         }
         else
         {
-            if(dt == DATATYPE_REFLECTION)
+            if (dt == DATATYPE_REFLECTION)
             {
                 fCanAssign = (dtDst == DATATYPE_OBJECT && blk->Dereference() == NULL);
             }
-            else if(dt == DATATYPE_OBJECT)
+            else if (dt == DATATYPE_OBJECT)
             {
-                fCanAssign = (src .Dereference() == NULL && dtDst == DATATYPE_REFLECTION);
+                fCanAssign = (src.Dereference() == NULL && dtDst == DATATYPE_REFLECTION);
             }
             else
             {
-                _ASSERTE(c_CLR_RT_DataTypeLookup[ dtDst ].m_flags & CLR_RT_DataTypeLookup::c_Numeric);
+                _ASSERTE(c_CLR_RT_DataTypeLookup[dtDst].m_flags & CLR_RT_DataTypeLookup::c_Numeric);
 
-                if(c_CLR_RT_DataTypeLookup[ dtDst ].m_sizeInBytes == sizeof(CLR_INT32) &&
-                   c_CLR_RT_DataTypeLookup[ dt    ].m_sizeInBytes <  sizeof(CLR_INT32))
+                if (c_CLR_RT_DataTypeLookup[dtDst].m_sizeInBytes == sizeof(CLR_INT32) &&
+                    c_CLR_RT_DataTypeLookup[dt].m_sizeInBytes < sizeof(CLR_INT32))
                 {
                     dt = dtDst;
                     fCanAssign = true;
@@ -2457,28 +2360,28 @@ static bool SetBlockHelper( CLR_RT_HeapBlock* blk, CLR_DataType dt, CLR_UINT8* b
             }
         }
 
-        if(fCanAssign)
+        if (fCanAssign)
         {
-            blk->ChangeDataType( dt );
-            memcpy( (void*)&blk->NumericByRef().u1, builtinValue, sizeof(CLR_UINT64) );
+            blk->ChangeDataType(dt);
+            memcpy((void *)&blk->NumericByRef().u1, builtinValue, sizeof(CLR_UINT64));
         }
     }
 
     return fCanAssign;
 }
 
-static CLR_RT_HeapBlock* GetScratchPad_Helper( int idx )
+static CLR_RT_HeapBlock *GetScratchPad_Helper(int idx)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_RT_HeapBlock_Array* array = g_CLR_RT_ExecutionEngine.m_scratchPadArray;
-    CLR_RT_HeapBlock        tmp;
-    CLR_RT_HeapBlock        ref;
+    CLR_RT_HeapBlock_Array *array = g_CLR_RT_ExecutionEngine.m_scratchPadArray;
+    CLR_RT_HeapBlock tmp;
+    CLR_RT_HeapBlock ref;
 
-    tmp.SetObjectReference( array );
+    tmp.SetObjectReference(array);
 
-    if(SUCCEEDED(ref.InitializeArrayReference( tmp, idx )))
+    if (SUCCEEDED(ref.InitializeArrayReference(tmp, idx)))
     {
-        return (CLR_RT_HeapBlock*)array->GetElement( idx );
+        return (CLR_RT_HeapBlock *)array->GetElement(idx);
     }
 
     return NULL;
@@ -2486,28 +2389,32 @@ static CLR_RT_HeapBlock* GetScratchPad_Helper( int idx )
 
 //--//
 
-bool CLR_DBG_Debugger::Debugging_Value_ResizeScratchPad( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_ResizeScratchPad(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_ResizeScratchPad* cmd = (CLR_DBG_Commands::Debugging_Value_ResizeScratchPad*)msg->m_payload;
-    CLR_RT_HeapBlock                                    ref;
-    bool                                                fRes = true;
 
-    if(cmd->m_size == 0)
+    CLR_DBG_Commands::Debugging_Value_ResizeScratchPad *cmd =
+        (CLR_DBG_Commands::Debugging_Value_ResizeScratchPad *)msg->m_payload;
+    CLR_RT_HeapBlock ref;
+    bool fRes = true;
+
+    if (cmd->m_size == 0)
     {
         g_CLR_RT_ExecutionEngine.m_scratchPadArray = NULL;
     }
     else
     {
-        if(SUCCEEDED(CLR_RT_HeapBlock_Array::CreateInstance( ref, cmd->m_size, g_CLR_RT_WellKnownTypes.m_Object )))
+        if (SUCCEEDED(CLR_RT_HeapBlock_Array::CreateInstance(ref, cmd->m_size, g_CLR_RT_WellKnownTypes.m_Object)))
         {
-            CLR_RT_HeapBlock_Array* pOld = g_CLR_RT_ExecutionEngine.m_scratchPadArray;
-            CLR_RT_HeapBlock_Array* pNew = ref.DereferenceArray();
+            CLR_RT_HeapBlock_Array *pOld = g_CLR_RT_ExecutionEngine.m_scratchPadArray;
+            CLR_RT_HeapBlock_Array *pNew = ref.DereferenceArray();
 
-            if(pOld)
+            if (pOld)
             {
-                memcpy( pNew->GetFirstElement(), pOld->GetFirstElement(), sizeof(CLR_RT_HeapBlock) * __min( pNew->m_numOfElements, pOld->m_numOfElements ) );
+                memcpy(
+                    pNew->GetFirstElement(),
+                    pOld->GetFirstElement(),
+                    sizeof(CLR_RT_HeapBlock) * __min(pNew->m_numOfElements, pOld->m_numOfElements));
             }
 
             g_CLR_RT_ExecutionEngine.m_scratchPadArray = pNew;
@@ -2523,256 +2430,268 @@ bool CLR_DBG_Debugger::Debugging_Value_ResizeScratchPad( WP_Message* msg)
     return false;
 }
 
-bool CLR_DBG_Debugger::Debugging_Value_GetStack( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_GetStack(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_GetStack* cmd = (CLR_DBG_Commands::Debugging_Value_GetStack*)msg->m_payload;
-    CLR_RT_StackFrame*                          call;
-    bool                                        isInline = false;
 
-    if((call = g_CLR_DBG_Debugger->CheckStackFrame( cmd->m_pid, cmd->m_depth, isInline )) != NULL)
+    CLR_DBG_Commands::Debugging_Value_GetStack *cmd = (CLR_DBG_Commands::Debugging_Value_GetStack *)msg->m_payload;
+    CLR_RT_StackFrame *call;
+    bool isInline = false;
+
+    if ((call = g_CLR_DBG_Debugger->CheckStackFrame(cmd->m_pid, cmd->m_depth, isInline)) != NULL)
     {
-        CLR_RT_HeapBlock* array;
-        CLR_UINT32        num;
+        CLR_RT_HeapBlock *array;
+        CLR_UINT32 num;
 #ifndef CLR_NO_IL_INLINE
-        CLR_RT_MethodDef_Instance& md = isInline ? call->m_inlineFrame->m_frame.m_call : call->m_call;
+        CLR_RT_MethodDef_Instance &md = isInline ? call->m_inlineFrame->m_frame.m_call : call->m_call;
 #else
-        CLR_RT_MethodDef_Instance& md = call->m_call;
+        CLR_RT_MethodDef_Instance &md = call->m_call;
 #endif
 
-        switch(cmd->m_kind)
+        switch (cmd->m_kind)
         {
-        case CLR_DBG_Commands::Debugging_Value_GetStack::c_Argument:
+            case CLR_DBG_Commands::Debugging_Value_GetStack::c_Argument:
 #ifndef CLR_NO_IL_INLINE
-            array = isInline ? call->m_inlineFrame->m_frame.m_args : call->m_arguments;
-            num   = isInline ? md.m_target->numArgs                : md.m_target->numArgs;
+                array = isInline ? call->m_inlineFrame->m_frame.m_args : call->m_arguments;
+                num = isInline ? md.m_target->numArgs : md.m_target->numArgs;
 #else
-            array = call->m_arguments;
-            num   = call->m_call.m_target->numArgs;
+                array = call->m_arguments;
+                num = call->m_call.m_target->numArgs;
 #endif
-            break;
+                break;
 
-        case CLR_DBG_Commands::Debugging_Value_GetStack::c_Local:
+            case CLR_DBG_Commands::Debugging_Value_GetStack::c_Local:
 #ifndef CLR_NO_IL_INLINE
-            array = isInline ? call->m_inlineFrame->m_frame.m_locals : call->m_locals;
-            num   = isInline ? md.m_target->numLocals                : md.m_target->numLocals;
+                array = isInline ? call->m_inlineFrame->m_frame.m_locals : call->m_locals;
+                num = isInline ? md.m_target->numLocals : md.m_target->numLocals;
 #else
-            array = call->m_locals;
-            num   = call->m_call.m_target->numLocals;
+                array = call->m_locals;
+                num = call->m_call.m_target->numLocals;
 #endif
-            break;
+                break;
 
-        case CLR_DBG_Commands::Debugging_Value_GetStack::c_EvalStack:
+            case CLR_DBG_Commands::Debugging_Value_GetStack::c_EvalStack:
 #ifndef CLR_NO_IL_INLINE
-            array = isInline ? call->m_inlineFrame->m_frame.m_evalStack                                   : call->m_evalStack;
-            num   = isInline ? (CLR_UINT32)(call->m_evalStack - call->m_inlineFrame->m_frame.m_evalStack) : (CLR_UINT32)call->TopValuePosition();
+                array = isInline ? call->m_inlineFrame->m_frame.m_evalStack : call->m_evalStack;
+                num = isInline ? (CLR_UINT32)(call->m_evalStack - call->m_inlineFrame->m_frame.m_evalStack)
+                               : (CLR_UINT32)call->TopValuePosition();
 #else
-            array =             call->m_evalStack;
-            num   = (CLR_UINT32)call->TopValuePosition();
+                array = call->m_evalStack;
+                num = (CLR_UINT32)call->TopValuePosition();
 #endif
-            break;
+                break;
 
-        default:
-            return false;
+            default:
+                return false;
         }
 
-        if(cmd->m_index >= num) return false;
+        if (cmd->m_index >= num)
+            return false;
 
-        CLR_RT_HeapBlock*        blk       = &array[ cmd->m_index ];
-        CLR_RT_HeapBlock*        reference = NULL;
-        CLR_RT_HeapBlock         tmp;
-        CLR_RT_TypeDef_Instance* pTD       = NULL;
-        CLR_RT_TypeDef_Instance  td;
+        CLR_RT_HeapBlock *blk = &array[cmd->m_index];
+        CLR_RT_HeapBlock *reference = NULL;
+        CLR_RT_HeapBlock tmp;
+        CLR_RT_TypeDef_Instance *pTD = NULL;
+        CLR_RT_TypeDef_Instance td;
 
-        if(cmd->m_kind != CLR_DBG_Commands::Debugging_Value_GetStack::c_EvalStack && IsBlockEnumMaybe( blk ))
+        if (cmd->m_kind != CLR_DBG_Commands::Debugging_Value_GetStack::c_EvalStack && IsBlockEnumMaybe(blk))
         {
-            CLR_UINT32                      iElement = cmd->m_index;
-            CLR_RT_SignatureParser          parser;
+            CLR_UINT32 iElement = cmd->m_index;
+            CLR_RT_SignatureParser parser;
             CLR_RT_SignatureParser::Element res;
-            CLR_RT_TypeDescriptor           desc;
+            CLR_RT_TypeDescriptor desc;
 
-            if(cmd->m_kind == CLR_DBG_Commands::Debugging_Value_GetStack::c_Argument)
+            if (cmd->m_kind == CLR_DBG_Commands::Debugging_Value_GetStack::c_Argument)
             {
-                parser.Initialize_MethodSignature( md.m_assm, md.m_target );
+                parser.Initialize_MethodSignature(md.m_assm, md.m_target);
 
                 iElement++; // Skip the return value, always at the head of the signature.
 
-                if(parser.m_flags & PIMAGE_CEE_CS_CALLCONV_HASTHIS)
+                if (parser.m_flags & PIMAGE_CEE_CS_CALLCONV_HASTHIS)
                 {
-                    if(iElement == 0) return false; // The requested argument is the "this" argument, it can never be a primitive.
+                    if (iElement == 0)
+                        return false; // The requested argument is the "this" argument, it can never be a primitive.
 
                     iElement--;
                 }
             }
             else
             {
-                parser.Initialize_MethodLocals( md.m_assm, md.m_target );
+                parser.Initialize_MethodLocals(md.m_assm, md.m_target);
             }
 
             do
             {
-                parser.Advance( res );
-            }
-            while(iElement--);
+                parser.Advance(res);
+            } while (iElement--);
 
             //
             // Arguments to a methods come from the eval stack and we don't fix up the eval stack for each call.
             // So some arguments have the wrong datatype, since an eval stack push always promotes to 32 bits.
             //
-            if(c_CLR_RT_DataTypeLookup[ blk->DataType() ].m_sizeInBytes == sizeof(CLR_INT32) &&
-               c_CLR_RT_DataTypeLookup[ res.m_dt        ].m_sizeInBytes <  sizeof(CLR_INT32)  )
+            if (c_CLR_RT_DataTypeLookup[blk->DataType()].m_sizeInBytes == sizeof(CLR_INT32) &&
+                c_CLR_RT_DataTypeLookup[res.m_dt].m_sizeInBytes < sizeof(CLR_INT32))
             {
-                tmp.Assign        ( *blk      );
-                tmp.ChangeDataType(  res.m_dt );
+                tmp.Assign(*blk);
+                tmp.ChangeDataType(res.m_dt);
 
-                reference = blk; blk = &tmp;
+                reference = blk;
+                blk = &tmp;
             }
 
             //
             // Check for enum.
             //
-            desc.InitializeFromType( res.m_cls );
+            desc.InitializeFromType(res.m_cls);
 
-            if(desc.m_handlerCls.m_target->IsEnum())
+            if (desc.m_handlerCls.m_target->IsEnum())
             {
-                td = desc.m_handlerCls; pTD = &td;
+                td = desc.m_handlerCls;
+                pTD = &td;
             }
         }
 
-        return g_CLR_DBG_Debugger->GetValue( msg, blk, reference, pTD );
+        return g_CLR_DBG_Debugger->GetValue(msg, blk, reference, pTD);
     }
 
     return false;
 }
 
-bool CLR_DBG_Debugger::Debugging_Value_GetField( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_GetField(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_GetField* cmd       = (CLR_DBG_Commands::Debugging_Value_GetField*)msg->m_payload;
-    CLR_RT_HeapBlock*                           blk       = cmd->m_heapblock;
-    CLR_RT_HeapBlock*                           reference = NULL;
-    CLR_RT_HeapBlock                            tmp;
-    CLR_RT_TypeDescriptor                       desc;
-    CLR_RT_TypeDef_Instance                     td;
-    CLR_RT_TypeDef_Instance*                    pTD       = NULL;
-    CLR_RT_FieldDef_Instance                    inst;
-    CLR_UINT32                                  offset;
 
-    if(blk != NULL && cmd->m_offset > 0)
+    CLR_DBG_Commands::Debugging_Value_GetField *cmd = (CLR_DBG_Commands::Debugging_Value_GetField *)msg->m_payload;
+    CLR_RT_HeapBlock *blk = cmd->m_heapblock;
+    CLR_RT_HeapBlock *reference = NULL;
+    CLR_RT_HeapBlock tmp;
+    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDef_Instance td;
+    CLR_RT_TypeDef_Instance *pTD = NULL;
+    CLR_RT_FieldDef_Instance inst;
+    CLR_UINT32 offset;
+
+    if (blk != NULL && cmd->m_offset > 0)
     {
-        if(FAILED(desc.InitializeFromObject( *blk ))) return false;
+        if (FAILED(desc.InitializeFromObject(*blk)))
+            return false;
 
-        td     = desc.m_handlerCls;
+        td = desc.m_handlerCls;
         offset = cmd->m_offset - 1;
 
-        while(true)
+        while (true)
         {
-            CLR_UINT32 iFields     = td.m_target->iFields_Num;
+            CLR_UINT32 iFields = td.m_target->iFields_Num;
             CLR_UINT32 totalFields = td.CrossReference().m_totalFields;
-            CLR_UINT32 dFields     = totalFields - iFields;
+            CLR_UINT32 dFields = totalFields - iFields;
 
-            if(offset >= dFields)
+            if (offset >= dFields)
             {
                 offset -= dFields;
                 break;
             }
 
-            if(!td.SwitchToParent()) return false;
+            if (!td.SwitchToParent())
+                return false;
         }
 
-        cmd->m_fd.Set( td.Assembly(), td.m_target->iFields_First + offset );
+        cmd->m_fd.Set(td.Assembly(), td.m_target->iFields_First + offset);
     }
 
-    if(!g_CLR_DBG_Debugger->CheckFieldDef( cmd->m_fd, inst )) return false;
+    if (!g_CLR_DBG_Debugger->CheckFieldDef(cmd->m_fd, inst))
+        return false;
 
-    if(blk == NULL)
+    if (blk == NULL)
     {
-        blk = CLR_RT_ExecutionEngine::AccessStaticField( cmd->m_fd );
+        blk = CLR_RT_ExecutionEngine::AccessStaticField(cmd->m_fd);
     }
     else
     {
-        if(cmd->m_offset == 0)
+        if (cmd->m_offset == 0)
         {
             cmd->m_offset = inst.CrossReference().m_offset;
         }
 
-        if(cmd->m_offset == 0) return false;
+        if (cmd->m_offset == 0)
+            return false;
 
-        switch(blk->DataType())
+        switch (blk->DataType())
         {
-            case DATATYPE_CLASS    :
+            case DATATYPE_CLASS:
             case DATATYPE_VALUETYPE:
                 break;
 
             default:
-                if(FAILED(blk->EnsureObjectReference( blk ))) return false;
+                if (FAILED(blk->EnsureObjectReference(blk)))
+                    return false;
                 break;
         }
 
-        switch(blk->DataType())
+        switch (blk->DataType())
         {
             case DATATYPE_DATETIME: // Special case.
             case DATATYPE_TIMESPAN: // Special case.
-                tmp.SetInteger( (CLR_INT64)blk->NumericByRefConst().s8 );
-                reference = blk; blk = &tmp;
+                tmp.SetInteger((CLR_INT64)blk->NumericByRefConst().s8);
+                reference = blk;
+                blk = &tmp;
                 break;
 
             default:
-                blk = &blk[ cmd->m_offset ];
+                blk = &blk[cmd->m_offset];
                 break;
         }
     }
 
-    if(IsBlockEnumMaybe( blk ))
+    if (IsBlockEnumMaybe(blk))
     {
-        if(SUCCEEDED(desc.InitializeFromFieldDefinition( inst )))
+        if (SUCCEEDED(desc.InitializeFromFieldDefinition(inst)))
         {
-            if(desc.m_handlerCls.m_target->IsEnum())
+            if (desc.m_handlerCls.m_target->IsEnum())
             {
                 pTD = &desc.m_handlerCls;
             }
         }
     }
 
-    return g_CLR_DBG_Debugger->GetValue( msg, blk, reference, pTD );
+    return g_CLR_DBG_Debugger->GetValue(msg, blk, reference, pTD);
 }
 
-bool CLR_DBG_Debugger::Debugging_Value_GetArray( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_GetArray(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_GetArray* cmd       = (CLR_DBG_Commands::Debugging_Value_GetArray*)msg->m_payload;
-    CLR_RT_HeapBlock*                           blk       = NULL;
-    CLR_RT_HeapBlock*                           reference = NULL;
-    CLR_RT_HeapBlock                            tmp;
-    CLR_RT_HeapBlock                            ref;
-    CLR_RT_TypeDef_Instance*                    pTD       = NULL;
-    CLR_RT_TypeDef_Instance                     td;
 
-    tmp.SetObjectReference( cmd->m_heapblock );
+    CLR_DBG_Commands::Debugging_Value_GetArray *cmd = (CLR_DBG_Commands::Debugging_Value_GetArray *)msg->m_payload;
+    CLR_RT_HeapBlock *blk = NULL;
+    CLR_RT_HeapBlock *reference = NULL;
+    CLR_RT_HeapBlock tmp;
+    CLR_RT_HeapBlock ref;
+    CLR_RT_TypeDef_Instance *pTD = NULL;
+    CLR_RT_TypeDef_Instance td;
 
-    if(SUCCEEDED(ref.InitializeArrayReference( tmp, cmd->m_index )))
+    tmp.SetObjectReference(cmd->m_heapblock);
+
+    if (SUCCEEDED(ref.InitializeArrayReference(tmp, cmd->m_index)))
     {
-        CLR_RT_HeapBlock_Array* array = ref.Array();
+        CLR_RT_HeapBlock_Array *array = ref.Array();
 
-        if(array->m_fReference)
+        if (array->m_fReference)
         {
-            blk = (CLR_RT_HeapBlock*)array->GetElement( cmd->m_index );
+            blk = (CLR_RT_HeapBlock *)array->GetElement(cmd->m_index);
         }
         else
         {
-            if(FAILED(tmp.LoadFromReference( ref ))) return false;
+            if (FAILED(tmp.LoadFromReference(ref)))
+                return false;
 
-            blk = &tmp; reference = (CLR_RT_HeapBlock*)-1;
+            blk = &tmp;
+            reference = (CLR_RT_HeapBlock *)-1;
         }
 
-        if(IsBlockEnumMaybe( blk ))
+        if (IsBlockEnumMaybe(blk))
         {
-            if(td.InitializeFromIndex( array->ReflectionDataConst().m_data.m_type ))
+            if (td.InitializeFromIndex(array->ReflectionDataConst().m_data.m_type))
             {
-                if(td.m_target->IsEnum())
+                if (td.m_target->IsEnum())
                 {
                     pTD = &td;
                 }
@@ -2780,66 +2699,67 @@ bool CLR_DBG_Debugger::Debugging_Value_GetArray( WP_Message* msg)
         }
     }
 
-    return g_CLR_DBG_Debugger->GetValue( msg, blk, reference, pTD );
+    return g_CLR_DBG_Debugger->GetValue(msg, blk, reference, pTD);
 }
 
-bool CLR_DBG_Debugger::Debugging_Value_GetBlock( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_GetBlock(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_GetBlock* cmd = (CLR_DBG_Commands::Debugging_Value_GetBlock*)msg->m_payload;
-    CLR_RT_HeapBlock*                           blk = cmd->m_heapblock;
 
-    return g_CLR_DBG_Debugger->GetValue( msg, blk, NULL, NULL );
+    CLR_DBG_Commands::Debugging_Value_GetBlock *cmd = (CLR_DBG_Commands::Debugging_Value_GetBlock *)msg->m_payload;
+    CLR_RT_HeapBlock *blk = cmd->m_heapblock;
+
+    return g_CLR_DBG_Debugger->GetValue(msg, blk, NULL, NULL);
 }
 
-bool CLR_DBG_Debugger::Debugging_Value_GetScratchPad( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_GetScratchPad(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_GetScratchPad* cmd = (CLR_DBG_Commands::Debugging_Value_GetScratchPad*)msg->m_payload;
-    CLR_RT_HeapBlock*                                blk = GetScratchPad_Helper( cmd->m_idx );
 
-    return g_CLR_DBG_Debugger->GetValue( msg, blk, NULL, NULL );
+    CLR_DBG_Commands::Debugging_Value_GetScratchPad *cmd =
+        (CLR_DBG_Commands::Debugging_Value_GetScratchPad *)msg->m_payload;
+    CLR_RT_HeapBlock *blk = GetScratchPad_Helper(cmd->m_idx);
+
+    return g_CLR_DBG_Debugger->GetValue(msg, blk, NULL, NULL);
 }
 
-bool CLR_DBG_Debugger::Debugging_Value_SetBlock( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_SetBlock(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_SetBlock* cmd = (CLR_DBG_Commands::Debugging_Value_SetBlock*)msg->m_payload;
-    CLR_RT_HeapBlock*                           blk = cmd->m_heapblock;
 
-    WP_ReplyToCommand(msg, SetBlockHelper( blk, (CLR_DataType)cmd->m_dt, cmd->m_builtinValue ), false, NULL, 0);
+    CLR_DBG_Commands::Debugging_Value_SetBlock *cmd = (CLR_DBG_Commands::Debugging_Value_SetBlock *)msg->m_payload;
+    CLR_RT_HeapBlock *blk = cmd->m_heapblock;
+
+    WP_ReplyToCommand(msg, SetBlockHelper(blk, (CLR_DataType)cmd->m_dt, cmd->m_builtinValue), false, NULL, 0);
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Value_SetArray( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_SetArray(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_SetArray* cmd      = (CLR_DBG_Commands::Debugging_Value_SetArray*)msg->m_payload;
-    CLR_RT_HeapBlock_Array*                     array    = cmd->m_heapblock;
-    CLR_RT_HeapBlock                            tmp;
-    bool                                        fSuccess = false;
 
-    tmp.SetObjectReference( cmd->m_heapblock );
+    CLR_DBG_Commands::Debugging_Value_SetArray *cmd = (CLR_DBG_Commands::Debugging_Value_SetArray *)msg->m_payload;
+    CLR_RT_HeapBlock_Array *array = cmd->m_heapblock;
+    CLR_RT_HeapBlock tmp;
+    bool fSuccess = false;
+
+    tmp.SetObjectReference(cmd->m_heapblock);
 
     //
     // We can only set values in arrays of primitive types.
     //
-    if(array != NULL && !array->m_fReference)
+    if (array != NULL && !array->m_fReference)
     {
         CLR_RT_HeapBlock ref;
 
-        if(SUCCEEDED(ref.InitializeArrayReference( tmp, cmd->m_index )))
+        if (SUCCEEDED(ref.InitializeArrayReference(tmp, cmd->m_index)))
         {
-            if(SUCCEEDED(tmp.LoadFromReference( ref )))
+            if (SUCCEEDED(tmp.LoadFromReference(ref)))
             {
-                if(SetBlockHelper( &tmp, tmp.DataType(), cmd->m_builtinValue ))
+                if (SetBlockHelper(&tmp, tmp.DataType(), cmd->m_builtinValue))
                 {
-                    if(SUCCEEDED(tmp.StoreToReference( ref, 0 )))
+                    if (SUCCEEDED(tmp.StoreToReference(ref, 0)))
                     {
                         fSuccess = true;
                     }
@@ -2855,120 +2775,124 @@ bool CLR_DBG_Debugger::Debugging_Value_SetArray( WP_Message* msg)
 
 //--//
 
-bool CLR_DBG_Debugger::Debugging_Value_AllocateObject( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_AllocateObject(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_AllocateObject* cmd = (CLR_DBG_Commands::Debugging_Value_AllocateObject*)msg->m_payload;
-    CLR_RT_HeapBlock*                                 blk = NULL;
-    CLR_RT_HeapBlock*                                 ptr = GetScratchPad_Helper( cmd->m_index );
 
-    if(ptr)
+    CLR_DBG_Commands::Debugging_Value_AllocateObject *cmd =
+        (CLR_DBG_Commands::Debugging_Value_AllocateObject *)msg->m_payload;
+    CLR_RT_HeapBlock *blk = NULL;
+    CLR_RT_HeapBlock *ptr = GetScratchPad_Helper(cmd->m_index);
+
+    if (ptr)
     {
-        if(SUCCEEDED(g_CLR_RT_ExecutionEngine.NewObjectFromIndex( *ptr, cmd->m_td )))
+        if (SUCCEEDED(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(*ptr, cmd->m_td)))
         {
             blk = ptr;
         }
     }
 
-    return g_CLR_DBG_Debugger->GetValue( msg, blk, NULL, NULL );
+    return g_CLR_DBG_Debugger->GetValue(msg, blk, NULL, NULL);
 }
 
-bool CLR_DBG_Debugger::Debugging_Value_AllocateString( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_AllocateString(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_AllocateString* cmd = (CLR_DBG_Commands::Debugging_Value_AllocateString*)msg->m_payload;
-    CLR_RT_HeapBlock*                                 blk = NULL;
-    CLR_RT_HeapBlock*                                 ptr = GetScratchPad_Helper( cmd->m_index );
 
-    if(ptr)
+    CLR_DBG_Commands::Debugging_Value_AllocateString *cmd =
+        (CLR_DBG_Commands::Debugging_Value_AllocateString *)msg->m_payload;
+    CLR_RT_HeapBlock *blk = NULL;
+    CLR_RT_HeapBlock *ptr = GetScratchPad_Helper(cmd->m_index);
+
+    if (ptr)
     {
-        CLR_RT_HeapBlock_String* str = CLR_RT_HeapBlock_String::CreateInstance( *ptr, cmd->m_size );
+        CLR_RT_HeapBlock_String *str = CLR_RT_HeapBlock_String::CreateInstance(*ptr, cmd->m_size);
 
-        if(str)
+        if (str)
         {
-            char* dst = (char*)str->StringText();
+            char *dst = (char *)str->StringText();
 
             //
             // Fill the string with spaces, it will be set at a later stage.
             //
-            memset( dst, ' ', cmd->m_size ); dst[ cmd->m_size ] = 0;
+            memset(dst, ' ', cmd->m_size);
+            dst[cmd->m_size] = 0;
 
             blk = ptr;
         }
     }
 
-    return g_CLR_DBG_Debugger->GetValue( msg, blk, NULL, NULL );
+    return g_CLR_DBG_Debugger->GetValue(msg, blk, NULL, NULL);
 }
 
-bool CLR_DBG_Debugger::Debugging_Value_AllocateArray( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_AllocateArray(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_AllocateArray* cmd = (CLR_DBG_Commands::Debugging_Value_AllocateArray*)msg->m_payload;
-    CLR_RT_HeapBlock*                                blk = NULL;
-    CLR_RT_HeapBlock*                                ptr = GetScratchPad_Helper( cmd->m_index );
 
-    if(ptr)
+    CLR_DBG_Commands::Debugging_Value_AllocateArray *cmd =
+        (CLR_DBG_Commands::Debugging_Value_AllocateArray *)msg->m_payload;
+    CLR_RT_HeapBlock *blk = NULL;
+    CLR_RT_HeapBlock *ptr = GetScratchPad_Helper(cmd->m_index);
+
+    if (ptr)
     {
         CLR_RT_ReflectionDef_Index reflex;
 
-        reflex.m_kind        = REFLECTION_TYPE;
-        reflex.m_levels      = cmd->m_depth;
+        reflex.m_kind = REFLECTION_TYPE;
+        reflex.m_levels = cmd->m_depth;
         reflex.m_data.m_type = cmd->m_td;
 
-        if(SUCCEEDED(CLR_RT_HeapBlock_Array::CreateInstance( *ptr, cmd->m_numOfElements, reflex )))
+        if (SUCCEEDED(CLR_RT_HeapBlock_Array::CreateInstance(*ptr, cmd->m_numOfElements, reflex)))
         {
             blk = ptr;
         }
     }
 
-    return g_CLR_DBG_Debugger->GetValue( msg, blk, NULL, NULL );
+    return g_CLR_DBG_Debugger->GetValue(msg, blk, NULL, NULL);
 }
 
 #endif //#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
 #if defined(NANOCLR_PROFILE_NEW)
-bool CLR_DBG_Debugger::Profiling_Command( WP_Message* msg)
+bool CLR_DBG_Debugger::Profiling_Command(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_DBG_Debugger*                    dbg     = g_CLR_DBG_Debugger;
-    CLR_DBG_Commands::Profiling_Command* cmd     = (CLR_DBG_Commands::Profiling_Command*)msg->m_payload;
-    CLR_UINT8                            command = cmd->m_command;
+    CLR_DBG_Debugger *dbg = g_CLR_DBG_Debugger;
+    CLR_DBG_Commands::Profiling_Command *cmd = (CLR_DBG_Commands::Profiling_Command *)msg->m_payload;
+    CLR_UINT8 command = cmd->m_command;
 
-    switch(command)
+    switch (command)
     {
         case CLR_DBG_Commands::Profiling_Command::c_Command_ChangeConditions:
-            return dbg->Profiling_ChangeConditions( msg );
+            return dbg->Profiling_ChangeConditions(msg);
 
         case CLR_DBG_Commands::Profiling_Command::c_Command_FlushStream:
-            return dbg->Profiling_FlushStream( msg );
+            return dbg->Profiling_FlushStream(msg);
 
         default:
             return false;
     }
 }
 
-bool CLR_DBG_Debugger::Profiling_ChangeConditions( WP_Message* msg )
+bool CLR_DBG_Debugger::Profiling_ChangeConditions(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    CLR_DBG_Commands::Profiling_Command* parent_cmd = (CLR_DBG_Commands::Profiling_Command*)msg->m_payload;
-    CLR_DBG_Commands::Profiling_ChangeConditions* cmd = (CLR_DBG_Commands::Profiling_ChangeConditions*)&parent_cmd[1];
+    CLR_DBG_Commands::Profiling_Command *parent_cmd = (CLR_DBG_Commands::Profiling_Command *)msg->m_payload;
+    CLR_DBG_Commands::Profiling_ChangeConditions *cmd = (CLR_DBG_Commands::Profiling_ChangeConditions *)&parent_cmd[1];
 
-    g_CLR_RT_ExecutionEngine.m_iProfiling_Conditions |=  cmd->m_set;
+    g_CLR_RT_ExecutionEngine.m_iProfiling_Conditions |= cmd->m_set;
     g_CLR_RT_ExecutionEngine.m_iProfiling_Conditions &= ~cmd->m_reset;
 
     CLR_DBG_Commands::Profiling_Command::Reply cmdReply;
 
     cmdReply.m_raw = g_CLR_RT_ExecutionEngine.m_iProfiling_Conditions;
 
-    WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
-    _ASSERTE(FIMPLIES(CLR_EE_PRF_IS(Allocations),  CLR_EE_PRF_IS(Enabled)));
-    _ASSERTE(FIMPLIES(CLR_EE_PRF_IS(Calls)      ,  CLR_EE_PRF_IS(Enabled)));
+    _ASSERTE(FIMPLIES(CLR_EE_PRF_IS(Allocations), CLR_EE_PRF_IS(Enabled)));
+    _ASSERTE(FIMPLIES(CLR_EE_PRF_IS(Calls), CLR_EE_PRF_IS(Enabled)));
 
-    if((cmd->m_set & CLR_RT_ExecutionEngine::c_fProfiling_Enabled) != 0)
+    if ((cmd->m_set & CLR_RT_ExecutionEngine::c_fProfiling_Enabled) != 0)
     {
         g_CLR_PRF_Profiler.SendMemoryLayout();
     }
@@ -2976,7 +2900,7 @@ bool CLR_DBG_Debugger::Profiling_ChangeConditions( WP_Message* msg )
     return true;
 }
 
-bool CLR_DBG_Debugger::Profiling_FlushStream( WP_Message* msg )
+bool CLR_DBG_Debugger::Profiling_FlushStream(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     CLR_DBG_Commands::Profiling_Command::Reply cmdReply;
@@ -2985,7 +2909,7 @@ bool CLR_DBG_Debugger::Profiling_FlushStream( WP_Message* msg )
 
     cmdReply.m_raw = 0;
 
-   WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
     return true;
 }
@@ -2998,58 +2922,60 @@ bool CLR_DBG_Debugger::Profiling_FlushStream( WP_Message* msg )
 
 struct AnalyzeObject
 {
-    CLR_RT_HeapBlock*     m_ptr;
-    bool                  m_fNull;
-    bool                  m_fBoxed;
-    bool                  m_fCanBeNull;
+    CLR_RT_HeapBlock *m_ptr;
+    bool m_fNull;
+    bool m_fBoxed;
+    bool m_fCanBeNull;
     CLR_RT_TypeDescriptor m_desc;
-    CLR_RT_HeapBlock      m_value;
+    CLR_RT_HeapBlock m_value;
 };
 
-static HRESULT AnalyzeObject_Helper( CLR_RT_HeapBlock* ptr, AnalyzeObject& ao )
+static HRESULT AnalyzeObject_Helper(CLR_RT_HeapBlock *ptr, AnalyzeObject &ao)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     NANOCLR_HEADER();
 
-    if(ptr && ptr->DataType() == DATATYPE_BYREF) ptr = ptr->Dereference();
+    if (ptr && ptr->DataType() == DATATYPE_BYREF)
+        ptr = ptr->Dereference();
 
     ao.m_ptr = ptr;
 
-    if(ptr == NULL || (ptr->DataType() == DATATYPE_OBJECT && ptr->Dereference() == NULL))
+    if (ptr == NULL || (ptr->DataType() == DATATYPE_OBJECT && ptr->Dereference() == NULL))
     {
-        ao.m_fNull      = true;
-        ao.m_fBoxed     = false;
+        ao.m_fNull = true;
+        ao.m_fBoxed = false;
         ao.m_fCanBeNull = true;
     }
     else
     {
-        NANOCLR_CHECK_HRESULT(ao.m_desc.InitializeFromObject( *ptr ));
+        NANOCLR_CHECK_HRESULT(ao.m_desc.InitializeFromObject(*ptr));
 
-        ao.m_fNull  = false;
+        ao.m_fNull = false;
         ao.m_fBoxed = (ptr->DataType() == DATATYPE_OBJECT && ptr->Dereference()->IsBoxed());
 
-        switch(ao.m_desc.m_flags & CLR_RT_DataTypeLookup::c_SemanticMask2 & ~CLR_RT_DataTypeLookup::c_SemanticMask)
+        switch (ao.m_desc.m_flags & CLR_RT_DataTypeLookup::c_SemanticMask2 & ~CLR_RT_DataTypeLookup::c_SemanticMask)
         {
-        case CLR_RT_DataTypeLookup::c_Array:
-        case CLR_RT_DataTypeLookup::c_ArrayList:
-            ao.m_fCanBeNull = true;
-            break;
-        default:
+            case CLR_RT_DataTypeLookup::c_Array:
+            case CLR_RT_DataTypeLookup::c_ArrayList:
+                ao.m_fCanBeNull = true;
+                break;
+            default:
             {
-                switch(ao.m_desc.m_flags & CLR_RT_DataTypeLookup::c_SemanticMask)
+                switch (ao.m_desc.m_flags & CLR_RT_DataTypeLookup::c_SemanticMask)
                 {
-                case CLR_RT_DataTypeLookup::c_Primitive:
-                case CLR_RT_DataTypeLookup::c_ValueType:
-                case CLR_RT_DataTypeLookup::c_Enum:
-                    ao.m_fCanBeNull = ao.m_fBoxed || (ao.m_desc.m_handlerCls.m_data == g_CLR_RT_WellKnownTypes.m_String.m_data);
-                    break;
+                    case CLR_RT_DataTypeLookup::c_Primitive:
+                    case CLR_RT_DataTypeLookup::c_ValueType:
+                    case CLR_RT_DataTypeLookup::c_Enum:
+                        ao.m_fCanBeNull =
+                            ao.m_fBoxed || (ao.m_desc.m_handlerCls.m_data == g_CLR_RT_WellKnownTypes.m_String.m_data);
+                        break;
 
-                default:
-                    ao.m_fCanBeNull = true;
-                    break;
+                    default:
+                        ao.m_fCanBeNull = true;
+                        break;
                 }
 
-            break;
+                break;
             }
         }
     }
@@ -3057,119 +2983,120 @@ static HRESULT AnalyzeObject_Helper( CLR_RT_HeapBlock* ptr, AnalyzeObject& ao )
     NANOCLR_NOCLEANUP();
 }
 
-static HRESULT Assign_Helper( CLR_RT_HeapBlock* blkDst, CLR_RT_HeapBlock* blkSrc )
+static HRESULT Assign_Helper(CLR_RT_HeapBlock *blkDst, CLR_RT_HeapBlock *blkSrc)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     NANOCLR_HEADER();
 
-    AnalyzeObject        aoDst;
-    AnalyzeObject        aoSrc;
-    CLR_RT_HeapBlock     srcVal; srcVal.SetObjectReference( NULL );
-    CLR_RT_ProtectFromGC gc( srcVal );
+    AnalyzeObject aoDst;
+    AnalyzeObject aoSrc;
+    CLR_RT_HeapBlock srcVal;
+    srcVal.SetObjectReference(NULL);
+    CLR_RT_ProtectFromGC gc(srcVal);
 
-    NANOCLR_CHECK_HRESULT(AnalyzeObject_Helper( blkDst, aoDst ));
-    NANOCLR_CHECK_HRESULT(AnalyzeObject_Helper( blkSrc, aoSrc ));
+    NANOCLR_CHECK_HRESULT(AnalyzeObject_Helper(blkDst, aoDst));
+    NANOCLR_CHECK_HRESULT(AnalyzeObject_Helper(blkSrc, aoSrc));
 
-    if(aoSrc.m_fNull)
+    if (aoSrc.m_fNull)
     {
-        if(aoDst.m_fCanBeNull == false)
+        if (aoDst.m_fCanBeNull == false)
         {
             NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
         }
 
-        NANOCLR_CHECK_HRESULT(srcVal.StoreToReference( *blkDst, 0 ));
+        NANOCLR_CHECK_HRESULT(srcVal.StoreToReference(*blkDst, 0));
     }
     else
     {
-        NANOCLR_CHECK_HRESULT(srcVal.LoadFromReference( *blkSrc ));
+        NANOCLR_CHECK_HRESULT(srcVal.LoadFromReference(*blkSrc));
 
-        if(aoDst.m_fNull)
+        if (aoDst.m_fNull)
         {
-            if(aoSrc.m_fCanBeNull == false)
+            if (aoSrc.m_fCanBeNull == false)
             {
-                NANOCLR_CHECK_HRESULT(srcVal.PerformBoxing( aoSrc.m_desc.m_handlerCls ));
+                NANOCLR_CHECK_HRESULT(srcVal.PerformBoxing(aoSrc.m_desc.m_handlerCls));
             }
 
-            blkDst->Assign( srcVal );
+            blkDst->Assign(srcVal);
         }
         else
         {
-            if(srcVal.IsAValueType())
+            if (srcVal.IsAValueType())
             {
-                if(blkDst->IsAValueType() == false)
+                if (blkDst->IsAValueType() == false)
                 {
-                    NANOCLR_CHECK_HRESULT(srcVal.PerformBoxing( aoSrc.m_desc.m_handlerCls ));
+                    NANOCLR_CHECK_HRESULT(srcVal.PerformBoxing(aoSrc.m_desc.m_handlerCls));
                 }
             }
             else
             {
-                if(blkDst->IsAValueType() == true)
+                if (blkDst->IsAValueType() == true)
                 {
-                    NANOCLR_CHECK_HRESULT(srcVal.PerformUnboxing( aoSrc.m_desc.m_handlerCls ));
+                    NANOCLR_CHECK_HRESULT(srcVal.PerformUnboxing(aoSrc.m_desc.m_handlerCls));
                 }
             }
 
-            NANOCLR_CHECK_HRESULT(blkDst->Reassign( srcVal ));
+            NANOCLR_CHECK_HRESULT(blkDst->Reassign(srcVal));
         }
     }
 
     NANOCLR_NOCLEANUP();
 }
 
-
-bool CLR_DBG_Debugger::Debugging_Value_Assign( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Value_Assign(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Value_Assign* cmd    = (CLR_DBG_Commands::Debugging_Value_Assign*)msg->m_payload;
-    CLR_RT_HeapBlock*                         blkDst = cmd->m_heapblockDst;
-    CLR_RT_HeapBlock*                         blkSrc = cmd->m_heapblockSrc;
 
-    if(blkDst && FAILED(Assign_Helper( blkDst, blkSrc )))
+    CLR_DBG_Commands::Debugging_Value_Assign *cmd = (CLR_DBG_Commands::Debugging_Value_Assign *)msg->m_payload;
+    CLR_RT_HeapBlock *blkDst = cmd->m_heapblockDst;
+    CLR_RT_HeapBlock *blkSrc = cmd->m_heapblockSrc;
+
+    if (blkDst && FAILED(Assign_Helper(blkDst, blkSrc)))
     {
         blkDst = NULL;
     }
 
-    return g_CLR_DBG_Debugger->GetValue( msg, blkDst, NULL, NULL );
+    return g_CLR_DBG_Debugger->GetValue(msg, blkDst, NULL, NULL);
 }
 
 //--//
 
-bool CLR_DBG_Debugger::Debugging_TypeSys_Assemblies( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_TypeSys_Assemblies(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_RT_Assembly_Index assemblies[ CLR_RT_TypeSystem::c_MaxAssemblies ];
-    int                   num = 0;
+
+    CLR_RT_Assembly_Index assemblies[CLR_RT_TypeSystem::c_MaxAssemblies];
+    int num = 0;
 
     NANOCLR_FOREACH_ASSEMBLY(g_CLR_RT_TypeSystem)
     {
-        assemblies[ num++ ].Set( pASSM->m_idx );
+        assemblies[num++].Set(pASSM->m_idx);
     }
     NANOCLR_FOREACH_ASSEMBLY_END();
 
-    WP_ReplyToCommand( msg, true, false, assemblies, sizeof(CLR_RT_Assembly_Index) * num );
+    WP_ReplyToCommand(msg, true, false, assemblies, sizeof(CLR_RT_Assembly_Index) * num);
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_TypeSys_AppDomains( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_TypeSys_AppDomains(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 #if defined(NANOCLR_APPDOMAINS)
-    
-    int        num                = 0;
-    CLR_UINT32 appDomainIDs[ 256 ];
+
+    int num = 0;
+    CLR_UINT32 appDomainIDs[256];
 
     NANOCLR_FOREACH_NODE(CLR_RT_AppDomain, appDomain, g_CLR_RT_ExecutionEngine.m_appDomains)
     {
-        appDomainIDs[ num++ ] = appDomain->m_id;
+        appDomainIDs[num++] = appDomain->m_id;
 
-        if(num >= ARRAYSIZE(appDomainIDs)) break;
+        if (num >= ARRAYSIZE(appDomainIDs))
+            break;
     }
     NANOCLR_FOREACH_NODE_END();
 
-    WP_ReplyToCommand( msg, true, false, appDomainIDs, sizeof(CLR_UINT32) * num );
+    WP_ReplyToCommand(msg, true, false, appDomainIDs, sizeof(CLR_UINT32) * num);
 
     return true;
 #else
@@ -3180,42 +3107,50 @@ bool CLR_DBG_Debugger::Debugging_TypeSys_AppDomains( WP_Message* msg)
 
 //--//
 
-bool CLR_DBG_Debugger::Debugging_Resolve_AppDomain( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Resolve_AppDomain(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 #if defined(NANOCLR_APPDOMAINS)
-    
-    CLR_DBG_Commands::Debugging_Resolve_AppDomain*        cmd           = (CLR_DBG_Commands::Debugging_Resolve_AppDomain*)msg->m_payload;
-    CLR_RT_AppDomain*                                     appDomain     = g_CLR_DBG_Debugger->GetAppDomainFromID( cmd->m_id );
-    CLR_UINT32                                            numAssemblies = 0;
-    CLR_DBG_Commands::Debugging_Resolve_AppDomain::Reply* cmdReply;
-    CLR_UINT8                                             buf[ sizeof(CLR_DBG_Commands::Debugging_Resolve_AppDomain::Reply) + sizeof(CLR_RT_Assembly_Index)*CLR_RT_TypeSystem::c_MaxAssemblies ];
-    size_t                                                count;
-    const char*                                                name;
-    CLR_RT_Assembly_Index*                                pAssemblyIndex;
 
-    if(appDomain)
+    CLR_DBG_Commands::Debugging_Resolve_AppDomain *cmd =
+        (CLR_DBG_Commands::Debugging_Resolve_AppDomain *)msg->m_payload;
+    CLR_RT_AppDomain *appDomain = g_CLR_DBG_Debugger->GetAppDomainFromID(cmd->m_id);
+    CLR_UINT32 numAssemblies = 0;
+    CLR_DBG_Commands::Debugging_Resolve_AppDomain::Reply *cmdReply;
+    CLR_UINT8
+        buf[sizeof(CLR_DBG_Commands::Debugging_Resolve_AppDomain::Reply) +
+            sizeof(CLR_RT_Assembly_Index) * CLR_RT_TypeSystem::c_MaxAssemblies];
+    size_t count;
+    const char *name;
+    CLR_RT_Assembly_Index *pAssemblyIndex;
+
+    if (appDomain)
     {
-        cmdReply = (CLR_DBG_Commands::Debugging_Resolve_AppDomain::Reply*)&buf;
+        cmdReply = (CLR_DBG_Commands::Debugging_Resolve_AppDomain::Reply *)&buf;
 
         cmdReply->m_state = appDomain->m_state;
 
-        name  = appDomain->m_strName->StringText();
-        count = __min( hal_strlen_s( name ) + 1, sizeof(cmdReply->m_szName) - 1 );
+        name = appDomain->m_strName->StringText();
+        count = __min(hal_strlen_s(name) + 1, sizeof(cmdReply->m_szName) - 1);
 
-        hal_strncpy_s( cmdReply->m_szName, ARRAYSIZE(cmdReply->m_szName), name, count );
+        hal_strncpy_s(cmdReply->m_szName, ARRAYSIZE(cmdReply->m_szName), name, count);
 
-        pAssemblyIndex = (CLR_RT_Assembly_Index*)(&cmdReply->m_assemblies);
+        pAssemblyIndex = (CLR_RT_Assembly_Index *)(&cmdReply->m_assemblies);
 
         NANOCLR_FOREACH_ASSEMBLY_IN_APPDOMAIN(appDomain)
         {
-            pAssemblyIndex->Set( pASSM->m_idx );
+            pAssemblyIndex->Set(pASSM->m_idx);
             pAssemblyIndex++;
             numAssemblies++;
         }
         NANOCLR_FOREACH_ASSEMBLY_IN_APPDOMAIN_END();
 
-        WP_ReplyToCommand( msg, true, false, cmdReply, sizeof(*cmdReply) + sizeof(CLR_RT_Assembly_Index) * (numAssemblies - 1) );
+        WP_ReplyToCommand(
+            msg,
+            true,
+            false,
+            cmdReply,
+            sizeof(*cmdReply) + sizeof(CLR_RT_Assembly_Index) * (numAssemblies - 1));
     }
     else
     {
@@ -3229,32 +3164,41 @@ bool CLR_DBG_Debugger::Debugging_Resolve_AppDomain( WP_Message* msg)
 #endif
 }
 
-bool CLR_DBG_Debugger::Debugging_Resolve_Assembly( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Resolve_Assembly(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Resolve_Assembly*       cmd = (CLR_DBG_Commands::Debugging_Resolve_Assembly*)msg->m_payload;
-    CLR_DBG_Commands::Debugging_Resolve_Assembly::Reply cmdReply;
-    CLR_RT_Assembly*                                    assm = g_CLR_DBG_Debugger->IsGoodAssembly( cmd->m_idx.Assembly() );
 
-    if(assm)
+    CLR_DBG_Commands::Debugging_Resolve_Assembly *cmd = (CLR_DBG_Commands::Debugging_Resolve_Assembly *)msg->m_payload;
+    CLR_DBG_Commands::Debugging_Resolve_Assembly::Reply cmdReply;
+    CLR_RT_Assembly *assm = g_CLR_DBG_Debugger->IsGoodAssembly(cmd->m_idx.Assembly());
+
+    if (assm)
     {
 #if defined(_WIN32)
-        //append path
-        if(assm->m_strPath != NULL)
+        // append path
+        if (assm->m_strPath != NULL)
         {
-            sprintf_s( cmdReply.m_szName, ARRAYSIZE(cmdReply.m_szName), "%s,%s", assm->m_szName, assm->m_strPath->c_str() );
+            sprintf_s(
+                cmdReply.m_szName,
+                ARRAYSIZE(cmdReply.m_szName),
+                "%s,%s",
+                assm->m_szName,
+                assm->m_strPath->c_str());
         }
         else
 #endif
         {
-            hal_strncpy_s( cmdReply.m_szName, ARRAYSIZE(cmdReply.m_szName), assm->m_szName, MAXSTRLEN(cmdReply.m_szName) );
+            hal_strncpy_s(
+                cmdReply.m_szName,
+                ARRAYSIZE(cmdReply.m_szName),
+                assm->m_szName,
+                MAXSTRLEN(cmdReply.m_szName));
         }
 
-        cmdReply.m_flags   = assm->m_flags;
+        cmdReply.m_flags = assm->m_flags;
         cmdReply.m_version = assm->m_header->version;
 
-        WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+        WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
         return true;
     }
@@ -3264,22 +3208,22 @@ bool CLR_DBG_Debugger::Debugging_Resolve_Assembly( WP_Message* msg)
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Resolve_Type( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Resolve_Type(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Resolve_Type*       cmd = (CLR_DBG_Commands::Debugging_Resolve_Type*)msg->m_payload;
+
+    CLR_DBG_Commands::Debugging_Resolve_Type *cmd = (CLR_DBG_Commands::Debugging_Resolve_Type *)msg->m_payload;
     CLR_DBG_Commands::Debugging_Resolve_Type::Reply cmdReply;
-    CLR_RT_TypeDef_Instance                         inst;
+    CLR_RT_TypeDef_Instance inst;
 
-    if(g_CLR_DBG_Debugger->CheckTypeDef( cmd->m_td, inst ))
+    if (g_CLR_DBG_Debugger->CheckTypeDef(cmd->m_td, inst))
     {
-        char*  szBuffer =           cmdReply.m_type;
-        size_t iBuffer  = MAXSTRLEN(cmdReply.m_type);
+        char *szBuffer = cmdReply.m_type;
+        size_t iBuffer = MAXSTRLEN(cmdReply.m_type);
 
-        if(SUCCEEDED(g_CLR_RT_TypeSystem.BuildTypeName( inst, szBuffer, iBuffer )))
+        if (SUCCEEDED(g_CLR_RT_TypeSystem.BuildTypeName(inst, szBuffer, iBuffer)))
         {
-            WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+            WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
             return true;
         }
@@ -3290,27 +3234,28 @@ bool CLR_DBG_Debugger::Debugging_Resolve_Type( WP_Message* msg)
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Resolve_Field( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Resolve_Field(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Resolve_Field*       cmd = (CLR_DBG_Commands::Debugging_Resolve_Field*)msg->m_payload;
+
+    CLR_DBG_Commands::Debugging_Resolve_Field *cmd = (CLR_DBG_Commands::Debugging_Resolve_Field *)msg->m_payload;
     CLR_DBG_Commands::Debugging_Resolve_Field::Reply cmdReply;
-    CLR_RT_FieldDef_Instance                         inst;
+    CLR_RT_FieldDef_Instance inst;
 
-    if(g_CLR_DBG_Debugger->CheckFieldDef( cmd->m_fd, inst ))
+    if (g_CLR_DBG_Debugger->CheckFieldDef(cmd->m_fd, inst))
     {
-        char*  szBuffer =           cmdReply.m_name;
-        size_t iBuffer  = MAXSTRLEN(cmdReply.m_name);
+        char *szBuffer = cmdReply.m_name;
+        size_t iBuffer = MAXSTRLEN(cmdReply.m_name);
 
-        if(SUCCEEDED(g_CLR_RT_TypeSystem.BuildFieldName( inst, szBuffer, iBuffer )))
+        if (SUCCEEDED(g_CLR_RT_TypeSystem.BuildFieldName(inst, szBuffer, iBuffer)))
         {
-            CLR_RT_TypeDef_Instance instClass; instClass.InitializeFromField( inst );
+            CLR_RT_TypeDef_Instance instClass;
+            instClass.InitializeFromField(inst);
 
-            cmdReply.m_td    = instClass;
+            cmdReply.m_td = instClass;
             cmdReply.m_index = inst.CrossReference().m_offset;
 
-            WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+            WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
             return true;
         }
@@ -3321,25 +3266,25 @@ bool CLR_DBG_Debugger::Debugging_Resolve_Field( WP_Message* msg)
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Resolve_Method( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Resolve_Method(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Resolve_Method*       cmd = (CLR_DBG_Commands::Debugging_Resolve_Method*)msg->m_payload;
-    CLR_DBG_Commands::Debugging_Resolve_Method::Reply cmdReply;
-    CLR_RT_MethodDef_Instance                         inst;
-    CLR_RT_TypeDef_Instance                           instOwner;
 
-    if(g_CLR_DBG_Debugger->CheckMethodDef( cmd->m_md, inst ) && instOwner.InitializeFromMethod( inst ))
+    CLR_DBG_Commands::Debugging_Resolve_Method *cmd = (CLR_DBG_Commands::Debugging_Resolve_Method *)msg->m_payload;
+    CLR_DBG_Commands::Debugging_Resolve_Method::Reply cmdReply;
+    CLR_RT_MethodDef_Instance inst;
+    CLR_RT_TypeDef_Instance instOwner;
+
+    if (g_CLR_DBG_Debugger->CheckMethodDef(cmd->m_md, inst) && instOwner.InitializeFromMethod(inst))
     {
-        char*  szBuffer =           cmdReply.m_method;
-        size_t iBuffer  = MAXSTRLEN(cmdReply.m_method);
+        char *szBuffer = cmdReply.m_method;
+        size_t iBuffer = MAXSTRLEN(cmdReply.m_method);
 
         cmdReply.m_td = instOwner;
 
-        CLR_SafeSprintf( szBuffer, iBuffer, "%s", inst.m_assm->GetString( inst.m_target->name ) );
+        CLR_SafeSprintf(szBuffer, iBuffer, "%s", inst.m_assm->GetString(inst.m_target->name));
 
-        WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+        WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
         return true;
     }
@@ -3349,163 +3294,170 @@ bool CLR_DBG_Debugger::Debugging_Resolve_Method( WP_Message* msg)
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Resolve_VirtualMethod( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Resolve_VirtualMethod(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Resolve_VirtualMethod*       cmd = (CLR_DBG_Commands::Debugging_Resolve_VirtualMethod*)msg->m_payload;
+
+    CLR_DBG_Commands::Debugging_Resolve_VirtualMethod *cmd =
+        (CLR_DBG_Commands::Debugging_Resolve_VirtualMethod *)msg->m_payload;
     CLR_DBG_Commands::Debugging_Resolve_VirtualMethod::Reply cmdReply;
-    CLR_RT_TypeDef_Index                                     cls;
-    CLR_RT_MethodDef_Index                                   md;
+    CLR_RT_TypeDef_Index cls;
+    CLR_RT_MethodDef_Index md;
 
     cmdReply.m_md.Clear();
 
-    if(SUCCEEDED(CLR_RT_TypeDescriptor::ExtractTypeIndexFromObject( *cmd->m_obj, cls )))
+    if (SUCCEEDED(CLR_RT_TypeDescriptor::ExtractTypeIndexFromObject(*cmd->m_obj, cls)))
     {
-        if(g_CLR_RT_EventCache.FindVirtualMethod( cls, cmd->m_md, md ))
+        if (g_CLR_RT_EventCache.FindVirtualMethod(cls, cmd->m_md, md))
         {
             cmdReply.m_md = md;
         }
     }
 
-    WP_ReplyToCommand( msg, true, false, &cmdReply, sizeof(cmdReply) );
+    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
 
     return true;
 }
-
 
 #endif //#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
 //--//
 
-
-bool CLR_DBG_Debugger::Debugging_Deployment_Status( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Deployment_Status(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands::Debugging_Deployment_Status::Reply* cmdReply;
-    CLR_UINT32                                            totLength;
-    CLR_UINT32                                            deploySectorsNum  = 0;
-    CLR_UINT32                                            deploySectorStart = 0;
-    CLR_UINT32                                            deployLength      = 0;
+    CLR_DBG_Commands::Debugging_Deployment_Status::Reply *cmdReply;
+    CLR_UINT32 totLength;
+    CLR_UINT32 deploySectorsNum = 0;
+    CLR_UINT32 deploySectorStart = 0;
+    CLR_UINT32 deployLength = 0;
 
     // find the first device in list with DEPLOYMENT blocks
     if (m_deploymentStorageDevice != NULL)
     {
         BlockStorageStream stream;
 
-        if(BlockStorageStream_InitializeWithBlockStorageDevice(&stream, BlockUsage_DEPLOYMENT, m_deploymentStorageDevice ))
+        if (BlockStorageStream_InitializeWithBlockStorageDevice(
+                &stream,
+                BlockUsage_DEPLOYMENT,
+                m_deploymentStorageDevice))
         {
             do
             {
-                if(deploySectorsNum == 0)
+                if (deploySectorsNum == 0)
                 {
                     deploySectorStart = BlockStorageStream_CurrentAddress(&stream);
                 }
-                deployLength     += stream.Length;
-                deploySectorsNum ++;
-            }
-            while(BlockStorageStream_NextStream(&stream) && stream.BaseAddress == (deploySectorStart + deployLength));
+                deployLength += stream.Length;
+                deploySectorsNum++;
+            } while (BlockStorageStream_NextStream(&stream) &&
+                     stream.BaseAddress == (deploySectorStart + deployLength));
         }
 
         totLength = sizeof(CLR_DBG_Commands::Debugging_Deployment_Status::Reply);
 
-        cmdReply = (CLR_DBG_Commands::Debugging_Deployment_Status::Reply*)CLR_RT_Memory::Allocate( totLength, true );
+        cmdReply = (CLR_DBG_Commands::Debugging_Deployment_Status::Reply *)CLR_RT_Memory::Allocate(totLength, true);
 
-        if(!cmdReply) return false;
+        if (!cmdReply)
+            return false;
 
-        CLR_RT_Memory::ZeroFill( cmdReply, totLength );
+        CLR_RT_Memory::ZeroFill(cmdReply, totLength);
 
-        cmdReply->EntryPoint          = g_CLR_RT_TypeSystem.m_entryPoint.m_data;
-        cmdReply->StorageStart        = deploySectorStart;
-        cmdReply->StorageLength       = deployLength;
+        cmdReply->EntryPoint = g_CLR_RT_TypeSystem.m_entryPoint.m_data;
+        cmdReply->StorageStart = deploySectorStart;
+        cmdReply->StorageLength = deployLength;
 
-        WP_ReplyToCommand( msg, true, false, cmdReply, totLength );
+        WP_ReplyToCommand(msg, true, false, cmdReply, totLength);
 
-        CLR_RT_Memory::Release( cmdReply );
+        CLR_RT_Memory::Release(cmdReply);
 
         return true;
     }
     else
     {
-        WP_ReplyToCommand( msg, false, false, NULL, 0 );
+        WP_ReplyToCommand(msg, false, false, NULL, 0);
         return false;
     }
 }
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
-bool CLR_DBG_Debugger::Debugging_Info_SetJMC_Method( const CLR_RT_MethodDef_Index& idx, bool fJMC )
+bool CLR_DBG_Debugger::Debugging_Info_SetJMC_Method(const CLR_RT_MethodDef_Index &idx, bool fJMC)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
     CLR_RT_MethodDef_Instance inst;
 
-    if(!CheckMethodDef( idx, inst )        ) return false;
-    if(inst.m_target->RVA == CLR_EmptyIndex) return false;
+    if (!CheckMethodDef(idx, inst))
+        return false;
+    if (inst.m_target->RVA == CLR_EmptyIndex)
+        return false;
 
-    inst.DebuggingInfo().SetJMC( fJMC );
+    inst.DebuggingInfo().SetJMC(fJMC);
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Info_SetJMC_Type( const CLR_RT_TypeDef_Index& idx, bool fJMC )
+bool CLR_DBG_Debugger::Debugging_Info_SetJMC_Type(const CLR_RT_TypeDef_Index &idx, bool fJMC)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    const CLR_RECORD_TYPEDEF*     td;
-          CLR_RT_TypeDef_Instance inst;
-          int                     totMethods;
-          CLR_RT_MethodDef_Index  md;
+    const CLR_RECORD_TYPEDEF *td;
+    CLR_RT_TypeDef_Instance inst;
+    int totMethods;
+    CLR_RT_MethodDef_Index md;
 
-    if(!CheckTypeDef( idx, inst )) return false;
+    if (!CheckTypeDef(idx, inst))
+        return false;
 
-    td         = inst.m_target;
+    td = inst.m_target;
     totMethods = td->vMethods_Num + td->iMethods_Num + td->sMethods_Num;
 
-    for(int i=0; i<totMethods; i++)
+    for (int i = 0; i < totMethods; i++)
     {
-        md.Set( idx.Assembly(), td->methods_First + i );
+        md.Set(idx.Assembly(), td->methods_First + i);
 
-        Debugging_Info_SetJMC_Method( md, fJMC );
+        Debugging_Info_SetJMC_Method(md, fJMC);
     }
 
     return true;
 }
 
-bool CLR_DBG_Debugger::Debugging_Info_SetJMC( WP_Message* msg)
+bool CLR_DBG_Debugger::Debugging_Info_SetJMC(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    
-    CLR_DBG_Commands::Debugging_Info_SetJMC* cmd  = (CLR_DBG_Commands::Debugging_Info_SetJMC*)msg->m_payload;
-    bool                                     fJMC = (cmd->m_fIsJMC != 0);
 
-    switch(cmd->m_kind)
+    CLR_DBG_Commands::Debugging_Info_SetJMC *cmd = (CLR_DBG_Commands::Debugging_Info_SetJMC *)msg->m_payload;
+    bool fJMC = (cmd->m_fIsJMC != 0);
+
+    switch (cmd->m_kind)
     {
-    case REFLECTION_ASSEMBLY:
+        case REFLECTION_ASSEMBLY:
         {
-            CLR_RT_Assembly* assm = g_CLR_DBG_Debugger->IsGoodAssembly( cmd->m_data.m_assm.Assembly() );
+            CLR_RT_Assembly *assm = g_CLR_DBG_Debugger->IsGoodAssembly(cmd->m_data.m_assm.Assembly());
 
-            if(!assm) return false;
+            if (!assm)
+                return false;
 
-            for(int i=0; i<assm->m_pTablesSize[ TBL_TypeDef ]; i++)
+            for (int i = 0; i < assm->m_pTablesSize[TBL_TypeDef]; i++)
             {
                 CLR_RT_TypeDef_Index idx;
 
-                idx.Set( cmd->m_data.m_assm.Assembly(), i );
+                idx.Set(cmd->m_data.m_assm.Assembly(), i);
 
-                g_CLR_DBG_Debugger->Debugging_Info_SetJMC_Type( idx, fJMC );
+                g_CLR_DBG_Debugger->Debugging_Info_SetJMC_Type(idx, fJMC);
             }
 
             return true;
         }
 
-    case REFLECTION_TYPE:
-        return g_CLR_DBG_Debugger->Debugging_Info_SetJMC_Type( cmd->m_data.m_type, fJMC );
+        case REFLECTION_TYPE:
+            return g_CLR_DBG_Debugger->Debugging_Info_SetJMC_Type(cmd->m_data.m_type, fJMC);
 
-    case REFLECTION_METHOD:
-        return g_CLR_DBG_Debugger->Debugging_Info_SetJMC_Method( cmd->m_data.m_method, fJMC );
+        case REFLECTION_METHOD:
+            return g_CLR_DBG_Debugger->Debugging_Info_SetJMC_Method(cmd->m_data.m_method, fJMC);
 
-    default:
-        return false;
+        default:
+            return false;
     }
 }
 

--- a/src/CLR/Include/WireProtocol_MonitorCommands.h
+++ b/src/CLR/Include/WireProtocol_MonitorCommands.h
@@ -117,23 +117,11 @@ typedef struct CLR_DBG_Commands_Monitor_CheckMemory
 
 }CLR_DBG_Commands_Monitor_CheckMemory;
 
-typedef struct CLR_DBG_Commands_Monitor_CheckMemory_Reply
-{
-    uint32_t crc;
-    
-}CLR_DBG_Commands_Monitor_CheckMemory_Reply;
+typedef uint32_t CLR_DBG_Commands_Monitor_CheckMemory_Reply;
 
-typedef struct CLR_DBG_Commands_Monitor_EraseMemory_Reply
-{
-    uint32_t ErrorCode;
+typedef uint32_t CLR_DBG_Commands_Monitor_EraseMemory_Reply;
 
-}CLR_DBG_Commands_Monitor_EraseMemory_Reply;
-
-typedef struct CLR_DBG_Commands_Monitor_WriteMemory_Reply
-{
-    uint32_t ErrorCode;
-
-}CLR_DBG_Commands_Monitor_WriteMemory_Reply;
+typedef uint32_t CLR_DBG_Commands_Monitor_WriteMemory_Reply;
 
 typedef struct MemoryMap_Range
 {

--- a/src/CLR/Include/WireProtocol_MonitorCommands.h
+++ b/src/CLR/Include/WireProtocol_MonitorCommands.h
@@ -18,39 +18,37 @@
 // backwards compatible with .NETMF
 typedef enum Monitor_Reboot_Options
 {
-    Monitor_Reboot_c_NormalReboot    = 0,
+    Monitor_Reboot_c_NormalReboot = 0,
     Monitor_Reboot_c_EnterBootloader = 1,
-    Monitor_Reboot_c_ClrRebootOnly   = 2,
+    Monitor_Reboot_c_ClrRebootOnly = 2,
     Monitor_Reboot_c_ClrStopDebugger = 4
-}Monitor_Reboot_Options;
+} Monitor_Reboot_Options;
 
 // structure for Access Memory operations
 typedef enum AccessMemory_Operations
 {
     // check if memory space is erased
-    AccessMemory_Check    = 0x00,
+    AccessMemory_Check = 0x00,
 
     // read block of data starting at a given address
-    AccessMemory_Read     = 0x01,
-    
+    AccessMemory_Read = 0x01,
+
     // write block of data starting at a given address
-    AccessMemory_Write    = 0x02,
+    AccessMemory_Write = 0x02,
 
-    // erase sector/block/page at a given address 
-    AccessMemory_Erase    = 0x03,
+    // erase sector/block/page at a given address
+    AccessMemory_Erase = 0x03,
 
+    AccessMemory_Mask = 0x0F
 
-    AccessMemory_Mask     = 0x0F
-
-}AccessMemory_Operations;
+} AccessMemory_Operations;
 
 typedef enum MemoryMap_Options
 {
-    Monitor_MemoryMap_c_RAM     = 0x00000001,
-    Monitor_MemoryMap_c_FLASH   = 0x00000002,
+    Monitor_MemoryMap_c_RAM = 0x00000001,
+    Monitor_MemoryMap_c_FLASH = 0x00000002,
 
-}MemoryMap_Options;
-
+} MemoryMap_Options;
 
 //////////////////////////////////////////
 // typedefs
@@ -62,7 +60,7 @@ typedef struct Monitor_Ping_Reply
     uint32_t m_source;
     uint32_t m_dbg_flags;
 
-}Monitor_Ping_Reply;
+} Monitor_Ping_Reply;
 
 // structure for command Monitor Ping
 // backwards compatible with .NETMF
@@ -71,51 +69,50 @@ typedef struct Monitor_Ping_Command
     uint32_t m_source;
     uint32_t m_dbg_flags;
 
-}Monitor_Ping_Command;
-
+} Monitor_Ping_Command;
 
 // structure with reply for OEM information command
 typedef struct Monitor_OemInfo_Reply
 {
-    ReleaseInfo   m_releaseInfo;
+    ReleaseInfo m_releaseInfo;
 
-}Monitor_OemInfo_Reply;
+} Monitor_OemInfo_Reply;
 
 typedef struct CLR_DBG_Commands_Monitor_ReadMemory
 {
-    uint32_t    address;
-    uint32_t    length;
-    unsigned char   data[1];
+    uint32_t address;
+    uint32_t length;
+    unsigned char data[1];
 
-}CLR_DBG_Commands_Monitor_ReadMemory;
+} CLR_DBG_Commands_Monitor_ReadMemory;
 
 typedef struct CLR_DBG_Commands_Monitor_WriteMemory
 {
-    uint32_t    address;
-    uint32_t    length;
-    unsigned char   data[1];
+    uint32_t address;
+    uint32_t length;
+    unsigned char data[1];
 
-}CLR_DBG_Commands_Monitor_WriteMemory;
+} CLR_DBG_Commands_Monitor_WriteMemory;
 
 typedef struct Monitor_Reboot_Command
 {
     uint32_t m_flags;
 
-}Monitor_Reboot_Command;
+} Monitor_Reboot_Command;
 
 typedef struct CLR_DBG_Commands_Monitor_EraseMemory
 {
     uint32_t address;
     uint32_t length;
 
-}CLR_DBG_Commands_Monitor_EraseMemory;
+} CLR_DBG_Commands_Monitor_EraseMemory;
 
 typedef struct CLR_DBG_Commands_Monitor_CheckMemory
 {
     uint32_t address;
     uint32_t length;
 
-}CLR_DBG_Commands_Monitor_CheckMemory;
+} CLR_DBG_Commands_Monitor_CheckMemory;
 
 typedef uint32_t CLR_DBG_Commands_Monitor_CheckMemory_Reply;
 
@@ -129,21 +126,20 @@ typedef struct MemoryMap_Range
     uint32_t m_length;
     uint32_t m_flags;
 
-}MemoryMap_Range;
-
+} MemoryMap_Range;
 
 typedef struct CLR_DBG_Commands_Monitor_MemoryMap
 {
     MemoryMap_Range m_map[1];
 
-}CLR_DBG_Commands_Monitor_MemoryMap;
+} CLR_DBG_Commands_Monitor_MemoryMap;
 
 typedef struct Monitor_QueryConfiguration_Command
 {
     uint32_t Configuration;
     uint32_t BlockIndex;
 
-}Monitor_QueryConfiguration_Command;
+} Monitor_QueryConfiguration_Command;
 
 typedef struct __nfpack Monitor_UpdateConfiguration_Command
 {
@@ -154,32 +150,33 @@ typedef struct __nfpack Monitor_UpdateConfiguration_Command
     uint32_t Done;
     uint8_t Data[1];
 
-}Monitor_UpdateConfiguration_Command;
+} Monitor_UpdateConfiguration_Command;
 
 typedef struct Monitor_UpdateConfiguration_Reply
 {
     uint32_t ErrorCode;
 
-}Monitor_UpdateConfiguration_Reply;
+} Monitor_UpdateConfiguration_Reply;
 
 //////////////////////////////////////////
 // function declarations (commands)
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-int Monitor_Ping(WP_Message* message);
-int Monitor_OemInfo(WP_Message* message);
-int Monitor_WriteMemory(WP_Message* message);
-int Monitor_ReadMemory(WP_Message* message);
-int Monitor_Reboot(WP_Message* message);
-int Monitor_EraseMemory(WP_Message* message);
-int Monitor_QueryConfiguration(WP_Message* message);
-int Monitor_UpdateConfiguration(WP_Message* message);
-int Monitor_CheckMemory(WP_Message* message);
-int Monitor_MemoryMap(WP_Message* message);
-int Monitor_FlashSectorMap(WP_Message* message);
+    int Monitor_Ping(WP_Message *message);
+    int Monitor_OemInfo(WP_Message *message);
+    int Monitor_WriteMemory(WP_Message *message);
+    int Monitor_ReadMemory(WP_Message *message);
+    int Monitor_Reboot(WP_Message *message);
+    int Monitor_EraseMemory(WP_Message *message);
+    int Monitor_QueryConfiguration(WP_Message *message);
+    int Monitor_UpdateConfiguration(WP_Message *message);
+    int Monitor_CheckMemory(WP_Message *message);
+    int Monitor_MemoryMap(WP_Message *message);
+    int Monitor_FlashSectorMap(WP_Message *message);
 
 #ifdef __cplusplus
 }

--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -1040,7 +1040,7 @@ private:
 
     bool CheckPermission( ByteAddress address, int mode );
 
-    bool AccessMemory( uint32_t location, uint32_t lengthInBytes, uint8_t* buf, uint32_t mode, uint32_t& errorCode );
+    void AccessMemory( uint32_t location, uint32_t lengthInBytes, uint8_t* buf, uint32_t mode, uint32_t* errorCode );
 
 #if defined(NANOCLR_APPDOMAINS)
     CLR_RT_AppDomain*  GetAppDomainFromID ( CLR_UINT32 id );

--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -18,50 +18,33 @@
 //#if defined(_MSC_VER)
 struct CLR_DBG_Commands
 {
-    static const unsigned int c_Monitor_Ping               = 0x00000000; // The payload is empty, this command is used to let the other side know we are here...
-    static const unsigned int c_Monitor_Message            = 0x00000001; // The payload is composed of the string characters, no zero at the end.
-    static const unsigned int c_Monitor_ReadMemory         = 0x00000002;
-    static const unsigned int c_Monitor_WriteMemory        = 0x00000003;
-    static const unsigned int c_Monitor_CheckMemory        = 0x00000004;
-    static const unsigned int c_Monitor_EraseMemory        = 0x00000005;
-    static const unsigned int c_Monitor_Execute            = 0x00000006;
-    static const unsigned int c_Monitor_Reboot             = 0x00000007;
-    static const unsigned int c_Monitor_MemoryMap          = 0x00000008;
-    static const unsigned int c_Monitor_ProgramExit        = 0x00000009; // The payload is empty, this command is used to tell the PC of a program termination
-    static const unsigned int c_Monitor_CheckSignature     = 0x0000000A;
-    static const unsigned int c_Monitor_DeploymentMap      = 0x0000000B;
-    static const unsigned int c_Monitor_FlashSectorMap     = 0x0000000C;
-    static const unsigned int c_Monitor_OemInfo            = 0x0000000E;
+    static const unsigned int c_Monitor_Ping =
+        0x00000000; // The payload is empty, this command is used to let the other side know we are here...
+    static const unsigned int c_Monitor_Message =
+        0x00000001; // The payload is composed of the string characters, no zero at the end.
+    static const unsigned int c_Monitor_ReadMemory = 0x00000002;
+    static const unsigned int c_Monitor_WriteMemory = 0x00000003;
+    static const unsigned int c_Monitor_CheckMemory = 0x00000004;
+    static const unsigned int c_Monitor_EraseMemory = 0x00000005;
+    static const unsigned int c_Monitor_Execute = 0x00000006;
+    static const unsigned int c_Monitor_Reboot = 0x00000007;
+    static const unsigned int c_Monitor_MemoryMap = 0x00000008;
+    static const unsigned int c_Monitor_ProgramExit =
+        0x00000009; // The payload is empty, this command is used to tell the PC of a program termination
+    static const unsigned int c_Monitor_CheckSignature = 0x0000000A;
+    static const unsigned int c_Monitor_DeploymentMap = 0x0000000B;
+    static const unsigned int c_Monitor_FlashSectorMap = 0x0000000C;
+    static const unsigned int c_Monitor_OemInfo = 0x0000000E;
     static const unsigned int c_Monitor_QueryConfiguration = 0x0000000F;
-    static const unsigned int c_Monitor_UpdateConfiguration= 0x00000010;
+    static const unsigned int c_Monitor_UpdateConfiguration = 0x00000010;
 
     //--//
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    
     struct Monitor_OemInfo
     {
         struct Reply
         {
-            NFReleaseInfo   m_releaseInfo;
+            NFReleaseInfo m_releaseInfo;
         };
     };
 
@@ -70,235 +53,175 @@ struct CLR_DBG_Commands
     /////////////////////////////////////////////////////////////////////////////////////////////////////////
     struct Monitor_Reboot
     {
-        static const unsigned int c_NormalReboot    = 0;
+        static const unsigned int c_NormalReboot = 0;
         static const unsigned int c_EnterBootloader = 1;
-        static const unsigned int c_ClrOnly   = 2;
-        static const unsigned int c_WaitForDebugger   = 4;
+        static const unsigned int c_ClrOnly = 2;
+        static const unsigned int c_WaitForDebugger = 4;
 
         unsigned int m_flags;
     };
 
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
     struct Monitor_Signature
-    {        
+    {
         unsigned int m_keyIndex;
-        unsigned int m_length;   
-        unsigned char  m_signature[ 1 ];
+        unsigned int m_length;
+        unsigned char m_signature[1];
     };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     struct Monitor_Execute
     {
         unsigned int m_address;
     };
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     struct Monitor_DeploymentMap
-    {    
+    {
         static const CLR_UINT32 c_CRC_Erased_Sentinel = 0x0;
 
         struct FlashSector
         {
             CLR_UINT32 m_start;
             CLR_UINT32 m_length;
-            
+
             CLR_UINT32 m_crc;
         };
 
         struct Reply
         {
 
-            FlashSector m_data[ 1 ];
+            FlashSector m_data[1];
         };
     };
-
-
-    
 
     struct Monitor_SignatureKeyUpdate
     {
         unsigned int m_keyIndex;
-        unsigned char  m_newKeySignature[ 128 ];
-        unsigned char  m_newKey[ 260 ];
+        unsigned char m_newKeySignature[128];
+        unsigned char m_newKey[260];
         unsigned int m_reserveLength;
-        unsigned char  m_reserveData[ 1 ];
+        unsigned char m_reserveData[1];
     };
 
     //--------------------------------------------------------------//
 
-    static const unsigned int c_Debugging_Execution_BasePtr              = 0x00020000; // Returns the pointer for the ExecutionEngine object.
-    static const unsigned int c_Debugging_Execution_ChangeConditions     = 0x00020001; // Sets/resets the state of the debugger.
-    static const unsigned int c_Debugging_Execution_SecurityKey          = 0x00020002; // Sets security key.
-    static const unsigned int c_Debugging_Execution_Unlock               = 0x00020003; // Unlock the low-level command, for mfg. test programs.
-    static const unsigned int c_Debugging_Execution_Allocate             = 0x00020004; // Permanently allocate some memory.
-    static const unsigned int c_Debugging_Execution_Breakpoints          = 0x00020005; // Sets breakpoints.
-    static const unsigned int c_Debugging_Execution_BreakpointHit        = 0x00020006; // Notification that a breakpoint was hit.
-    static const unsigned int c_Debugging_Execution_BreakpointStatus     = 0x00020007; // Queries last breakpoint hit.
-    static const unsigned int c_Debugging_Execution_QueryCLRCapabilities = 0x00020008; // Queries capabilities of the CLR.
-    static const unsigned int c_Debugging_Execution_SetCurrentAppDomain  = 0x00020009; // Sets the current AppDomain.  This is required before
-                                                                                 // performing certain debugging operations, such as
-                                                                                 // accessing a static field, or doing function evaluation,
+    static const unsigned int c_Debugging_Execution_BasePtr =
+        0x00020000; // Returns the pointer for the ExecutionEngine object.
+    static const unsigned int c_Debugging_Execution_ChangeConditions =
+        0x00020001;                                                           // Sets/resets the state of the debugger.
+    static const unsigned int c_Debugging_Execution_SecurityKey = 0x00020002; // Sets security key.
+    static const unsigned int c_Debugging_Execution_Unlock =
+        0x00020003; // Unlock the low-level command, for mfg. test programs.
+    static const unsigned int c_Debugging_Execution_Allocate = 0x00020004;    // Permanently allocate some memory.
+    static const unsigned int c_Debugging_Execution_Breakpoints = 0x00020005; // Sets breakpoints.
+    static const unsigned int c_Debugging_Execution_BreakpointHit =
+        0x00020006; // Notification that a breakpoint was hit.
+    static const unsigned int c_Debugging_Execution_BreakpointStatus = 0x00020007; // Queries last breakpoint hit.
+    static const unsigned int c_Debugging_Execution_QueryCLRCapabilities =
+        0x00020008; // Queries capabilities of the CLR.
+    static const unsigned int c_Debugging_Execution_SetCurrentAppDomain =
+        0x00020009; // Sets the current AppDomain.  This is required before
+                    // performing certain debugging operations, such as
+                    // accessing a static field, or doing function evaluation,
 
-    static const unsigned int c_Debugging_Thread_Create                  = 0x00020010; // OBSOLETE - Use c_Debugging_Thread_CreateEx instead.
-    static const unsigned int c_Debugging_Thread_List                    = 0x00020011; // Lists the active/waiting threads.
-    static const unsigned int c_Debugging_Thread_Stack                   = 0x00020012; // Lists the call stack for a thread.
-    static const unsigned int c_Debugging_Thread_Kill                    = 0x00020013; // Kills a thread.
-    static const unsigned int c_Debugging_Thread_Suspend                 = 0x00020014; // Suspends the execution of a thread.
-    static const unsigned int c_Debugging_Thread_Resume                  = 0x00020015; // Resumes the execution of a thread.
-    static const unsigned int c_Debugging_Thread_GetException            = 0x00020016; // Gets the current exception.
-    static const unsigned int c_Debugging_Thread_Unwind                  = 0x00020017; // Unwinds to given stack frame.
-    static const unsigned int c_Debugging_Thread_CreateEx                = 0x00020018; // Creates a new thread but Thread.CurrentThread will return the identity of the passed thread.
-    static const unsigned int c_Debugging_Thread_Get                     = 0x00021000; // Gets the current thread.
-                                                                 
-    static const unsigned int c_Debugging_Stack_Info                     = 0x00020020; // Gets more info on a stack frame.
-    static const unsigned int c_Debugging_Stack_SetIP                    = 0x00020021; // Sets the IP on a given thread.
-                                                                 
-    static const unsigned int c_Debugging_Value_ResizeScratchPad         = 0x00020030; // Resizes the scratchpad area.
-    static const unsigned int c_Debugging_Value_GetStack                 = 0x00020031; // Reads a value from the stack frame.
-    static const unsigned int c_Debugging_Value_GetField                 = 0x00020032; // Reads a value from an object's field.
-    static const unsigned int c_Debugging_Value_GetArray                 = 0x00020033; // Reads a value from an array's element.
-    static const unsigned int c_Debugging_Value_GetBlock                 = 0x00020034; // Reads a value from a heap block.
-    static const unsigned int c_Debugging_Value_GetScratchPad            = 0x00020035; // Reads a value from the scratchpad area.
-    static const unsigned int c_Debugging_Value_SetBlock                 = 0x00020036; // Writes a value to a heap block.
-    static const unsigned int c_Debugging_Value_SetArray                 = 0x00020037; // Writes a value to an array's element.
-    static const unsigned int c_Debugging_Value_AllocateObject           = 0x00020038; // Creates a new instance of an object.
-    static const unsigned int c_Debugging_Value_AllocateString           = 0x00020039; // Creates a new instance of a string.
-    static const unsigned int c_Debugging_Value_AllocateArray            = 0x0002003A; // Creates a new instance of an array.
-    static const unsigned int c_Debugging_Value_Assign                   = 0x0002003B; // Assigns a value to another value.
-                                                                 
-    static const unsigned int c_Debugging_TypeSys_Assemblies                = 0x00020040; // Lists all the assemblies in the system.
-    static const unsigned int c_Debugging_TypeSys_AppDomains                = 0x00020044; // Lists all the AppDomans loaded.
-                                                                 
-    static const unsigned int c_Debugging_Resolve_Assembly               = 0x00020050; // Resolves an assembly.
-    static const unsigned int c_Debugging_Resolve_Type                   = 0x00020051; // Resolves a type to a string.
-    static const unsigned int c_Debugging_Resolve_Field                  = 0x00020052; // Resolves a field to a string.
-    static const unsigned int c_Debugging_Resolve_Method                 = 0x00020053; // Resolves a method to a string.
-    static const unsigned int c_Debugging_Resolve_VirtualMethod          = 0x00020054; // Resolves a virtual method to the actual implementation.
-    static const unsigned int c_Debugging_Resolve_AppDomain              = 0x00020055; // Resolves an AppDomain to it's name, and list its loaded assemblies.
+    static const unsigned int c_Debugging_Thread_Create =
+        0x00020010; // OBSOLETE - Use c_Debugging_Thread_CreateEx instead.
+    static const unsigned int c_Debugging_Thread_List = 0x00020011;         // Lists the active/waiting threads.
+    static const unsigned int c_Debugging_Thread_Stack = 0x00020012;        // Lists the call stack for a thread.
+    static const unsigned int c_Debugging_Thread_Kill = 0x00020013;         // Kills a thread.
+    static const unsigned int c_Debugging_Thread_Suspend = 0x00020014;      // Suspends the execution of a thread.
+    static const unsigned int c_Debugging_Thread_Resume = 0x00020015;       // Resumes the execution of a thread.
+    static const unsigned int c_Debugging_Thread_GetException = 0x00020016; // Gets the current exception.
+    static const unsigned int c_Debugging_Thread_Unwind = 0x00020017;       // Unwinds to given stack frame.
+    static const unsigned int c_Debugging_Thread_CreateEx =
+        0x00020018; // Creates a new thread but Thread.CurrentThread will return the identity of the passed thread.
+    static const unsigned int c_Debugging_Thread_Get = 0x00021000; // Gets the current thread.
 
+    static const unsigned int c_Debugging_Stack_Info = 0x00020020;  // Gets more info on a stack frame.
+    static const unsigned int c_Debugging_Stack_SetIP = 0x00020021; // Sets the IP on a given thread.
 
+    static const unsigned int c_Debugging_Value_ResizeScratchPad = 0x00020030; // Resizes the scratchpad area.
+    static const unsigned int c_Debugging_Value_GetStack = 0x00020031;         // Reads a value from the stack frame.
+    static const unsigned int c_Debugging_Value_GetField = 0x00020032;         // Reads a value from an object's field.
+    static const unsigned int c_Debugging_Value_GetArray = 0x00020033;         // Reads a value from an array's element.
+    static const unsigned int c_Debugging_Value_GetBlock = 0x00020034;         // Reads a value from a heap block.
+    static const unsigned int c_Debugging_Value_GetScratchPad = 0x00020035;  // Reads a value from the scratchpad area.
+    static const unsigned int c_Debugging_Value_SetBlock = 0x00020036;       // Writes a value to a heap block.
+    static const unsigned int c_Debugging_Value_SetArray = 0x00020037;       // Writes a value to an array's element.
+    static const unsigned int c_Debugging_Value_AllocateObject = 0x00020038; // Creates a new instance of an object.
+    static const unsigned int c_Debugging_Value_AllocateString = 0x00020039; // Creates a new instance of a string.
+    static const unsigned int c_Debugging_Value_AllocateArray = 0x0002003A;  // Creates a new instance of an array.
+    static const unsigned int c_Debugging_Value_Assign = 0x0002003B;         // Assigns a value to another value.
 
+    static const unsigned int c_Debugging_TypeSys_Assemblies = 0x00020040; // Lists all the assemblies in the system.
+    static const unsigned int c_Debugging_TypeSys_AppDomains = 0x00020044; // Lists all the AppDomans loaded.
 
+    static const unsigned int c_Debugging_Resolve_Assembly = 0x00020050; // Resolves an assembly.
+    static const unsigned int c_Debugging_Resolve_Type = 0x00020051;     // Resolves a type to a string.
+    static const unsigned int c_Debugging_Resolve_Field = 0x00020052;    // Resolves a field to a string.
+    static const unsigned int c_Debugging_Resolve_Method = 0x00020053;   // Resolves a method to a string.
+    static const unsigned int c_Debugging_Resolve_VirtualMethod =
+        0x00020054; // Resolves a virtual method to the actual implementation.
+    static const unsigned int c_Debugging_Resolve_AppDomain =
+        0x00020055; // Resolves an AppDomain to it's name, and list its loaded assemblies.
 
+    static const unsigned int c_Debugging_UpgradeToSsl = 0x00020069; //
 
+    //--//
 
+    static const unsigned int c_Debugging_Button_Report = 0x00020080; // Reports a button press/release.
+    static const unsigned int c_Debugging_Button_Inject = 0x00020081; // Injects a button press/release.
 
+    static const unsigned int c_Debugging_Deployment_Status =
+        0x000200B0; // Returns entryPoint and boundary of deployment area.
 
-    static const unsigned int c_Debugging_UpgradeToSsl                   = 0x00020069; //
+    static const unsigned int c_Debugging_Info_SetJMC = 0x000200C0; // Sets code to be flagged as JMC (Just my code).
 
-    //--//                                                       
-                                                                 
-    static const unsigned int c_Debugging_Button_Report                  = 0x00020080; // Reports a button press/release.
-    static const unsigned int c_Debugging_Button_Inject                  = 0x00020081; // Injects a button press/release.
-                                                                                                                   
-    static const unsigned int c_Debugging_Deployment_Status              = 0x000200B0; // Returns entryPoint and boundary of deployment area.
-                                                                 
-    static const unsigned int c_Debugging_Info_SetJMC                    = 0x000200C0; // Sets code to be flagged as JMC (Just my code).
-
-    static const unsigned int c_Profiling_Command                        = 0x00030000; // Various incoming commands regarding profiling
-    static const unsigned int c_Profiling_Stream                         = 0x00030001; // Stream for MFProfiler information.
+    static const unsigned int c_Profiling_Command = 0x00030000; // Various incoming commands regarding profiling
+    static const unsigned int c_Profiling_Stream = 0x00030001;  // Stream for MFProfiler information.
 
     //--//
 
     struct Debugging_Execution_Unlock
     {
-        unsigned char m_command[ 128 ];
-        unsigned char m_hash   [ 128 ];
+        unsigned char m_command[128];
+        unsigned char m_hash[128];
     };
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // !!! KEEP IN SYNC WITH nanoFramework.Tools.Debugger.WireProtocol.Commands.Debugging_Execution_QueryCLRCapabilities (in managed code) !!! //
+    // !!! KEEP IN SYNC WITH nanoFramework.Tools.Debugger.WireProtocol.Commands.Debugging_Execution_QueryCLRCapabilities
+    // (in managed code) !!! //
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     struct Debugging_Execution_QueryCLRCapabilities
     {
-        static const CLR_UINT32 c_CapabilityFlags               = 1;
-        static const CLR_UINT32 c_CapabilityVersion             = 3;
-        static const CLR_UINT32 c_HalSystemInfo                 = 5;
-        static const CLR_UINT32 c_ClrInfo                       = 6;
-        static const CLR_UINT32 c_TargetReleaseInfo             = 7;
-        static const CLR_UINT32 c_InteropNativeAssemblies       = 8;
-        static const CLR_UINT32 c_InteropNativeAssembliesCount  = 9;
+        static const CLR_UINT32 c_CapabilityFlags = 1;
+        static const CLR_UINT32 c_CapabilityVersion = 3;
+        static const CLR_UINT32 c_HalSystemInfo = 5;
+        static const CLR_UINT32 c_ClrInfo = 6;
+        static const CLR_UINT32 c_TargetReleaseInfo = 7;
+        static const CLR_UINT32 c_InteropNativeAssemblies = 8;
+        static const CLR_UINT32 c_InteropNativeAssembliesCount = 9;
 
-        static const CLR_UINT32 c_CapabilityFlags_FloatingPoint             = 0x00000001;
-        static const CLR_UINT32 c_CapabilityFlags_SourceLevelDebugging      = 0x00000002;
-        static const CLR_UINT32 c_CapabilityFlags_AppDomains                = 0x00000004;
-        static const CLR_UINT32 c_CapabilityFlags_ExceptionFilters          = 0x00000008;
-        static const CLR_UINT32 c_CapabilityFlags_IncrementalDeployment     = 0x00000010;
-        static const CLR_UINT32 c_CapabilityFlags_SoftReboot                = 0x00000020;
-        static const CLR_UINT32 c_CapabilityFlags_Profiling                 = 0x00000040;
-        static const CLR_UINT32 c_CapabilityFlags_Profiling_Allocations     = 0x00000080;
-        static const CLR_UINT32 c_CapabilityFlags_Profiling_Calls           = 0x00000100;
-        static const CLR_UINT32 c_CapabilityFlags_ThreadCreateEx            = 0x00000400;
-        static const CLR_UINT32 c_CapabilityFlags_ConfigBlockRequiresErase  = 0x00000800;
-        static const CLR_UINT32 c_CapabilityFlags_HasNanoBooter             = 0x00001000;
-        static const CLR_UINT32 c_CapabilityFlags_PlatformCapabiliy_0       = 0x00010000;
-        static const CLR_UINT32 c_CapabilityFlags_PlatformCapabiliy_1       = 0x00020000;
-        static const CLR_UINT32 c_CapabilityFlags_TargetCapabiliy_0         = 0x00040000;
-        static const CLR_UINT32 c_CapabilityFlags_TargetCapabiliy_1         = 0x00080000;
+        static const CLR_UINT32 c_CapabilityFlags_FloatingPoint = 0x00000001;
+        static const CLR_UINT32 c_CapabilityFlags_SourceLevelDebugging = 0x00000002;
+        static const CLR_UINT32 c_CapabilityFlags_AppDomains = 0x00000004;
+        static const CLR_UINT32 c_CapabilityFlags_ExceptionFilters = 0x00000008;
+        static const CLR_UINT32 c_CapabilityFlags_IncrementalDeployment = 0x00000010;
+        static const CLR_UINT32 c_CapabilityFlags_SoftReboot = 0x00000020;
+        static const CLR_UINT32 c_CapabilityFlags_Profiling = 0x00000040;
+        static const CLR_UINT32 c_CapabilityFlags_Profiling_Allocations = 0x00000080;
+        static const CLR_UINT32 c_CapabilityFlags_Profiling_Calls = 0x00000100;
+        static const CLR_UINT32 c_CapabilityFlags_ThreadCreateEx = 0x00000400;
+        static const CLR_UINT32 c_CapabilityFlags_ConfigBlockRequiresErase = 0x00000800;
+        static const CLR_UINT32 c_CapabilityFlags_HasNanoBooter = 0x00001000;
+        static const CLR_UINT32 c_CapabilityFlags_PlatformCapabiliy_0 = 0x00010000;
+        static const CLR_UINT32 c_CapabilityFlags_PlatformCapabiliy_1 = 0x00020000;
+        static const CLR_UINT32 c_CapabilityFlags_TargetCapabiliy_0 = 0x00040000;
+        static const CLR_UINT32 c_CapabilityFlags_TargetCapabiliy_1 = 0x00080000;
 
         CLR_UINT32 m_cmd;
 
         struct __nfpack SoftwareVersion
         {
-            char BuildDate[ 22 ];
+            char BuildDate[22];
             char CompilerInfo[16];
             unsigned int CompilerVersion;
         };
@@ -306,26 +229,24 @@ struct CLR_DBG_Commands
         struct __nfpack ClrInfo
         {
             NFReleaseInfo m_clrReleaseInfo;
-            NFVersion     m_TargetFrameworkVersion;
+            NFVersion m_TargetFrameworkVersion;
         };
-        
+
         struct __nfpack NativeAssemblyDetails
         {
             uint32_t CheckSum;
             NFVersion Version;
             uint8_t AssemblyName[128];
-
         };
 
-        union ReplyUnion
-        {
-            CLR_UINT32          u_capsFlags;
-            SoftwareVersion     u_SoftwareVersion;
-            HalSystemInfo       u_HalSystemInfo;
-            ClrInfo             u_ClrInfo;
-            NFReleaseInfo       u_TargetReleaseInfo;
-        };        
-    };    
+        union ReplyUnion {
+            CLR_UINT32 u_capsFlags;
+            SoftwareVersion u_SoftwareVersion;
+            HalSystemInfo u_HalSystemInfo;
+            ClrInfo u_ClrInfo;
+            NFReleaseInfo u_TargetReleaseInfo;
+        };
+    };
 
     //--//
 
@@ -335,7 +256,7 @@ struct CLR_DBG_Commands
 
         struct Reply
         {
-            CLR_UINT32                         m_found;
+            CLR_UINT32 m_found;
             CLR_RT_HeapBlock_EndPoint::Address m_addr;
         };
     };
@@ -343,11 +264,11 @@ struct CLR_DBG_Commands
     struct Debugging_Messaging_Send
     {
         CLR_RT_HeapBlock_EndPoint::Address m_addr;
-        unsigned char                              m_data[ 1 ];
+        unsigned char m_data[1];
 
         struct Reply
         {
-            CLR_UINT32                         m_found;
+            CLR_UINT32 m_found;
             CLR_RT_HeapBlock_EndPoint::Address m_addr;
         };
     };
@@ -355,17 +276,16 @@ struct CLR_DBG_Commands
     struct Debugging_Messaging_Reply
     {
         CLR_RT_HeapBlock_EndPoint::Address m_addr;
-        unsigned char                              m_data[ 1 ];
+        unsigned char m_data[1];
 
         struct Reply
         {
-            CLR_UINT32                         m_found;
+            CLR_UINT32 m_found;
             CLR_RT_HeapBlock_EndPoint::Address m_addr;
         };
     };
 
     //--//
-    
 
     struct Debugging_Execution_BasePtr
     {
@@ -388,7 +308,7 @@ struct CLR_DBG_Commands
 
     struct Debugging_Execution_SecurityKey
     {
-        CLR_UINT8 m_key[ 32 ];
+        CLR_UINT8 m_key[32];
     };
 
     struct Debugging_Execution_Allocate
@@ -411,8 +331,7 @@ struct CLR_DBG_Commands
         };
     };
 
-
-    //struct Debugging_MFUpdate_Start
+    // struct Debugging_MFUpdate_Start
     //{
     //    char       m_provider[64];
     //    CLR_UINT32 m_updateId;
@@ -429,7 +348,7 @@ struct CLR_DBG_Commands
     //    };
     //};
 
-    //struct Debugging_MFUpdate_AuthCommand
+    // struct Debugging_MFUpdate_AuthCommand
     //{
     //    CLR_UINT32 m_updateHandle;
     //    CLR_UINT32 m_authCommand;
@@ -444,7 +363,7 @@ struct CLR_DBG_Commands
     //    };
     //};
 
-    //struct Debugging_MFUpdate_Authenticate
+    // struct Debugging_MFUpdate_Authenticate
     //{
     //    CLR_UINT32 m_updateHandle;
     //    CLR_UINT32 m_authenticationLen;
@@ -456,10 +375,10 @@ struct CLR_DBG_Commands
     //    };
     //};
 
-    //struct Debugging_MFUpdate_GetMissingPkts
+    // struct Debugging_MFUpdate_GetMissingPkts
     //{
     //    CLR_UINT32 m_updateHandle;
-    //    
+    //
     //    struct Reply
     //    {
     //        CLR_INT32 m_success;
@@ -468,7 +387,7 @@ struct CLR_DBG_Commands
     //    };
     //};
 
-    //struct Debugging_MFUpdate_AddPacket
+    // struct Debugging_MFUpdate_AddPacket
     //{
     //    CLR_INT32 m_updateHandle;
     //    CLR_UINT32 m_packetIndex;
@@ -482,7 +401,7 @@ struct CLR_DBG_Commands
     //    };
     //};
 
-    //struct Debugging_MFUpdate_Install
+    // struct Debugging_MFUpdate_Install
     //{
     //    CLR_INT32 m_updateHandle;
     //    CLR_UINT32 m_updateValidationSize;
@@ -493,73 +412,71 @@ struct CLR_DBG_Commands
     //        CLR_UINT32 m_success;
     //    };
     //};
-    
 
     struct Debugging_Execution_BreakpointDef
     {
-        static const CLR_UINT16 c_STEP_IN            = 0x0001;
-        static const CLR_UINT16 c_STEP_OVER          = 0x0002;
-        static const CLR_UINT16 c_STEP_OUT           = 0x0004;
-        static const CLR_UINT16 c_HARD               = 0x0008;
-        static const CLR_UINT16 c_EXCEPTION_THROWN   = 0x0010;
-        static const CLR_UINT16 c_EXCEPTION_CAUGHT   = 0x0020;
+        static const CLR_UINT16 c_STEP_IN = 0x0001;
+        static const CLR_UINT16 c_STEP_OVER = 0x0002;
+        static const CLR_UINT16 c_STEP_OUT = 0x0004;
+        static const CLR_UINT16 c_HARD = 0x0008;
+        static const CLR_UINT16 c_EXCEPTION_THROWN = 0x0010;
+        static const CLR_UINT16 c_EXCEPTION_CAUGHT = 0x0020;
         static const CLR_UINT16 c_EXCEPTION_UNCAUGHT = 0x0040;
-        static const CLR_UINT16 c_THREAD_TERMINATED  = 0x0080;
-        static const CLR_UINT16 c_THREAD_CREATED     = 0x0100;
-        static const CLR_UINT16 c_ASSEMBLIES_LOADED  = 0x0200;
-        static const CLR_UINT16 c_LAST_BREAKPOINT    = 0x0400;
-        static const CLR_UINT16 c_STEP_JMC           = 0x0800;
-        static const CLR_UINT16 c_BREAK              = 0x1000;
-        static const CLR_UINT16 c_EVAL_COMPLETE      = 0x2000;
-        static const CLR_UINT16 c_EXCEPTION_UNWIND   = 0x4000;
-        static const CLR_UINT16 c_EXCEPTION_FINALLY  = 0x8000;
+        static const CLR_UINT16 c_THREAD_TERMINATED = 0x0080;
+        static const CLR_UINT16 c_THREAD_CREATED = 0x0100;
+        static const CLR_UINT16 c_ASSEMBLIES_LOADED = 0x0200;
+        static const CLR_UINT16 c_LAST_BREAKPOINT = 0x0400;
+        static const CLR_UINT16 c_STEP_JMC = 0x0800;
+        static const CLR_UINT16 c_BREAK = 0x1000;
+        static const CLR_UINT16 c_EVAL_COMPLETE = 0x2000;
+        static const CLR_UINT16 c_EXCEPTION_UNWIND = 0x4000;
+        static const CLR_UINT16 c_EXCEPTION_FINALLY = 0x8000;
 
-        static const CLR_UINT16 c_STEP               = c_STEP_IN | c_STEP_OVER | c_STEP_OUT;
+        static const CLR_UINT16 c_STEP = c_STEP_IN | c_STEP_OVER | c_STEP_OUT;
 
-        static const CLR_INT32 c_PID_ANY             = 0x7FFFFFFF;
+        static const CLR_INT32 c_PID_ANY = 0x7FFFFFFF;
 
-        static const CLR_UINT32 c_DEPTH_EXCEPTION_FIRST_CHANCE    = 0x00000000;
-        static const CLR_UINT32 c_DEPTH_EXCEPTION_USERS_CHANCE    = 0x00000001;
-        static const CLR_UINT32 c_DEPTH_EXCEPTION_HANDLER_FOUND   = 0x00000002;
+        static const CLR_UINT32 c_DEPTH_EXCEPTION_FIRST_CHANCE = 0x00000000;
+        static const CLR_UINT32 c_DEPTH_EXCEPTION_USERS_CHANCE = 0x00000001;
+        static const CLR_UINT32 c_DEPTH_EXCEPTION_HANDLER_FOUND = 0x00000002;
 
-        static const CLR_UINT32 c_DEPTH_STEP_NORMAL               = 0x00000010;
-        static const CLR_UINT32 c_DEPTH_STEP_RETURN               = 0x00000020;
-        static const CLR_UINT32 c_DEPTH_STEP_CALL                 = 0x00000030;
-        static const CLR_UINT32 c_DEPTH_STEP_EXCEPTION_FILTER     = 0x00000040;
-        static const CLR_UINT32 c_DEPTH_STEP_EXCEPTION_HANDLER    = 0x00000050;
-        static const CLR_UINT32 c_DEPTH_STEP_INTERCEPT            = 0x00000060;
-        static const CLR_UINT32 c_DEPTH_STEP_EXIT                 = 0x00000070;
+        static const CLR_UINT32 c_DEPTH_STEP_NORMAL = 0x00000010;
+        static const CLR_UINT32 c_DEPTH_STEP_RETURN = 0x00000020;
+        static const CLR_UINT32 c_DEPTH_STEP_CALL = 0x00000030;
+        static const CLR_UINT32 c_DEPTH_STEP_EXCEPTION_FILTER = 0x00000040;
+        static const CLR_UINT32 c_DEPTH_STEP_EXCEPTION_HANDLER = 0x00000050;
+        static const CLR_UINT32 c_DEPTH_STEP_INTERCEPT = 0x00000060;
+        static const CLR_UINT32 c_DEPTH_STEP_EXIT = 0x00000070;
 
-        static const CLR_UINT32 c_DEPTH_UNCAUGHT                  = 0xFFFFFFFF;
+        static const CLR_UINT32 c_DEPTH_UNCAUGHT = 0xFFFFFFFF;
 
+        CLR_UINT16 m_id;
+        CLR_UINT16 m_flags;
 
-        CLR_UINT16             m_id;
-        CLR_UINT16             m_flags;
-
-        CLR_INT32              m_pid;
-        CLR_UINT32             m_depth;
+        CLR_INT32 m_pid;
+        CLR_UINT32 m_depth;
 
         //
         // m_IPStart, m_IPEnd are used for optimizing stepping operations.
         // A STEP_IN | STEP_OVER breakpoint will be hit in the given stack frame
         // only if the IP is outside of the given range [m_IPStart m_IPEnd).
         //
-        CLR_UINT32             m_IPStart;
-        CLR_UINT32             m_IPEnd;
+        CLR_UINT32 m_IPStart;
+        CLR_UINT32 m_IPEnd;
 
         CLR_RT_MethodDef_Index m_md;
-        CLR_UINT32             m_IP;
+        CLR_UINT32 m_IP;
 
-        CLR_RT_TypeDef_Index   m_td;
+        CLR_RT_TypeDef_Index m_td;
 
-        CLR_UINT32             m_depthExceptionHandler;
+        CLR_UINT32 m_depthExceptionHandler;
     };
 
     struct Debugging_Execution_Breakpoints
     {
-        CLR_UINT32                        m_flags;
+        CLR_UINT32 m_flags;
 
-        Debugging_Execution_BreakpointDef m_data[ 1 ];
+        Debugging_Execution_BreakpointDef m_data[1];
     };
 
     struct Debugging_Execution_BreakpointHit
@@ -585,8 +502,8 @@ struct CLR_DBG_Commands
     struct Debugging_Thread_CreateEx
     {
         CLR_RT_MethodDef_Index m_md;
-        int                    m_scratchPad;
-        CLR_UINT32             m_pid;
+        int m_scratchPad;
+        CLR_UINT32 m_pid;
 
         struct Reply
         {
@@ -601,7 +518,7 @@ struct CLR_DBG_Commands
         struct Reply
         {
             CLR_UINT32 m_num;
-            CLR_UINT32 m_pids[ 1 ];
+            CLR_UINT32 m_pids[1];
         };
     };
 
@@ -616,18 +533,17 @@ struct CLR_DBG_Commands
             struct Call
             {
                 CLR_RT_MethodDef_Index m_md;
-                CLR_UINT32             m_IP;
+                CLR_UINT32 m_IP;
 #if defined(NANOCLR_APPDOMAINS)
-                CLR_UINT32             m_appDomainID;
-                CLR_UINT32             m_flags;
+                CLR_UINT32 m_appDomainID;
+                CLR_UINT32 m_flags;
 #endif
-
             };
 
             CLR_UINT32 m_num;
             CLR_UINT32 m_status;
             CLR_UINT32 m_flags;
-            Call       m_data[ 1 ];
+            Call m_data[1];
         };
     };
 
@@ -685,10 +601,10 @@ struct CLR_DBG_Commands
         struct Reply
         {
             CLR_RT_MethodDef_Index m_md;
-            CLR_UINT32             m_IP;
-            CLR_UINT32             m_numOfArguments;
-            CLR_UINT32             m_numOfLocals;
-            CLR_UINT32             m_depthOfEvalStack;
+            CLR_UINT32 m_IP;
+            CLR_UINT32 m_numOfArguments;
+            CLR_UINT32 m_numOfLocals;
+            CLR_UINT32 m_depthOfEvalStack;
         };
     };
 
@@ -705,39 +621,39 @@ struct CLR_DBG_Commands
 
     struct Debugging_Value
     {
-        CLR_RT_HeapBlock*       m_referenceID;
-        CLR_UINT32              m_dt;                // CLR_RT_HeapBlock::DataType ()
-        CLR_UINT32              m_flags;             // CLR_RT_HeapBlock::DataFlags()
-        CLR_UINT32              m_size;              // CLR_RT_HeapBlock::DataSize ()
+        CLR_RT_HeapBlock *m_referenceID;
+        CLR_UINT32 m_dt;    // CLR_RT_HeapBlock::DataType ()
+        CLR_UINT32 m_flags; // CLR_RT_HeapBlock::DataFlags()
+        CLR_UINT32 m_size;  // CLR_RT_HeapBlock::DataSize ()
 
         //
         // For primitive types
         //
-        CLR_UINT8               m_builtinValue[ 128 ]; // Space for string preview...
+        CLR_UINT8 m_builtinValue[128]; // Space for string preview...
 
         //
         // For DATATYPE_STRING
         //
-        CLR_UINT32              m_bytesInString;
-        const char*                  m_charsInString;
+        CLR_UINT32 m_bytesInString;
+        const char *m_charsInString;
 
         //
         // For DATATYPE_VALUETYPE or DATATYPE_CLASSTYPE
         //
-        CLR_RT_TypeDef_Index    m_td;
+        CLR_RT_TypeDef_Index m_td;
 
         //
         // For DATATYPE_SZARRAY
         //
-        CLR_UINT32              m_array_numOfElements;
-        CLR_UINT32              m_array_depth;
-        CLR_RT_TypeDef_Index    m_array_typeIndex;
+        CLR_UINT32 m_array_numOfElements;
+        CLR_UINT32 m_array_depth;
+        CLR_RT_TypeDef_Index m_array_typeIndex;
 
         //
         // For values from an array.
         //
-        CLR_RT_HeapBlock_Array* m_arrayref_referenceID;
-        CLR_UINT32              m_arrayref_index;
+        CLR_RT_HeapBlock_Array *m_arrayref_referenceID;
+        CLR_UINT32 m_arrayref_index;
     };
 
     struct Debugging_Value_ResizeScratchPad
@@ -747,15 +663,14 @@ struct CLR_DBG_Commands
 
     struct Debugging_Value_GetStack
     {
-        static const CLR_UINT32 c_Local     = 0;
-        static const CLR_UINT32 c_Argument  = 1;
+        static const CLR_UINT32 c_Local = 0;
+        static const CLR_UINT32 c_Argument = 1;
         static const CLR_UINT32 c_EvalStack = 2;
 
         CLR_UINT32 m_pid;
         CLR_UINT32 m_depth;
         CLR_UINT32 m_kind;
         CLR_UINT32 m_index;
-
 
         //
         // The reply is an array of Debugging_Value
@@ -764,10 +679,9 @@ struct CLR_DBG_Commands
 
     struct Debugging_Value_GetField
     {
-        CLR_RT_HeapBlock*     m_heapblock;
-        CLR_UINT32            m_offset;
+        CLR_RT_HeapBlock *m_heapblock;
+        CLR_UINT32 m_offset;
         CLR_RT_FieldDef_Index m_fd;
-
 
         //
         // The reply is an array of Debugging_Value
@@ -776,9 +690,8 @@ struct CLR_DBG_Commands
 
     struct Debugging_Value_GetArray
     {
-        CLR_RT_HeapBlock* m_heapblock;
-        CLR_UINT32        m_index;
-
+        CLR_RT_HeapBlock *m_heapblock;
+        CLR_UINT32 m_index;
 
         //
         // The reply is an array of Debugging_Value
@@ -787,8 +700,7 @@ struct CLR_DBG_Commands
 
     struct Debugging_Value_GetBlock
     {
-        CLR_RT_HeapBlock* m_heapblock;
-
+        CLR_RT_HeapBlock *m_heapblock;
 
         //
         // The reply is an array of Debugging_Value
@@ -799,7 +711,6 @@ struct CLR_DBG_Commands
     {
         CLR_UINT32 m_idx;
 
-
         //
         // The reply is an array of Debugging_Value
         //
@@ -807,23 +718,23 @@ struct CLR_DBG_Commands
 
     struct Debugging_Value_SetBlock
     {
-        CLR_RT_HeapBlock* m_heapblock;
-        CLR_UINT32        m_dt;                // CLR_RT_HeapBlock::DataType ()
-        CLR_UINT8         m_builtinValue[ 8 ];
+        CLR_RT_HeapBlock *m_heapblock;
+        CLR_UINT32 m_dt; // CLR_RT_HeapBlock::DataType ()
+        CLR_UINT8 m_builtinValue[8];
     };
 
     struct Debugging_Value_SetArray
     {
-        CLR_RT_HeapBlock_Array* m_heapblock;
-        CLR_UINT32              m_index;
-        CLR_UINT8               m_builtinValue[ 8 ];
+        CLR_RT_HeapBlock_Array *m_heapblock;
+        CLR_UINT32 m_index;
+        CLR_UINT8 m_builtinValue[8];
     };
 
     //--//
 
     struct Debugging_Value_AllocateObject
     {
-        int                  m_index;
+        int m_index;
         CLR_RT_TypeDef_Index m_td;
 
         //
@@ -833,7 +744,7 @@ struct CLR_DBG_Commands
 
     struct Debugging_Value_AllocateString
     {
-        int        m_index;
+        int m_index;
         CLR_UINT32 m_size;
 
         //
@@ -843,10 +754,10 @@ struct CLR_DBG_Commands
 
     struct Debugging_Value_AllocateArray
     {
-        int                  m_index;
+        int m_index;
         CLR_RT_TypeDef_Index m_td;
-        CLR_UINT32           m_depth;
-        CLR_UINT32           m_numOfElements;
+        CLR_UINT32 m_depth;
+        CLR_UINT32 m_numOfElements;
 
         //
         // The reply is an array of Debugging_Value
@@ -855,8 +766,8 @@ struct CLR_DBG_Commands
 
     struct Debugging_Value_Assign
     {
-        CLR_RT_HeapBlock* m_heapblockSrc;
-        CLR_RT_HeapBlock* m_heapblockDst;
+        CLR_RT_HeapBlock *m_heapblockSrc;
+        CLR_RT_HeapBlock *m_heapblockDst;
 
         //
         // The reply is an array of Debugging_Value
@@ -866,7 +777,7 @@ struct CLR_DBG_Commands
     //--//
 
     struct Debugging_TypeSys_Assemblies
-    {        
+    {
         //
         // The reply is just an array of CLR_RT_Assembly_Index.
         //
@@ -877,32 +788,32 @@ struct CLR_DBG_Commands
         //
         // The reply is just an array of AppDomainIDs
         //
-    };    
+    };
 
     //--//
 
     struct Debugging_Resolve_AppDomain
-    {        
-        CLR_UINT32 m_id;        
+    {
+        CLR_UINT32 m_id;
 
         struct Reply
         {
             CLR_UINT32 m_state;
-            char       m_szName[ 512 ];
-            CLR_UINT32 m_assemblies[ 1 ]; //Array of CLR_RT_Assembly_Index
+            char m_szName[512];
+            CLR_UINT32 m_assemblies[1]; // Array of CLR_RT_Assembly_Index
         };
     };
 
     struct Debugging_Resolve_Assembly
     {
-         CLR_RT_Assembly_Index m_idx;
+        CLR_RT_Assembly_Index m_idx;
 
-         struct Reply
-         {
-              CLR_UINT32         m_flags;
-              CLR_RECORD_VERSION m_version;
-              char               m_szName[ 512 ];
-         };
+        struct Reply
+        {
+            CLR_UINT32 m_flags;
+            CLR_RECORD_VERSION m_version;
+            char m_szName[512];
+        };
     };
 
     struct Debugging_Resolve_Type
@@ -911,7 +822,7 @@ struct CLR_DBG_Commands
 
         struct Reply
         {
-            char m_type[ 512 ];
+            char m_type[512];
         };
     };
 
@@ -922,8 +833,8 @@ struct CLR_DBG_Commands
         struct Reply
         {
             CLR_RT_TypeDef_Index m_td;
-            CLR_UINT32           m_index;
-            char                 m_name[ 512 ];
+            CLR_UINT32 m_index;
+            char m_name[512];
         };
     };
 
@@ -934,14 +845,14 @@ struct CLR_DBG_Commands
         struct Reply
         {
             CLR_RT_TypeDef_Index m_td;
-            char                 m_method[ 512 ];
+            char m_method[512];
         };
     };
 
     struct Debugging_Resolve_VirtualMethod
     {
         CLR_RT_MethodDef_Index m_md;
-        CLR_RT_HeapBlock*      m_obj;
+        CLR_RT_HeapBlock *m_obj;
 
         struct Reply
         {
@@ -952,7 +863,7 @@ struct CLR_DBG_Commands
     //--//
 
     struct Debugging_Deployment_Status
-    {    
+    {
         struct FlashSector
         {
             CLR_UINT32 Start;
@@ -964,7 +875,7 @@ struct CLR_DBG_Commands
             CLR_UINT32 EntryPoint;
             CLR_UINT32 StorageStart;
             CLR_UINT32 StorageLength;
-            
+
             // FlashSector SectorData[ 1 ];
         };
     };
@@ -974,21 +885,20 @@ struct CLR_DBG_Commands
     struct Debugging_Info_SetJMC
     {
         CLR_UINT32 m_fIsJMC;
-        CLR_UINT32 m_kind;    // CLR_ReflectionType
+        CLR_UINT32 m_kind; // CLR_ReflectionType
 
-        union
-        {
-            CLR_RT_Assembly_Index  m_assm;
-            CLR_RT_TypeDef_Index   m_type;
+        union {
+            CLR_RT_Assembly_Index m_assm;
+            CLR_RT_TypeDef_Index m_type;
             CLR_RT_MethodDef_Index m_method;
-            CLR_UINT32             m_raw;
+            CLR_UINT32 m_raw;
         } m_data;
     };
 
     struct Profiling_Command
     {
         static const CLR_UINT8 c_Command_ChangeConditions = 0x01;
-        static const CLR_UINT8 c_Command_FlushStream      = 0x02;
+        static const CLR_UINT8 c_Command_FlushStream = 0x02;
 
         CLR_UINT8 m_command;
 
@@ -1009,15 +919,13 @@ struct CLR_DBG_Commands
         CLR_UINT16 m_seqId;
         CLR_UINT16 m_bitLen;
     };
-    
 };
 //#endif
 
 struct CLR_DBG_Debugger
 {
-    CLR_Messaging*              m_messaging;
-    static BlockStorageDevice*  m_deploymentStorageDevice;
-
+    CLR_Messaging *m_messaging;
+    static BlockStorageDevice *m_deploymentStorageDevice;
 
     //--//
 
@@ -1026,135 +934,131 @@ struct CLR_DBG_Debugger
 
     static HRESULT CreateInstance();
 
-    HRESULT Debugger_Initialize( COM_HANDLE port );
+    HRESULT Debugger_Initialize(COM_HANDLE port);
 
     static HRESULT DeleteInstance();
 
     void Debugger_Cleanup();
 
-    static void BroadcastEvent( unsigned int cmd, unsigned int payloadSize, unsigned char* payload, unsigned int flags );
+    static void BroadcastEvent(unsigned int cmd, unsigned int payloadSize, unsigned char *payload, unsigned int flags);
 
-    void PurgeCache     ();
+    void PurgeCache();
 
-private:
+  private:
+    bool CheckPermission(ByteAddress address, int mode);
 
-    bool CheckPermission( ByteAddress address, int mode );
-
-    void AccessMemory( uint32_t location, uint32_t lengthInBytes, uint8_t* buf, uint32_t mode, uint32_t* errorCode );
+    void AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t *buf, uint32_t mode, uint32_t *errorCode);
 
 #if defined(NANOCLR_APPDOMAINS)
-    CLR_RT_AppDomain*  GetAppDomainFromID ( CLR_UINT32 id );
+    CLR_RT_AppDomain *GetAppDomainFromID(CLR_UINT32 id);
 #endif
 
-    CLR_RT_StackFrame* CheckStackFrame    ( CLR_INT32 pid, CLR_UINT32 depth, bool& isInline                                        );
-    HRESULT            CreateListOfThreads(                 CLR_DBG_Commands::Debugging_Thread_List ::Reply*& cmdReply, int& totLen );
-    HRESULT            CreateListOfCalls  ( CLR_INT32 pid, CLR_DBG_Commands::Debugging_Thread_Stack::Reply*& cmdReply, int& totLen );
+    CLR_RT_StackFrame *CheckStackFrame(CLR_INT32 pid, CLR_UINT32 depth, bool &isInline);
+    HRESULT CreateListOfThreads(CLR_DBG_Commands::Debugging_Thread_List ::Reply *&cmdReply, int &totLen);
+    HRESULT CreateListOfCalls(CLR_INT32 pid, CLR_DBG_Commands::Debugging_Thread_Stack::Reply *&cmdReply, int &totLen);
 
-    CLR_RT_Assembly*   IsGoodAssembly( CLR_IDX                       idxAssm                                  );
-    bool               CheckTypeDef  ( const CLR_RT_TypeDef_Index&   td     , CLR_RT_TypeDef_Instance&   inst );
-    bool               CheckFieldDef ( const CLR_RT_FieldDef_Index&  fd     , CLR_RT_FieldDef_Instance&  inst );
-    bool               CheckMethodDef( const CLR_RT_MethodDef_Index& md     , CLR_RT_MethodDef_Instance& inst );
+    CLR_RT_Assembly *IsGoodAssembly(CLR_IDX idxAssm);
+    bool CheckTypeDef(const CLR_RT_TypeDef_Index &td, CLR_RT_TypeDef_Instance &inst);
+    bool CheckFieldDef(const CLR_RT_FieldDef_Index &fd, CLR_RT_FieldDef_Instance &inst);
+    bool CheckMethodDef(const CLR_RT_MethodDef_Index &md, CLR_RT_MethodDef_Instance &inst);
 
-    bool               GetValue( WP_Message* msg, CLR_RT_HeapBlock* ptr, CLR_RT_HeapBlock* reference, CLR_RT_TypeDef_Instance* pTD );
+    bool GetValue(WP_Message *msg, CLR_RT_HeapBlock *ptr, CLR_RT_HeapBlock *reference, CLR_RT_TypeDef_Instance *pTD);
 
-    bool AllocateAndQueueMessage( CLR_UINT32 cmd, unsigned int length, unsigned char* data, CLR_RT_HeapBlock_EndPoint::Port port, CLR_RT_HeapBlock_EndPoint::Address addr, CLR_UINT32 found );
+    bool AllocateAndQueueMessage(
+        CLR_UINT32 cmd,
+        unsigned int length,
+        unsigned char *data,
+        CLR_RT_HeapBlock_EndPoint::Port port,
+        CLR_RT_HeapBlock_EndPoint::Address addr,
+        CLR_UINT32 found);
 
-    bool ProcessHeader                           ( WP_Message* msg );
-    bool ProcessPayload                          ( WP_Message* msg );
+    bool ProcessHeader(WP_Message *msg);
+    bool ProcessPayload(WP_Message *msg);
 
-       
-public:  
-    static CLR_RT_Thread* GetThreadFromPid ( CLR_INT32 pid );
+  public:
+    static CLR_RT_Thread *GetThreadFromPid(CLR_INT32 pid);
 
-    static bool Monitor_Ping                            ( WP_Message* msg );
-    static bool Monitor_Reboot                          ( WP_Message* msg );
-    static bool Debugging_Execution_QueryCLRCapabilities( WP_Message* msg );
+    static bool Monitor_Ping(WP_Message *msg);
+    static bool Monitor_Reboot(WP_Message *msg);
+    static bool Debugging_Execution_QueryCLRCapabilities(WP_Message *msg);
 
-    static bool Monitor_ReadMemory                      ( WP_Message* msg );
-    static bool Monitor_WriteMemory                     ( WP_Message* msg );
-    static bool Monitor_CheckMemory                     ( WP_Message* msg );
-    static bool Monitor_EraseMemory                     ( WP_Message* msg );
-    static bool Monitor_Execute                         ( WP_Message* msg );
-    static bool Monitor_MemoryMap                       ( WP_Message* msg );
-    static bool Monitor_FlashSectorMap                  ( WP_Message* msg );
-    static bool Monitor_DeploymentMap                   ( WP_Message* msg );
-    static bool Monitor_QueryConfiguration              ( WP_Message* msg );
-    static bool Monitor_UpdateConfiguration             ( WP_Message* msg );
+    static bool Monitor_ReadMemory(WP_Message *msg);
+    static bool Monitor_WriteMemory(WP_Message *msg);
+    static bool Monitor_CheckMemory(WP_Message *msg);
+    static bool Monitor_EraseMemory(WP_Message *msg);
+    static bool Monitor_Execute(WP_Message *msg);
+    static bool Monitor_MemoryMap(WP_Message *msg);
+    static bool Monitor_FlashSectorMap(WP_Message *msg);
+    static bool Monitor_DeploymentMap(WP_Message *msg);
+    static bool Monitor_QueryConfiguration(WP_Message *msg);
+    static bool Monitor_UpdateConfiguration(WP_Message *msg);
 
-                                             
-    static bool Debugging_Execution_BasePtr             ( WP_Message* msg );
-    static bool Debugging_Execution_ChangeConditions    ( WP_Message* msg );
+    static bool Debugging_Execution_BasePtr(WP_Message *msg);
+    static bool Debugging_Execution_ChangeConditions(WP_Message *msg);
 
-    static bool Debugging_Execution_Allocate            ( WP_Message* msg );
+    static bool Debugging_Execution_Allocate(WP_Message *msg);
 
-    static bool Debugging_UpgradeToSsl                  ( WP_Message* msg );
-
-
-
-
-
-
-
+    static bool Debugging_UpgradeToSsl(WP_Message *msg);
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-    static bool Debugging_Execution_Breakpoints         ( WP_Message* msg );
-    static bool Debugging_Execution_BreakpointStatus    ( WP_Message* msg );
-    static bool Debugging_Execution_SetCurrentAppDomain ( WP_Message* msg );
+    static bool Debugging_Execution_Breakpoints(WP_Message *msg);
+    static bool Debugging_Execution_BreakpointStatus(WP_Message *msg);
+    static bool Debugging_Execution_SetCurrentAppDomain(WP_Message *msg);
 
-    static bool Debugging_Thread_CreateEx               ( WP_Message* msg );
-    static bool Debugging_Thread_List                   ( WP_Message* msg );
-    static bool Debugging_Thread_Stack                  ( WP_Message* msg );
-    static bool Debugging_Thread_Kill                   ( WP_Message* msg );
-    static bool Debugging_Thread_Suspend                ( WP_Message* msg );
-    static bool Debugging_Thread_Resume                 ( WP_Message* msg );
-    static bool Debugging_Thread_GetException           ( WP_Message* msg );
-    static bool Debugging_Thread_Unwind                 ( WP_Message* msg );
-    static bool Debugging_Thread_Get                    ( WP_Message* msg );
-                                             
-    static bool Debugging_Stack_Info                    ( WP_Message* msg );
-    static bool Debugging_Stack_SetIP                   ( WP_Message* msg );
-                                             
-    static bool Debugging_Value_ResizeScratchPad        ( WP_Message* msg );
-    static bool Debugging_Value_GetStack                ( WP_Message* msg );
-    static bool Debugging_Value_GetField                ( WP_Message* msg );
-    static bool Debugging_Value_GetArray                ( WP_Message* msg );
-    static bool Debugging_Value_GetBlock                ( WP_Message* msg );
-    static bool Debugging_Value_GetScratchPad           ( WP_Message* msg );
-    static bool Debugging_Value_SetBlock                ( WP_Message* msg );
-    static bool Debugging_Value_SetArray                ( WP_Message* msg );
-    static bool Debugging_Value_AllocateObject          ( WP_Message* msg );
-    static bool Debugging_Value_AllocateString          ( WP_Message* msg );
-    static bool Debugging_Value_AllocateArray           ( WP_Message* msg );
-    static bool Debugging_Value_Assign                  ( WP_Message* msg );
-                                             
-    static bool Debugging_TypeSys_Assemblies            ( WP_Message* msg );
-    static bool Debugging_TypeSys_AppDomains            ( WP_Message* msg );
-                                             
-    static bool Debugging_Resolve_AppDomain             ( WP_Message* msg );
-    static bool Debugging_Resolve_Assembly              ( WP_Message* msg );
-    static bool Debugging_Resolve_Type                  ( WP_Message* msg );
-    static bool Debugging_Resolve_Field                 ( WP_Message* msg );
-    static bool Debugging_Resolve_Method                ( WP_Message* msg );
-    static bool Debugging_Resolve_VirtualMethod         ( WP_Message* msg );
+    static bool Debugging_Thread_CreateEx(WP_Message *msg);
+    static bool Debugging_Thread_List(WP_Message *msg);
+    static bool Debugging_Thread_Stack(WP_Message *msg);
+    static bool Debugging_Thread_Kill(WP_Message *msg);
+    static bool Debugging_Thread_Suspend(WP_Message *msg);
+    static bool Debugging_Thread_Resume(WP_Message *msg);
+    static bool Debugging_Thread_GetException(WP_Message *msg);
+    static bool Debugging_Thread_Unwind(WP_Message *msg);
+    static bool Debugging_Thread_Get(WP_Message *msg);
+
+    static bool Debugging_Stack_Info(WP_Message *msg);
+    static bool Debugging_Stack_SetIP(WP_Message *msg);
+
+    static bool Debugging_Value_ResizeScratchPad(WP_Message *msg);
+    static bool Debugging_Value_GetStack(WP_Message *msg);
+    static bool Debugging_Value_GetField(WP_Message *msg);
+    static bool Debugging_Value_GetArray(WP_Message *msg);
+    static bool Debugging_Value_GetBlock(WP_Message *msg);
+    static bool Debugging_Value_GetScratchPad(WP_Message *msg);
+    static bool Debugging_Value_SetBlock(WP_Message *msg);
+    static bool Debugging_Value_SetArray(WP_Message *msg);
+    static bool Debugging_Value_AllocateObject(WP_Message *msg);
+    static bool Debugging_Value_AllocateString(WP_Message *msg);
+    static bool Debugging_Value_AllocateArray(WP_Message *msg);
+    static bool Debugging_Value_Assign(WP_Message *msg);
+
+    static bool Debugging_TypeSys_Assemblies(WP_Message *msg);
+    static bool Debugging_TypeSys_AppDomains(WP_Message *msg);
+
+    static bool Debugging_Resolve_AppDomain(WP_Message *msg);
+    static bool Debugging_Resolve_Assembly(WP_Message *msg);
+    static bool Debugging_Resolve_Type(WP_Message *msg);
+    static bool Debugging_Resolve_Field(WP_Message *msg);
+    static bool Debugging_Resolve_Method(WP_Message *msg);
+    static bool Debugging_Resolve_VirtualMethod(WP_Message *msg);
 #endif //#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
-    static bool Debugging_Deployment_Status             ( WP_Message* msg );
+    static bool Debugging_Deployment_Status(WP_Message *msg);
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-    static bool Debugging_Info_SetJMC                   ( WP_Message* msg );
-    
-    bool Debugging_Info_SetJMC_Type                     ( const CLR_RT_TypeDef_Index&   idx, bool fJMC );
-    bool Debugging_Info_SetJMC_Method                   ( const CLR_RT_MethodDef_Index& idx, bool fJMC );
+    static bool Debugging_Info_SetJMC(WP_Message *msg);
+
+    bool Debugging_Info_SetJMC_Type(const CLR_RT_TypeDef_Index &idx, bool fJMC);
+    bool Debugging_Info_SetJMC_Method(const CLR_RT_MethodDef_Index &idx, bool fJMC);
 #endif //#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
-    static bool Profiling_Command                       ( WP_Message* msg );
-    bool Profiling_ChangeConditions                     ( WP_Message* msg );
-    bool Profiling_FlushStream                          ( WP_Message* msg );
+    static bool Profiling_Command(WP_Message *msg);
+    bool Profiling_ChangeConditions(WP_Message *msg);
+    bool Profiling_FlushStream(WP_Message *msg);
 };
 
 //--//
 
-extern CLR_DBG_Debugger* g_CLR_DBG_Debugger;
+extern CLR_DBG_Debugger *g_CLR_DBG_Debugger;
 
 //--//
 
@@ -1166,4 +1070,3 @@ extern const CLR_UINT32 c_Debugger_Lookup_Reply_count;
 //--//
 
 #endif // _NANOCLR_DEBUGGING_H_
-

--- a/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
@@ -17,7 +17,7 @@
 //////////////////////////////////////////////////////////////////////
 // helper functions
 
-int NanoBooter_GetReleaseInfo(ReleaseInfo* releaseInfo)
+int NanoBooter_GetReleaseInfo(ReleaseInfo *releaseInfo)
 {
     releaseInfo->version.usMajor = VERSION_MAJOR;
     releaseInfo->version.usMinor = VERSION_MINOR;
@@ -32,12 +32,12 @@ int NanoBooter_GetReleaseInfo(ReleaseInfo* releaseInfo)
     return true;
 }
 
-static int AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t* buffer, int32_t mode, uint32_t* errorCode)
+static int AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t *buffer, int32_t mode, uint32_t *errorCode)
 {
     // reset error code
     *errorCode = AccessMemoryErrorCode_NoError;
-    
-    switch(mode)
+
+    switch (mode)
     {
         case AccessMemory_Write:
             // use FLASH driver to perform write operation
@@ -68,29 +68,28 @@ static int AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t* buff
 
 ////////////////////////////////////////////////////
 
-int Monitor_Ping(WP_Message* message)
+int Monitor_Ping(WP_Message *message)
 {
-    if((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
+    if ((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
         Monitor_Ping_Reply cmdReply;
         cmdReply.m_source = Monitor_Ping_c_Ping_Source_NanoBooter;
         cmdReply.m_dbg_flags = 0;
 
-    #if defined(WP_IMPLEMENTS_CRC32)
-        cmdReply.m_dbg_flags |= Monitor_Ping_c_Ping_WPFlag_SupportsCRC32;    
-    #endif
+#if defined(WP_IMPLEMENTS_CRC32)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_Ping_WPFlag_SupportsCRC32;
+#endif
 
-    // Wire Protocol packet size 
-    #if (WP_PACKET_SIZE == 512)
+// Wire Protocol packet size
+#if (WP_PACKET_SIZE == 512)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0512;
-    #elif (WP_PACKET_SIZE == 256)
+#elif (WP_PACKET_SIZE == 256)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0256;
-    #elif (WP_PACKET_SIZE == 128)
+#elif (WP_PACKET_SIZE == 128)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0128;
-    #elif (WP_PACKET_SIZE == 1024)
+#elif (WP_PACKET_SIZE == 1024)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_1024;
-    #endif
-
+#endif
 
         WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
     }
@@ -98,70 +97,71 @@ int Monitor_Ping(WP_Message* message)
     return true;
 }
 
-int Monitor_OemInfo(WP_Message* message)
+int Monitor_OemInfo(WP_Message *message)
 {
-    if((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
+    if ((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
-        Monitor_OemInfo_Reply cmdReply;     
-        
+        Monitor_OemInfo_Reply cmdReply;
+
         bool fOK = NanoBooter_GetReleaseInfo(&cmdReply.m_releaseInfo) == true;
-        
+
         WP_ReplyToCommand(message, fOK, false, &cmdReply, sizeof(cmdReply));
     }
 
     return true;
 }
 
-int Monitor_ReadMemory(WP_Message* message)
+int Monitor_ReadMemory(WP_Message *message)
 {
-    CLR_DBG_Commands_Monitor_ReadMemory* cmd = (CLR_DBG_Commands_Monitor_ReadMemory*)message->m_payload;
+    CLR_DBG_Commands_Monitor_ReadMemory *cmd = (CLR_DBG_Commands_Monitor_ReadMemory *)message->m_payload;
 
-    unsigned char buf[ 1024 ];
-    unsigned int len = cmd->length; if(len > sizeof(buf)) len = sizeof(buf);
+    unsigned char buf[1024];
+    unsigned int len = cmd->length;
+    if (len > sizeof(buf))
+        len = sizeof(buf);
     uint32_t errorCode;
 
-    AccessMemory(cmd->address, len, buf, AccessMemory_Read, &errorCode );
+    AccessMemory(cmd->address, len, buf, AccessMemory_Read, &errorCode);
 
     WP_ReplyToCommand(message, true, false, buf, len);
 
     return true;
 }
 
-int Monitor_WriteMemory(WP_Message* message)
+int Monitor_WriteMemory(WP_Message *message)
 {
-    CLR_DBG_Commands_Monitor_WriteMemory* cmd = (CLR_DBG_Commands_Monitor_WriteMemory*)message->m_payload;
+    CLR_DBG_Commands_Monitor_WriteMemory *cmd = (CLR_DBG_Commands_Monitor_WriteMemory *)message->m_payload;
     CLR_DBG_Commands_Monitor_WriteMemory_Reply cmdReply;
-
 
     // TODO: not sure if we really need this
     // if(!m_signedDataState.VerifyContiguousData(cmd->m_address, cmd->m_length))
     // {
     //     m_signedDataState.EraseMemoryAndReset();
-        
+
     //     return false;
     // }
 
     // TODO: not sure if we really need this
     // nanoBooter_OnStateChange(State_MemoryWrite, (void*)cmd->m_address);
 
-    // assume at RAM, directly use the original address 
+    // assume at RAM, directly use the original address
     AccessMemory(cmd->address, cmd->length, cmd->data, AccessMemory_Write, &cmdReply);
-  
+
     WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
 
     return true;
 }
 
-int Monitor_Reboot(WP_Message* message)
+int Monitor_Reboot(WP_Message *message)
 {
-    Monitor_Reboot_Command* cmd = (Monitor_Reboot_Command*)message->m_payload;
+    Monitor_Reboot_Command *cmd = (Monitor_Reboot_Command *)message->m_payload;
 
     WP_ReplyToCommand(message, true, false, NULL, 0);
 
-    if(cmd != NULL)
+    if (cmd != NULL)
     {
         // only reset if we are not trying to get into the bootloader
-        if((cmd->m_flags & Monitor_Reboot_c_EnterBootloader) != Monitor_Reboot_c_EnterBootloader)
+        if ((cmd->m_flags & Monitor_Reboot_c_EnterBootloader) != Monitor_Reboot_c_EnterBootloader)
         {
             // RESET CPU
             // because ChibiOS relies on CMSIS it's recommended to make use of the CMSIS API
@@ -172,55 +172,61 @@ int Monitor_Reboot(WP_Message* message)
     return true;
 }
 
-int Monitor_EraseMemory(WP_Message* message)
+int Monitor_EraseMemory(WP_Message *message)
 {
-    CLR_DBG_Commands_Monitor_EraseMemory* cmd = (CLR_DBG_Commands_Monitor_EraseMemory*)message->m_payload;
+    CLR_DBG_Commands_Monitor_EraseMemory *cmd = (CLR_DBG_Commands_Monitor_EraseMemory *)message->m_payload;
     CLR_DBG_Commands_Monitor_EraseMemory_Reply cmdReply;
 
     // TODO: not sure if we really need this
     // nanoBooter_OnStateChange( State_MemoryErase, (void*)cmd->m_address );
-    
+
     AccessMemory(cmd->address, cmd->length, NULL, AccessMemory_Erase, &cmdReply);
 
     WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
-        
+
     return true;
 }
 
-int Monitor_QueryConfiguration(WP_Message* message)
+int Monitor_QueryConfiguration(WP_Message *message)
 {
-    bool success     = false;
+    bool success = false;
 
     // include handling of configuration block only if feature is available
-  #if (HAS_CONFIG_BLOCK == TRUE)
+#if (HAS_CONFIG_BLOCK == TRUE)
 
-    Monitor_QueryConfiguration_Command *cmd = (Monitor_QueryConfiguration_Command*)message->m_payload;
-    int size          = 0;
+    Monitor_QueryConfiguration_Command *cmd = (Monitor_QueryConfiguration_Command *)message->m_payload;
+    int size = 0;
 
     HAL_Configuration_NetworkInterface configNetworkInterface;
     HAL_Configuration_Wireless80211 configWireless80211NetworkInterface;
 
-    switch((DeviceConfigurationOption)cmd->Configuration)
+    switch ((DeviceConfigurationOption)cmd->Configuration)
     {
         case DeviceConfigurationOption_Network:
 
-            if(ConfigurationManager_GetConfigurationBlock((void *)&configNetworkInterface, (DeviceConfigurationOption)cmd->Configuration, cmd->BlockIndex) == true)
+            if (ConfigurationManager_GetConfigurationBlock(
+                    (void *)&configNetworkInterface,
+                    (DeviceConfigurationOption)cmd->Configuration,
+                    cmd->BlockIndex) == true)
             {
                 size = sizeof(HAL_Configuration_NetworkInterface);
                 success = true;
 
-                WP_ReplyToCommand( message, success, false, (uint8_t*)&configNetworkInterface, size );
-            }            
+                WP_ReplyToCommand(message, success, false, (uint8_t *)&configNetworkInterface, size);
+            }
             break;
 
         case DeviceConfigurationOption_Wireless80211Network:
 
-            if(ConfigurationManager_GetConfigurationBlock((void *)&configWireless80211NetworkInterface, (DeviceConfigurationOption)cmd->Configuration, cmd->BlockIndex) == true)
+            if (ConfigurationManager_GetConfigurationBlock(
+                    (void *)&configWireless80211NetworkInterface,
+                    (DeviceConfigurationOption)cmd->Configuration,
+                    cmd->BlockIndex) == true)
             {
                 size = sizeof(HAL_Configuration_Wireless80211);
                 success = true;
 
-                WP_ReplyToCommand( message, success, false, (uint8_t*)&configWireless80211NetworkInterface, size );
+                WP_ReplyToCommand(message, success, false, (uint8_t *)&configWireless80211NetworkInterface, size);
             }
             break;
 
@@ -229,45 +235,51 @@ int Monitor_QueryConfiguration(WP_Message* message)
             break;
 
         default:
-            break;            
+            break;
     }
 
-    if(!success)
+    if (!success)
     {
-        WP_ReplyToCommand( message, success, false, NULL, size );
+        WP_ReplyToCommand(message, success, false, NULL, size);
     }
 
-  #else
+#else
 
     (void)message;
 
-  #endif // (HAS_CONFIG_BLOCK == TRUE)
+#endif // (HAS_CONFIG_BLOCK == TRUE)
 
     return success;
 }
 
-int Monitor_UpdateConfiguration(WP_Message* message)
+int Monitor_UpdateConfiguration(WP_Message *message)
 {
     bool success = false;
 
     // include handling of configuration block only if feature is available
-  #if (HAS_CONFIG_BLOCK == TRUE)
-    
-    Monitor_UpdateConfiguration_Command* cmd = (Monitor_UpdateConfiguration_Command*)message->m_payload;
+#if (HAS_CONFIG_BLOCK == TRUE)
+
+    Monitor_UpdateConfiguration_Command *cmd = (Monitor_UpdateConfiguration_Command *)message->m_payload;
     Monitor_UpdateConfiguration_Reply cmdReply;
 
-    switch((DeviceConfigurationOption)cmd->Configuration)
+    switch ((DeviceConfigurationOption)cmd->Configuration)
     {
         case DeviceConfigurationOption_Network:
         case DeviceConfigurationOption_Wireless80211Network:
         case DeviceConfigurationOption_X509CaRootBundle:
         case DeviceConfigurationOption_All:
-            if(ConfigurationManager_StoreConfigurationBlock(cmd->Data, (DeviceConfigurationOption)cmd->Configuration, cmd->BlockIndex, cmd->Length, cmd->Offset, cmd->Done) == true)
+            if (ConfigurationManager_StoreConfigurationBlock(
+                    cmd->Data,
+                    (DeviceConfigurationOption)cmd->Configuration,
+                    cmd->BlockIndex,
+                    cmd->Length,
+                    cmd->Offset,
+                    cmd->Done) == true)
             {
                 cmdReply.ErrorCode = 0;
                 success = true;
             }
-            else 
+            else
             {
                 cmdReply.ErrorCode = 100;
             }
@@ -279,58 +291,58 @@ int Monitor_UpdateConfiguration(WP_Message* message)
 
     WP_ReplyToCommand(message, success, false, &cmdReply, sizeof(cmdReply));
 
-  #else
+#else
 
     (void)message;
 
-  #endif // (HAS_CONFIG_BLOCK == TRUE)
+#endif // (HAS_CONFIG_BLOCK == TRUE)
 
     return success;
 }
 
-int Monitor_CheckMemory(WP_Message* message)
+int Monitor_CheckMemory(WP_Message *message)
 {
     bool ret = false;
 
-    CLR_DBG_Commands_Monitor_CheckMemory* cmd = (CLR_DBG_Commands_Monitor_CheckMemory*)message->m_payload;
+    CLR_DBG_Commands_Monitor_CheckMemory *cmd = (CLR_DBG_Commands_Monitor_CheckMemory *)message->m_payload;
     CLR_DBG_Commands_Monitor_CheckMemory_Reply cmdReply;
     uint32_t errorCode;
 
-    ret = AccessMemory(cmd->address, cmd->length, (uint8_t*)&cmdReply, AccessMemory_Check, &errorCode);
+    ret = AccessMemory(cmd->address, cmd->length, (uint8_t *)&cmdReply, AccessMemory_Check, &errorCode);
 
     WP_ReplyToCommand(message, ret, false, &cmdReply, sizeof(cmdReply));
 
     return ret;
 }
 
-int Monitor_MemoryMap(WP_Message* message)
+int Monitor_MemoryMap(WP_Message *message)
 {
     MemoryMap_Range map[2];
 
     // if(m_signedDataState.CheckDirty())
     // {
     //     m_signedDataState.EraseMemoryAndReset();
-        
+
     //     return false;
     // }
 
     map[0].m_address = HalSystemConfig.RAM1.Base;
-    map[0].m_length  = HalSystemConfig.RAM1.Size;
-    map[0].m_flags   = Monitor_MemoryMap_c_RAM;
+    map[0].m_length = HalSystemConfig.RAM1.Size;
+    map[0].m_flags = Monitor_MemoryMap_c_RAM;
 
     map[1].m_address = HalSystemConfig.FLASH1.Base;
-    map[1].m_length  = HalSystemConfig.FLASH1.Size;
-    map[1].m_flags   = Monitor_MemoryMap_c_FLASH;
+    map[1].m_length = HalSystemConfig.FLASH1.Size;
+    map[1].m_flags = Monitor_MemoryMap_c_FLASH;
 
     WP_ReplyToCommand(message, true, false, map, sizeof(map));
 
     return true;
 }
 
-int Monitor_FlashSectorMap(WP_Message* message)
+int Monitor_FlashSectorMap(WP_Message *message)
 {
 
-    if((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
+    if ((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
         struct Flash_BlockRegionInfo
         {
@@ -344,54 +356,55 @@ int Monitor_FlashSectorMap(WP_Message* message)
         unsigned int rangeCount = 0;
         unsigned int rangeIndex = 0;
 
-        for(int cnt = 0; cnt < 2; cnt++)
+        for (int cnt = 0; cnt < 2; cnt++)
         {
-            BlockStorageDevice* device = BlockStorageList_GetFirstDevice();
+            BlockStorageDevice *device = BlockStorageList_GetFirstDevice();
 
-            if(device == NULL)
+            if (device == NULL)
             {
                 WP_ReplyToCommand(message, true, false, NULL, 0);
                 return false;
             }
 
-            if(cnt == 1)
+            if (cnt == 1)
             {
-                pData = (struct Flash_BlockRegionInfo*)platform_malloc(rangeCount * sizeof(struct Flash_BlockRegionInfo));
+                pData =
+                    (struct Flash_BlockRegionInfo *)platform_malloc(rangeCount * sizeof(struct Flash_BlockRegionInfo));
 
-                if(pData == NULL)
+                if (pData == NULL)
                 {
                     WP_ReplyToCommand(message, true, false, NULL, 0);
                     return false;
                 }
             }
 
-            DeviceBlockInfo* deviceInfo = BlockStorageDevice_GetDeviceInfo(device);
+            DeviceBlockInfo *deviceInfo = BlockStorageDevice_GetDeviceInfo(device);
 
-            for(unsigned int i = 0; i < deviceInfo->NumRegions;  i++)
+            for (unsigned int i = 0; i < deviceInfo->NumRegions; i++)
             {
-                const BlockRegionInfo* pRegion = &deviceInfo->Regions[ i ];
+                const BlockRegionInfo *pRegion = &deviceInfo->Regions[i];
 
-                for(unsigned int j = 0; j < pRegion->NumBlockRanges; j++)
+                for (unsigned int j = 0; j < pRegion->NumBlockRanges; j++)
                 {
 
-                    if(cnt == 0)
+                    if (cnt == 0)
                     {
                         rangeCount++;
                     }
                     else
                     {
-                        pData[ rangeIndex ].StartAddress  = BlockRegionInfo_BlockAddress(pRegion, pRegion->BlockRanges[ j ].StartBlock);
-                        pData[ rangeIndex ].NumBlocks = BlockRange_GetBlockCount(pRegion->BlockRanges[j]);
-                        pData[ rangeIndex ].BytesPerBlock = pRegion->BytesPerBlock;
-                        pData[ rangeIndex ].Usage  = pRegion->BlockRanges[ j ].RangeType & BlockRange_USAGE_MASK;
+                        pData[rangeIndex].StartAddress =
+                            BlockRegionInfo_BlockAddress(pRegion, pRegion->BlockRanges[j].StartBlock);
+                        pData[rangeIndex].NumBlocks = BlockRange_GetBlockCount(pRegion->BlockRanges[j]);
+                        pData[rangeIndex].BytesPerBlock = pRegion->BytesPerBlock;
+                        pData[rangeIndex].Usage = pRegion->BlockRanges[j].RangeType & BlockRange_USAGE_MASK;
                         rangeIndex++;
                     }
                 }
             }
         }
 
-
-        WP_ReplyToCommand(message, true, false, (void*)pData, rangeCount * sizeof(struct Flash_BlockRegionInfo));
+        WP_ReplyToCommand(message, true, false, (void *)pData, rangeCount * sizeof(struct Flash_BlockRegionInfo));
 
         platform_free(pData);
     }

--- a/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
+++ b/targets/CMSIS-OS/ChibiOS/nanoBooter/WireProtocol_MonitorCommands.c
@@ -145,7 +145,7 @@ int Monitor_WriteMemory(WP_Message* message)
     // nanoBooter_OnStateChange(State_MemoryWrite, (void*)cmd->m_address);
 
     // assume at RAM, directly use the original address 
-    AccessMemory(cmd->address, cmd->length, cmd->data, AccessMemory_Write, &cmdReply.ErrorCode);
+    AccessMemory(cmd->address, cmd->length, cmd->data, AccessMemory_Write, &cmdReply);
   
     WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
 
@@ -180,7 +180,7 @@ int Monitor_EraseMemory(WP_Message* message)
     // TODO: not sure if we really need this
     // nanoBooter_OnStateChange( State_MemoryErase, (void*)cmd->m_address );
     
-    AccessMemory(cmd->address, cmd->length, NULL, AccessMemory_Erase, &cmdReply.ErrorCode);
+    AccessMemory(cmd->address, cmd->length, NULL, AccessMemory_Erase, &cmdReply);
 
     WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
         
@@ -296,7 +296,7 @@ int Monitor_CheckMemory(WP_Message* message)
     CLR_DBG_Commands_Monitor_CheckMemory_Reply cmdReply;
     uint32_t errorCode;
 
-    ret = AccessMemory(cmd->address, cmd->length, (uint8_t*)&cmdReply.crc, AccessMemory_Check, &errorCode);
+    ret = AccessMemory(cmd->address, cmd->length, (uint8_t*)&cmdReply, AccessMemory_Check, &errorCode);
 
     WP_ReplyToCommand(message, ret, false, &cmdReply, sizeof(cmdReply));
 

--- a/targets/FreeRTOS/NXP/nanoBooter/WireProtocol_MonitorCommands.c
+++ b/targets/FreeRTOS/NXP/nanoBooter/WireProtocol_MonitorCommands.c
@@ -141,7 +141,7 @@ int Monitor_WriteMemory(WP_Message* message)
     // nanoBooter_OnStateChange(State_MemoryWrite, (void*)cmd->m_address);
 
     // assume at RAM, directly use the original address 
-    AccessMemory(cmd->address, cmd->length, cmd->data, AccessMemory_Write, &cmdReply.ErrorCode);
+    AccessMemory(cmd->address, cmd->length, cmd->data, AccessMemory_Write, &cmdReply);
   
     WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
 
@@ -176,7 +176,7 @@ int Monitor_EraseMemory(WP_Message* message)
     // TODO: not sure if we really need this
     // nanoBooter_OnStateChange( State_MemoryErase, (void*)cmd->m_address );
     
-    AccessMemory(cmd->address, cmd->length, NULL, AccessMemory_Erase, &cmdReply.ErrorCode);
+    AccessMemory(cmd->address, cmd->length, NULL, AccessMemory_Erase, &cmdReply);
 
     WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
         
@@ -268,7 +268,7 @@ int Monitor_CheckMemory(WP_Message* message)
     CLR_DBG_Commands_Monitor_CheckMemory_Reply cmdReply;
     uint32_t errorCode;
 
-    ret = AccessMemory(cmd->address, cmd->length, (uint8_t*)&cmdReply.crc, AccessMemory_Check, &errorCode);
+    ret = AccessMemory(cmd->address, cmd->length, (uint8_t*)&cmdReply, AccessMemory_Check, &errorCode);
 
     WP_ReplyToCommand(message, ret, false, &cmdReply, sizeof(cmdReply));
 

--- a/targets/FreeRTOS/NXP/nanoBooter/WireProtocol_MonitorCommands.c
+++ b/targets/FreeRTOS/NXP/nanoBooter/WireProtocol_MonitorCommands.c
@@ -20,7 +20,7 @@
 //////////////////////////////////////////////////////////////////////
 // helper functions
 
-int NanoBooter_GetReleaseInfo(ReleaseInfo* releaseInfo)
+int NanoBooter_GetReleaseInfo(ReleaseInfo *releaseInfo)
 {
     releaseInfo->version.usMajor = VERSION_MAJOR;
     releaseInfo->version.usMinor = VERSION_MINOR;
@@ -35,12 +35,12 @@ int NanoBooter_GetReleaseInfo(ReleaseInfo* releaseInfo)
     return true;
 }
 
-static int AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t* buffer, int32_t mode, uint32_t* errorCode)
+static int AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t *buffer, int32_t mode, uint32_t *errorCode)
 {
     // reset error code
     *errorCode = AccessMemoryErrorCode_NoError;
-    
-    switch(mode)
+
+    switch (mode)
     {
         case AccessMemory_Write:
             // use FLASH driver to perform write operation
@@ -52,9 +52,10 @@ static int AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t* buff
 
         case AccessMemory_Check:
             return iMXRTFlexSPIDriver_IsBlockErased(NULL, location, lengthInBytes);
-        
+
         case AccessMemory_Read:
-            return iMXRTFlexSPIDriver_Read(NULL, location, lengthInBytes, buffer);;
+            return iMXRTFlexSPIDriver_Read(NULL, location, lengthInBytes, buffer);
+            ;
 
         default:
             // default return is FALSE
@@ -64,29 +65,28 @@ static int AccessMemory(uint32_t location, uint32_t lengthInBytes, uint8_t* buff
 
 ////////////////////////////////////////////////////
 
-int Monitor_Ping(WP_Message* message)
+int Monitor_Ping(WP_Message *message)
 {
-    if((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
+    if ((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
         Monitor_Ping_Reply cmdReply;
         cmdReply.m_source = Monitor_Ping_c_Ping_Source_NanoBooter;
         cmdReply.m_dbg_flags = 0;
 
-    #if defined(WP_IMPLEMENTS_CRC32)
-        cmdReply.m_dbg_flags |= Monitor_Ping_c_Ping_WPFlag_SupportsCRC32;    
-    #endif
+#if defined(WP_IMPLEMENTS_CRC32)
+        cmdReply.m_dbg_flags |= Monitor_Ping_c_Ping_WPFlag_SupportsCRC32;
+#endif
 
-    // Wire Protocol packet size 
-    #if (WP_PACKET_SIZE == 512)
+// Wire Protocol packet size
+#if (WP_PACKET_SIZE == 512)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0512;
-    #elif (WP_PACKET_SIZE == 256)
+#elif (WP_PACKET_SIZE == 256)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0256;
-    #elif (WP_PACKET_SIZE == 128)
+#elif (WP_PACKET_SIZE == 128)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_0128;
-    #elif (WP_PACKET_SIZE == 1024)
+#elif (WP_PACKET_SIZE == 1024)
         cmdReply.m_dbg_flags |= Monitor_Ping_c_PacketSize_1024;
-    #endif
-
+#endif
 
         WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
     }
@@ -94,70 +94,71 @@ int Monitor_Ping(WP_Message* message)
     return true;
 }
 
-int Monitor_OemInfo(WP_Message* message)
+int Monitor_OemInfo(WP_Message *message)
 {
-    if((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
+    if ((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
-        Monitor_OemInfo_Reply cmdReply;     
-        
+        Monitor_OemInfo_Reply cmdReply;
+
         bool fOK = NanoBooter_GetReleaseInfo(&cmdReply.m_releaseInfo) == true;
-        
+
         WP_ReplyToCommand(message, fOK, false, &cmdReply, sizeof(cmdReply));
     }
 
     return true;
 }
 
-int Monitor_ReadMemory(WP_Message* message)
+int Monitor_ReadMemory(WP_Message *message)
 {
-    CLR_DBG_Commands_Monitor_ReadMemory* cmd = (CLR_DBG_Commands_Monitor_ReadMemory*)message->m_payload;
+    CLR_DBG_Commands_Monitor_ReadMemory *cmd = (CLR_DBG_Commands_Monitor_ReadMemory *)message->m_payload;
 
-    unsigned char buf[ 1024 ];
-    unsigned int len = cmd->length; if(len > sizeof(buf)) len = sizeof(buf);
+    unsigned char buf[1024];
+    unsigned int len = cmd->length;
+    if (len > sizeof(buf))
+        len = sizeof(buf);
     uint32_t errorCode;
 
-    AccessMemory(cmd->address, len, buf, AccessMemory_Read, &errorCode );
+    AccessMemory(cmd->address, len, buf, AccessMemory_Read, &errorCode);
 
     WP_ReplyToCommand(message, true, false, buf, len);
 
     return true;
 }
 
-int Monitor_WriteMemory(WP_Message* message)
+int Monitor_WriteMemory(WP_Message *message)
 {
-    CLR_DBG_Commands_Monitor_WriteMemory* cmd = (CLR_DBG_Commands_Monitor_WriteMemory*)message->m_payload;
+    CLR_DBG_Commands_Monitor_WriteMemory *cmd = (CLR_DBG_Commands_Monitor_WriteMemory *)message->m_payload;
     CLR_DBG_Commands_Monitor_WriteMemory_Reply cmdReply;
-
 
     // TODO: not sure if we really need this
     // if(!m_signedDataState.VerifyContiguousData(cmd->m_address, cmd->m_length))
     // {
     //     m_signedDataState.EraseMemoryAndReset();
-        
+
     //     return false;
     // }
 
     // TODO: not sure if we really need this
     // nanoBooter_OnStateChange(State_MemoryWrite, (void*)cmd->m_address);
 
-    // assume at RAM, directly use the original address 
+    // assume at RAM, directly use the original address
     AccessMemory(cmd->address, cmd->length, cmd->data, AccessMemory_Write, &cmdReply);
-  
+
     WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
 
     return true;
 }
 
-int Monitor_Reboot(WP_Message* message)
+int Monitor_Reboot(WP_Message *message)
 {
-    Monitor_Reboot_Command* cmd = (Monitor_Reboot_Command*)message->m_payload;
+    Monitor_Reboot_Command *cmd = (Monitor_Reboot_Command *)message->m_payload;
 
     WP_ReplyToCommand(message, true, false, NULL, 0);
 
-    if(cmd != NULL)
+    if (cmd != NULL)
     {
         // only reset if we are not trying to get into the bootloader
-        if((cmd->m_flags & Monitor_Reboot_c_EnterBootloader) != Monitor_Reboot_c_EnterBootloader)
+        if ((cmd->m_flags & Monitor_Reboot_c_EnterBootloader) != Monitor_Reboot_c_EnterBootloader)
         {
             // RESET CPU
             // because ChibiOS relies on CMSIS it's recommended to make use of the CMSIS API
@@ -168,36 +169,36 @@ int Monitor_Reboot(WP_Message* message)
     return true;
 }
 
-int Monitor_EraseMemory(WP_Message* message)
+int Monitor_EraseMemory(WP_Message *message)
 {
-    CLR_DBG_Commands_Monitor_EraseMemory* cmd = (CLR_DBG_Commands_Monitor_EraseMemory*)message->m_payload;
+    CLR_DBG_Commands_Monitor_EraseMemory *cmd = (CLR_DBG_Commands_Monitor_EraseMemory *)message->m_payload;
     CLR_DBG_Commands_Monitor_EraseMemory_Reply cmdReply;
 
     // TODO: not sure if we really need this
     // nanoBooter_OnStateChange( State_MemoryErase, (void*)cmd->m_address );
-    
+
     AccessMemory(cmd->address, cmd->length, NULL, AccessMemory_Erase, &cmdReply);
 
     WP_ReplyToCommand(message, true, false, &cmdReply, sizeof(cmdReply));
-        
+
     return true;
 }
 
-int Monitor_QueryConfiguration(WP_Message* message)
+int Monitor_QueryConfiguration(WP_Message *message)
 {
-    bool success     = false;
+    bool success = false;
 
     // include handling of configuration block only if feature is available
-  #if (HAS_CONFIG_BLOCK == TRUE)
+#if (HAS_CONFIG_BLOCK == TRUE)
 
-    Monitor_QueryConfiguration_Command *cmd = (Monitor_QueryConfiguration_Command*)message->m_payload;
-    int size          = 0;
+    Monitor_QueryConfiguration_Command *cmd = (Monitor_QueryConfiguration_Command *)message->m_payload;
+    int size = 0;
 
-    switch((DeviceConfigurationOption)cmd->Configuration)
+    switch ((DeviceConfigurationOption)cmd->Configuration)
     {
         case DeviceConfigurationOption_Network:
 
-            // TODO missing implementation for now          
+            // TODO missing implementation for now
             break;
 
         case DeviceConfigurationOption_Wireless80211Network:
@@ -210,34 +211,34 @@ int Monitor_QueryConfiguration(WP_Message* message)
             break;
 
         default:
-            break;            
+            break;
     }
 
-    if(!success)
+    if (!success)
     {
-        WP_ReplyToCommand( message, success, false, NULL, size );
+        WP_ReplyToCommand(message, success, false, NULL, size);
     }
 
-  #else
+#else
 
     (void)message;
 
-  #endif // (HAS_CONFIG_BLOCK == TRUE)
+#endif // (HAS_CONFIG_BLOCK == TRUE)
 
     return success;
 }
 
-int Monitor_UpdateConfiguration(WP_Message* message)
+int Monitor_UpdateConfiguration(WP_Message *message)
 {
     bool success = false;
 
     // include handling of configuration block only if feature is available
-  #if (HAS_CONFIG_BLOCK == TRUE)
-    
-    Monitor_UpdateConfiguration_Command* cmd = (Monitor_UpdateConfiguration_Command*)message->m_payload;
+#if (HAS_CONFIG_BLOCK == TRUE)
+
+    Monitor_UpdateConfiguration_Command *cmd = (Monitor_UpdateConfiguration_Command *)message->m_payload;
     Monitor_UpdateConfiguration_Reply cmdReply;
 
-    switch((DeviceConfigurationOption)cmd->Configuration)
+    switch ((DeviceConfigurationOption)cmd->Configuration)
     {
         case DeviceConfigurationOption_Network:
         case DeviceConfigurationOption_Wireless80211Network:
@@ -251,58 +252,58 @@ int Monitor_UpdateConfiguration(WP_Message* message)
 
     WP_ReplyToCommand(message, success, false, &cmdReply, sizeof(cmdReply));
 
-  #else
+#else
 
     (void)message;
 
-  #endif // (HAS_CONFIG_BLOCK == TRUE)
+#endif // (HAS_CONFIG_BLOCK == TRUE)
 
     return success;
 }
 
-int Monitor_CheckMemory(WP_Message* message)
+int Monitor_CheckMemory(WP_Message *message)
 {
     bool ret = false;
 
-    CLR_DBG_Commands_Monitor_CheckMemory* cmd = (CLR_DBG_Commands_Monitor_CheckMemory*)message->m_payload;
+    CLR_DBG_Commands_Monitor_CheckMemory *cmd = (CLR_DBG_Commands_Monitor_CheckMemory *)message->m_payload;
     CLR_DBG_Commands_Monitor_CheckMemory_Reply cmdReply;
     uint32_t errorCode;
 
-    ret = AccessMemory(cmd->address, cmd->length, (uint8_t*)&cmdReply, AccessMemory_Check, &errorCode);
+    ret = AccessMemory(cmd->address, cmd->length, (uint8_t *)&cmdReply, AccessMemory_Check, &errorCode);
 
     WP_ReplyToCommand(message, ret, false, &cmdReply, sizeof(cmdReply));
 
     return ret;
 }
 
-int Monitor_MemoryMap(WP_Message* message)
+int Monitor_MemoryMap(WP_Message *message)
 {
     MemoryMap_Range map[2];
 
     // if(m_signedDataState.CheckDirty())
     // {
     //     m_signedDataState.EraseMemoryAndReset();
-        
+
     //     return false;
     // }
 
     map[0].m_address = HalSystemConfig.RAM1.Base;
-    map[0].m_length  = HalSystemConfig.RAM1.Size;
-    map[0].m_flags   = Monitor_MemoryMap_c_RAM;
+    map[0].m_length = HalSystemConfig.RAM1.Size;
+    map[0].m_flags = Monitor_MemoryMap_c_RAM;
 
     map[1].m_address = HalSystemConfig.FLASH1.Base;
-    map[1].m_length  = HalSystemConfig.FLASH1.Size;
-    map[1].m_flags   = Monitor_MemoryMap_c_FLASH;
+    map[1].m_length = HalSystemConfig.FLASH1.Size;
+    map[1].m_flags = Monitor_MemoryMap_c_FLASH;
 
     WP_ReplyToCommand(message, true, false, map, sizeof(map));
 
     return true;
 }
 
-int Monitor_FlashSectorMap(WP_Message* message)
+int Monitor_FlashSectorMap(WP_Message *message)
 {
 
-    if((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
+    if ((message->m_header.m_flags & WP_Flags_c_Reply) == 0)
     {
         struct Flash_BlockRegionInfo
         {
@@ -316,54 +317,55 @@ int Monitor_FlashSectorMap(WP_Message* message)
         unsigned int rangeCount = 0;
         unsigned int rangeIndex = 0;
 
-        for(int cnt = 0; cnt < 2; cnt++)
+        for (int cnt = 0; cnt < 2; cnt++)
         {
-            BlockStorageDevice* device = BlockStorageList_GetFirstDevice();
+            BlockStorageDevice *device = BlockStorageList_GetFirstDevice();
 
-            if(device == NULL)
+            if (device == NULL)
             {
                 WP_ReplyToCommand(message, true, false, NULL, 0);
                 return false;
             }
 
-            if(cnt == 1)
+            if (cnt == 1)
             {
-                pData = (struct Flash_BlockRegionInfo*)platform_malloc(rangeCount * sizeof(struct Flash_BlockRegionInfo));
+                pData =
+                    (struct Flash_BlockRegionInfo *)platform_malloc(rangeCount * sizeof(struct Flash_BlockRegionInfo));
 
-                if(pData == NULL)
+                if (pData == NULL)
                 {
                     WP_ReplyToCommand(message, true, false, NULL, 0);
                     return false;
                 }
             }
 
-            DeviceBlockInfo* deviceInfo = BlockStorageDevice_GetDeviceInfo(device);
+            DeviceBlockInfo *deviceInfo = BlockStorageDevice_GetDeviceInfo(device);
 
-            for(unsigned int i = 0; i < deviceInfo->NumRegions;  i++)
+            for (unsigned int i = 0; i < deviceInfo->NumRegions; i++)
             {
-                const BlockRegionInfo* pRegion = &deviceInfo->Regions[ i ];
+                const BlockRegionInfo *pRegion = &deviceInfo->Regions[i];
 
-                for(unsigned int j = 0; j < pRegion->NumBlockRanges; j++)
+                for (unsigned int j = 0; j < pRegion->NumBlockRanges; j++)
                 {
 
-                    if(cnt == 0)
+                    if (cnt == 0)
                     {
                         rangeCount++;
                     }
                     else
                     {
-                        pData[ rangeIndex ].StartAddress  = BlockRegionInfo_BlockAddress(pRegion, pRegion->BlockRanges[ j ].StartBlock);
-                        pData[ rangeIndex ].NumBlocks = BlockRange_GetBlockCount(pRegion->BlockRanges[j]);
-                        pData[ rangeIndex ].BytesPerBlock = pRegion->BytesPerBlock;
-                        pData[ rangeIndex ].Usage  = pRegion->BlockRanges[ j ].RangeType & BlockRange_USAGE_MASK;
+                        pData[rangeIndex].StartAddress =
+                            BlockRegionInfo_BlockAddress(pRegion, pRegion->BlockRanges[j].StartBlock);
+                        pData[rangeIndex].NumBlocks = BlockRange_GetBlockCount(pRegion->BlockRanges[j]);
+                        pData[rangeIndex].BytesPerBlock = pRegion->BytesPerBlock;
+                        pData[rangeIndex].Usage = pRegion->BlockRanges[j].RangeType & BlockRange_USAGE_MASK;
                         rangeIndex++;
                     }
                 }
             }
         }
 
-
-        WP_ReplyToCommand(message, true, false, (void*)pData, rangeCount * sizeof(struct Flash_BlockRegionInfo));
+        WP_ReplyToCommand(message, true, false, (void *)pData, rangeCount * sizeof(struct Flash_BlockRegionInfo));
 
         platform_free(pData);
     }


### PR DESCRIPTION
## Description
- Function doesn't return a bool anymore, the return value is carried in the errorCode argument.
- Update declaration accordingly.
- Change declaration of Wire Protocol strucs that had a single element.

## Motivation and Context
- Simplification of the function declaration. Returning the outcome in the proper way.

## How Has This Been Tested?<!-- (if applicable) -->
- Several deployments from VS.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
