### PR TITLE
Fix STM32 LLD flash write

### DIFF
--- a/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
+++ b/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
@@ -33,25 +33,25 @@ SMT32FlashDriver STM32FLASH;
 // Unlock the FLASH control register access
 bool HAL_FLASH_Unlock(void)
 {
-  if((FLASH->CR & FLASH_CR_LOCK) != RESET)
-  {
-    // Authorize the FLASH Registers access
-    FLASH->KEYR = FLASH_KEY1;
-    FLASH->KEYR = FLASH_KEY2;
-  }
-  else
-  {
-    return false;
-  }
+    if ((FLASH->CR & FLASH_CR_LOCK) != RESET)
+    {
+        // Authorize the FLASH Registers access
+        FLASH->KEYR = FLASH_KEY1;
+        FLASH->KEYR = FLASH_KEY2;
+    }
+    else
+    {
+        return false;
+    }
 
-  return true; 
+    return true;
 }
 
 // Locks the FLASH control register access
 void HAL_FLASH_Lock(void)
 {
-  // Set the LOCK Bit to lock the FLASH Registers access
-  FLASH->CR |= FLASH_CR_LOCK;
+    // Set the LOCK Bit to lock the FLASH Registers access
+    FLASH->CR |= FLASH_CR_LOCK;
 }
 
 bool FLASH_WaitForLastOperation(uint32_t timeout)
@@ -63,11 +63,12 @@ bool FLASH_WaitForLastOperation(uint32_t timeout)
     //  flag will be set
     // no need to overload this with a timeout workflow as the watchdog will quick-in if execution gets stuck
 
-    while(__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY) != RESET);
-    
-    if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_ALL_ERRORS) != RESET)
+    while (__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY) != RESET)
+        ;
+
+    if (__HAL_FLASH_GET_FLAG(FLASH_FLAG_ALL_ERRORS) != RESET)
     {
-      return false;
+        return false;
     }
 
     // Check FLASH End of Operation flag
@@ -79,39 +80,38 @@ bool FLASH_WaitForLastOperation(uint32_t timeout)
 
     // If there is no error flag set
     return true;
-}  
+}
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) ||\
-    defined(STM32F469xx) || defined(STM32F479xx) ||\
-    defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F412Zx) ||\
-    defined(STM32F412Vx) || defined(STM32F412Rx) || defined(STM32F412Cx) ||\
-    defined(STM32F401xC) ||\
-    defined(STM32F410Tx) || defined(STM32F410Cx) || defined(STM32F410Rx) ||\
-    defined(STM32F401xE) || defined(STM32F411xE) || defined(STM32F446xx)
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) ||                    \
+    defined(STM32F469xx) || defined(STM32F479xx) || defined(STM32F405xx) || defined(STM32F415xx) ||                    \
+    defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F412Zx) || defined(STM32F412Vx) ||                    \
+    defined(STM32F412Rx) || defined(STM32F412Cx) || defined(STM32F401xC) || defined(STM32F410Tx) ||                    \
+    defined(STM32F410Cx) || defined(STM32F410Rx) || defined(STM32F401xE) || defined(STM32F411xE) ||                    \
+    defined(STM32F446xx)
 
 void FLASH_FlushCaches(void)
 {
-  // Flush instruction cache 
-  if(READ_BIT(FLASH->ACR, FLASH_ACR_ICEN)!= RESET)
-  {
-    // Disable instruction cache
-    __HAL_FLASH_INSTRUCTION_CACHE_DISABLE();
-    // Reset instruction cache
-    __HAL_FLASH_INSTRUCTION_CACHE_RESET();
-    // Enable instruction cache
-    __HAL_FLASH_INSTRUCTION_CACHE_ENABLE();
-  }
-  
-  // Flush data cache
-  if(READ_BIT(FLASH->ACR, FLASH_ACR_DCEN) != RESET)
-  {
-    // Disable data cache 
-    __HAL_FLASH_DATA_CACHE_DISABLE();
-    // Reset data cache
-    __HAL_FLASH_DATA_CACHE_RESET();
-    // Enable data cache
-    __HAL_FLASH_DATA_CACHE_ENABLE();
-  }
+    // Flush instruction cache
+    if (READ_BIT(FLASH->ACR, FLASH_ACR_ICEN) != RESET)
+    {
+        // Disable instruction cache
+        __HAL_FLASH_INSTRUCTION_CACHE_DISABLE();
+        // Reset instruction cache
+        __HAL_FLASH_INSTRUCTION_CACHE_RESET();
+        // Enable instruction cache
+        __HAL_FLASH_INSTRUCTION_CACHE_ENABLE();
+    }
+
+    // Flush data cache
+    if (READ_BIT(FLASH->ACR, FLASH_ACR_DCEN) != RESET)
+    {
+        // Disable data cache
+        __HAL_FLASH_DATA_CACHE_DISABLE();
+        // Reset data cache
+        __HAL_FLASH_DATA_CACHE_RESET();
+        // Enable data cache
+        __HAL_FLASH_DATA_CACHE_ENABLE();
+    }
 }
 #endif // define STM32F4xxxx
 
