### PR TITLE
Several fixes with lastest CC13x2_26x2 SDK

### DIFF
--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/TI_CC1352R1_LAUNCHXL.syscfg
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/TI_CC1352R1_LAUNCHXL.syscfg
@@ -11,8 +11,8 @@
 const CCFG     = scripting.addModule("/ti/devices/CCFG");
 const DMA      = scripting.addModule("/ti/drivers/DMA");
 const RTOS     = scripting.addModule("/ti/drivers/RTOS");
-const UART     = scripting.addModule("/ti/drivers/UART", {}, false);
-const UART1    = UART.addInstance();
+const UART2    = scripting.addModule("/ti/drivers/UART2", {}, false);
+const UART21   = UART2.addInstance();
 const easylink = scripting.addModule("/ti/easylink/easylink");
 
 /**
@@ -21,11 +21,11 @@ const easylink = scripting.addModule("/ti/easylink/easylink");
 CCFG.forceVddr          = true;
 CCFG.ccfgTemplate.$name = "ti_devices_CCFGTemplate0";
 
-UART1.$hardware           = system.deviceData.board.components.XDS110UART;
-UART1.$name               = "UART0";
-UART1.txPinInstance.$name = "CONFIG_PIN_0";
-UART1.rxPinInstance.$name = "CONFIG_PIN_1";
-UART1.uart.$assign        = "UART0";
+UART21.$hardware           = system.deviceData.board.components.XDS110UART;
+UART21.$name               = "UART0";
+UART21.txPinInstance.$name = "CONFIG_PIN_2";
+UART21.rxPinInstance.$name = "CONFIG_PIN_3";
+UART21.uart.$assign        = "UART0";
 
 easylink.EasyLink_Phy_5kbpsSlLr                                    = true;
 easylink.defaultPhy                                                = "EasyLink_Phy_5kbpsSlLr";
@@ -42,5 +42,5 @@ easylink.radioConfigEasylinkPhy200kbps2gfsk.codeExportConfig.$name = "ti_devices
  * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
  * re-solve from scratch.
  */
-UART1.uart.txPin.$suggestSolution = "boosterpack.4";
-UART1.uart.rxPin.$suggestSolution = "boosterpack.3";
+UART21.uart.txPin.$suggestSolution = "boosterpack.4";
+UART21.uart.rxPin.$suggestSolution = "boosterpack.3";

--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/nanoCLR/main.c
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/nanoCLR/main.c
@@ -49,7 +49,7 @@ int main(void)
     Task_Params taskParams;
 
     // Call board init functions
-    Board_initGeneral();
+    Board_init();
 
     // setup Task thread
     Task_Params_init(&taskParams);
@@ -83,7 +83,6 @@ int main(void)
     }
 
     GPIO_init();
-    UART_init();
     ConfigUART();
 
     BIOS_start();

--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_common.h.in
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_common.h.in
@@ -50,9 +50,9 @@
 
 /////////////////////////////////////
 #if defined(DEBUG)
-    #define MANAGED_HEAP_SIZE       (35*1024)
+    #define MANAGED_HEAP_SIZE       (30*1024)
 #else
-    #define MANAGED_HEAP_SIZE       (42*1024)
+    #define MANAGED_HEAP_SIZE       (37*1024)
 #endif
 /////////////////////////////////////
 

--- a/targets/TI-SimpleLink/common/GenericPort.cpp
+++ b/targets/TI-SimpleLink/common/GenericPort.cpp
@@ -23,15 +23,15 @@ extern "C" uint32_t DebuggerPort_WriteProxy(const char *format, ...)
     va_list arg;
     uint32_t chars = 0;
 
