### PR TITLE
Fix Read/Write in System.Device.I2c

### DIFF
--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -2838,7 +2838,8 @@ static const TypeIndexLookup c_TypeIndexLookup[] = {
 
     TIL("System.Net.Sockets", "SocketException", m_SocketException),
 
-    TIL("Windows.Devices.I2c", "I2cTransferResult", m_I2cTransferResult),
+    TIL("System.Device.I2c", "I2cTransferResult", m_I2cTransferResult),
+    TIL("Windows.Devices.I2c", "I2cTransferResult", m_I2cTransferResult_old),
 
 #if (HAL_USE_ESP32_RMT_OPTION == TRUE)
     TIL("nanoFramework.Hardware.Esp32.Rmt", "RmtCommand", m_RmtCommand),

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -1573,6 +1573,7 @@ struct CLR_RT_WellKnownTypes
     CLR_RT_TypeDef_Index m_SocketException;
 
     CLR_RT_TypeDef_Index m_I2cTransferResult;
+    CLR_RT_TypeDef_Index m_I2cTransferResult_old;
 
 #if (HAL_USE_ESP32_RMT_OPTION == TRUE)
     CLR_RT_TypeDef_Index m_RmtCommand;

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -359,11 +359,14 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
         {
             // get buffer
             writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
-
-            // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
-            palI2c->WriteSize = writeBuffer->m_numOfElements;
+            if (byteArray != NULL)
+            {
+                // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
+                palI2c->WriteSize = writeBuffer->m_numOfElements;
+            }
         }
-        else
+
+        if (writeBuffer == NULL)
         {
             // nothing to write, have to zero this
             palI2c->WriteSize = 0;
@@ -374,11 +377,14 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
         {
             // get buffer
             readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
-
-            // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
-            palI2c->ReadSize = readBuffer->m_numOfElements;
+            if (readBuffer != NULL)
+            {
+                // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
+                palI2c->ReadSize = readBuffer->m_numOfElements;
+            }
         }
-        else
+
+        if (readBuffer == NULL)
         {
             // nothing to read, have to zero this
             palI2c->ReadSize = 0;

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -359,7 +359,7 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
         {
             // get buffer
             writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
-            if (byteArray != NULL)
+            if (writeBuffer != NULL)
             {
                 // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
                 palI2c->WriteSize = writeBuffer->m_numOfElements;

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -543,7 +543,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::
             // stack
             CLR_RT_HeapBlock &top = stack.PushValueAndClear();
             NANOCLR_CHECK_HRESULT(
-                g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+                g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult_old));
             result = top.Dereference();
             FAULT_ON_NULL(result);
 

--- a/targets/FreeRTOS/NXP/nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/FreeRTOS/NXP/nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -195,11 +195,14 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
         {
             // get buffer
             writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
-
-            pI2Cx->txBuffer = writeBuffer->GetFirstElement();
-            pI2Cx->txSize = writeBuffer->m_numOfElements;
+            if (writeBuffer != NULL)
+            {
+                pI2Cx->txBuffer = writeBuffer->GetFirstElement();
+                pI2Cx->txSize = writeBuffer->m_numOfElements;
+            }
         }
-        else
+        
+        if ( writeBuffer == NULL )
         {
             pI2Cx->txBuffer = NULL;
             pI2Cx->txSize = 0;
@@ -210,11 +213,14 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
         {
             // get buffer
             readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
-
-            pI2Cx->rxBuffer = readBuffer->GetFirstElement();
-            pI2Cx->rxSize = readBuffer->m_numOfElements;
+            if (readBuffer != NULL)
+            {
+                pI2Cx->rxBuffer = readBuffer->GetFirstElement();
+                pI2Cx->rxSize = readBuffer->m_numOfElements;
+            }
         }
-        else
+        
+        if ( readBuffer == NULL )
         {
             pI2Cx->rxBuffer = NULL;
             pI2Cx->rxSize = 0;

--- a/targets/FreeRTOS/NXP/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/FreeRTOS/NXP/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -271,7 +271,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::
 
         // Create return object
         NANOCLR_CHECK_HRESULT(
-            g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+            g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult_old));
         result = top.Dereference();
         FAULT_ON_NULL(result);
 

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -128,24 +128,28 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
         if (writeSpanByte != NULL)
         {
             writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
+            if ( writeBuffer != NULL)
+            {
+                // grab the pointer to the array by getting the first element of the array
+                writeData = writeBuffer->GetFirstElement();
 
-            // grab the pointer to the array by getting the first element of the array
-            writeData = writeBuffer->GetFirstElement();
-
-            // get the size of the buffer by reading the number of elements in the HeapBlock array
-            writeSize = writeBuffer->m_numOfElements;
+                // get the size of the buffer by reading the number of elements in the HeapBlock array
+                writeSize = writeBuffer->m_numOfElements;
+            }
         }
 
         readSpanByte = stack.Arg2().Dereference();
-        if (readSpanByte != NULL)
+        if (readSpanByte != 0)
         {
             readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
+            if ( readBuffer != NULL)
+            {
+                // grab the pointer to the array by getting the first element of the array
+                readData = readBuffer->GetFirstElement();
 
-            // grab the pointer to the array by getting the first element of the array
-            readData = readBuffer->GetFirstElement();
-
-            // get the size of the buffer by reading the number of elements in the HeapBlock array
-            readSize = readBuffer->m_numOfElements;
+                // get the size of the buffer by reading the number of elements in the HeapBlock array
+                readSize = readBuffer->m_numOfElements;
+            }
         }
 
         i2c_cmd_handle_t cmd = i2c_cmd_link_create();
@@ -211,13 +215,7 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
 
             // set the bytes transferred field
             result[I2cTransferResult::FIELD___bytesTransferred].SetInteger((CLR_UINT32)(writeSize + readSize));
-
-            if (readSize > 0)
-            {
-                // because this was a Read transaction, need to copy from DMA buffer to managed buffer
-                memcpy(readBuffer->GetFirstElement(), &readData[0], readSize);
-            }
-        }
+         }
     }
     NANOCLR_NOCLEANUP();
 }

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -184,7 +184,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::NativeTransmit
         i2c_cmd_link_delete(cmd);
 
         // create return object
-        NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+        NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult_old));
         result = top.Dereference(); FAULT_ON_NULL(result);
 
         if (i2cStatus != ESP_OK)

