### PR TITLE
Work TI SimpleLink

### DIFF
--- a/targets/TI-SimpleLink/nanoCLR/nanoFramework.TI.EasyLink/nf_ti_easylink.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/nanoFramework.TI.EasyLink/nf_ti_easylink.cpp
@@ -5,6 +5,8 @@
 
 #include "nf_ti_easylink.h"
 
+// clang-format off
+
 static const CLR_RT_MethodHandler method_lookup[] =
 {
     NULL,
@@ -32,6 +34,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
     Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::GetConfiguration___U4__nanoFrameworkTIEasyLinkControlOption,
     NULL,
     NULL,
@@ -41,17 +44,19 @@ static const CLR_RT_MethodHandler method_lookup[] =
     Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::DisposeNative___VOID,
     Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::UpdateRxAddressFilterNative___VOID,
     Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::InitNative___U1,
-    Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::ReceiveNative___U1__BYREF_nanoFrameworkTIEasyLinkReceivedPacket__I4,
+    Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::ReceiveNative___U1__BYREF_nanoFrameworkTIEasyLinkReceivedPacket__SystemTimeSpan,
     Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::SetConfigurationNative___U1__nanoFrameworkTIEasyLinkControlOption__U4,
     Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::SetFrequencyNative___U1__U4,
     Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::SetRfPowerNative___U1__I1,
-    Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::TransmitNative___U1__nanoFrameworkTIEasyLinkTransmitPacket__I4__I4,
+    Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::TransmitNative___U1__nanoFrameworkTIEasyLinkTransmitPacket__SystemTimeSpan__SystemTimeSpan,
 };
 
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_TI_EasyLink =
 {
     "nanoFramework.TI.EasyLink",
-    0xEC93F5DE,
+    0x948DBCF9,
     method_lookup,
-    { 100, 0, 0, 2 }
+    { 100, 0, 0, 3 }
 };
+
+// clang-format on

--- a/targets/TI-SimpleLink/nanoCLR/nanoFramework.TI.EasyLink/nf_ti_easylink.h
+++ b/targets/TI-SimpleLink/nanoCLR/nanoFramework.TI.EasyLink/nf_ti_easylink.h
@@ -9,6 +9,8 @@
 #include <nanoCLR_Interop.h>
 #include <nanoCLR_Runtime.h>
 #include <nanoHAL.h>
+#include <nanoPAL_Events.h>
+#include <corlib_native.h>
 
 // TI-RTOS Header files
 #include <ti/drivers/rf/RF.h>
@@ -57,11 +59,11 @@ struct Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController
     NANOCLR_NATIVE_DECLARE(DisposeNative___VOID);
     NANOCLR_NATIVE_DECLARE(UpdateRxAddressFilterNative___VOID);
     NANOCLR_NATIVE_DECLARE(InitNative___U1);
-    NANOCLR_NATIVE_DECLARE(ReceiveNative___U1__BYREF_nanoFrameworkTIEasyLinkReceivedPacket__I4);
+    NANOCLR_NATIVE_DECLARE(ReceiveNative___U1__BYREF_nanoFrameworkTIEasyLinkReceivedPacket__SystemTimeSpan);
     NANOCLR_NATIVE_DECLARE(SetConfigurationNative___U1__nanoFrameworkTIEasyLinkControlOption__U4);
     NANOCLR_NATIVE_DECLARE(SetFrequencyNative___U1__U4);
     NANOCLR_NATIVE_DECLARE(SetRfPowerNative___U1__I1);
-    NANOCLR_NATIVE_DECLARE(TransmitNative___U1__nanoFrameworkTIEasyLinkTransmitPacket__I4__I4);
+    NANOCLR_NATIVE_DECLARE(TransmitNative___U1__nanoFrameworkTIEasyLinkTransmitPacket__SystemTimeSpan__SystemTimeSpan);
 
     //--//
 

--- a/targets/TI-SimpleLink/nanoCLR/nanoFramework.TI.EasyLink/nf_ti_easylink.h
+++ b/targets/TI-SimpleLink/nanoCLR/nanoFramework.TI.EasyLink/nf_ti_easylink.h
@@ -27,7 +27,6 @@ struct Library_nf_ti_easylink_nanoFramework_TI_EasyLink_TransmitPacket
     static const int FIELD___payload = 2;
 
     //--//
-
 };
 
 struct Library_nf_ti_easylink_nanoFramework_TI_EasyLink_ReceivedPacket
