### PR TITLE
Fix initialization of network config block

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/ORGPAL_PALTHREE/common/targetHAL_ConfigurationManager.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ORGPAL_PALTHREE/common/targetHAL_ConfigurationManager.cpp
@@ -14,13 +14,16 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
 {
     (void)configurationIndex;
 
+    // zero memory
+    memset(pconfig, 0, sizeof(HAL_Configuration_NetworkInterface));
+
     // make sure the config block marker is set
     memcpy(pconfig->Marker, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
     
     pconfig->InterfaceType = NetworkInterfaceType_Ethernet;
     pconfig->StartupAddressMode = AddressMode_DHCP;
     pconfig->AutomaticDNS = 1;
-    pconfig->SpecificConfigId = 0;
+    pconfig->SpecificConfigId = UINT32_MAX;
 
     // set MAC address with ST provided MAC for development boards
     // 00:80:E1:01:35:D1

--- a/targets/CMSIS-OS/ChibiOS/ORGPAL_PALTHREE/common/targetHAL_ConfigurationManager.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ORGPAL_PALTHREE/common/targetHAL_ConfigurationManager.cpp
@@ -10,7 +10,7 @@
 
 // Default initialisation for Network interface config blocks
 // strong implementation replacing ChibiOS 'weak' one
-bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig, uint32_t configurationIndex)
+bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface *pconfig, uint32_t configurationIndex)
 {
     (void)configurationIndex;
 
@@ -19,7 +19,7 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
 
     // make sure the config block marker is set
     memcpy(pconfig->Marker, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
-    
+
     pconfig->InterfaceType = NetworkInterfaceType_Ethernet;
     pconfig->StartupAddressMode = AddressMode_DHCP;
     pconfig->AutomaticDNS = 1;

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/common/targetHAL_ConfigurationManager.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/common/targetHAL_ConfigurationManager.cpp
@@ -14,13 +14,16 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
 {
     (void)configurationIndex;
 
+    // zero memory
+    memset(pconfig, 0, sizeof(HAL_Configuration_NetworkInterface));
+
     // make sure the config block marker is set
     memcpy(pconfig->Marker, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
     
     pconfig->InterfaceType = NetworkInterfaceType_Ethernet;
     pconfig->StartupAddressMode = AddressMode_DHCP;
     pconfig->AutomaticDNS = 1;
-    pconfig->SpecificConfigId = 0;
+    pconfig->SpecificConfigId = UINT32_MAX;
 
     // set MAC address with ST provided MAC for development boards
     // 00:80:E1:01:35:D1

--- a/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/common/targetHAL_ConfigurationManager.cpp
+++ b/targets/CMSIS-OS/ChibiOS/ST_STM32F769I_DISCOVERY/common/targetHAL_ConfigurationManager.cpp
@@ -10,7 +10,7 @@
 
 // Default initialisation for Network interface config blocks
 // strong implementation replacing ChibiOS 'weak' one
-bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig, uint32_t configurationIndex)
+bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface *pconfig, uint32_t configurationIndex)
 {
     (void)configurationIndex;
 
@@ -19,7 +19,7 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
 
     // make sure the config block marker is set
     memcpy(pconfig->Marker, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
-    
+
     pconfig->InterfaceType = NetworkInterfaceType_Ethernet;
     pconfig->StartupAddressMode = AddressMode_DHCP;
     pconfig->AutomaticDNS = 1;

--- a/targets/TI-SimpleLink/common/targetHAL_ConfigurationManager_CC13x2_26x2.cpp
+++ b/targets/TI-SimpleLink/common/targetHAL_ConfigurationManager_CC13x2_26x2.cpp
@@ -497,6 +497,9 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
 {
     (void)configurationIndex;
 
+    // zero memory
+    memset(pconfig, 0, sizeof(HAL_Configuration_NetworkInterface));
+
     uint16_t macAddressLen = SL_MAC_ADDR_LEN;
 
     memset(pconfig, 0, sizeof(HAL_Configuration_NetworkInterface));

--- a/targets/TI-SimpleLink/common/targetHAL_ConfigurationManager_CC13x2_26x2.cpp
+++ b/targets/TI-SimpleLink/common/targetHAL_ConfigurationManager_CC13x2_26x2.cpp
@@ -14,25 +14,25 @@ typedef struct
 {
     SlFileAttributes_t attribute;
     char fileName[SL_FS_MAX_FILE_NAME_LENGTH];
-}slGetfileList_t;
+} slGetfileList_t;
 
 // This configuration manager implementation is valid for CC13x2_26x2 devices.
-// Because everything that is meant to be stored in the configure block is handled by the SimpleLink 
+// Because everything that is meant to be stored in the configure block is handled by the SimpleLink
 // persistent storage, this code is either empty or acts as a proxy to the SimpleLink API
 
 // network configuration blocks are stored as files in file storage
-void* ConfigurationManagerCC13x2_26x2_FindNetworkConfigurationBlocks()
+void *ConfigurationManagerCC13x2_26x2_FindNetworkConfigurationBlocks()
 {
     int32_t ret = 1;
     int32_t retGetFileList = 1;
-    slGetfileList_t* fileList;
+    slGetfileList_t *fileList;
     int32_t index = -1;
 
     int32_t i;
     uint32_t fileCount = 0;
 
     // allocate memory for file list buffer
-    fileList = (slGetfileList_t*)platform_malloc(sizeof(slGetfileList_t) * NETWORK_CONFIG_MAX_COUNT);
+    fileList = (slGetfileList_t *)platform_malloc(sizeof(slGetfileList_t) * NETWORK_CONFIG_MAX_COUNT);
 
     // check succesfull malloc
     if (fileList == NULL)
@@ -44,21 +44,24 @@ void* ConfigurationManagerCC13x2_26x2_FindNetworkConfigurationBlocks()
     memset(fileList, 0x0, sizeof(sizeof(SlFileAttributes_t) * NETWORK_CONFIG_MAX_COUNT));
 
     // first pass: find out how many files of this type we have
-    while(retGetFileList > 0)
+    while (retGetFileList > 0)
     {
-        retGetFileList = sl_FsGetFileList( &index, NETWORK_CONFIG_MAX_COUNT, 
-                                                (uint8_t)(SL_FS_MAX_FILE_NAME_LENGTH + sizeof(SlFileAttributes_t)),
-                                                (unsigned char*)fileList, SL_FS_GET_FILE_ATTRIBUTES);
+        retGetFileList = sl_FsGetFileList(
+            &index,
+            NETWORK_CONFIG_MAX_COUNT,
+            (uint8_t)(SL_FS_MAX_FILE_NAME_LENGTH + sizeof(SlFileAttributes_t)),
+            (unsigned char *)fileList,
+            SL_FS_GET_FILE_ATTRIBUTES);
         if (retGetFileList < 0)
         {
             // error getting file list, or no more files
             break;
         }
-        
+
         for (i = 0; i < retGetFileList; i++)
         {
             // check file name
-            if(memcmp(fileList[i].fileName, NETWORK_CONFIG_FILE_NAME, sizeof(NETWORK_CONFIG_FILE_NAME)) == 0)
+            if (memcmp(fileList[i].fileName, NETWORK_CONFIG_FILE_NAME, sizeof(NETWORK_CONFIG_FILE_NAME)) == 0)
             {
                 fileCount++;
             }
@@ -66,7 +69,8 @@ void* ConfigurationManagerCC13x2_26x2_FindNetworkConfigurationBlocks()
     }
 
     // allocate config struct
-    HAL_CONFIGURATION_NETWORK *networkConfigs = (HAL_CONFIGURATION_NETWORK *)platform_malloc(offsetof(HAL_CONFIGURATION_NETWORK, Configs) + fileCount * sizeof(networkConfigs->Configs[0]));
+    HAL_CONFIGURATION_NETWORK *networkConfigs = (HAL_CONFIGURATION_NETWORK *)platform_malloc(
+        offsetof(HAL_CONFIGURATION_NETWORK, Configs) + fileCount * sizeof(networkConfigs->Configs[0]));
     // set collection count
     networkConfigs->Count = fileCount;
 
@@ -76,8 +80,8 @@ void* ConfigurationManagerCC13x2_26x2_FindNetworkConfigurationBlocks()
     return networkConfigs;
 }
 
-// wireless profiles are stored as SimpleLink WLAN profile 
-void* ConfigurationManagerCC13x2_26x2_FindNetworkWireless80211ConfigurationBlocks()
+// wireless profiles are stored as SimpleLink WLAN profile
+void *ConfigurationManagerCC13x2_26x2_FindNetworkWireless80211ConfigurationBlocks()
 {
     int16_t index, status;
     signed char name[32];
@@ -89,17 +93,20 @@ void* ConfigurationManagerCC13x2_26x2_FindNetworkWireless80211ConfigurationBlock
     uint16_t profileCount = 0;
 
     // first pass: find out how many profiles are stored
-    for(index = 0; index < SL_WLAN_MAX_PROFILES; index++)
+    for (index = 0; index < SL_WLAN_MAX_PROFILES; index++)
     {
         status = sl_WlanProfileGet(index, name, &nameLength, macAddr, &secParams, &secExtParams, &priority);
-        if( status >= 0)
+        if (status >= 0)
         {
             profileCount++;
         }
     }
 
     // allocate config struct
-    HAL_CONFIGURATION_NETWORK_WIRELESS80211 *networkWirelessConfigs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211 *)platform_malloc(offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) + profileCount * sizeof(networkWirelessConfigs->Configs[0]));
+    HAL_CONFIGURATION_NETWORK_WIRELESS80211 *networkWirelessConfigs =
+        (HAL_CONFIGURATION_NETWORK_WIRELESS80211 *)platform_malloc(
+            offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) +
+            profileCount * sizeof(networkWirelessConfigs->Configs[0]));
 
     // set collection count
     networkWirelessConfigs->Count = profileCount;
@@ -110,56 +117,81 @@ void* ConfigurationManagerCC13x2_26x2_FindNetworkWireless80211ConfigurationBlock
 // initialization of configuration manager
 void ConfigurationManager_Initialize()
 {
-    memset( (void*)&g_TargetConfiguration, 0, sizeof(g_TargetConfiguration));
+    memset((void *)&g_TargetConfiguration, 0, sizeof(g_TargetConfiguration));
 
     // enumerate the blocks
     ConfigurationManager_EnumerateConfigurationBlocks();
 };
 
-// Enumerates the configuration blocks from the configuration flash sector 
+// Enumerates the configuration blocks from the configuration flash sector
 void ConfigurationManager_EnumerateConfigurationBlocks()
 {
     // find network configuration blocks
-    HAL_CONFIGURATION_NETWORK* networkConfigs = (HAL_CONFIGURATION_NETWORK*)ConfigurationManagerCC13x2_26x2_FindNetworkConfigurationBlocks();
+    HAL_CONFIGURATION_NETWORK *networkConfigs =
+        (HAL_CONFIGURATION_NETWORK *)ConfigurationManagerCC13x2_26x2_FindNetworkConfigurationBlocks();
 
     // check network configs count
-    if(networkConfigs->Count == 0)
+    if (networkConfigs->Count == 0)
     {
         // there is no network config block available, get a default
-        HAL_Configuration_NetworkInterface* networkConfig = (HAL_Configuration_NetworkInterface*)platform_malloc(sizeof(HAL_Configuration_NetworkInterface));
-        if(InitialiseNetworkDefaultConfig(networkConfig, 0))
+        HAL_Configuration_NetworkInterface *networkConfig =
+            (HAL_Configuration_NetworkInterface *)platform_malloc(sizeof(HAL_Configuration_NetworkInterface));
+        if (InitialiseNetworkDefaultConfig(networkConfig, 0))
         {
             // config block created, store it
-            ConfigurationManager_StoreConfigurationBlock(networkConfig, DeviceConfigurationOption_Network, 0, sizeof(HAL_Configuration_NetworkInterface), 0, false);
-            
+            ConfigurationManager_StoreConfigurationBlock(
+                networkConfig,
+                DeviceConfigurationOption_Network,
+                0,
+                sizeof(HAL_Configuration_NetworkInterface),
+                0,
+                false);
+
             // have to enumerate again to pick it up
-            networkConfigs = (HAL_CONFIGURATION_NETWORK*)ConfigurationManagerCC13x2_26x2_FindNetworkConfigurationBlocks();
+            networkConfigs =
+                (HAL_CONFIGURATION_NETWORK *)ConfigurationManagerCC13x2_26x2_FindNetworkConfigurationBlocks();
         }
 
         platform_free(networkConfig);
     }
 
     // find wireless 80211 network configuration blocks
-    HAL_CONFIGURATION_NETWORK_WIRELESS80211* networkWirelessConfigs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211*)ConfigurationManagerCC13x2_26x2_FindNetworkWireless80211ConfigurationBlocks();
+    HAL_CONFIGURATION_NETWORK_WIRELESS80211 *networkWirelessConfigs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211 *)
+        ConfigurationManagerCC13x2_26x2_FindNetworkWireless80211ConfigurationBlocks();
 
     // // find X509 certificate blocks
-    // HAL_CONFIGURATION_X509_CERTIFICATE* certificateStore = (HAL_CONFIGURATION_X509_CERTIFICATE*)ConfigurationManager_FindX509CertificateConfigurationBlocks((uint32_t)&__nanoConfig_start__, (uint32_t)&__nanoConfig_end__);
+    // HAL_CONFIGURATION_X509_CERTIFICATE* certificateStore =
+    // (HAL_CONFIGURATION_X509_CERTIFICATE*)ConfigurationManager_FindX509CertificateConfigurationBlocks((uint32_t)&__nanoConfig_start__,
+    // (uint32_t)&__nanoConfig_end__);
 
     // alloc memory for g_TargetConfiguration
     // because this is a struct of structs that use flexible members the memory has to be allocated from the heap
-    // the malloc size for each struct is computed separately 
-    uint32_t sizeOfNetworkInterfaceConfigs = offsetof(HAL_CONFIGURATION_NETWORK, Configs) + networkConfigs->Count * sizeof(networkConfigs->Configs[0]);
-    uint32_t sizeOfWireless80211Configs = offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) + networkWirelessConfigs->Count * sizeof(networkWirelessConfigs->Configs[0]);
-    // uint32_t sizeOfX509CertificateStore = offsetof(HAL_CONFIGURATION_X509_CERTIFICATE, Certificates) + certificateStore->Count * sizeof(certificateStore->Certificates[0]);
+    // the malloc size for each struct is computed separately
+    uint32_t sizeOfNetworkInterfaceConfigs =
+        offsetof(HAL_CONFIGURATION_NETWORK, Configs) + networkConfigs->Count * sizeof(networkConfigs->Configs[0]);
+    uint32_t sizeOfWireless80211Configs = offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) +
+                                          networkWirelessConfigs->Count * sizeof(networkWirelessConfigs->Configs[0]);
+    // uint32_t sizeOfX509CertificateStore = offsetof(HAL_CONFIGURATION_X509_CERTIFICATE, Certificates) +
+    // certificateStore->Count * sizeof(certificateStore->Certificates[0]);
 
