### PR TITLE
Fix Timeout.InfiniteTimeSpan

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_TimeSpan.cpp
+++ b/src/CLR/CorLib/corlib_native_System_TimeSpan.cpp
@@ -5,136 +5,169 @@
 //
 #include "CorLib.h"
 
-
-HRESULT Library_corlib_native_System_TimeSpan::Equals___BOOLEAN__OBJECT( CLR_RT_StackFrame& stack )
+HRESULT Library_corlib_native_System_TimeSpan::Equals___BOOLEAN__OBJECT(CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    NANOCLR_CHECK_HRESULT(CompareTo___I4__OBJECT( stack ));
+    NANOCLR_CHECK_HRESULT(CompareTo___I4__OBJECT(stack));
 
     {
-        CLR_RT_HeapBlock& res = stack.TopValue();
+        CLR_RT_HeapBlock &res = stack.TopValue();
 
-        res.SetBoolean( res.NumericByRef().s4 == 0 );
+        res.SetBoolean(res.NumericByRef().s4 == 0);
     }
 
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_corlib_native_System_TimeSpan::ToString___STRING( CLR_RT_StackFrame& stack )
+HRESULT Library_corlib_native_System_TimeSpan::ToString___STRING(CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    char       rgBuffer[ 128 ];
-    char*      szBuffer =           rgBuffer;
-    size_t     iBuffer  = ARRAYSIZE(rgBuffer);
-    CLR_INT64* val      = GetValuePtr( stack ); FAULT_ON_NULL(val);
+    char rgBuffer[128];
+    char *szBuffer = rgBuffer;
+    size_t iBuffer = ARRAYSIZE(rgBuffer);
+    CLR_INT64 *val = GetValuePtr(stack);
+    FAULT_ON_NULL(val);
 
-    HAL_Time_TimeSpanToStringEx( *val, szBuffer, iBuffer );
+    HAL_Time_TimeSpanToStringEx(*val, szBuffer, iBuffer);
 
-    NANOCLR_SET_AND_LEAVE(stack.SetResult_String( rgBuffer ));
+    NANOCLR_SET_AND_LEAVE(stack.SetResult_String(rgBuffer));
 
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_corlib_native_System_TimeSpan::_ctor___VOID__I4__I4__I4( CLR_RT_StackFrame& stack )
+HRESULT Library_corlib_native_System_TimeSpan::_ctor___VOID__I4__I4__I4(CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock* pArgs = &(stack.Arg1());
-    CLR_INT64*        val   = GetValuePtr( stack ); FAULT_ON_NULL(val);
+    CLR_RT_HeapBlock *pArgs = &(stack.Arg1());
+    CLR_INT64 *val = GetValuePtr(stack);
+    FAULT_ON_NULL(val);
 
-    ConstructTimeSpan( val, 0, pArgs[ 0 ].NumericByRef().s4, pArgs[ 1 ].NumericByRef().s4, pArgs[ 2 ].NumericByRef().s4, 0 );
+    ConstructTimeSpan(val, 0, pArgs[0].NumericByRef().s4, pArgs[1].NumericByRef().s4, pArgs[2].NumericByRef().s4, 0);
 
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_corlib_native_System_TimeSpan::_ctor___VOID__I4__I4__I4__I4( CLR_RT_StackFrame& stack )
+HRESULT Library_corlib_native_System_TimeSpan::_ctor___VOID__I4__I4__I4__I4(CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock* pArgs = &(stack.Arg1());
-    CLR_INT64*        val   = GetValuePtr( stack ); FAULT_ON_NULL(val);
+    CLR_RT_HeapBlock *pArgs = &(stack.Arg1());
+    CLR_INT64 *val = GetValuePtr(stack);
+    FAULT_ON_NULL(val);
 
-    ConstructTimeSpan( val, pArgs[ 0 ].NumericByRef().s4, pArgs[ 1 ].NumericByRef().s4, pArgs[ 2 ].NumericByRef().s4, pArgs[ 3 ].NumericByRef().s4, 0 );
+    ConstructTimeSpan(
+        val,
+        pArgs[0].NumericByRef().s4,
+        pArgs[1].NumericByRef().s4,
+        pArgs[2].NumericByRef().s4,
+        pArgs[3].NumericByRef().s4,
+        0);
 
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_corlib_native_System_TimeSpan::_ctor___VOID__I4__I4__I4__I4__I4( CLR_RT_StackFrame& stack )
+HRESULT Library_corlib_native_System_TimeSpan::_ctor___VOID__I4__I4__I4__I4__I4(CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock* pArgs = &(stack.Arg1());
-    CLR_INT64*        val   = GetValuePtr( stack ); FAULT_ON_NULL(val);
+    CLR_RT_HeapBlock *pArgs = &(stack.Arg1());
+    CLR_INT64 *val = GetValuePtr(stack);
+    FAULT_ON_NULL(val);
 
-    ConstructTimeSpan( val, pArgs[ 0 ].NumericByRef().s4, pArgs[ 1 ].NumericByRef().s4, pArgs[ 2 ].NumericByRef().s4, pArgs[ 3 ].NumericByRef().s4, pArgs[ 4 ].NumericByRef().s4 );
+    ConstructTimeSpan(
+        val,
+        pArgs[0].NumericByRef().s4,
+        pArgs[1].NumericByRef().s4,
+        pArgs[2].NumericByRef().s4,
+        pArgs[3].NumericByRef().s4,
+        pArgs[4].NumericByRef().s4);
 
     NANOCLR_NOCLEANUP();
 }
 
-void Library_corlib_native_System_TimeSpan::ConstructTimeSpan( CLR_INT64* val, CLR_INT32 days, CLR_INT32 hours, CLR_INT32 minutes, CLR_INT32 seconds, CLR_INT32 msec )
+void Library_corlib_native_System_TimeSpan::ConstructTimeSpan(
+    CLR_INT64 *val,
+    CLR_INT32 days,
+    CLR_INT32 hours,
+    CLR_INT32 minutes,
+    CLR_INT32 seconds,
+    CLR_INT32 msec)
 
 {
-    *val = ((CLR_INT64)days) * TIME_CONVERSION__ONEDAY   +
-           hours * TIME_CONVERSION__ONEHOUR              +
-           minutes * TIME_CONVERSION__ONEMINUTE          +
-           seconds * TIME_CONVERSION__ONESECOND;
+    *val = ((CLR_INT64)days) * TIME_CONVERSION__ONEDAY + hours * TIME_CONVERSION__ONEHOUR +
+           minutes * TIME_CONVERSION__ONEMINUTE + seconds * TIME_CONVERSION__ONESECOND;
 
     *val *= 1000;
-    *val += msec;
-    *val *= TIME_CONVERSION__TICKUNITS;
+
+    if ((*val == 0) && (msec == -1))
+    {
+        // this is the edge case for creating a System.Threading.Timeout.InfiniteTimeSpan
+        *val = -1;
+    }
+    else
+    {
+        // remaining situation, just take the milliseconds value as it is and convert to ticks
+        *val += msec;
+        *val *= TIME_CONVERSION__TICKUNITS;
+    }
 }
 
-HRESULT Library_corlib_native_System_TimeSpan::CompareTo___I4__OBJECT( CLR_RT_StackFrame& stack )
+HRESULT Library_corlib_native_System_TimeSpan::CompareTo___I4__OBJECT(CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock* pRight = stack.Arg1().Dereference();
+    CLR_RT_HeapBlock *pRight = stack.Arg1().Dereference();
 
-    if(pRight)
+    if (pRight)
     {
-        NANOCLR_SET_AND_LEAVE(Compare___STATIC__I4__SystemTimeSpan__SystemTimeSpan( stack ));
+        NANOCLR_SET_AND_LEAVE(Compare___STATIC__I4__SystemTimeSpan__SystemTimeSpan(stack));
     }
 
-    stack.SetResult_I4( 1 );
+    stack.SetResult_I4(1);
 
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_corlib_native_System_TimeSpan::Compare___STATIC__I4__SystemTimeSpan__SystemTimeSpan( CLR_RT_StackFrame& stack )
+HRESULT Library_corlib_native_System_TimeSpan::Compare___STATIC__I4__SystemTimeSpan__SystemTimeSpan(
+    CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_INT64*       pLeft;
-    CLR_INT64*       pRight;
+    CLR_INT64 *pLeft;
+    CLR_INT64 *pRight;
     CLR_RT_HeapBlock resLeft;
     CLR_RT_HeapBlock resRight;
 
-    pLeft  = Library_corlib_native_System_TimeSpan::GetValuePtr( stack        ); FAULT_ON_NULL(pLeft);
-    pRight = Library_corlib_native_System_TimeSpan::GetValuePtr( stack.Arg1() ); FAULT_ON_NULL(pRight);
+    pLeft = Library_corlib_native_System_TimeSpan::GetValuePtr(stack);
+    FAULT_ON_NULL(pLeft);
+    pRight = Library_corlib_native_System_TimeSpan::GetValuePtr(stack.Arg1());
+    FAULT_ON_NULL(pRight);
 
-    resLeft .SetInteger( *pLeft  );
-    resRight.SetInteger( *pRight );
+    resLeft.SetInteger(*pLeft);
+    resRight.SetInteger(*pRight);
 
-    stack.SetResult_I4( CLR_RT_HeapBlock::Compare_Signed_Values( resLeft, resRight ) );
+    stack.SetResult_I4(CLR_RT_HeapBlock::Compare_Signed_Values(resLeft, resRight));
 
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_corlib_native_System_TimeSpan::Equals___STATIC__BOOLEAN__SystemTimeSpan__SystemTimeSpan( CLR_RT_StackFrame& stack )
+HRESULT Library_corlib_native_System_TimeSpan::Equals___STATIC__BOOLEAN__SystemTimeSpan__SystemTimeSpan(
+    CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    NANOCLR_CHECK_HRESULT(Compare___STATIC__I4__SystemTimeSpan__SystemTimeSpan( stack ));
+    NANOCLR_CHECK_HRESULT(Compare___STATIC__I4__SystemTimeSpan__SystemTimeSpan(stack));
 
     stack.ConvertResultToBoolean();
 
@@ -143,51 +176,52 @@ HRESULT Library_corlib_native_System_TimeSpan::Equals___STATIC__BOOLEAN__SystemT
 
 //--//
 
-CLR_INT64* Library_corlib_native_System_TimeSpan::NewObject( CLR_RT_StackFrame& stack )
+CLR_INT64 *Library_corlib_native_System_TimeSpan::NewObject(CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
-    CLR_RT_HeapBlock& ref = stack.PushValue();
+    CLR_RT_HeapBlock &ref = stack.PushValue();
 
-    ref.SetDataId( CLR_RT_HEAPBLOCK_RAW_ID( DATATYPE_TIMESPAN, 0, 1 ) );
-    ref.ClearData(                                                    );
+    ref.SetDataId(CLR_RT_HEAPBLOCK_RAW_ID(DATATYPE_TIMESPAN, 0, 1));
+    ref.ClearData();
 
-    return (CLR_INT64*)&ref.NumericByRef().s8;
+    return (CLR_INT64 *)&ref.NumericByRef().s8;
 }
 
-CLR_INT64* Library_corlib_native_System_TimeSpan::GetValuePtr( CLR_RT_StackFrame& stack )
+CLR_INT64 *Library_corlib_native_System_TimeSpan::GetValuePtr(CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
-    return GetValuePtr( stack.Arg0() );
+    return GetValuePtr(stack.Arg0());
 }
 
-CLR_INT64* Library_corlib_native_System_TimeSpan::GetValuePtr( CLR_RT_HeapBlock& ref )
+CLR_INT64 *Library_corlib_native_System_TimeSpan::GetValuePtr(CLR_RT_HeapBlock &ref)
 {
     NATIVE_PROFILE_CLR_CORE();
-    CLR_RT_HeapBlock* obj = &ref;
-    CLR_DataType      dt  = obj->DataType();
+    CLR_RT_HeapBlock *obj = &ref;
+    CLR_DataType dt = obj->DataType();
 
-    if(dt == DATATYPE_OBJECT || dt == DATATYPE_BYREF)
+    if (dt == DATATYPE_OBJECT || dt == DATATYPE_BYREF)
     {
-        obj = obj->Dereference(); if(!obj) return NULL;
+        obj = obj->Dereference();
+        if (!obj)
+            return NULL;
 
         dt = obj->DataType();
     }
 
-    if(dt == DATATYPE_TIMESPAN)
+    if (dt == DATATYPE_TIMESPAN)
     {
-        return (CLR_INT64*)&obj->NumericByRef().s8;
+        return (CLR_INT64 *)&obj->NumericByRef().s8;
     }
 
-    if(dt == DATATYPE_I8)
+    if (dt == DATATYPE_I8)
     {
-        return (CLR_INT64*)&obj->NumericByRef().s8;
+        return (CLR_INT64 *)&obj->NumericByRef().s8;
     }
 
-    if(dt == DATATYPE_VALUETYPE && obj->ObjectCls().m_data == g_CLR_RT_WellKnownTypes.m_TimeSpan.m_data)
+    if (dt == DATATYPE_VALUETYPE && obj->ObjectCls().m_data == g_CLR_RT_WellKnownTypes.m_TimeSpan.m_data)
     {
-        return (CLR_INT64*)&obj[ FIELD___ticks ].NumericByRef().s8;
+        return (CLR_INT64 *)&obj[FIELD___ticks].NumericByRef().s8;
     }
 
     return NULL;
 }
-


### PR DESCRIPTION
## Description
- The .NET "infinite value" wasn't been properly handled by the constructor resulting on an invalid ticks value for the infinite timespan.

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
