### PR TITLE
Removes duplicate `elseif`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -693,11 +693,6 @@ if(RTOS_CHIBIOS_CHECK)
         endif()
 
     endif()
-#######################
-# FreeRTOS
-elseif(RTOS_FREERTOS_CHECK)
-
-    add_subdirectory(targets/FreeRTOS)
 
 #######################
 # FreeRTOS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,33 +699,7 @@ if(RTOS_CHIBIOS_CHECK)
 elseif(RTOS_FREERTOS_CHECK)
 
     add_subdirectory(targets/FreeRTOS)
-   
-    # now add the subdirectory for the board
-    # try to find board in the targets folder
-    if(EXISTS ${PROJECT_SOURCE_DIR}/targets/FreeRTOS/NXP/${FREERTOS_BOARD})
-        # board found
-        message(STATUS "Support for target board '${FREERTOS_BOARD}' found")
 
-        # add TARGET board directory
-        add_subdirectory("targets/FreeRTOS/NXP/${FREERTOS_BOARD}")
-
-    else()
-
-        # try to find board in the Community targets folder
-        if(EXISTS ${PROJECT_SOURCE_DIR}/targets-community/FreeRTOS/NXP/${FREERTOS_BOARD})
-            # board found
-            message(STATUS "Support for target board '${FREERTOS_BOARD}' found in Community targets")
-
-            # add TARGET board directory from Community
-            add_subdirectory("targets-community/FreeRTOS/NXP/${FREERTOS_BOARD}")
-
-        else()
-        # board NOT found in targets folder
-            # board NOT found in targets folder
-            message(FATAL_ERROR "\n\nSorry but support for ${FREERTOS_BOARD} target is not available...\n\You can wait for that to be added or you might want to contribute and start working on a PR for that.\n\n")
-        endif()
-
-    endif()
 #######################
 # FreeRTOS ESP32
 elseif(RTOS_FREERTOS_ESP32_CHECK)


### PR DESCRIPTION
## Description
The code `elseif(RTOS_FREERTOS_CHECK)` is duplicated in CMakeLists.txt. It was likely caused by a merge.

## Motivation and Context
Code fix

## How Has This Been Tested?<!-- (if applicable) -->
If the build pipeline still works, then no issues are caused.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