-    g_TargetConfiguration.NetworkInterfaceConfigs = (HAL_CONFIGURATION_NETWORK*)platform_malloc(sizeOfNetworkInterfaceConfigs);
-    g_TargetConfiguration.Wireless80211Configs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211*)platform_malloc(sizeOfWireless80211Configs);
-    // g_TargetConfiguration.CertificateStore = (HAL_CONFIGURATION_X509_CERTIFICATE*)platform_malloc(sizeOfX509CertificateStore);
+    g_TargetConfiguration.NetworkInterfaceConfigs =
+        (HAL_CONFIGURATION_NETWORK *)platform_malloc(sizeOfNetworkInterfaceConfigs);
+    g_TargetConfiguration.Wireless80211Configs =
+        (HAL_CONFIGURATION_NETWORK_WIRELESS80211 *)platform_malloc(sizeOfWireless80211Configs);
+    // g_TargetConfiguration.CertificateStore =
+    // (HAL_CONFIGURATION_X509_CERTIFICATE*)platform_malloc(sizeOfX509CertificateStore);
 
     // copy structs to g_TargetConfiguration
-    memcpy((HAL_CONFIGURATION_NETWORK*)g_TargetConfiguration.NetworkInterfaceConfigs, networkConfigs, sizeOfNetworkInterfaceConfigs);
-    memcpy((HAL_CONFIGURATION_NETWORK_WIRELESS80211*)g_TargetConfiguration.Wireless80211Configs, networkWirelessConfigs, sizeOfWireless80211Configs);
-    // memcpy((HAL_CONFIGURATION_X509_CERTIFICATE*)g_TargetConfiguration.CertificateStore, certificateStore, sizeOfX509CertificateStore);
+    memcpy(
+        (HAL_CONFIGURATION_NETWORK *)g_TargetConfiguration.NetworkInterfaceConfigs,
+        networkConfigs,
+        sizeOfNetworkInterfaceConfigs);
+    memcpy(
+        (HAL_CONFIGURATION_NETWORK_WIRELESS80211 *)g_TargetConfiguration.Wireless80211Configs,
+        networkWirelessConfigs,
+        sizeOfWireless80211Configs);
+    // memcpy((HAL_CONFIGURATION_X509_CERTIFICATE*)g_TargetConfiguration.CertificateStore, certificateStore,
+    // sizeOfX509CertificateStore);
 
     // now free the memory of the original structs
     platform_free(networkConfigs);