-    if( CLR_EE_DBG_IS_NOT( Enabled ) )
+    if (CLR_EE_DBG_IS_NOT(Enabled))
     {
-        if(SemaphoreP_pend(uartMutex, UART2_WAIT_FOREVER) == SemaphoreP_OK)
+        if (SemaphoreP_pend(uartMutex, UART2_WAIT_FOREVER) == SemaphoreP_OK)
         {
-            va_start( arg, format );
+            va_start(arg, format);
 
-            chars = CLR_Debug::PrintfV( format, arg );
+            chars = CLR_Debug::PrintfV(format, arg);
 
-            va_end( arg );
+            va_end(arg);
 
             SemaphoreP_post(uartMutex);
         }
@@ -40,21 +40,16 @@ extern "C" uint32_t DebuggerPort_WriteProxy(const char *format, ...)
     return chars;
 }
 
-uint32_t GenericPort_Write( int portNum, const char* data, size_t size )
+uint32_t GenericPort_Write(int portNum, const char *data, size_t size)
 {
     (void)portNum;
     size_t bytesWritten;
 
-    if( CLR_EE_DBG_IS_NOT( Enabled ) )
+    if (CLR_EE_DBG_IS_NOT(Enabled))
     {
         // debugger port is NOT in use, OK to output to UART
         // send characters directly to the UART port
-        UART2_writeTimeout(
-            uart, 
-            data, 
-            size, 
-            &bytesWritten, 
-            UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod);
+        UART2_writeTimeout(uart, data, size, &bytesWritten, UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod);
 
         return bytesWritten;
     }

--- a/targets/TI-SimpleLink/common/WireProtocol_HAL_Interface.c
+++ b/targets/TI-SimpleLink/common/WireProtocol_HAL_Interface.c
@@ -23,41 +23,34 @@ WP_Message inboundMessage;
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // The functions below are the ones that need to be ported to new channels/HALs when required
 // These are to be considered as a reference implementations when working on new ports
-// 
+//
 // This reference implementation provides communication through:
-// - serial port (UART/USART) 
+// - serial port (UART/USART)
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-int WP_ReceiveBytes(
-    uint8_t* ptr, 
-    uint16_t* size)
+int WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
 {
     // save for latter comparison
     uint16_t requestedSize = *size;
     size_t read;
 
-    //int readData = 0;
+    // int readData = 0;
     // sanity check for request of 0 size
-    if(*size)
+    if (*size)
     {
         //////////////////////////////////////////////////////////
         //               PORTING CHANGE REQUIRED HERE           //
         //////////////////////////////////////////////////////////
         // change here to read (size) bytes from the input stream
-        // preferably with read timeout and being able to check 
+        // preferably with read timeout and being able to check
         // if the requested number of bytes was actually read
         //////////////////////////////////////////////////////////
-        
-        // non blocking read from serial port with 500ms timeout
-        UART2_readTimeout(
-            uart, 
-            ptr, 
-            requestedSize,
-            &read,
-            UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod);
 
-        ptr  += read;
+        // non blocking read from serial port with 500ms timeout
+        UART2_readTimeout(uart, ptr, requestedSize, &read, UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod);
+
+        ptr += read;
         *size -= read;
 
         // check if the requested read matches the actual read count
@@ -67,7 +60,7 @@ int WP_ReceiveBytes(
     return true;
 }
 
-int WP_TransmitMessage(WP_Message* message)
+int WP_TransmitMessage(WP_Message *message)
 {
     uint32_t writeResult;
     bool operationResult = false;
@@ -76,26 +69,31 @@ int WP_TransmitMessage(WP_Message* message)
     //              PORTING CHANGE REQUIRED HERE             //
     ///////////////////////////////////////////////////////////
     // change here to write (size) bytes to the output stream
-    // preferably with timeout and being able to check 
+    // preferably with timeout and being able to check
     // if the write was successfull or at least buffered
     //////////////////////////////////////////////////////////
 
-    TRACE( TRACE_HEADERS, "TXMSG: 0x%08X, 0x%08X, 0x%08X\n", message->m_header.m_cmd, message->m_header.m_flags, message->m_header.m_size );
+    TRACE(
+        TRACE_HEADERS,
+        "TXMSG: 0x%08X, 0x%08X, 0x%08X\n",
+        message->m_header.m_cmd,
+        message->m_header.m_flags,
+        message->m_header.m_size);
 
     // write header to uart
     UART2_writeTimeout(
-        uart, 
-        (const void *)&message->m_header, 
+        uart,
+        (const void *)&message->m_header,
         sizeof(message->m_header),
         &writeResult,
         UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod);
 
-    if(writeResult == sizeof(message->m_header))
+    if (writeResult == sizeof(message->m_header))
     {
         operationResult = true;
 
         // if there is anything on the payload send it to the output stream
-        if(message->m_header.m_size && message->m_payload)
+        if (message->m_header.m_size && message->m_payload)
         {
             ///////////////////////////////////////////////////////////
             //              PORTING CHANGE REQUIRED HERE             //
@@ -107,17 +105,17 @@ int WP_TransmitMessage(WP_Message* message)
             operationResult = false;
 
             UART2_writeTimeout(
-                uart, 
-                (const void *)message->m_payload, 
+                uart,
+                (const void *)message->m_payload,
                 message->m_header.m_size,
                 &writeResult,
                 UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod);
 
-            if(writeResult == message->m_header.m_size)
+            if (writeResult == message->m_header.m_size)
             {
                 operationResult = true;
 
-                TRACE0( TRACE_ERRORS, "TXMSG: OK\n");                    
+                TRACE0(TRACE_ERRORS, "TXMSG: OK\n");
             }
         }
     }

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL.c
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL.c
@@ -7,7 +7,6 @@
 #include <board.h>
 #include <ti/drivers/dpl/SemaphoreP.h>
 
-
 #include <ti_drivers_config.h>
 
 extern UART2_Handle uart;

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL.c
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL.c
@@ -3,14 +3,14 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#include <ti/drivers/UART.h>
+#include <ti/drivers/UART2.h>
 #include <board.h>
 #include <ti/drivers/dpl/SemaphoreP.h>
-#include <ti/sysbios/knl/Clock.h>
+
 
 #include <ti_drivers_config.h>
 
-extern UART_Handle uart;
+extern UART2_Handle uart;
 
 SemaphoreP_Handle uartMutex;
 
@@ -20,9 +20,6 @@ SemaphoreP_Handle uartMutex;
 // The clean alternative would be to add the GCC attribute used in those functions, but that's not our code to touch.
 
 void dummyFunction(void) __attribute__((used));
-
-// UART operations timeout
-#define UART_TIMEOUT_MILLISECONDS 500000
 
 // Never called.
 void dummyFunction(void)
@@ -34,19 +31,17 @@ void dummyFunction(void)
 // configure UART
 void ConfigUART()
 {
-    UART_Params uartParams;
+    UART2_Params uartParams;
 
     // Create a UART with data processing off
-    UART_Params_init(&uartParams);
+    UART2_Params_init(&uartParams);
 
-    uartParams.writeDataMode = UART_DATA_BINARY;
-    uartParams.readDataMode = UART_DATA_BINARY;
-    uartParams.readEcho = UART_ECHO_OFF;
+    uartParams.writeMode = UART2_Mode_BLOCKING;
+    uartParams.readMode = UART2_Mode_BLOCKING;
     uartParams.baudRate = 921600;
-    uartParams.readTimeout = UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod;
-    uartParams.writeTimeout = UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod;
+    uartParams.readReturnMode = UART2_ReadReturnMode_FULL;
 
-    uart = UART_open(UART0, &uartParams);
+    uart = UART2_open(UART0, &uartParams);
 
     if (uart == NULL)
     {

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL_Events.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL_Events.cpp
@@ -120,8 +120,7 @@ void Events_SetBoolTimer( bool* timerCompleteFlag, uint32_t millisecondsFromNow 
         // As only one timer running at a time we will just save it
         saveTimerCompleteFlag = timerCompleteFlag;
 
-        // need to convert from milliseconds to ticks
-        Clock_setPeriod(boolEventsTimer, millisecondsFromNow * (1000 / Clock_tickPeriod));
+        Clock_setPeriod(boolEventsTimer, millisecondsFromNow);
         Clock_start(boolEventsTimer);
     }
 }

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL_Time.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL_Time.cpp
@@ -10,7 +10,7 @@
 
 static Clock_Handle nextEventTimer;
 
-static void NextEventTimer_Callback( UArg arg )
+static void NextEventTimer_Callback(UArg arg)
 {
     (void)arg;
 
@@ -39,23 +39,23 @@ HRESULT Time_Uninitialize()
     return S_OK;
 }
 
-void Time_SetCompare ( uint64_t compareValueTicks )
+void Time_SetCompare(uint64_t compareValueTicks)
 {
-    if(compareValueTicks == 0)
+    if (compareValueTicks == 0)
     {
-        // compare value is 0 so dequeue and schedule immediately 
+        // compare value is 0 so dequeue and schedule immediately
         HAL_COMPLETION::DequeueAndExec();
     }
-    else if(compareValueTicks == HAL_COMPLETION_IDLE_VALUE)
+    else if (compareValueTicks == HAL_COMPLETION_IDLE_VALUE)
     {
         // wait for infinity, don't need to do anything here
         return;
-    }    
+    }
     else
     {
-        if (HAL_Time_CurrentSysTicks() >= compareValueTicks) 
-        { 
-            // already missed the event, dequeue and execute immediately 
+        if (HAL_Time_CurrentSysTicks() >= compareValueTicks)
+        {
+            // already missed the event, dequeue and execute immediately
             HAL_COMPLETION::DequeueAndExec();
         }
         else
@@ -63,11 +63,11 @@ void Time_SetCompare ( uint64_t compareValueTicks )
             // need to stop the timer, in case it's running
             Clock_stop(nextEventTimer);
 
-            // compareValueTicks is the time (in sys ticks) that is being requested to fire an HAL_COMPLETION::DequeueAndExec()
-            // need to subtract the current system time to set when the timer will fire
+            // compareValueTicks is the time (in sys ticks) that is being requested to fire an
+            // HAL_COMPLETION::DequeueAndExec() need to subtract the current system time to set when the timer will fire
             compareValueTicks -= HAL_Time_CurrentSysTicks();
-            
-            if (compareValueTicks == 0) 
+
+            if (compareValueTicks == 0)
             {
                 // compare value is 0 so dequeue and execute immediately
                 // no need to call the timer
@@ -76,7 +76,7 @@ void Time_SetCompare ( uint64_t compareValueTicks )
             }
 
             // need to convert from milliseconds to ticks
-            Clock_setPeriod(nextEventTimer, compareValueTicks/ Clock_tickPeriod );
+            Clock_setPeriod(nextEventTimer, compareValueTicks / Clock_tickPeriod);
             Clock_start(nextEventTimer);
         }
     }

--- a/targets/TI-SimpleLink/nanoCLR/targetPAL_Time.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/targetPAL_Time.cpp
@@ -75,7 +75,8 @@ void Time_SetCompare ( uint64_t compareValueTicks )
                 return;
             }
 
-            Clock_setPeriod(nextEventTimer, compareValueTicks);
+            // need to convert from milliseconds to ticks
+            Clock_setPeriod(nextEventTimer, compareValueTicks/ Clock_tickPeriod );
             Clock_start(nextEventTimer);
         }
     }


### PR DESCRIPTION
## Description
- Move UART code to new UART2 driver.
- Fix calls to Clock_setPeriod (where using ticks instead of millisec).
- Replace old style call to Board_initGeneral and UART_init.
- Tweak managed heap size.
- Update SysConfig file to use UART1 driver.

## Motivation and Context
- New UART driver has a better API and works better.
- Wrong use of Clock_setPeriod  was causing issue with events.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
