### PR TITLE
Fixes AzureRTOS sources destination path

### DIFF
--- a/targets/AzureRTOS/CMakeLists.txt
+++ b/targets/AzureRTOS/CMakeLists.txt
@@ -73,7 +73,7 @@ else()
         NF_DIRECTORY_EXISTS_NOT_EMPTY(${CMAKE_BINARY_DIR}/AzureRTOS_Source/ SOURCE_EXISTS)
 
         if(NOT ${SOURCE_EXISTS})
-            file(COPY "${RTOS_SOURCE_FOLDER}/" DESTINATION "${CMAKE_BINARY_DIR}/AzureRTOS_Source/common/src") #TODO: is this correct?
+            file(COPY "${RTOS_SOURCE_FOLDER}/" DESTINATION "${CMAKE_BINARY_DIR}/AzureRTOS_Source/")
         else()
             message(STATUS "Using local cache of AzureRTOS source from ${RTOS_SOURCE_FOLDER}")
         endif()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In the build process when using local sources for AzureRTOS the destination path is wrong, leading to configuration errors.

## Description
<!--- Describe your changes in detail -->
Corrected the destination path for the source copy of AzureRTOS.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New build has been successfully completed in Visual Studio Code

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: piwi1263 <piwi1263@gmail.com>