@@ -39,7 +38,6 @@ struct Library_nf_ti_easylink_nanoFramework_TI_EasyLink_ReceivedPacket
     static const int FIELD___rxTimeout = 5;
 
     //--//
-
 };
 
 struct Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController
@@ -67,10 +65,9 @@ struct Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController
 
     //--//
 
-    static HRESULT UpdateRxAddressFilter( CLR_RT_StackFrame& stack );
-
+    static HRESULT UpdateRxAddressFilter(CLR_RT_StackFrame &stack);
 };
 
 extern const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_TI_EasyLink;
 
-#endif  //_NF_TI_EASYLINK_H_
+#endif //_NF_TI_EASYLINK_H_

--- a/targets/TI-SimpleLink/nanoCLR/nanoFramework.TI.EasyLink/nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/nanoFramework.TI.EasyLink/nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController.cpp
@@ -4,12 +4,29 @@
 //
 
 #include "nf_ti_easylink.h"
+#include <xdc/runtime/Error.h>
+#include <ti/sysbios/knl/Task.h>
 
 typedef Library_nf_ti_easylink_nanoFramework_TI_EasyLink_TransmitPacket TransmitPacket;
 typedef Library_nf_ti_easylink_nanoFramework_TI_EasyLink_ReceivedPacket ReceivedPacket;
 
 static EasyLink_RxPacket latestRxPacket;
 static EasyLink_Status latestOperationStatus;
+static EasyLink_Params easyLink_params;
+
+static Task_Handle abortEasyLinkTask;
+
+// Task to abort EasyLink
+static void AbortEasyLink(UArg arg0, UArg arg1)
+{
+    (void)arg0;
+    (void)arg1;
+
+    latestOperationStatus = EasyLink_abort();
+
+    // fire event for EasyLink init completed
+    Events_Set(SYSTEM_EVENT_FLAG_RADIO);
+}
 
 // handler for TX operation done
 static void TxDone(EasyLink_Status status)
@@ -154,11 +171,69 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::Dis
 {
     NANOCLR_HEADER();
 
-    (void)stack;
+    Task_Params taskParams;
+
+    CLR_RT_HeapBlock hbTimeout;
+    CLR_INT64 *timeoutTicks;
+    CLR_INT32 timeout_ms;
+    bool eventResult = true;
 
     // stop any ongoing async operation that could be occurring
     // don't bother checking the return result
-    EasyLink_abort();
+
+    // set timeout
+    // !! need to cast to CLR_INT64 otherwise it wont setup a proper timeout infinite
+    hbTimeout.SetInteger((CLR_INT64)-1);
+    NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeoutTicks));
+
+    if (stack.m_customState == 1)
+    {
+        // setup Task thread
+        Task_Params_init(&taskParams);
+        taskParams.stackSize = 512;
+        taskParams.priority = 4;
+
+        // create task
+        abortEasyLinkTask = Task_create((Task_FuncPtr)AbortEasyLink, &taskParams, Error_IGNORE);
+        if (abortEasyLinkTask == NULL)
+        {
+            // store result
+            latestOperationStatus = EasyLink_Status_Aborted;
+
+            // prevent event from being processed
+            eventResult = false;
+        }
+        else
+        {
+            // bump custom state
+            stack.m_customState = 2;
+        }
+    }
+
+    while (eventResult)
+    {
+        // non-blocking wait allowing other threads to run while we wait for the receive operation to complete
+        NANOCLR_CHECK_HRESULT(
+            g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeoutTicks, Event_Radio, eventResult));
+
+        Task_delete(&abortEasyLinkTask);
+
+        if (eventResult)
+        {
+            // event occurred!!
+        }
+        else
+        {
+            // timeout occurred
+            // nothing else that can be done here
+        }
+
+        // done here
+        break;
+    }
+
+    // pop timeout heap block from stack
+    stack.PopValue();
 
     NANOCLR_NOCLEANUP();
 }
@@ -174,14 +249,12 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::Ini
     NANOCLR_HEADER();
 
     uint8_t i = 0;
-    EasyLink_Status status;
     EasyLink_PhyType phyType = (EasyLink_PhyType)0;
 
     CLR_RT_HeapBlock *pThis = stack.This();
     FAULT_ON_NULL(pThis);
 
-    // Initialize the EasyLink parameters to their default values
-    EasyLink_Params easyLink_params;
+    // initialize the EasyLink parameters to their default values
     EasyLink_Params_init(&easyLink_params);
 
     // get managed Phy Type
