### PR TITLE
Support multiple variants choice per target variant file

### DIFF
--- a/install-scripts/Set-VSCode-CMakes.ps1
+++ b/install-scripts/Set-VSCode-CMakes.ps1
@@ -51,8 +51,11 @@ function Set-VSCode-CMakes {
 
                 $cmakeTemplate = Get-Content -Raw -Encoding UTF8 $_.FullName | ConvertFrom-Json
 
-                foreach ($newChoice in $cmakeTemplate.linkage.choices) {
+                $cmakeTemplate.linkage.choices.PSObject.Properties | Foreach-object {
 
+                    $newChoice = New-Object -TypeName psobject 
+                    $newChoice | Add-Member -MemberType NoteProperty -Name $_.Name -Value $_.Value
+                    
                     $addChoice = $true
             
                     # loop through each existing linkage choice


### PR DESCRIPTION

## Description
- Fix PS to support multiple variants in cmake-variants template.

## Motivation and Context
- Currently only supported one configuration in the template. 

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
