### PR TITLE
Fix CMake for Windows.Device.Gpio

### DIFF
--- a/CMake/Modules/FindSystem.Device.Gpio.cmake
+++ b/CMake/Modules/FindSystem.Device.Gpio.cmake
@@ -33,6 +33,12 @@ set(System.Device.Gpio_SRCS
     Hardware.cpp
 )
 
+# TODO remove this IF() clause here when Windows.Devices.Gpio is removed
+if(NOT API_Windows.Devices.Gpio)
+    # need to have this here in case Windows.Devices.Gpio is not included
+    list(APPEND System.Device.Gpio_SRCS cpu_gpio.cpp)
+endif()
+
 foreach(SRC_FILE ${System.Device.Gpio_SRCS})
     set(System.Device.Gpio_SRC_FILE SRC_FILE-NOTFOUND)
     find_file(System.Device.Gpio_SRC_FILE ${SRC_FILE}


### PR DESCRIPTION
## Description
- Fix CMake for Windows.Device.Gpio to add cpu_gpio.cpp 

## Motivation and Context
- Need to implement a temporary fix to add cpu_gpio.cpp when Windows.Devices.Gpio is not in the build options.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