@@ -204,25 +277,33 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::Ini
 
     easyLink_params.ui32ModType = phyType;
 
-    // Initialize EasyLink
-    status = EasyLink_init(&easyLink_params);
-    if (status != EasyLink_Status_Success)
-    {
-        // fail to start
-        stack.SetResult_U1(status);
+    // try to start EasyLink
+    latestOperationStatus = EasyLink_init(&easyLink_params);
 
-        NANOCLR_SET_AND_LEAVE(S_OK);
+    if (latestOperationStatus != EasyLink_Status_Success)
+    {
+        // something went wrong
+        // call abort to force any TX/RX operation that could be lingering
+        EasyLink_abort();
+
+        // try again
+        latestOperationStatus = EasyLink_init(&easyLink_params);
+
+        // need to setup Rx address, if any is set
+        if (latestOperationStatus == EasyLink_Status_Success)
+        {
+            UpdateRxAddressFilter(stack);
+        }
     }
 
-    latestOperationStatus = EasyLink_Status_Success;
-
-    stack.SetResult_U1(status);
+    // return operation status
+    stack.SetResult_U1(latestOperationStatus);
 
     NANOCLR_NOCLEANUP();
 }
 
 HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
-    ReceiveNative___U1__BYREF_nanoFrameworkTIEasyLinkReceivedPacket__I4(CLR_RT_StackFrame &stack)
+    ReceiveNative___U1__BYREF_nanoFrameworkTIEasyLinkReceivedPacket__SystemTimeSpan(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
 
@@ -232,9 +313,9 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
     CLR_RT_HeapBlock *packet;
     CLR_RT_HeapBlock hbObj;
 
+    CLR_INT64 *timeoutDuration;
+    CLR_UINT64 timeoutMiliseconds;
     CLR_INT64 *timeoutTicks;
-    CLR_INT32 timeout_ms;
-    EasyLink_Status status;
     bool eventResult = true;
 
     // get a pointer to the managed object instance and check that it's not NULL
@@ -244,43 +325,56 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
     // check disposed
     if (pThis[FIELD___disposed].NumericByRef().u1 != 0)
     {
-        // don't throw if the execution has reached here from an aborted async operation
-        if (latestOperationStatus == EasyLink_Status_Aborted)
-        {
-            // return operation status
-            stack.SetResult_U1(latestOperationStatus);
-
-            NANOCLR_SET_AND_LEAVE(S_OK);
-        }
-        else
-        {
-            // has to throw exception on all other situations
-            NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
-        }
+        // has to throw exception on all other situations
+        NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
     }
 
     // get value for timeout parameter
-    timeout_ms = stack.Arg2().NumericByRef().s4;
+    // timeout parameter its a TimeSpan, which is a primitive type stored as an heap block, therefore needs to
+    // be accessed indirectly
+    timeoutDuration = Library_corlib_native_System_TimeSpan::GetValuePtr(stack.Arg2());
+    FAULT_ON_NULL(timeoutDuration);
 
-    // set timeout
-    rxTimeout.SetInteger(timeout_ms);
+    // check for .NET infinite timeout (-1)
+    if (*(CLR_UINT64 *)timeoutDuration == -1)
+    {
+        // "convert" to EasyLink infinite timeout
+        timeoutMiliseconds = 0;
+    }
+    else
+    {
+        timeoutMiliseconds = *(CLR_UINT64 *)timeoutDuration / TIME_CONVERSION__TO_MILLISECONDS;
+    }
+
+    // set thread timeout
+    // wait forever because EasyLink timeout will make this work
+    rxTimeout.SetInteger((CLR_INT64)-1);
     NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(rxTimeout, timeoutTicks));
+
+    // set timeout for EasyLink, only required on the 1st pass
+    if (stack.m_customState == 1)
+    {
+        // EasyLink RX timeout
+        EasyLink_setCtrl(EasyLink_Ctrl_AsyncRx_TimeOut, EasyLink_ms_To_RadioTime(timeoutMiliseconds));
+    }
 
     // setup the operation
     if (stack.m_customState == 1)
     {
         // enter receive mode
-        status = EasyLink_receiveAsync(RxDone, 0);
-        if (status != EasyLink_Status_Success)
+        latestOperationStatus = EasyLink_receiveAsync(RxDone, 0);
+        if (latestOperationStatus != EasyLink_Status_Success)
         {
             // fail to start
-            stack.SetResult_U1(status);
 
-            NANOCLR_SET_AND_LEAVE(S_OK);
+            // prevent event from being processed
+            eventResult = false;
         }
-
-        // bump custom state
-        stack.m_customState = 2;
+        else
+        {
+            // bump custom state
+            stack.m_customState = 2;
+        }
     }
 
     while (eventResult)
