### PR TITLE
Fix CMakes for ST Cube packages

### DIFF
--- a/CMake/Modules/CHIBIOS_STM32F7xx_sources.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F7xx_sources.cmake
@@ -134,7 +134,6 @@ list(APPEND CHIBIOS_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/nf
 list(APPEND CHIBIOS_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/ONEWIREv1) 
 # component STM32_QSPI (Quad-SPI)
 list(APPEND CHIBIOS_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/targets/CMSIS-OS/ChibiOS/nf-overlay/os/hal/ports/STM32/LLD/QSPIv1)
-list(APPEND CHIBIOS_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/STM32_CubePackage_Source/Drivers/STM32F7xx_HAL_Driver/Inc")
 
 ###############################################################################################################################
 # Add above the required include directory(ies) for a new nanoFramework overlay component that you are adding

--- a/CMake/Modules/FindSTM32F0_CubePackage.cmake
+++ b/CMake/Modules/FindSTM32F0_CubePackage.cmake
@@ -4,7 +4,7 @@
 #
 
 # set include directories
-list(APPEND STM32F0_CubePackage_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/STM32F0_CubePackage_Source/Drivers/STM32F0xx_HAL_Driver/Inc")
+list(APPEND STM32F0_CubePackage_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/STM32F0_CubePackage_Source/Drivers/STM32F0xx_HAL_Driver/Inc)
 
 # source files
 set(STM32F0_CubePackage_SRCS
@@ -17,7 +17,7 @@ foreach(SRC_FILE ${STM32F0_CubePackage_SRCS})
     find_file(STM32F0_CubePackage_SRC_FILE ${SRC_FILE}
         PATHS 
 
-        "${CMAKE_BINARY_DIR}/STM32F0_CubePackage_Source/Drivers/STM32F0xx_HAL_Driver/Src"
+        ${CMAKE_BINARY_DIR}/STM32F0_CubePackage_Source/Drivers/STM32F0xx_HAL_Driver/Src
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )

--- a/CMake/Modules/FindSTM32F4_CubePackage.cmake
+++ b/CMake/Modules/FindSTM32F4_CubePackage.cmake
@@ -4,7 +4,7 @@
 #
 
 # set include directories
-list(APPEND STM32F4_CubePackage_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/STM32F4_CubePackage_Source/Drivers/STM32F4xx_HAL_Driver/Inc")
+list(APPEND STM32F4_CubePackage_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/STM32F4_CubePackage_Source/Drivers/STM32F4xx_HAL_Driver/Inc)
 
 # source files
 set(STM32F4_CubePackage_SRCS
@@ -21,7 +21,7 @@ foreach(SRC_FILE ${STM32F4_CubePackage_SRCS})
     find_file(STM32F4_CubePackage_SRC_FILE ${SRC_FILE}
         PATHS 
 
-        "${CMAKE_BINARY_DIR}/STM32F4_CubePackage_Source/Drivers/STM32F4xx_HAL_Driver/Src"
+        ${CMAKE_BINARY_DIR}/STM32F4_CubePackage_Source/Drivers/STM32F4xx_HAL_Driver/Src
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )

--- a/CMake/Modules/FindSTM32F7_CubePackage.cmake
+++ b/CMake/Modules/FindSTM32F7_CubePackage.cmake
@@ -4,12 +4,13 @@
 #
 
 # set include directories
-list(APPEND STM32F7_CubePackage_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/STM32F7_CubePackage_Source/Drivers/STM32F7xx_HAL_Driver/Inc")
+list(APPEND STM32F7_CubePackage_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/STM32F7_CubePackage_Source/Drivers/STM32F7xx_HAL_Driver/Inc)
 
 # source files
 set(STM32F7_CubePackage_SRCS
 
     # add HAL files here as required
+    stm32f7xx_hal_rcc.c
 
     # SPIFFS
     stm32f7xx_hal_dma.c
@@ -21,7 +22,7 @@ foreach(SRC_FILE ${STM32F7_CubePackage_SRCS})
     find_file(STM32F7_CubePackage_SRC_FILE ${SRC_FILE}
         PATHS 
 
-            "${CMAKE_BINARY_DIR}/STM32F7_CubePackage_Source/Drivers/STM32F7xx_HAL_Driver/Src/"
+            ${CMAKE_BINARY_DIR}/STM32F7_CubePackage_Source/Drivers/STM32F7xx_HAL_Driver/Src
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )

--- a/CMake/Modules/STM32_CubePackage.cmake
+++ b/CMake/Modules/STM32_CubePackage.cmake
@@ -19,6 +19,9 @@ macro(ProcessSTM32CubePackage)
         endif()
     endif()
 
+    # store the package name for later use
+    set(TARGET_STM32_CUBE_PACKAGE STM32${TARGET_SERIES_SHORT} CACHE INTERNAL "name for STM32 Cube package")
+
     if(NO_STM32_CUBE_PACKAGE_SOURCE)
         # no STM Cube package source specified, download it from nanoFramework fork
 
@@ -30,22 +33,22 @@ macro(ProcessSTM32CubePackage)
             message(FATAL_ERROR "error: could not find Git, make sure you have it installed.")
         endif()
 
-        message(STATUS "STM32 ${TARGET_SERIES_SHORT} Cube package from GitHub repo")
+        message(STATUS "STM32${TARGET_SERIES_SHORT} Cube package from GitHub repo")
 
         # need to setup a separate CMake project to download the code from the GitHub repository
         # otherwise it won't be available before the actual build step
-        configure_file("${CMAKE_SOURCE_DIR}/CMake/STM32.CubePackage.CMakeLists.cmake.in"
-                    "${CMAKE_BINARY_DIR}/STM32${TARGET_SERIES_SHORT}-CubePackage_Download/CMakeLists.txt")
+        configure_file(${CMAKE_SOURCE_DIR}/CMake/STM32.CubePackage.CMakeLists.cmake.in
+                       ${CMAKE_BINARY_DIR}/STM32${TARGET_SERIES_SHORT}-CubePackage_Download/CMakeLists.txt)
 
         # setup CMake project for STM32_CubePackage download
         execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
                         RESULT_VARIABLE result
-                        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/STM32${TARGET_SERIES_SHORT}-CubePackage_Download")
+                        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/STM32${TARGET_SERIES_SHORT}-CubePackage_Download)
 
         # run build on STM32_CubePackage download CMake project to perform the download
         execute_process(COMMAND ${CMAKE_COMMAND} --build .
                         RESULT_VARIABLE result
-                        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/STM32${TARGET_SERIES_SHORT}-CubePackage_Download")
+                        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/STM32${TARGET_SERIES_SHORT}-CubePackage_Download)
 
         # add STM32_CubePackage as external project
         # need to specify nanoframework as the active branch


### PR DESCRIPTION
## Description
- Fix CMakes for ST Cube packages

## Motivation and Context
- Improvements in CMake syntax.
- Remove inclusion of include path in wrong place.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