@@ -173,14 +205,14 @@ EncryptionType GetEncryption(SlWlanSecParams_t secParams)
     {
         case SL_WLAN_SEC_TYPE_WEP:
             return EncryptionType_WEP;
-    
-        // deprecated
-        // case SL_WLAN_SEC_TYPE_WPA:
-        //     return EncryptionType_WPA;
-    
+
+            // deprecated
+            // case SL_WLAN_SEC_TYPE_WPA:
+            //     return EncryptionType_WPA;
+
         case SL_WLAN_SEC_TYPE_WPA_WPA2:
             return EncryptionType_WPA2;
-    
+
         default:
             return EncryptionType_None;
     }
@@ -192,29 +224,32 @@ AuthenticationType GetAuthentication(SlWlanSecParams_t secParams)
     {
         case SL_WLAN_SEC_TYPE_OPEN:
             return AuthenticationType_Open;
-    
+
         case SL_WLAN_SEC_TYPE_WEP:
             return AuthenticationType_WEP;
-    
-        // deprecated
-        // case SL_WLAN_SEC_TYPE_WPA:
-        //     return AuthenticationType_WPA;
-    
+
+            // deprecated
+            // case SL_WLAN_SEC_TYPE_WPA:
+            //     return AuthenticationType_WPA;
+
         case SL_WLAN_SEC_TYPE_WPA_WPA2:
             return AuthenticationType_WPA2;
-    
+
         case SL_WLAN_SEC_TYPE_WEP_SHARED:
             return AuthenticationType_Shared;
-    
+
         default:
             return AuthenticationType_None;
     }
 }
 