@@ -297,43 +391,51 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
         {
             // event occurred!!
 
-            // check operation status
-            if (latestOperationStatus == EasyLink_Status_Success)
+            if (stack.m_customState == 2)
             {
-                // RX operation successful, OK to populate class
+                // receive operation ongoing
 
-                // need to create ReceivedPacket object to return on "out" argument
-                // find <ReceivedPacket> type definition, don't bother checking the result as it exists for sure
-                g_CLR_RT_TypeSystem.FindTypeDef("ReceivedPacket", "nanoFramework.TI.EasyLink", receivedPacketTypeDef);
+                // check operation status
+                if (latestOperationStatus == EasyLink_Status_Success)
+                {
+                    // RX operation successful, OK to populate class
 
-                // create instance of <ReceivedPacket>
-                NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(hbObj, receivedPacketTypeDef));
+                    // need to create ReceivedPacket object to return on "out" argument
+                    // find <ReceivedPacket> type definition, don't bother checking the result as it exists for sure
+                    g_CLR_RT_TypeSystem.FindTypeDef(
+                        "ReceivedPacket",
+                        "nanoFramework.TI.EasyLink",
+                        receivedPacketTypeDef);
 
-                // need to dereference to access class fields
-                packet = hbObj.Dereference();
+                    // create instance of <ReceivedPacket>
+                    NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(hbObj, receivedPacketTypeDef));
 
-                // fill fields
-                packet[ReceivedPacket::FIELD___rxTimeout].NumericByRef().u4 = latestRxPacket.rxTimeout;
-                packet[ReceivedPacket::FIELD___rssi].NumericByRef().s1 = latestRxPacket.rssi;
-                packet[ReceivedPacket::FIELD___absoluteTime].NumericByRef().u4 = latestRxPacket.absTime;
+                    // need to dereference to access class fields
+                    packet = hbObj.Dereference();
 
-                // address it's an array
-                NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance(
-                    packet[ReceivedPacket::FIELD___address],
-                    (CLR_UINT32)ARRAYSIZE(latestRxPacket.dstAddr),
-                    g_CLR_RT_WellKnownTypes.m_UInt8));
-                buffer = packet[ReceivedPacket::FIELD___address].DereferenceArray();
-                // copy address
-                memcpy(buffer->GetFirstElement(), latestRxPacket.dstAddr, ARRAYSIZE(latestRxPacket.dstAddr));
+                    // fill fields
+                    packet[ReceivedPacket::FIELD___rxTimeout].NumericByRef().u4 = latestRxPacket.rxTimeout;
+                    packet[ReceivedPacket::FIELD___rssi].NumericByRef().s1 = latestRxPacket.rssi;
+                    packet[ReceivedPacket::FIELD___absoluteTime].NumericByRef().u4 = latestRxPacket.absTime;
 
-                // payload it's an array
-                NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance(
-                    packet[ReceivedPacket::FIELD___payload],
-                    (CLR_UINT32)ARRAYSIZE(latestRxPacket.payload),
-                    g_CLR_RT_WellKnownTypes.m_UInt8));
-                buffer = packet[ReceivedPacket::FIELD___payload].DereferenceArray();
-                // copy payload content
-                memcpy(buffer->GetFirstElement(), latestRxPacket.payload, ARRAYSIZE(latestRxPacket.payload));
+                    // address it's an array
+                    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance(
+                        packet[ReceivedPacket::FIELD___address],
+                        (CLR_UINT32)ARRAYSIZE(latestRxPacket.dstAddr),
+                        g_CLR_RT_WellKnownTypes.m_UInt8));
+                    buffer = packet[ReceivedPacket::FIELD___address].DereferenceArray();
+                    // copy address
+                    memcpy(buffer->GetFirstElement(), latestRxPacket.dstAddr, ARRAYSIZE(latestRxPacket.dstAddr));
+
+                    // payload it's an array
+                    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance(
+                        packet[ReceivedPacket::FIELD___payload],
+                        (CLR_UINT32)ARRAYSIZE(latestRxPacket.payload),
+                        g_CLR_RT_WellKnownTypes.m_UInt8));
+                    buffer = packet[ReceivedPacket::FIELD___payload].DereferenceArray();
+                    // copy payload content
+                    memcpy(buffer->GetFirstElement(), latestRxPacket.payload, ARRAYSIZE(latestRxPacket.payload));
+                }
             }
 
             // done here
