### PR TITLE
Fix wake-up from standby

### DIFF
--- a/targets/TI-SimpleLink/nanoCLR/nanoFramework.Hardware.TI/nf_hardware_ti_native_nanoFramework_Hardware_TI_Power.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/nanoFramework.Hardware.TI/nf_hardware_ti_native_nanoFramework_Hardware_TI_Power.cpp
@@ -116,5 +116,12 @@ HRESULT Library_nf_hardware_ti_native_nanoFramework_Hardware_TI_Power::
 
     ClockP_sleep(standbyDurationMilsec);
 
+    // need to reset the CPU after waking from standby
+    CPU_Reset();
+
+    //////////////////////////////////////
+    // THE EXECUTION NEVER REACHES HERE //
+    //////////////////////////////////////
+
     NANOCLR_NOCLEANUP();
 }


### PR DESCRIPTION
## Description
- Add reset after returning from standby.

## Motivation and Context
- Because of the way the "power mode policy" is implemented in TI SimpleLink after returning from standby a reset is required because only the RTC was active therefore the CLR completely looses track of everything time related. 

## How Has This Been Tested?<!-- (if applicable) -->
- Hardware.TI power sample.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