--- a/targets/TI-SimpleLink/nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -165,11 +165,14 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
         {
             // get buffer
             writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
-
-            // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
-            palI2c->i2cTransaction.writeCount = writeBuffer->m_numOfElements;
+            if (writeBuffer != NULL)
+            {
+                // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
+                palI2c->i2cTransaction.writeCount = writeBuffer->m_numOfElements;
+            }
         }
-        else
+
+        if (writeBuffer == NULL)
         {
             // nothing to write, have to zero this
             palI2c->i2cTransaction.writeCount = 0;
@@ -180,11 +183,14 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
         {
             // get buffer
             readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
-
-            // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
-            palI2c->i2cTransaction.readCount = readBuffer->m_numOfElements;
+            if (readBuffer != NULL)
+            {
+                // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
+                palI2c->i2cTransaction.readCount = readBuffer->m_numOfElements;
+            }
         }
-        else
+
+        if (readBuffer == NULL)
         {
             // nothing to read, have to zero this
             palI2c->i2cTransaction.readCount = 0;

--- a/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
+++ b/targets/TI-SimpleLink/nanoCLR/Windows.Devices.I2c/win_dev_i2c_native_Windows_Devices_I2C_I2cDevice.cpp
@@ -229,7 +229,7 @@ HRESULT Library_win_dev_i2c_native_Windows_Devices_I2c_I2cDevice::
                 // managed stack
                 CLR_RT_HeapBlock &top = stack.PushValueAndClear();
                 NANOCLR_CHECK_HRESULT(
-                    g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+                    g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult_old));
                 result = top.Dereference();
                 FAULT_ON_NULL(result);
 


### PR DESCRIPTION
## Description

Fixes issues when a null parameter is passed into nativeTransmit() method.
As the parameter is a SpanByte structure we don't get a null parameter but a SpanByte structure with a null array

Also found an issue with the I2cTransferResult return type.  If Windows.Devices.I2c assembly not loaded then it couldn't find type.
Added new I2cTransferResult for System.Device.I2C and renamed variable for one used by Windows.Devices.I2c
m_I2cTransferResult ->  m_I2cTransferResult_old.

The Windows.Devices.I2c I2cTransferResult  can be removed once no longer used.

## Motivation and Context
- Fixes nanoFramework/Home#659

## How Has This Been Tested?<!-- (if applicable) -->

Tested on ESP32 only with nf_ssd1306 supplied test program for writes
and a BMP280 test program for reads


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
