### PR TITLE
Changes for RS485 mode

### DIFF
--- a/src/Windows.Devices.SerialCommunication/win_dev_serial_native.cpp
+++ b/src/Windows.Devices.SerialCommunication/win_dev_serial_native.cpp
@@ -3,9 +3,9 @@
 // See LICENSE file in the project root for full license information.
 //
 
-
 #include "win_dev_serial_native.h"
 
+// clang-format off
 
 static const CLR_RT_MethodHandler method_lookup[] =
 {
@@ -28,6 +28,8 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice::get_BytesToRead___U4,
+    NULL,
+    NULL,
     NULL,
     NULL,
     NULL,
@@ -81,7 +83,9 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Windows_Devices_SerialCommunication =
 {
     "Windows.Devices.SerialCommunication",
-    0x82260711,
+    0x84A8FB94,
     method_lookup,
-    { 100, 1, 1, 1 }
+    { 100, 1, 1, 2 }
 };
+
+// clang-format on

--- a/src/Windows.Devices.SerialCommunication/win_dev_serial_native.h
+++ b/src/Windows.Devices.SerialCommunication/win_dev_serial_native.h
@@ -26,6 +26,12 @@ typedef enum __nfpack SerialHandshake
     SerialHandshake_XOnXOff = 3,
 } SerialHandshake;
 
+typedef enum __nfpack SerialMode
+{
+    SerialMode_Normal = 0,
+    SerialMode_RS485 = 1,
+} SerialMode;
+
 typedef enum __nfpack SerialParity
 {
     SerialParity_None = 0,
@@ -73,7 +79,8 @@ struct Library_win_dev_serial_native_Windows_Devices_SerialCommunication_SerialD
     static const int FIELD___stopBits = 14;
     static const int FIELD___bytesReceived = 15;
     static const int FIELD___watchChar = 16;
-    static const int FIELD___callbacksDataReceivedEvent = 17;
+    static const int FIELD___mode = 17;
+    static const int FIELD___callbacksDataReceivedEvent = 18;
 
     NANOCLR_NATIVE_DECLARE(get_BytesToRead___U4);
     NANOCLR_NATIVE_DECLARE(NativeDispose___VOID);

--- a/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/CMSIS-OS/ChibiOS/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -455,6 +455,12 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
         // parity @ CR1:PS
         // TODO
 
+        // Check RS485 mode is not selected as currently not supported
+        if ((SerialMode)pThis[FIELD___mode].NumericByRef().s4 != SerialMode_Normal)
+        {
+             NANOCLR_SET_AND_LEAVE(CLR_E_NOTIMPL);
+        }
+
         // stop bits @ CR2:STOP1&STOP0
         // clear bits for stop bits setting
         palUart->Uart_cfg.cr2 &= ~USART_CR2_STOP;

--- a/targets/FreeRTOS/NXP/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/FreeRTOS/NXP/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -297,6 +297,12 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
             NANOCLR_SET_AND_LEAVE(CLR_E_IO);
         }
 
+        // Check RS485 mode is not selected as currently not supported
+        if ((SerialMode)pThis[FIELD___mode].NumericByRef().s4 != SerialMode_Normal)
+        {
+             NANOCLR_SET_AND_LEAVE(CLR_E_NOTIMPL);
+        }
+
         config->baudRate_Bps = (uint32_t)pThis[FIELD___baudRate].NumericByRef().s4;
 
         switch (pThis[FIELD___dataBits].NumericByRef().s4)

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -459,6 +459,19 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
                 break;
         }
 
+        bool rs485Mode = ((SerialMode)pThis[FIELD___mode].NumericByRef().s4 == SerialMode_RS485);
+        if ( rs485Mode )
+        {
+                // Disable any flow control & Set RS485 half duplex mode
+                uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
+                uart_set_mode(uart_num, UART_MODE_RS485_HALF_DUPLEX);
+        }
+        else
+        {
+                // Reset to normal mode
+                uart_set_mode(uart_num, UART_MODE_UART);
+        }
+        
         // Already Initialised ?
         if (GetPalUartFromUartNum(uart_num)->SerialDevice)
         {
@@ -503,11 +516,18 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
             NANOCLR_SET_AND_LEAVE(CLR_E_PIN_UNAVAILABLE);
         }
 
-        // Don't use RTS/CTS if no hardware handshake enabled
-        if (uart_config.flow_ctrl == UART_HW_FLOWCTRL_DISABLE)
+        // Don't use RTS/CTS pins if no hardware handshake enabled unless in RS485 mode
+        if ( rs485Mode ) 
         {
-            rtsPin = UART_PIN_NO_CHANGE;
-            ctsPin = UART_PIN_NO_CHANGE;
+            ctsPin = UART_PIN_NO_CHANGE; // no need for a CTS pin enabled, just RTS
+        }
+        else
+        {
+            if (uart_config.flow_ctrl == UART_HW_FLOWCTRL_DISABLE)
+            {
+                rtsPin = UART_PIN_NO_CHANGE;
+                ctsPin = UART_PIN_NO_CHANGE;
+            }
         }
 
         if (uart_set_pin(uart_num, txPin, rxPin, rtsPin, ctsPin) != ESP_OK)


### PR DESCRIPTION
## Description
Add RS485 for ESP32 only

## Motivation and Context
- Resolves nanoFramework/Home#673

## How Has This Been Tested?<!-- (if applicable) -->
Simple test program to send data and check results on logic analyser

`
			
                        Configuration.SetPinFunction(34, DeviceFunction.COM2_RX);
			Configuration.SetPinFunction(13, DeviceFunction.COM2_TX);
			Configuration.SetPinFunction(12, DeviceFunction.COM2_RTS);

			sd = SerialDevice.FromId("COM2");

			sd.BaudRate = 230400;

			sd.DataBits = 8;
			sd.Parity = SerialParity.None;
			sd.StopBits = SerialStopBitCount.One;

			sd.Mode = SerialMode.RS485;

			inputDataReader = new DataReader(sd.InputStream);
			inputDataReader.InputStreamOptions = InputStreamOptions.Partial;

			sd.DataReceived += Sd_DataReceived;

			DataWriter outputDataWriter = new DataWriter(sd.OutputStream);

			while (true)
			{

				outputDataWriter.WriteString("abc\n");
				outputDataWriter.Store();


				Thread.Sleep(5);
			}
`

TX & RTS
RTS does seem to stay on a little longer than expected after last byte sent but that's done by ESP IDF

![rs485_2](https://user-images.githubusercontent.com/22250953/103708410-6ab95c00-5015-11eb-9410-cf707c18ea41.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
