### PR TITLE
Fix nanoHAL_Uninitialize for TI SimpleLink

### DIFF
--- a/targets/TI-SimpleLink/nanoCLR/targetHAL.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/targetHAL.cpp
@@ -11,13 +11,16 @@
 #include <nanoHAL_ConfigurationManager.h>
 // #include <FreeRTOS.h>
 
-#if (HAL_USE_I2C == TRUE)
+#if (HAL_USE_I2C_OPTION == TRUE)
 #include <ti/drivers/I2C.h>
 #include <win_dev_i2c_native_target.h>
 #endif
-#if (HAL_USE_SPI == TRUE)
+#if (HAL_USE_SPI_OPTION == TRUE)
 #include <ti/drivers/SPI.h>
 #include <win_dev_spi_native_target.h>
+#endif
+#if (HAL_USE_SPI == ON)
+#include <easylink/EasyLink.h>
 #endif
 
 //
@@ -83,18 +86,18 @@ void nanoHAL_Initialize()
 
     CPU_GPIO_Initialize();
 
-#if (HAL_USE_SPI == TRUE)
+#if (HAL_USE_SPI_OPTION == TRUE)
     nanoSPI_Initialize();
 #endif
 
     // no PAL events required until now
     // PalEvent_Initialize();
 
-#if (HAL_USE_I2C == TRUE)
+#if (HAL_USE_I2C_OPTION == TRUE)
     I2C1_PAL.i2c = NULL;
 #endif
 
-#if (HAL_USE_SPI == TRUE)
+#if (HAL_USE_SPI_OPTION == TRUE)
     SPI1_PAL.masterSpi = NULL;
 #endif
 
@@ -127,18 +130,22 @@ void nanoHAL_Uninitialize()
     // TODO need to call this but it's preventing the debug session from starting
     // Network_Uninitialize();
 
-#if (HAL_USE_SPI == TRUE)
+#if (HAL_USE_SPI_OPTION == TRUE)
     nanoSPI_Uninitialize();
 #endif
 
     CPU_GPIO_Uninitialize();
 
-#if (HAL_USE_I2C == TRUE)
+#if (HAL_USE_I2C_OPTION == TRUE)
     I2C_close(I2C1_PAL.i2c);
 #endif
 
-#if (HAL_USE_SPI == TRUE)
+#if (HAL_USE_SPI_OPTION == TRUE)
     SPI_close(SPI1_PAL.masterSpi);
+#endif
+
+#if (HAL_USE_EASYLINK == ON)
+    EasyLink_abort();
 #endif
 
     Events_Uninitialize();

--- a/targets/TI-SimpleLink/nanoCLR/target_platform.h.in
+++ b/targets/TI-SimpleLink/nanoCLR/target_platform.h.in
@@ -18,9 +18,12 @@
 #define SL_APP_SNTP         @NF_NETWORKING_SNTP@
 
 // enable I2C
-#define HAL_USE_I2C @API_Windows.Devices.I2c@
+#define HAL_USE_I2C @HAL_USE_I2C_OPTION@
 
 // enable SPI
-#define HAL_USE_SPI @API_Windows.Devices.Spi@
+#define HAL_USE_SPI @HAL_USE_SPI_OPTION@
+
+// enable EasyLink
+#define HAL_USE_EASYLINK @API_nanoFramework.TI.EasyLink@
 
 #endif /* _TARGET_TI_SIMPLELINK_NANOCLR_H_ */


### PR DESCRIPTION
## Description
- Add code to abort EasyLink on uninitialize.
- Fix define names used for target platform.

## Motivation and Context
- Fixes issues caused on CLR rebooting without aborting EasyLink tasks that may be pending.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
