### PR TITLE
Fix to receiveChannel exception

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/nanoFramework.Hardware.Esp32.Rmt/nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Esp32_Rmt_ReceiverChannel.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/nanoFramework.Hardware.Esp32.Rmt/nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Esp32_Rmt_ReceiverChannel.cpp
@@ -15,7 +15,7 @@ HRESULT Library_nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_E
     CLR_INT32 bufferSizeRmtItems;
     CLR_INT32 clockDiv = 80; // Default
     gpio_number = (gpio_num_t)stack.Arg1().NumericByRef().s1;
-    bufferSizeRmtItems = (CLR_INT32)stack.Arg2().NumericByRef().s1;
+    bufferSizeRmtItems = (CLR_INT32)stack.Arg2().NumericByRef().s4;
 
     channel = RmtChannel::FindNextChannel();
     if (channel < 0)


### PR DESCRIPTION
## Description
If number of buffer items was greater then 128 a negative value was created as RMT using wrong size for argument.

## Motivation and Context
Fix exception

## How Has This Been Tested?<!-- (if applicable) -->
Supplied test program

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