@@ -119,41 +119,53 @@ void FLASH_FlushCaches(void)
 // Driver exported functions.                                                //
 ///////////////////////////////////////////////////////////////////////////////
 
-void flash_lld_init() {
+void flash_lld_init()
+{
     stm32FlashObjectInit(&STM32FLASH);
 }
 
-void flash_lld_readBytes(uint32_t startAddress, uint32_t length, uint8_t* buffer) {
+void flash_lld_readBytes(uint32_t startAddress, uint32_t length, uint8_t *buffer)
+{
 
-    __IO uint8_t* cursor = (__IO uint8_t*)startAddress;
-    __IO uint8_t* endAddress = (__IO uint8_t*)(startAddress + length);
+    __IO uint8_t *cursor = (__IO uint8_t *)startAddress;
+    __IO uint8_t *endAddress = (__IO uint8_t *)(startAddress + length);
 
-    // copy contents from flash to buffer starting from the start address 
-    while(cursor < endAddress)
+    // copy contents from flash to buffer starting from the start address
+    while (cursor < endAddress)
     {
         *buffer++ = *cursor++;
     }
 }
 
-int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffer) {
+int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t *buffer)
+{
 
-    __IO uint8_t* cursor = (__IO uint8_t*)startAddress;
-    __IO uint8_t* endAddress = (__IO uint8_t*)(startAddress + length);
+    __IO uint8_t *cursor = (__IO uint8_t *)startAddress;
+    __IO uint8_t *endAddress = (__IO uint8_t *)(startAddress + length);
 
     // default to false
     bool success = false;
+    bool addressAligned = true;
+
+    // check for even address alignment
+    if (startAddress % (uint32_t)2)
+    {
+        // address is not aligned,
+        // can't write using half words
+        addressAligned = false;
+    }
 
     // unlock the FLASH
-    if(HAL_FLASH_Unlock())
+    if (HAL_FLASH_Unlock())
     {
         // Clear pending flags (if any)
         __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
 
-        while(cursor < endAddress)
+        while (cursor < endAddress)
         {
             // if buffer has enough data, program half-words (16 bits) in a single operation to speed up things
             // NOTE: assuming that the supply voltage is able to cope with half-word programming
-            if((endAddress - cursor) >= 2)
+            if (addressAligned && (endAddress - cursor) >= 2)
             {
                 // clear the program size mask
                 FLASH->CR &= CR_PSIZE_MASK;
@@ -162,12 +174,12 @@ int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffe
                 // proceed to program the flash by setting the PG Bit
                 FLASH->CR |= FLASH_CR_PG;
 
-                *(__IO uint16_t*)cursor = *((uint16_t*)buffer);
+                *(__IO uint16_t *)cursor = *((uint16_t *)buffer);
 
-#if defined(STM32F756xx) || defined(STM32F746xx) || defined(STM32F745xx) || defined(STM32F767xx) || \
-    defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) || defined(STM32F722xx) || \
-	defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
-    
+#if defined(STM32F756xx) || defined(STM32F746xx) || defined(STM32F745xx) || defined(STM32F767xx) ||                    \
+    defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) || defined(STM32F722xx) ||                    \
+    defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
+
                 // Data synchronous Barrier, forcing the CPU to respect the sequence of instruction without optimization
                 __DSB();
 #endif
@@ -186,24 +198,25 @@ int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffe
                 // proceed to program the flash by setting the PG Bit
                 FLASH->CR |= FLASH_CR_PG;
 
-                *(__IO uint8_t*)cursor = *buffer;
+                *(__IO uint8_t *)cursor = *buffer;
 
-#if defined(STM32F756xx) || defined(STM32F746xx) || defined(STM32F745xx) || defined(STM32F767xx) || \
-    defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) || defined(STM32F722xx) || \
-	defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
-    
+#if defined(STM32F756xx) || defined(STM32F746xx) || defined(STM32F745xx) || defined(STM32F767xx) ||                    \
+    defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) || defined(STM32F722xx) ||                    \
+    defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
+
                 // Data synchronous Barrier, forcing the CPU to respect the sequence of instruction without optimization
                 __DSB();
-#endif                
+#endif
 
-                // update flash pointer by the 'extra' byte that was programmed
-                cursor += 2;
+                // update flash and buffer pointers
+                cursor++;
+                buffer++;
             }