@@ -343,28 +445,21 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
         {
             // timeout occurred
 
-            // stop ongoing RX async operation
-            // don't bother checking the return result
-            EasyLink_abort();
-
-            // set return
-            latestOperationStatus = EasyLink_Status_Aborted;
-
-            // instead of throwing a timeout exception return OK
-            // the failure it's already on the return result
-
             // done here
             break;
         }
     }
 
-    // sanity check
-    _ASSERTE(stack.Arg1().DataType() == DATATYPE_BYREF);
+    if (latestOperationStatus == EasyLink_Status_Success)
+    {
+        // sanity check
+        _ASSERTE(stack.Arg1().DataType() == DATATYPE_BYREF);
 
-    // packet it's passed as "out" meaning BYREF
-    // need to store the ReceivedPacket object in its reference
-    // hbObj it's either NULL or it's a properly formated ReceivedPacket object
-    NANOCLR_CHECK_HRESULT(hbObj.StoreToReference(stack.Arg1(), 0));
+        // packet it's passed as "out" meaning BYREF
+        // need to store the ReceivedPacket object in its reference
+        // hbObj it's either NULL or it's a properly formated ReceivedPacket object
+        NANOCLR_CHECK_HRESULT(hbObj.StoreToReference(stack.Arg1(), 0));
+    }
 
     // pop timeout heap block from stack
     stack.PopValue();
@@ -435,7 +530,7 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::Set
 }
 
 HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
-    TransmitNative___U1__nanoFrameworkTIEasyLinkTransmitPacket__I4__I4(CLR_RT_StackFrame &stack)
+    TransmitNative___U1__nanoFrameworkTIEasyLinkTransmitPacket__SystemTimeSpan__SystemTimeSpan(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
 
@@ -444,11 +539,12 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
     CLR_RT_HeapBlock txTimeout;
     CLR_RT_HeapBlock *packet;
 
+    CLR_INT64 *timeoutDuration;
+    CLR_INT64 *dueTimeDuration;
+    CLR_UINT64 timeoutMiliseconds;
+    CLR_UINT64 dueTimeMiliseconds;
     CLR_INT64 *timeoutTicks;
-    CLR_INT32 timeout_ms;
-    uint32_t dueTime;
     uint32_t absTime;
-    EasyLink_Status status;
     EasyLink_TxPacket txPacket = {{0}, 0, 0, {0}};
     bool eventResult = true;
 
@@ -459,27 +555,38 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
     // check disposed
     if (pThis[FIELD___disposed].NumericByRef().u1 != 0)
     {
-        // don't throw if the execution has reached here from an aborted async operation
-        if (latestOperationStatus == EasyLink_Status_Aborted)
-        {
-            // return operation status
-            stack.SetResult_U1(latestOperationStatus);
-
-            NANOCLR_SET_AND_LEAVE(S_OK);
-        }
-        else
-        {
-            // has to throw exception on all other situations
-            NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
-        }
+        // has to throw exception on all other situations
+        NANOCLR_SET_AND_LEAVE(CLR_E_OBJECT_DISPOSED);
     }
 
     // get value for timeout parameter
-    timeout_ms = stack.Arg2().NumericByRef().s4;
+    // timeout parameter its a TimeSpan, which is a primitive type stored as an heap block, therefore needs to
+    // be accessed indirectly
+    timeoutDuration = Library_corlib_native_System_TimeSpan::GetValuePtr(stack.Arg2());
+    FAULT_ON_NULL(timeoutDuration);
 
-    // set timeout
-    txTimeout.SetInteger(timeout_ms);
+    // check for .NET infinite timeout (-1)
+    if (*(CLR_UINT64 *)timeoutDuration == -1)
+    {
+        // "convert" to EasyLink infinite timeout
+        timeoutMiliseconds = 0;
+    }
+    else
+    {
+        timeoutMiliseconds = *(CLR_UINT64 *)timeoutDuration / TIME_CONVERSION__TO_MILLISECONDS;
+    }
 
+    // set timeout, if any
+    if (timeoutMiliseconds > 0)
+    {
+        // add 100ms to allow EasyLink timeout to occur before CLR thread timeout
+        txTimeout.SetInteger(timeoutMiliseconds + 100);
+    }
+    else
+    {
+        // no timeout so wait forever
+        txTimeout.SetInteger((CLR_INT64)-1);
+    }
     NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(txTimeout, timeoutTicks));
 
     // setup the operation and init buffers
