### PR TITLE
Revert warning in ESP32 build

### DIFF
--- a/CMake/toolchain.xtensa-esp32-elf.cmake
+++ b/CMake/toolchain.xtensa-esp32-elf.cmake
@@ -57,8 +57,8 @@ set(GCC_ESP32_LINKER_LD, " -L ${ESP32_IDF_PATH}/components/esp32/ld  -T esp32_ou
 
 set(CMAKE_CXX_FLAGS "" CACHE INTERNAL "")
 
-set(CMAKE_C_FLAGS_DEBUG "-std=gnu99 -Og -ggdb -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -Wundef -mfix-esp32-psram-cache-issue -DWITH_POSIX -DHAVE_CONFIG_H -DESP_PLATFORM -D IDF_VER=\"v3.3.1\" -MMD -MP  " CACHE INTERNAL "c compiler flags debug")
-set(CMAKE_CXX_FLAGS_DEBUG " -Og -ggdb -std=gnu++11 -fno-exceptions -fno-rtti  -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -Wundef -mfix-esp32-psram-cache-issue -DESP_PLATFORM " CACHE INTERNAL "cxx compiler flags debug")
+set(CMAKE_C_FLAGS_DEBUG "-std=gnu99 -Og -ggdb -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -mfix-esp32-psram-cache-issue -DWITH_POSIX -DHAVE_CONFIG_H -DESP_PLATFORM -D IDF_VER=\"v3.3.1\" -MMD -MP  " CACHE INTERNAL "c compiler flags debug")
+set(CMAKE_CXX_FLAGS_DEBUG " -Og -ggdb -std=gnu++11 -fno-exceptions -fno-rtti  -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -mfix-esp32-psram-cache-issue -DESP_PLATFORM " CACHE INTERNAL "cxx compiler flags debug")
 
 set(CMAKE_ASM_FLAGS_DEBUG " -g3 -ggdb" CACHE INTERNAL "asm compiler flags debug")
 
@@ -66,10 +66,10 @@ set(CMAKE_ASM_FLAGS_DEBUG " -g3 -ggdb" CACHE INTERNAL "asm compiler flags debug"
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG " -nostdlib -u call_user_start_cpu0  -Wl,--gc-sections -Wl,-static " CACHE INTERNAL "linker flags debug")
 
 # set release flags
-set(CMAKE_C_FLAGS_RELEASE " -std=gnu99 -Os -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -MMD -MP -Wall -Wextra -Werror -Wundef -mfix-esp32-psram-cache-issue -D IDF_VER=\"v3.3.1\"  " CACHE INTERNAL "c compiler flags release")
-set(CMAKE_C_FLAGS_MINSIZEREL " -std=gnu99 -Os -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -MMD -MP -Wall -Wextra -Werror -Wundef -mfix-esp32-psram-cache-issue -D IDF_VER=\"v3.3.1\"  " CACHE INTERNAL "c compiler flags minsizerel")
-set(CMAKE_CXX_FLAGS_RELEASE " -Os -std=gnu++11 -g3 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -Wundef -mfix-esp32-psram-cache-issue -DESP_PLATFORM " CACHE INTERNAL "cxx compiler flags release")
-set(CMAKE_CXX_FLAGS_MINSIZEREL " -Os -std=gnu++11 -g3 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -Wundef -mfix-esp32-psram-cache-issue -DESP_PLATFORM " CACHE INTERNAL "cxx compiler flags minsizerel")
+set(CMAKE_C_FLAGS_RELEASE " -std=gnu99 -Os -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -MMD -MP -Wall -Wextra -Werror -mfix-esp32-psram-cache-issue -D IDF_VER=\"v3.3.1\"  " CACHE INTERNAL "c compiler flags release")
+set(CMAKE_C_FLAGS_MINSIZEREL " -std=gnu99 -Os -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -MMD -MP -Wall -Wextra -Werror -mfix-esp32-psram-cache-issue -D IDF_VER=\"v3.3.1\"  " CACHE INTERNAL "c compiler flags minsizerel")
+set(CMAKE_CXX_FLAGS_RELEASE " -Os -std=gnu++11 -g3 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -mfix-esp32-psram-cache-issue -DESP_PLATFORM " CACHE INTERNAL "cxx compiler flags release")
+set(CMAKE_CXX_FLAGS_MINSIZEREL " -Os -std=gnu++11 -g3 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Wextra -Werror -mfix-esp32-psram-cache-issue -DESP_PLATFORM " CACHE INTERNAL "cxx compiler flags minsizerel")
 
 set(CMAKE_ASM_FLAGS_RELEASE "" CACHE INTERNAL "asm compiler flags release")
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE " -nostdlib -u call_user_start_cpu0  -Wl,--gc-sections -Wl,-static " CACHE INTERNAL "linker flags release")


### PR DESCRIPTION
## Description
- Remove  -Wundef warning for ESP32 build

## Motivation and Context
- Was impossible to deal with the amount of define errors from headers being pulled from IDF, FreeRTOS and 3rd party libraries.
- Tried adding a pragma directive to ignore these, but it seems that this particular warning can't be disabled with a directive.
- Removed all the issues and potential issues with the above turned ON before removing it.

**NOTE: This should be addressed at some point because having the defines correctly defined and used is paramount.**

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
