### PR TITLE
Fix duplicate output on Win32 target

### DIFF
--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -277,11 +277,8 @@ int CLR_Debug::PrintfV(const char *format, va_list arg)
     Emit(buffer, (int)iBuffer);
 
 #if defined(_WIN32)
-    OutputDebugStringA(buffer);
-
     std::string outputString(buffer, iBuffer);
     SaveMessage(outputString);
-
 #endif
 
 #if !defined(_WIN32)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Remove call to OutputDebugStringA which is already called in the Emit().

## Motivation and Context
- Output messages where duplicated on Win32 targets.

## How Has This Been Tested?<!-- (if applicable) -->
- Running the Win32 nanoCRL.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
