### PR TITLE
Replace default radom implementation for WIN32

### DIFF
--- a/src/CLR/Core/Core.vcxproj
+++ b/src/CLR/Core/Core.vcxproj
@@ -53,7 +53,6 @@
     <ClCompile Include="GarbageCollector_Compaction.cpp" />
     <ClCompile Include="GarbageCollector_ComputeReachabilityGraph.cpp" />
     <ClCompile Include="Interpreter.cpp" />
-    <ClCompile Include="Random.cpp" />
     <ClCompile Include="Streams.cpp" />
     <ClCompile Include="StringTable.cpp" />
     <ClCompile Include="Thread.cpp" />

--- a/src/CLR/Core/Core.vcxproj.filters
+++ b/src/CLR/Core/Core.vcxproj.filters
@@ -132,9 +132,6 @@
     <ClCompile Include="CLR_RT_HeapBlock_Queue.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Random.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\Helpers\nanoprintf\nanoprintf.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/targets/win32/nanoCLR/nanoCLR.vcxproj
+++ b/targets/win32/nanoCLR/nanoCLR.vcxproj
@@ -108,7 +108,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>NANOCLR_REFLECTION=TRUE;WIN32;_DEBUG;_CONSOLE;VERSION_MAJOR=$(NBGV_VersionMajor);VERSION_MINOR=$(NBGV_VersionMinor);VERSION_BUILD=$(NBGV_BuildNumber);VERSION_REVISION=$(NBGV_VersionHeight);VERSION_STRING="$(NBGV_AssemblyInformationalVersion)";OEMSYSTEMINFOSTRING="WIN_32 PLAYGROUND APP";TARGETNAMESTRING="CLR_WIN32";TARGETINFOSTRING="CLR_WIN32";PLATFORMNAMESTRING="WIN32";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\src\CLR\Helpers\Base64;.;..\Include;..\..\..\src\CLR\Include;..\..\..\src\HAL\Include;..\..\..\src\PAL\Include;..\..\..\src\nanoFramework.Runtime.Events</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\src\CLR\Core;..\..\..\src\CLR\CorLib;..\..\..\src\CLR\Helpers\Base64;.;..\Include;..\..\..\src\CLR\Include;..\..\..\src\HAL\Include;..\..\..\src\PAL\Include;..\..\..\src\nanoFramework.Runtime.Events</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -135,7 +135,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NANOCLR_REFLECTION=TRUE;WIN32;NDEBUG;_CONSOLE;VERSION_MAJOR=$(NBGV_VersionMajor);VERSION_MINOR=$(NBGV_VersionMinor);VERSION_BUILD=$(NBGV_BuildNumber);VERSION_REVISION=$(NBGV_VersionHeight);VERSION_STRING="$(NBGV_AssemblyInformationalVersion)";OEMSYSTEMINFOSTRING="WIN_32 PLAYGROUND APP";TARGETNAMESTRING="CLR_WIN32";TARGETINFOSTRING="CLR_WIN32";PLATFORMNAMESTRING="WIN32";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\src\CLR\Helpers\Base64;.;..\Include;..\..\..\src\CLR\Include;..\..\..\src\HAL\Include;..\..\..\src\PAL\Include;..\..\..\src\nanoFramework.Runtime.Events</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\src\CLR\Core;..\..\..\src\CLR\CorLib;..\..\..\src\CLR\Helpers\Base64;.;..\Include;..\..\..\src\CLR\Include;..\..\..\src\HAL\Include;..\..\..\src\PAL\Include;..\..\..\src\nanoFramework.Runtime.Events</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -198,6 +198,7 @@
     </ClCompile>
     <ClCompile Include="main.cpp" />
     <ClCompile Include="targetPAL_Time.cpp" />
+    <ClCompile Include="targetRandom.cpp" />
     <ClCompile Include="Target_BlockStorage.cpp" />
     <ClCompile Include="targetHAL_Time.cpp" />
     <ClCompile Include="Various.cpp">

--- a/targets/win32/nanoCLR/nanoCLR.vcxproj.filters
+++ b/targets/win32/nanoCLR/nanoCLR.vcxproj.filters
@@ -128,6 +128,9 @@
     <ClCompile Include="..\..\..\src\HAL\nanoHAL_Time.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="targetRandom.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Text Include="README.txt" />

--- a/targets/win32/nanoCLR/targetRandom.cpp
+++ b/targets/win32/nanoCLR/targetRandom.cpp
@@ -11,7 +11,7 @@ void CLR_RT_Random::Initialize()
 {
 }
 
-void CLR_RT_Random::Initialize( int seed )
+void CLR_RT_Random::Initialize(int seed)
 {
     (void)seed;
 }
@@ -30,11 +30,11 @@ double CLR_RT_Random::NextDouble()
     return ((double)randomDevice()) / ((double)0xFFFFFFFF);
 }
 
-void CLR_RT_Random::NextBytes(unsigned char* buffer, unsigned int count)
+void CLR_RT_Random::NextBytes(unsigned char *buffer, unsigned int count)
 {
     std::random_device randomDevice;
 
-    for(unsigned int i = 0; i < count; i++)
+    for (unsigned int i = 0; i < count; i++)
     {
         buffer[i] = (unsigned char)randomDevice();
     }

--- a/targets/win32/nanoCLR/targetRandom.cpp
+++ b/targets/win32/nanoCLR/targetRandom.cpp
@@ -1,0 +1,41 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include "stdafx.h"
+#include <Core.h>
+#include <random>
+
+void CLR_RT_Random::Initialize()
+{
+}
+
+void CLR_RT_Random::Initialize( int seed )
+{
+    (void)seed;
+}
+
+uint32_t CLR_RT_Random::Next()
+{
+    std::random_device randomDevice;
+
+    return randomDevice();
+}
+
+double CLR_RT_Random::NextDouble()
+{
+    std::random_device randomDevice;
+
+    return ((double)randomDevice()) / ((double)0xFFFFFFFF);
+}
+
+void CLR_RT_Random::NextBytes(unsigned char* buffer, unsigned int count)
+{
+    std::random_device randomDevice;
+
+    for(unsigned int i = 0; i < count; i++)
+    {
+        buffer[i] = (unsigned char)randomDevice();
+    }
+}


### PR DESCRIPTION
## Description
- Replace standard implementation with Win32 one using a true random generator.

## Motivation and Context
- Improves random API in WIN32 CLR.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