-                
+
             // wait 500ms for any flash operation to be completed
             success = FLASH_WaitForLastOperation(500);
-            
-            if(!success)
+
+            if (!success)
             {
                 // quit on failure
                 break;
@@ -212,7 +225,7 @@ int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffe
 
         // after the program operation is completed disable the PG Bit
         FLASH->CR &= (~FLASH_CR_PG);
-                
+
         // lock the FLASH
         HAL_FLASH_Lock();
     }
@@ -220,122 +233,124 @@ int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t* buffe
     return success;
 }
 
-int flash_lld_isErased(uint32_t startAddress, uint32_t length) {
+int flash_lld_isErased(uint32_t startAddress, uint32_t length)
+{
 
-    __IO uint32_t* cursor = (__IO uint32_t*)startAddress;
-    __IO uint32_t* endAddress = (__IO uint32_t*)(startAddress + length);
+    __IO uint32_t *cursor = (__IO uint32_t *)startAddress;
+    __IO uint32_t *endAddress = (__IO uint32_t *)(startAddress + length);
 
     // an erased flash address has to read FLASH_ERASED_WORD
     // OK to check by word (32 bits) because the erase is performed by 'page' whose size is word multiple
-    while(cursor < endAddress)
+    while (cursor < endAddress)
     {
-        if(*cursor++ != FLASH_ERASED_WORD)
+        if (*cursor++ != FLASH_ERASED_WORD)
         {
             // found an address with something other than FLASH_ERASED_WORD!!
             return false;
         }
     }
-    
+
     // reached here so the segment must be erased
     return true;
 }
 
 uint8_t flash_lld_getSector(uint32_t address)
 {
-  uint8_t sector = 0;
+    uint8_t sector = 0;
 
-  if((address < ADDR_FLASH_SECTOR_1) && (address >= ADDR_FLASH_SECTOR_0))
-  {
-    sector = FLASH_SECTOR_0;
-  }
-  else if((address < ADDR_FLASH_SECTOR_2) && (address >= ADDR_FLASH_SECTOR_1))
-  {
-    sector = FLASH_SECTOR_1;
-  }
-  else if((address < ADDR_FLASH_SECTOR_3) && (address >= ADDR_FLASH_SECTOR_2))
-  {
-    sector = FLASH_SECTOR_2;
-  }
-  else if((address < ADDR_FLASH_SECTOR_4) && (address >= ADDR_FLASH_SECTOR_3))
-  {
-    sector = FLASH_SECTOR_3;
-  }
+    if ((address < ADDR_FLASH_SECTOR_1) && (address >= ADDR_FLASH_SECTOR_0))
+    {
+        sector = FLASH_SECTOR_0;
+    }
+    else if ((address < ADDR_FLASH_SECTOR_2) && (address >= ADDR_FLASH_SECTOR_1))
+    {
+        sector = FLASH_SECTOR_1;
+    }
+    else if ((address < ADDR_FLASH_SECTOR_3) && (address >= ADDR_FLASH_SECTOR_2))
+    {
+        sector = FLASH_SECTOR_2;
+    }
+    else if ((address < ADDR_FLASH_SECTOR_4) && (address >= ADDR_FLASH_SECTOR_3))
+    {
+        sector = FLASH_SECTOR_3;
+    }
 
 // need to wrap the else ifs below because not all target devices have all the sectors defined
 #if defined(FLASH_SECTOR_4)
-  else if((address < ADDR_FLASH_SECTOR_5) && (address >= ADDR_FLASH_SECTOR_4))
-  {
-    sector = FLASH_SECTOR_4;
-  }
+    else if ((address < ADDR_FLASH_SECTOR_5) && (address >= ADDR_FLASH_SECTOR_4))
+    {
+        sector = FLASH_SECTOR_4;
+    }
 #endif
 #if defined(FLASH_SECTOR_5)
-  else if((address < ADDR_FLASH_SECTOR_6) && (address >= ADDR_FLASH_SECTOR_5))
-  {
-    sector = FLASH_SECTOR_5;
-  }
+    else if ((address < ADDR_FLASH_SECTOR_6) && (address >= ADDR_FLASH_SECTOR_5))
+    {
+        sector = FLASH_SECTOR_5;
+    }
 #endif
 #if defined(FLASH_SECTOR_6)
-  else if((address < ADDR_FLASH_SECTOR_7) && (address >= ADDR_FLASH_SECTOR_6))
-  {
-    sector = FLASH_SECTOR_6;
-  }
+    else if ((address < ADDR_FLASH_SECTOR_7) && (address >= ADDR_FLASH_SECTOR_6))
+    {
+        sector = FLASH_SECTOR_6;
+    }
 #endif
 // the next one is for devices that have FLASH sector 8 defined (see next one for devices WITHOUT sector 8)
 #if defined(FLASH_SECTOR_7) && defined(FLASH_SECTOR_8)
-  else if((address < ADDR_FLASH_SECTOR_8) && (address >= ADDR_FLASH_SECTOR_7))
-  {
-    sector = FLASH_SECTOR_7;
-  }
+    else if ((address < ADDR_FLASH_SECTOR_8) && (address >= ADDR_FLASH_SECTOR_7))
+    {
+        sector = FLASH_SECTOR_7;
+    }
 #endif
 // this next one needs to be here for devices that don't have FLASH sector 8
 #if defined(FLASH_SECTOR_7) && !defined(FLASH_SECTOR_8)
-  else if(address >= ADDR_FLASH_SECTOR_7)
-  {
-    sector = FLASH_SECTOR_7;
-  }
+    else if (address >= ADDR_FLASH_SECTOR_7)
+    {
+        sector = FLASH_SECTOR_7;
+    }
 #endif
 #if defined(FLASH_SECTOR_8)
-  else if((address < ADDR_FLASH_SECTOR_9) && (address >= ADDR_FLASH_SECTOR_8))
-  {
-    sector = FLASH_SECTOR_8;
-  }
+    else if ((address < ADDR_FLASH_SECTOR_9) && (address >= ADDR_FLASH_SECTOR_8))
+    {
+        sector = FLASH_SECTOR_8;
+    }
 #endif
 #if defined(FLASH_SECTOR_9)
-  else if((address < ADDR_FLASH_SECTOR_10) && (address >= ADDR_FLASH_SECTOR_9))
-  {
-    sector = FLASH_SECTOR_9;
-  }
+    else if ((address < ADDR_FLASH_SECTOR_10) && (address >= ADDR_FLASH_SECTOR_9))
+    {
+        sector = FLASH_SECTOR_9;
+    }
 #endif
 #if defined(FLASH_SECTOR_10)
-  else if((address < ADDR_FLASH_SECTOR_11) && (address >= ADDR_FLASH_SECTOR_10))
-  {
-    sector = FLASH_SECTOR_10;
-  }
-#endif  
-  else /* (address < FLASH_END_ADDR) && (address >= ADDR_FLASH_SECTOR_11) */
-  {
-    sector = FLASH_SECTOR_11;
-  }
+    else if ((address < ADDR_FLASH_SECTOR_11) && (address >= ADDR_FLASH_SECTOR_10))
+    {
+        sector = FLASH_SECTOR_10;
+    }
+#endif
+    else /* (address < FLASH_END_ADDR) && (address >= ADDR_FLASH_SECTOR_11) */
+    {
+        sector = FLASH_SECTOR_11;
+    }
 
-  return sector;
+    return sector;
 }
 
-int flash_lld_erase(uint32_t address) {
+int flash_lld_erase(uint32_t address)
+{
 
     // default to false
     bool success = false;
 
     // unlock the FLASH
-    if(HAL_FLASH_Unlock())
+    if (HAL_FLASH_Unlock())
     {
-        // Clear pending flags (if any)  
+        // Clear pending flags (if any)
         __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
-        
+
         // get the sector number to erase
         uint8_t sectorNumber = flash_lld_getSector(address);
 
         // Need to add offset of 4 when sector higher than FLASH_SECTOR_11
-        if(sectorNumber > FLASH_SECTOR_11) 
+        if (sectorNumber > FLASH_SECTOR_11)
         {
             sectorNumber += 4U;
         }
@@ -345,14 +360,14 @@ int flash_lld_erase(uint32_t address) {
         SET_BIT(FLASH->CR, FLASH_PSIZE_HALF_WORD);
         CLEAR_BIT(FLASH->CR, FLASH_CR_SNB);
         FLASH->CR |= FLASH_CR_SER | (sectorNumber << POSITION_VAL(FLASH_CR_SNB));
-        
+
         // start erase operation
         FLASH->CR |= FLASH_CR_STRT;
 
-#if defined(STM32F756xx) || defined(STM32F746xx) || defined(STM32F745xx) || defined(STM32F767xx) || \
-    defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) || defined(STM32F722xx) || \
-	  defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
-    
+#if defined(STM32F756xx) || defined(STM32F746xx) || defined(STM32F745xx) || defined(STM32F767xx) ||                    \
+    defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) || defined(STM32F722xx) ||                    \
+    defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx)
+
         // Data synchronous Barrier, forcing the CPU to respect the sequence of instruction without optimization
         __DSB();
 #endif
@@ -363,13 +378,12 @@ int flash_lld_erase(uint32_t address) {
         // after erase operation completed disable the SER and SNB Bits
         CLEAR_BIT(FLASH->CR, (FLASH_CR_SER | FLASH_CR_SNB));
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) ||\
-    defined(STM32F469xx) || defined(STM32F479xx) ||\
-    defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F412Zx) ||\
-    defined(STM32F412Vx) || defined(STM32F412Rx) || defined(STM32F412Cx) ||\
-    defined(STM32F401xC) ||\
-    defined(STM32F410Tx) || defined(STM32F410Cx) || defined(STM32F410Rx) ||\
-    defined(STM32F401xE) || defined(STM32F411xE) || defined(STM32F446xx)
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) ||                    \
+    defined(STM32F469xx) || defined(STM32F479xx) || defined(STM32F405xx) || defined(STM32F415xx) ||                    \
+    defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F412Zx) || defined(STM32F412Vx) ||                    \
+    defined(STM32F412Rx) || defined(STM32F412Cx) || defined(STM32F401xC) || defined(STM32F410Tx) ||                    \
+    defined(STM32F410Cx) || defined(STM32F410Rx) || defined(STM32F401xE) || defined(STM32F411xE) ||                    \
+    defined(STM32F446xx)
 
         // Flush the caches to be sure of the data consistency
         FLASH_FlushCaches();


### PR DESCRIPTION
## Description
- Add check for evenly aligned address.
- Fix byte writing to flash.

## Motivation and Context
- Operation was failing on unaligned addresses.
- Operation was failing for bytes access.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
