### PR TITLE
Update WIN32 CICD build Image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -336,6 +336,9 @@ jobs:
 
   steps:
   - task: NuGetToolInstaller@0
+    inputs:
+      versionSpec: '5.8.0'
+    displayName: 'Install specifc version of NuGet'
 
   - task: VSBuild@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -332,7 +332,7 @@ jobs:
   - Check_Code_Style
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   steps:
   - task: NuGetToolInstaller@0


### PR DESCRIPTION
## Description
WIN32 CICD currently uses VS2017. VS2019 will be required in future, so we should update if possible.

## Motivation and Context
Ensures that we dont get caught out by azure-pipelines removing VS2017 as a valid image.

This failed on the last pass (possibily due to an issue with the extension. This has now been resolved, so this PR should guide the next step.

- Resolves nanoframework/Home#667

## How Has This Been Tested?

## Screenshots

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