@@ -501,33 +608,44 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
         // dereference the address buffer
         address = packet[TransmitPacket::FIELD___address].DereferenceArray();
 
-        // get payload length
-        txPacket.len = payloadBuffer->m_numOfElements;
-
         // copy buffer to packet
         memcpy(txPacket.dstAddr, address->GetFirstElement(), address->m_numOfElements);
 
-        // get dueTime managed argument
-        dueTime = stack.Arg3().NumericByRef().s4;
+        // get dueTime managed parameter
 
-        if (dueTime > 0)
+        // dueTime parameter its a TimeSpan, which is a primitive type stored as an heap block, therefore needs to
+        // be accessed indirectly
+        dueTimeDuration = Library_corlib_native_System_TimeSpan::GetValuePtr(stack.Arg3());
+        FAULT_ON_NULL(dueTimeDuration);
+
+        dueTimeMiliseconds = *(CLR_UINT64 *)dueTimeDuration / TIME_CONVERSION__TO_MILLISECONDS;
+
+        if (dueTimeMiliseconds > 0)
         {
             EasyLink_getAbsTime(&absTime);
-            txPacket.absTime = absTime + EasyLink_ms_To_RadioTime(dueTime);
+            txPacket.absTime = absTime + EasyLink_ms_To_RadioTime(dueTimeMiliseconds);
+        }
+        else
+        {
+            // Set Tx absolute time to current time + 100ms
+            txPacket.absTime = absTime + EasyLink_ms_To_RadioTime(100);
         }
 
         // start transmission
-        status = EasyLink_transmitAsync(&txPacket, TxDone);
-        if (status != EasyLink_Status_Success)
+        latestOperationStatus = EasyLink_transmitAsync(&txPacket, TxDone);
+
+        if (latestOperationStatus != EasyLink_Status_Success)
         {
             // fail to start
-            stack.SetResult_U1(status);
 
-            NANOCLR_SET_AND_LEAVE(S_OK);
+            // prevent event from being processed
+            eventResult = false;
         }
-
-        // bump custom state
-        stack.m_customState = 2;
+        else
+        {
+            // bump custom state
+            stack.m_customState = 2;
+        }
     }
 
     while (eventResult)
@@ -539,27 +657,26 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
         if (eventResult)
         {
             // event occurred
-
-            // done here
-            break;
         }
         else
         {
             // timeout occurred
 
-            // stop ongoing TX async operation
-            // don't bother checking the return result
-            EasyLink_abort();
-
-            // set return
-            latestOperationStatus = EasyLink_Status_Aborted;
+            latestOperationStatus = EasyLink_Status_Tx_Error;
 
             // instead of throwing a timeout exception return OK
             // the failure it's already on the return result
-
-            // done here
-            break;
         }
+
+        if( (latestOperationStatus != EasyLink_Status_Success) &&
+            (latestOperationStatus != EasyLink_Status_Aborted))
+        {
+            // abort EasyLink operation
+            EasyLink_abort();
+        }
+
+        // done here
+        break;
     }
 
     // pop timeout heap block from stack

--- a/targets/TI-SimpleLink/nanoCLR/nanoFramework.TI.EasyLink/nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/nanoFramework.TI.EasyLink/nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController.cpp
@@ -668,8 +668,7 @@ HRESULT Library_nf_ti_easylink_nanoFramework_TI_EasyLink_EasyLinkController::
             // the failure it's already on the return result
         }
 
-        if( (latestOperationStatus != EasyLink_Status_Success) &&
-            (latestOperationStatus != EasyLink_Status_Aborted))
+        if ((latestOperationStatus != EasyLink_Status_Success) && (latestOperationStatus != EasyLink_Status_Aborted))
         {
             // abort EasyLink operation
             EasyLink_abort();


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- Rework Init to add call to abort in case of a lingering operation is keeping the RF core busy.
- Rework Dispose to call abort in order to make sure there are no pending operations messing up with the RF core.
- Rework Tx and Rx calls to use new TimeSpan parameters.
- Improvements in Tx and Rx calls to better handle thread suspend & continuation.
- Update assembly declarations.

## Motivation and Context
- General improvements.
- Following nanoframework/lib-nanoFramework.TI.EasyLink#24.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [x] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