-// Gets the network configuration block from the configuration flash sector 
-bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, DeviceConfigurationOption configuration, uint32_t configurationIndex)
+// Gets the network configuration block from the configuration flash sector
+bool ConfigurationManager_GetConfigurationBlock(
+    void *configurationBlock,
+    DeviceConfigurationOption configuration,
+    uint32_t configurationIndex)
 {
-    unsigned char* fileName = NULL;
+    unsigned char *fileName = NULL;
 
     int32_t fileHandle;
     uint32_t token = 0;
@@ -224,32 +259,31 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
     uint8_t dummyMAC[SL_MAC_ADDR_LEN];
     uint32_t dummyPriority;
 
-    HAL_Configuration_Wireless80211* wirelessConfigBlock = NULL;
-
+    HAL_Configuration_Wireless80211 *wirelessConfigBlock = NULL;
 
     // validate if the requested block exists
     // Count has to be non zero
     // requested Index has to exist (array index starts at zero, so need to add one)
-    if(configuration == DeviceConfigurationOption_Network)
+    if (configuration == DeviceConfigurationOption_Network)
     {
-        if( g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0 ||
+        if (g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0 ||
             (configurationIndex + 1) > g_TargetConfiguration.NetworkInterfaceConfigs->Count)
         {
             // the requested config block is beyond the available count
             return false;
         }
     }
-    else if(configuration == DeviceConfigurationOption_Wireless80211Network)
+    else if (configuration == DeviceConfigurationOption_Wireless80211Network)
     {
-        if(g_TargetConfiguration.Wireless80211Configs->Count == 0 ||
+        if (g_TargetConfiguration.Wireless80211Configs->Count == 0 ||
             (configurationIndex + 1) > g_TargetConfiguration.Wireless80211Configs->Count)
         {
             return false;
         }
     }
-    else if(configuration == DeviceConfigurationOption_X509CaRootBundle)
+    else if (configuration == DeviceConfigurationOption_X509CaRootBundle)
     {
-        if(g_TargetConfiguration.CertificateStore->Count == 0 ||
+        if (g_TargetConfiguration.CertificateStore->Count == 0 ||
             (configurationIndex + 1) > g_TargetConfiguration.CertificateStore->Count)
         {
             return false;
@@ -264,31 +298,33 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
         // sizeOfBlock += ((HAL_Configuration_X509CaRootBundle*)blockAddress)->CertificateSize;
     }
 
-    if(configuration == DeviceConfigurationOption_Network)
+    if (configuration == DeviceConfigurationOption_Network)
     {
         // network config blocks are stored as files
 
         // compose file name
-        fileName = (unsigned char*)platform_malloc(sizeof(NETWORK_CONFIG_FILE_NAME));
+        fileName = (unsigned char *)platform_malloc(sizeof(NETWORK_CONFIG_FILE_NAME));
         memcpy(fileName, NETWORK_CONFIG_FILE_NAME, sizeof(NETWORK_CONFIG_FILE_NAME));
         // insert index number at position N as char
         fileName[NETWORK_CONFIG_FILE_INDEX_POSITION] = '0' + configurationIndex;
 
-        fileHandle = sl_FsOpen( fileName,
-                                SL_FS_READ,
-                                (uint32_t *)&token);
-        
+        fileHandle = sl_FsOpen(fileName, SL_FS_READ, (uint32_t *)&token);
+
         // on error there is no file handle, rather a negative error code
-        if(fileHandle > 0)
+        if (fileHandle > 0)
         {
-            retVal = sl_FsRead(fileHandle, 0, (unsigned char*)configurationBlock, sizeof(HAL_Configuration_NetworkInterface));
-            
+            retVal = sl_FsRead(
+                fileHandle,
+                0,
+                (unsigned char *)configurationBlock,
+                sizeof(HAL_Configuration_NetworkInterface));
+
             // on success the return value is the amount of bytes written
-            if(retVal == sizeof(HAL_Configuration_NetworkInterface))
+            if (retVal == sizeof(HAL_Configuration_NetworkInterface))
             {
                 retVal = sl_FsClose(fileHandle, 0, 0, 0);
 
-                if( retVal < 0 )
+                if (retVal < 0)
                 {
                     // error closing file, API ceremony suggests calling "abort" operation
                     uint8_t signature = 'A';
@@ -297,7 +333,7 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
             }
         }
 
-        if(fileName != NULL)
+        if (fileName != NULL)
         {
             platform_free(fileName);
         }
@@ -305,16 +341,26 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
         // done!
         return true;
     }
-    else if(configuration == DeviceConfigurationOption_Wireless80211Network)
+    else if (configuration == DeviceConfigurationOption_Wireless80211Network)
     {
-        wirelessConfigBlock = (HAL_Configuration_Wireless80211*)configurationBlock;
+        wirelessConfigBlock = (HAL_Configuration_Wireless80211 *)configurationBlock;
 
         // make sure the config block marker is set
-        memcpy(configurationBlock, c_MARKER_CONFIGURATION_WIRELESS80211_V1, sizeof(c_MARKER_CONFIGURATION_WIRELESS80211_V1));
+        memcpy(
+            configurationBlock,
+            c_MARKER_CONFIGURATION_WIRELESS80211_V1,
+            sizeof(c_MARKER_CONFIGURATION_WIRELESS80211_V1));
 
         // get profile from SimpleLink
-        retVal = sl_WlanProfileGet(configurationIndex, (signed char *)wirelessConfigBlock->Ssid, &dummyNameLen, &dummyMAC[0], &secParams, NULL, &dummyPriority);
-        if(retVal == SL_ERROR_WLAN_GET_PROFILE_INVALID_INDEX)
+        retVal = sl_WlanProfileGet(
+            configurationIndex,
+            (signed char *)wirelessConfigBlock->Ssid,
+            &dummyNameLen,
+            &dummyMAC[0],
+            &secParams,
+            NULL,
+            &dummyPriority);
+        if (retVal == SL_ERROR_WLAN_GET_PROFILE_INVALID_INDEX)
         {
             return false;
         }
@@ -326,8 +372,7 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
 
         // password is hidden, NULL the string
         memset(wirelessConfigBlock->Password, 0, sizeof(wirelessConfigBlock->Password));
-        //wirelessConfigBlock->Radio 
-        
+        // wirelessConfigBlock->Radio
 
         // done
         return true;
@@ -342,24 +387,30 @@ uint8_t GetSecurityType(AuthenticationType authentication)
     {
         case AuthenticationType_Open:
             return SL_WLAN_SEC_TYPE_OPEN;
-    
+
         case AuthenticationType_WEP:
             return SL_WLAN_SEC_TYPE_WEP;
-    
+
         case AuthenticationType_WPA:
         case AuthenticationType_WPA2:
             return SL_WLAN_SEC_TYPE_WPA_WPA2;
-    
+
         case AuthenticationType_Shared:
             return SL_WLAN_SEC_TYPE_WEP_SHARED;
-    
+
         default:
             return SL_WLAN_SEC_TYPE_OPEN;
     }
 }
 
-// Stores the configuration block to the file system 
-bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, DeviceConfigurationOption configuration, uint32_t configurationIndex, uint32_t blockSize, uint32_t offset, bool done)
+// Stores the configuration block to the file system
+bool ConfigurationManager_StoreConfigurationBlock(
+    void *configurationBlock,
+    DeviceConfigurationOption configuration,
+    uint32_t configurationIndex,
+    uint32_t blockSize,
+    uint32_t offset,
+    bool done)
 {
     // this platform doesn't need to handle this
     (void)done;
@@ -367,43 +418,47 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
     bool requiresEnumeration = false;
     bool success = false;
 
-    unsigned char* fileName = NULL;
+    unsigned char *fileName = NULL;
 
     int32_t fileHandle;
     uint32_t token = 0;
     int32_t retVal;
     SlWlanSecParams_t secParams;
 
-    if(configuration == DeviceConfigurationOption_Network)
+    if (configuration == DeviceConfigurationOption_Network)
     {
         // network config blocks are stored as files
 
         // compose file name
-        fileName = (unsigned char*)platform_malloc(sizeof(NETWORK_CONFIG_FILE_NAME));
+        fileName = (unsigned char *)platform_malloc(sizeof(NETWORK_CONFIG_FILE_NAME));
         memcpy(fileName, NETWORK_CONFIG_FILE_NAME, sizeof(NETWORK_CONFIG_FILE_NAME));
         // insert index number at position N as char
         fileName[NETWORK_CONFIG_FILE_INDEX_POSITION] = '0' + configurationIndex;
 
-        fileHandle = sl_FsOpen( fileName,
-                                SL_FS_CREATE | SL_FS_OVERWRITE |
-                                SL_FS_CREATE_MAX_SIZE(sizeof(HAL_Configuration_NetworkInterface)) |
-                                SL_FS_CREATE_PUBLIC_WRITE | SL_FS_CREATE_NOSIGNATURE,
-                                (uint32_t *)&token);
-        
+        fileHandle = sl_FsOpen(
+            fileName,
+            SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_MAX_SIZE(sizeof(HAL_Configuration_NetworkInterface)) |
+                SL_FS_CREATE_PUBLIC_WRITE | SL_FS_CREATE_NOSIGNATURE,
+            (uint32_t *)&token);
+
         // on error there is no file handle, rather a negative error code
-        if(fileHandle > 0)
+        if (fileHandle > 0)
         {
             // make sure the config block marker is set
-            memcpy(configurationBlock, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1)); 
+            memcpy(configurationBlock, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
 
-            retVal = sl_FsWrite(fileHandle, 0, (unsigned char*)configurationBlock, sizeof(HAL_Configuration_NetworkInterface));
-            
+            retVal = sl_FsWrite(
+                fileHandle,
+                0,
+                (unsigned char *)configurationBlock,
+                sizeof(HAL_Configuration_NetworkInterface));
+
             // on success the return value is the amount of bytes written
-            if(retVal == sizeof(HAL_Configuration_NetworkInterface))
+            if (retVal == sizeof(HAL_Configuration_NetworkInterface))
             {
                 retVal = sl_FsClose(fileHandle, 0, 0, 0);
 
-                if( retVal < 0 )
+                if (retVal < 0)
                 {
                     // error closing file, API ceremony suggests calling "abort" operation
                     uint8_t signature = 'A';
@@ -418,14 +473,14 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
             }
         }
 
-        if(fileName != NULL)
+        if (fileName != NULL)
         {
             platform_free(fileName);
         }
     }
-    else if(configuration == DeviceConfigurationOption_Wireless80211Network)
+    else if (configuration == DeviceConfigurationOption_Wireless80211Network)
     {
-        HAL_Configuration_Wireless80211* wirelessConfigBlock = (HAL_Configuration_Wireless80211*)configurationBlock;
+        HAL_Configuration_Wireless80211 *wirelessConfigBlock = (HAL_Configuration_Wireless80211 *)configurationBlock;
 
         secParams.Type = GetSecurityType(wirelessConfigBlock->Authentication);
         secParams.Key = (signed char *)wirelessConfigBlock->Password;
@@ -433,8 +488,15 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
 
         // add profile to SimpleLink
         // TODO - default priority is 0
-        retVal = sl_WlanProfileAdd((const signed char *)wirelessConfigBlock->Ssid, hal_strlen_s((const char *)(wirelessConfigBlock->Ssid)), NULL, &secParams, NULL, 0, 0);
-        if(retVal < 0)
+        retVal = sl_WlanProfileAdd(
+            (const signed char *)wirelessConfigBlock->Ssid,
+            hal_strlen_s((const char *)(wirelessConfigBlock->Ssid)),
+            NULL,
+            &secParams,
+            NULL,
+            0,
+            0);
+        if (retVal < 0)
         {
             return false;
         }
@@ -443,14 +505,14 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
         success = true;
         requiresEnumeration = true;
     }
-    else if(configuration == DeviceConfigurationOption_X509CaRootBundle)
+    else if (configuration == DeviceConfigurationOption_X509CaRootBundle)
     {
         // CA root certificate bundle is stored as a file /sys/certstore.lst
         // currently we don't support updating this
         success = false;
     }
 
-    if(success == true && requiresEnumeration)
+    if (success == true && requiresEnumeration)
     {
         // free the current allocation(s)
         platform_free(g_TargetConfiguration.NetworkInterfaceConfigs);
@@ -465,15 +527,24 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
 }
 
 // Updates a configuration block
-bool ConfigurationManager_UpdateConfigurationBlock(void* configurationBlock, DeviceConfigurationOption configuration, uint32_t configurationIndex)
+bool ConfigurationManager_UpdateConfigurationBlock(
+    void *configurationBlock,
+    DeviceConfigurationOption configuration,
+    uint32_t configurationIndex)
 {
     // CC13x2_26x2 stores the config blocks on the file system so we don't care about sizes
 
-    switch(configuration)
+    switch (configuration)
     {
         case DeviceConfigurationOption_Network:
         case DeviceConfigurationOption_Wireless80211Network:
-            return ConfigurationManager_StoreConfigurationBlock(configurationBlock, configuration, configurationIndex, 0, 0, false);    
+            return ConfigurationManager_StoreConfigurationBlock(
+                configurationBlock,
+                configuration,
+                configurationIndex,
+                0,
+                0,
+                false);
 
         // this configuration option is not supported
         case DeviceConfigurationOption_X509CaRootBundle:
@@ -484,16 +555,16 @@ bool ConfigurationManager_UpdateConfigurationBlock(void* configurationBlock, Dev
 }
 
 //  Default initialisation for wireless config block
-void InitialiseWirelessDefaultConfig(HAL_Configuration_Wireless80211 * pconfig, uint32_t configurationIndex)
+void InitialiseWirelessDefaultConfig(HAL_Configuration_Wireless80211 *pconfig, uint32_t configurationIndex)
 {
     (void)pconfig;
     (void)configurationIndex;
 
-    // TODO    
+    // TODO
 }
 
 //  Default initialisation for Network interface config blocks
-bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig, uint32_t configurationIndex)
+bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface *pconfig, uint32_t configurationIndex)
 {
     (void)configurationIndex;
 
@@ -506,7 +577,7 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
 
     // make sure the config block marker is set
     memcpy(pconfig->Marker, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
-    
+
     pconfig->InterfaceType = NetworkInterfaceType_Wireless80211;
     pconfig->StartupAddressMode = AddressMode_DHCP;
     pconfig->AutomaticDNS = 1;

--- a/targets/TI-SimpleLink/common/targetHAL_ConfigurationManager_CC32xx.cpp
+++ b/targets/TI-SimpleLink/common/targetHAL_ConfigurationManager_CC32xx.cpp
@@ -14,25 +14,25 @@ typedef struct
 {
     SlFileAttributes_t attribute;
     char fileName[SL_FS_MAX_FILE_NAME_LENGTH];
-}slGetfileList_t;
+} slGetfileList_t;
 
 // This configuration manager implementation is valid for CC32xx devices.
-// Because everything that is meant to be stored in the configure block is handled by the SimpleLink 
+// Because everything that is meant to be stored in the configure block is handled by the SimpleLink
 // persistent storage, this code is either empty or acts as a proxy to the SimpleLink API
 
 // network configuration blocks are stored as files in file storage
-void* ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks()
+void *ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks()
 {
     int32_t ret = 1;
     int32_t retGetFileList = 1;
-    slGetfileList_t* fileList;
+    slGetfileList_t *fileList;
     int32_t index = -1;
 
     int32_t i;
     uint32_t fileCount = 0;
 
     // allocate memory for file list buffer
-    fileList = (slGetfileList_t*)platform_malloc(sizeof(slGetfileList_t) * NETWORK_CONFIG_MAX_COUNT);
+    fileList = (slGetfileList_t *)platform_malloc(sizeof(slGetfileList_t) * NETWORK_CONFIG_MAX_COUNT);
 
     // check succesfull malloc
     if (fileList == NULL)
@@ -44,21 +44,24 @@ void* ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks()
     memset(fileList, 0x0, sizeof(sizeof(SlFileAttributes_t) * NETWORK_CONFIG_MAX_COUNT));
 
     // first pass: find out how many files of this type we have
-    while(retGetFileList > 0)
+    while (retGetFileList > 0)
     {
-        retGetFileList = sl_FsGetFileList( &index, NETWORK_CONFIG_MAX_COUNT, 
-                                                (uint8_t)(SL_FS_MAX_FILE_NAME_LENGTH + sizeof(SlFileAttributes_t)),
-                                                (unsigned char*)fileList, SL_FS_GET_FILE_ATTRIBUTES);
+        retGetFileList = sl_FsGetFileList(
+            &index,
+            NETWORK_CONFIG_MAX_COUNT,
+            (uint8_t)(SL_FS_MAX_FILE_NAME_LENGTH + sizeof(SlFileAttributes_t)),
+            (unsigned char *)fileList,
+            SL_FS_GET_FILE_ATTRIBUTES);
         if (retGetFileList < 0)
         {
             // error getting file list, or no more files
             break;
         }
-        
+
         for (i = 0; i < retGetFileList; i++)
         {
             // check file name
-            if(memcmp(fileList[i].fileName, NETWORK_CONFIG_FILE_NAME, sizeof(NETWORK_CONFIG_FILE_NAME)) == 0)
+            if (memcmp(fileList[i].fileName, NETWORK_CONFIG_FILE_NAME, sizeof(NETWORK_CONFIG_FILE_NAME)) == 0)
             {
                 fileCount++;
             }
@@ -66,7 +69,8 @@ void* ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks()
     }
 
     // allocate config struct
-    HAL_CONFIGURATION_NETWORK *networkConfigs = (HAL_CONFIGURATION_NETWORK *)platform_malloc(offsetof(HAL_CONFIGURATION_NETWORK, Configs) + fileCount * sizeof(networkConfigs->Configs[0]));
+    HAL_CONFIGURATION_NETWORK *networkConfigs = (HAL_CONFIGURATION_NETWORK *)platform_malloc(
+        offsetof(HAL_CONFIGURATION_NETWORK, Configs) + fileCount * sizeof(networkConfigs->Configs[0]));
     // set collection count
     networkConfigs->Count = fileCount;
 
@@ -76,8 +80,8 @@ void* ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks()
     return networkConfigs;
 }
 
-// wireless profiles are stored as SimpleLink WLAN profile 
-void* ConfigurationManagerCC32xx_FindNetworkWireless80211ConfigurationBlocks()
+// wireless profiles are stored as SimpleLink WLAN profile
+void *ConfigurationManagerCC32xx_FindNetworkWireless80211ConfigurationBlocks()
 {
     int16_t index, status;
     signed char name[32];
@@ -89,17 +93,20 @@ void* ConfigurationManagerCC32xx_FindNetworkWireless80211ConfigurationBlocks()
     uint16_t profileCount = 0;
 
     // first pass: find out how many profiles are stored
-    for(index = 0; index < SL_WLAN_MAX_PROFILES; index++)
+    for (index = 0; index < SL_WLAN_MAX_PROFILES; index++)
     {
         status = sl_WlanProfileGet(index, name, &nameLength, macAddr, &secParams, &secExtParams, &priority);
-        if( status >= 0)
+        if (status >= 0)
         {
             profileCount++;
         }
     }
 
     // allocate config struct
-    HAL_CONFIGURATION_NETWORK_WIRELESS80211 *networkWirelessConfigs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211 *)platform_malloc(offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) + profileCount * sizeof(networkWirelessConfigs->Configs[0]));
+    HAL_CONFIGURATION_NETWORK_WIRELESS80211 *networkWirelessConfigs =
+        (HAL_CONFIGURATION_NETWORK_WIRELESS80211 *)platform_malloc(
+            offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) +
+            profileCount * sizeof(networkWirelessConfigs->Configs[0]));
 
     // set collection count
     networkWirelessConfigs->Count = profileCount;
@@ -110,56 +117,80 @@ void* ConfigurationManagerCC32xx_FindNetworkWireless80211ConfigurationBlocks()
 // initialization of configuration manager
 void ConfigurationManager_Initialize()
 {
-    memset( (void*)&g_TargetConfiguration, 0, sizeof(g_TargetConfiguration));
+    memset((void *)&g_TargetConfiguration, 0, sizeof(g_TargetConfiguration));
 
     // enumerate the blocks
     ConfigurationManager_EnumerateConfigurationBlocks();
 };
 
-// Enumerates the configuration blocks from the configuration flash sector 
+// Enumerates the configuration blocks from the configuration flash sector
 void ConfigurationManager_EnumerateConfigurationBlocks()
 {
     // find network configuration blocks
-    HAL_CONFIGURATION_NETWORK* networkConfigs = (HAL_CONFIGURATION_NETWORK*)ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks();
+    HAL_CONFIGURATION_NETWORK *networkConfigs =
+        (HAL_CONFIGURATION_NETWORK *)ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks();
 
     // check network configs count
-    if(networkConfigs->Count == 0)
+    if (networkConfigs->Count == 0)
     {
         // there is no network config block available, get a default
-        HAL_Configuration_NetworkInterface* networkConfig = (HAL_Configuration_NetworkInterface*)platform_malloc(sizeof(HAL_Configuration_NetworkInterface));
-        if(InitialiseNetworkDefaultConfig(networkConfig, 0))
+        HAL_Configuration_NetworkInterface *networkConfig =
+            (HAL_Configuration_NetworkInterface *)platform_malloc(sizeof(HAL_Configuration_NetworkInterface));
+        if (InitialiseNetworkDefaultConfig(networkConfig, 0))
         {
             // config block created, store it
-            ConfigurationManager_StoreConfigurationBlock(networkConfig, DeviceConfigurationOption_Network, 0, sizeof(HAL_Configuration_NetworkInterface), 0, false);
-            
+            ConfigurationManager_StoreConfigurationBlock(
+                networkConfig,
+                DeviceConfigurationOption_Network,
+                0,
+                sizeof(HAL_Configuration_NetworkInterface),
+                0,
+                false);
+
             // have to enumerate again to pick it up
-            networkConfigs = (HAL_CONFIGURATION_NETWORK*)ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks();
+            networkConfigs = (HAL_CONFIGURATION_NETWORK *)ConfigurationManagerCC32xx_FindNetworkConfigurationBlocks();
         }
 
         platform_free(networkConfig);
     }
 
     // find wireless 80211 network configuration blocks
-    HAL_CONFIGURATION_NETWORK_WIRELESS80211* networkWirelessConfigs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211*)ConfigurationManagerCC32xx_FindNetworkWireless80211ConfigurationBlocks();
+    HAL_CONFIGURATION_NETWORK_WIRELESS80211 *networkWirelessConfigs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211 *)
+        ConfigurationManagerCC32xx_FindNetworkWireless80211ConfigurationBlocks();
 
     // // find X509 certificate blocks
-    // HAL_CONFIGURATION_X509_CERTIFICATE* certificateStore = (HAL_CONFIGURATION_X509_CERTIFICATE*)ConfigurationManager_FindX509CertificateConfigurationBlocks((uint32_t)&__nanoConfig_start__, (uint32_t)&__nanoConfig_end__);
+    // HAL_CONFIGURATION_X509_CERTIFICATE* certificateStore =
+    // (HAL_CONFIGURATION_X509_CERTIFICATE*)ConfigurationManager_FindX509CertificateConfigurationBlocks((uint32_t)&__nanoConfig_start__,
+    // (uint32_t)&__nanoConfig_end__);
 
     // alloc memory for g_TargetConfiguration
     // because this is a struct of structs that use flexible members the memory has to be allocated from the heap
-    // the malloc size for each struct is computed separately 
-    uint32_t sizeOfNetworkInterfaceConfigs = offsetof(HAL_CONFIGURATION_NETWORK, Configs) + networkConfigs->Count * sizeof(networkConfigs->Configs[0]);
-    uint32_t sizeOfWireless80211Configs = offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) + networkWirelessConfigs->Count * sizeof(networkWirelessConfigs->Configs[0]);
-    // uint32_t sizeOfX509CertificateStore = offsetof(HAL_CONFIGURATION_X509_CERTIFICATE, Certificates) + certificateStore->Count * sizeof(certificateStore->Certificates[0]);
+    // the malloc size for each struct is computed separately
+    uint32_t sizeOfNetworkInterfaceConfigs =
+        offsetof(HAL_CONFIGURATION_NETWORK, Configs) + networkConfigs->Count * sizeof(networkConfigs->Configs[0]);
+    uint32_t sizeOfWireless80211Configs = offsetof(HAL_CONFIGURATION_NETWORK_WIRELESS80211, Configs) +
+                                          networkWirelessConfigs->Count * sizeof(networkWirelessConfigs->Configs[0]);
+    // uint32_t sizeOfX509CertificateStore = offsetof(HAL_CONFIGURATION_X509_CERTIFICATE, Certificates) +
+    // certificateStore->Count * sizeof(certificateStore->Certificates[0]);
 
-    g_TargetConfiguration.NetworkInterfaceConfigs = (HAL_CONFIGURATION_NETWORK*)platform_malloc(sizeOfNetworkInterfaceConfigs);
-    g_TargetConfiguration.Wireless80211Configs = (HAL_CONFIGURATION_NETWORK_WIRELESS80211*)platform_malloc(sizeOfWireless80211Configs);
-    // g_TargetConfiguration.CertificateStore = (HAL_CONFIGURATION_X509_CERTIFICATE*)platform_malloc(sizeOfX509CertificateStore);
+    g_TargetConfiguration.NetworkInterfaceConfigs =
+        (HAL_CONFIGURATION_NETWORK *)platform_malloc(sizeOfNetworkInterfaceConfigs);
+    g_TargetConfiguration.Wireless80211Configs =
+        (HAL_CONFIGURATION_NETWORK_WIRELESS80211 *)platform_malloc(sizeOfWireless80211Configs);
+    // g_TargetConfiguration.CertificateStore =
+    // (HAL_CONFIGURATION_X509_CERTIFICATE*)platform_malloc(sizeOfX509CertificateStore);
 
     // copy structs to g_TargetConfiguration
-    memcpy((HAL_CONFIGURATION_NETWORK*)g_TargetConfiguration.NetworkInterfaceConfigs, networkConfigs, sizeOfNetworkInterfaceConfigs);
-    memcpy((HAL_CONFIGURATION_NETWORK_WIRELESS80211*)g_TargetConfiguration.Wireless80211Configs, networkWirelessConfigs, sizeOfWireless80211Configs);
-    // memcpy((HAL_CONFIGURATION_X509_CERTIFICATE*)g_TargetConfiguration.CertificateStore, certificateStore, sizeOfX509CertificateStore);
+    memcpy(
+        (HAL_CONFIGURATION_NETWORK *)g_TargetConfiguration.NetworkInterfaceConfigs,
+        networkConfigs,
+        sizeOfNetworkInterfaceConfigs);
+    memcpy(
+        (HAL_CONFIGURATION_NETWORK_WIRELESS80211 *)g_TargetConfiguration.Wireless80211Configs,
+        networkWirelessConfigs,
+        sizeOfWireless80211Configs);
+    // memcpy((HAL_CONFIGURATION_X509_CERTIFICATE*)g_TargetConfiguration.CertificateStore, certificateStore,
+    // sizeOfX509CertificateStore);
 
     // now free the memory of the original structs
     platform_free(networkConfigs);
@@ -173,14 +204,14 @@ EncryptionType GetEncryption(SlWlanSecParams_t secParams)
     {
         case SL_WLAN_SEC_TYPE_WEP:
             return EncryptionType_WEP;
-    
-        // deprecated
-        // case SL_WLAN_SEC_TYPE_WPA:
-        //     return EncryptionType_WPA;
-    
+
+            // deprecated
+            // case SL_WLAN_SEC_TYPE_WPA:
+            //     return EncryptionType_WPA;
+
         case SL_WLAN_SEC_TYPE_WPA_WPA2:
             return EncryptionType_WPA2;
-    
+
         default:
             return EncryptionType_None;
     }
@@ -192,29 +223,32 @@ AuthenticationType GetAuthentication(SlWlanSecParams_t secParams)
     {
         case SL_WLAN_SEC_TYPE_OPEN:
             return AuthenticationType_Open;
-    
+
         case SL_WLAN_SEC_TYPE_WEP:
             return AuthenticationType_WEP;
-    
-        // deprecated
-        // case SL_WLAN_SEC_TYPE_WPA:
-        //     return AuthenticationType_WPA;
-    
+
+            // deprecated
+            // case SL_WLAN_SEC_TYPE_WPA:
+            //     return AuthenticationType_WPA;
+
         case SL_WLAN_SEC_TYPE_WPA_WPA2:
             return AuthenticationType_WPA2;
-    
+
         case SL_WLAN_SEC_TYPE_WEP_SHARED:
             return AuthenticationType_Shared;
-    
+
         default:
             return AuthenticationType_None;
     }
 }
 
-// Gets the network configuration block from the configuration flash sector 
-bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, DeviceConfigurationOption configuration, uint32_t configurationIndex)
+// Gets the network configuration block from the configuration flash sector
+bool ConfigurationManager_GetConfigurationBlock(
+    void *configurationBlock,
+    DeviceConfigurationOption configuration,
+    uint32_t configurationIndex)
 {
-    unsigned char* fileName = NULL;
+    unsigned char *fileName = NULL;
 
     int32_t fileHandle;
     uint32_t token = 0;
@@ -224,32 +258,31 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
     uint8_t dummyMAC[SL_MAC_ADDR_LEN];
     uint32_t dummyPriority;
 
-    HAL_Configuration_Wireless80211* wirelessConfigBlock = NULL;
-
+    HAL_Configuration_Wireless80211 *wirelessConfigBlock = NULL;
 
     // validate if the requested block exists
     // Count has to be non zero
     // requested Index has to exist (array index starts at zero, so need to add one)
-    if(configuration == DeviceConfigurationOption_Network)
+    if (configuration == DeviceConfigurationOption_Network)
     {
-        if( g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0 ||
+        if (g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0 ||
             (configurationIndex + 1) > g_TargetConfiguration.NetworkInterfaceConfigs->Count)
         {
             // the requested config block is beyond the available count
             return false;
         }
     }
-    else if(configuration == DeviceConfigurationOption_Wireless80211Network)
+    else if (configuration == DeviceConfigurationOption_Wireless80211Network)
     {
-        if(g_TargetConfiguration.Wireless80211Configs->Count == 0 ||
+        if (g_TargetConfiguration.Wireless80211Configs->Count == 0 ||
             (configurationIndex + 1) > g_TargetConfiguration.Wireless80211Configs->Count)
         {
             return false;
         }
     }
-    else if(configuration == DeviceConfigurationOption_X509CaRootBundle)
+    else if (configuration == DeviceConfigurationOption_X509CaRootBundle)
     {
-        if(g_TargetConfiguration.CertificateStore->Count == 0 ||
+        if (g_TargetConfiguration.CertificateStore->Count == 0 ||
             (configurationIndex + 1) > g_TargetConfiguration.CertificateStore->Count)
         {
             return false;
@@ -264,31 +297,33 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
         // sizeOfBlock += ((HAL_Configuration_X509CaRootBundle*)blockAddress)->CertificateSize;
     }
 
-    if(configuration == DeviceConfigurationOption_Network)
+    if (configuration == DeviceConfigurationOption_Network)
     {
         // network config blocks are stored as files
 
         // compose file name
-        fileName = (unsigned char*)platform_malloc(sizeof(NETWORK_CONFIG_FILE_NAME));
+        fileName = (unsigned char *)platform_malloc(sizeof(NETWORK_CONFIG_FILE_NAME));
         memcpy(fileName, NETWORK_CONFIG_FILE_NAME, sizeof(NETWORK_CONFIG_FILE_NAME));
         // insert index number at position N as char
         fileName[NETWORK_CONFIG_FILE_INDEX_POSITION] = '0' + configurationIndex;
 
-        fileHandle = sl_FsOpen( fileName,
-                                SL_FS_READ,
-                                (uint32_t *)&token);
-        
+        fileHandle = sl_FsOpen(fileName, SL_FS_READ, (uint32_t *)&token);
+
         // on error there is no file handle, rather a negative error code
-        if(fileHandle > 0)
+        if (fileHandle > 0)
         {
-            retVal = sl_FsRead(fileHandle, 0, (unsigned char*)configurationBlock, sizeof(HAL_Configuration_NetworkInterface));
-            
+            retVal = sl_FsRead(
+                fileHandle,
+                0,
+                (unsigned char *)configurationBlock,
+                sizeof(HAL_Configuration_NetworkInterface));
+
             // on success the return value is the amount of bytes written
-            if(retVal == sizeof(HAL_Configuration_NetworkInterface))
+            if (retVal == sizeof(HAL_Configuration_NetworkInterface))
             {
                 retVal = sl_FsClose(fileHandle, 0, 0, 0);
 
-                if( retVal < 0 )
+                if (retVal < 0)
                 {
                     // error closing file, API ceremony suggests calling "abort" operation
                     uint8_t signature = 'A';
@@ -297,7 +332,7 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
             }
         }
 
-        if(fileName != NULL)
+        if (fileName != NULL)
         {
             platform_free(fileName);
         }
@@ -305,16 +340,26 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
         // done!
         return true;
     }
-    else if(configuration == DeviceConfigurationOption_Wireless80211Network)
+    else if (configuration == DeviceConfigurationOption_Wireless80211Network)
     {
-        wirelessConfigBlock = (HAL_Configuration_Wireless80211*)configurationBlock;
+        wirelessConfigBlock = (HAL_Configuration_Wireless80211 *)configurationBlock;
 
         // make sure the config block marker is set
-        memcpy(configurationBlock, c_MARKER_CONFIGURATION_WIRELESS80211_V1, sizeof(c_MARKER_CONFIGURATION_WIRELESS80211_V1));
+        memcpy(
+            configurationBlock,
+            c_MARKER_CONFIGURATION_WIRELESS80211_V1,
+            sizeof(c_MARKER_CONFIGURATION_WIRELESS80211_V1));
 
         // get profile from SimpleLink
-        retVal = sl_WlanProfileGet(configurationIndex, (signed char *)wirelessConfigBlock->Ssid, &dummyNameLen, &dummyMAC[0], &secParams, NULL, &dummyPriority);
-        if(retVal == SL_ERROR_WLAN_GET_PROFILE_INVALID_INDEX)
+        retVal = sl_WlanProfileGet(
+            configurationIndex,
+            (signed char *)wirelessConfigBlock->Ssid,
+            &dummyNameLen,
+            &dummyMAC[0],
+            &secParams,
+            NULL,
+            &dummyPriority);
+        if (retVal == SL_ERROR_WLAN_GET_PROFILE_INVALID_INDEX)
         {
             return false;
         }
@@ -326,8 +371,7 @@ bool ConfigurationManager_GetConfigurationBlock(void* configurationBlock, Device
 
         // password is hidden, NULL the string
         memset(wirelessConfigBlock->Password, 0, sizeof(wirelessConfigBlock->Password));
-        //wirelessConfigBlock->Radio 
-        
+        // wirelessConfigBlock->Radio
 
         // done
         return true;
@@ -342,24 +386,30 @@ uint8_t GetSecurityType(AuthenticationType authentication)
     {
         case AuthenticationType_Open:
             return SL_WLAN_SEC_TYPE_OPEN;
-    
+
         case AuthenticationType_WEP:
             return SL_WLAN_SEC_TYPE_WEP;
-    
+
         case AuthenticationType_WPA:
         case AuthenticationType_WPA2:
             return SL_WLAN_SEC_TYPE_WPA_WPA2;
-    
+
         case AuthenticationType_Shared:
             return SL_WLAN_SEC_TYPE_WEP_SHARED;
-    
+
         default:
             return SL_WLAN_SEC_TYPE_OPEN;
     }
 }
 
-// Stores the configuration block to the file system 
-bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, DeviceConfigurationOption configuration, uint32_t configurationIndex, uint32_t blockSize, uint32_t offset, bool done)
+// Stores the configuration block to the file system
+bool ConfigurationManager_StoreConfigurationBlock(
+    void *configurationBlock,
+    DeviceConfigurationOption configuration,
+    uint32_t configurationIndex,
+    uint32_t blockSize,
+    uint32_t offset,
+    bool done)
 {
     // this platform doesn't need to handle this
     (void)done;
@@ -367,43 +417,47 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
     bool requiresEnumeration = false;
     bool success = false;
 
-    unsigned char* fileName = NULL;
+    unsigned char *fileName = NULL;
 
     int32_t fileHandle;
     uint32_t token = 0;
     int32_t retVal;
     SlWlanSecParams_t secParams;
 
-    if(configuration == DeviceConfigurationOption_Network)
+    if (configuration == DeviceConfigurationOption_Network)
     {
         // network config blocks are stored as files
 
         // compose file name
-        fileName = (unsigned char*)platform_malloc(sizeof(NETWORK_CONFIG_FILE_NAME));
+        fileName = (unsigned char *)platform_malloc(sizeof(NETWORK_CONFIG_FILE_NAME));
         memcpy(fileName, NETWORK_CONFIG_FILE_NAME, sizeof(NETWORK_CONFIG_FILE_NAME));
         // insert index number at position N as char
         fileName[NETWORK_CONFIG_FILE_INDEX_POSITION] = '0' + configurationIndex;
 
-        fileHandle = sl_FsOpen( fileName,
-                                SL_FS_CREATE | SL_FS_OVERWRITE |
-                                SL_FS_CREATE_MAX_SIZE(sizeof(HAL_Configuration_NetworkInterface)) |
-                                SL_FS_CREATE_PUBLIC_WRITE | SL_FS_CREATE_NOSIGNATURE,
-                                (uint32_t *)&token);
-        
+        fileHandle = sl_FsOpen(
+            fileName,
+            SL_FS_CREATE | SL_FS_OVERWRITE | SL_FS_CREATE_MAX_SIZE(sizeof(HAL_Configuration_NetworkInterface)) |
+                SL_FS_CREATE_PUBLIC_WRITE | SL_FS_CREATE_NOSIGNATURE,
+            (uint32_t *)&token);
+
         // on error there is no file handle, rather a negative error code
-        if(fileHandle > 0)
+        if (fileHandle > 0)
         {
             // make sure the config block marker is set
-            memcpy(configurationBlock, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1)); 
+            memcpy(configurationBlock, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
 
-            retVal = sl_FsWrite(fileHandle, 0, (unsigned char*)configurationBlock, sizeof(HAL_Configuration_NetworkInterface));
-            
+            retVal = sl_FsWrite(
+                fileHandle,
+                0,
+                (unsigned char *)configurationBlock,
+                sizeof(HAL_Configuration_NetworkInterface));
+
             // on success the return value is the amount of bytes written
-            if(retVal == sizeof(HAL_Configuration_NetworkInterface))
+            if (retVal == sizeof(HAL_Configuration_NetworkInterface))
             {
                 retVal = sl_FsClose(fileHandle, 0, 0, 0);
 
-                if( retVal < 0 )
+                if (retVal < 0)
                 {
                     // error closing file, API ceremony suggests calling "abort" operation
                     uint8_t signature = 'A';
@@ -418,14 +472,14 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
             }
         }
 
-        if(fileName != NULL)
+        if (fileName != NULL)
         {
             platform_free(fileName);
         }
     }
-    else if(configuration == DeviceConfigurationOption_Wireless80211Network)
+    else if (configuration == DeviceConfigurationOption_Wireless80211Network)
     {
-        HAL_Configuration_Wireless80211* wirelessConfigBlock = (HAL_Configuration_Wireless80211*)configurationBlock;
+        HAL_Configuration_Wireless80211 *wirelessConfigBlock = (HAL_Configuration_Wireless80211 *)configurationBlock;
 
         secParams.Type = GetSecurityType(wirelessConfigBlock->Authentication);
         secParams.Key = (signed char *)wirelessConfigBlock->Password;
@@ -433,8 +487,15 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
 
         // add profile to SimpleLink
         // TODO - default priority is 0
-        retVal = sl_WlanProfileAdd((const signed char *)wirelessConfigBlock->Ssid, hal_strlen_s((const char *)(wirelessConfigBlock->Ssid)), NULL, &secParams, NULL, 0, 0);
-        if(retVal < 0)
+        retVal = sl_WlanProfileAdd(
+            (const signed char *)wirelessConfigBlock->Ssid,
+            hal_strlen_s((const char *)(wirelessConfigBlock->Ssid)),
+            NULL,
+            &secParams,
+            NULL,
+            0,
+            0);
+        if (retVal < 0)
         {
             return false;
         }
@@ -443,14 +504,14 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
         success = true;
         requiresEnumeration = true;
     }
-    else if(configuration == DeviceConfigurationOption_X509CaRootBundle)
+    else if (configuration == DeviceConfigurationOption_X509CaRootBundle)
     {
         // CA root certificate bundle is stored as a file /sys/certstore.lst
         // currently we don't support updating this
         success = false;
     }
 
-    if(success == true && requiresEnumeration)
+    if (success == true && requiresEnumeration)
     {
         // free the current allocation(s)
         platform_free(g_TargetConfiguration.NetworkInterfaceConfigs);
@@ -465,15 +526,24 @@ bool ConfigurationManager_StoreConfigurationBlock(void* configurationBlock, Devi
 }
 
 // Updates a configuration block
-bool ConfigurationManager_UpdateConfigurationBlock(void* configurationBlock, DeviceConfigurationOption configuration, uint32_t configurationIndex)
+bool ConfigurationManager_UpdateConfigurationBlock(
+    void *configurationBlock,
+    DeviceConfigurationOption configuration,
+    uint32_t configurationIndex)
 {
     // CC32xx stores the config blocks on the file system so we don't care about sizes
 
-    switch(configuration)
+    switch (configuration)
     {
         case DeviceConfigurationOption_Network:
         case DeviceConfigurationOption_Wireless80211Network:
-            return ConfigurationManager_StoreConfigurationBlock(configurationBlock, configuration, configurationIndex, 0, 0, false);    
+            return ConfigurationManager_StoreConfigurationBlock(
+                configurationBlock,
+                configuration,
+                configurationIndex,
+                0,
+                0,
+                false);
 
         // this configuration option is not supported
         case DeviceConfigurationOption_X509CaRootBundle:
@@ -484,16 +554,16 @@ bool ConfigurationManager_UpdateConfigurationBlock(void* configurationBlock, Dev
 }
 
 //  Default initialisation for wireless config block
-void InitialiseWirelessDefaultConfig(HAL_Configuration_Wireless80211 * pconfig, uint32_t configurationIndex)
+void InitialiseWirelessDefaultConfig(HAL_Configuration_Wireless80211 *pconfig, uint32_t configurationIndex)
 {
     (void)pconfig;
     (void)configurationIndex;
 
-    // TODO    
+    // TODO
 }
 
 //  Default initialisation for Network interface config blocks
-bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig, uint32_t configurationIndex)
+bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface *pconfig, uint32_t configurationIndex)
 {
     (void)configurationIndex;
 
@@ -506,7 +576,7 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
 
     // make sure the config block marker is set
     memcpy(pconfig->Marker, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
-    
+
     pconfig->InterfaceType = NetworkInterfaceType_Wireless80211;
     pconfig->StartupAddressMode = AddressMode_DHCP;
     pconfig->AutomaticDNS = 1;

--- a/targets/TI-SimpleLink/common/targetHAL_ConfigurationManager_CC32xx.cpp
+++ b/targets/TI-SimpleLink/common/targetHAL_ConfigurationManager_CC32xx.cpp
@@ -497,6 +497,9 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
 {
     (void)configurationIndex;
 
+    // zero memory
+    memset(pconfig, 0, sizeof(HAL_Configuration_NetworkInterface));
+
     uint16_t macAddressLen = SL_MAC_ADDR_LEN;
 
     memset(pconfig, 0, sizeof(HAL_Configuration_NetworkInterface));


### PR DESCRIPTION
## Description
- Missing zeroing the memory.
- The specific config ID was being, wrongly, set to 0.

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
