### PR TITLE
Fix bool timer implementation in WIN32

### DIFF
--- a/targets/win32/nanoCLR/nanoCLR.vcxproj
+++ b/targets/win32/nanoCLR/nanoCLR.vcxproj
@@ -179,7 +179,7 @@
     <ClCompile Include="..\..\..\src\PAL\AsyncProcCall\AsyncContinuations.cpp" />
     <ClCompile Include="..\..\..\src\PAL\Double\nanoPAL_NativeDouble.cpp" />
     <ClCompile Include="CLRStartup.cpp" />
-    <ClCompile Include="Events.cpp" />
+    <ClCompile Include="targetPAL_Events.cpp" />
     <ClCompile Include="FileStore_Win32.cpp" />
     <ClCompile Include="Generated\CLR_RT_InteropAssembliesTable.cpp" />
     <ClCompile Include="Memory.cpp" />

--- a/targets/win32/nanoCLR/nanoCLR.vcxproj.filters
+++ b/targets/win32/nanoCLR/nanoCLR.vcxproj.filters
@@ -53,9 +53,6 @@
     <ClCompile Include="Various.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Events.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="WatchDog.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -129,6 +126,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="targetRandom.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="targetPAL_Events.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/targets/win32/nanoCLR/targetPAL_Time.cpp
+++ b/targets/win32/nanoCLR/targetPAL_Time.cpp
@@ -19,82 +19,13 @@ void Time_SetCompare(UINT64 CompareValue)
     // convert to milliseconds for OS timer
     auto compareMs = CompareValue / (CPU_TicksPerSecond() * (uint64_t)1000);
     ASSERT(compareMs < UINT32_MAX);
-    if (compareMs == 0)
-        TimerCallback();
-    else
-        pCompletionsTimer = std::make_unique<Microsoft::Win32::Timer>((UINT32)compareMs, TimerCallback);
-}
 
-//
-//
-//// timer for next event
-// static virtual_timer_t nextEventTimer;
-// void*  nextEventCallbackDummyArg = NULL;
-//
-// static void NextEventTimer_Callback( void* arg )
-//{
-//    (void)arg;
-//
-//    // this call also schedules the next one, if there is one
-//    HAL_COMPLETION::DequeueAndExec();
-//}
-//
-// HRESULT Time_Initialize()
-//{
-//    // need to setup the timer at boot, but stopped
-//    chVTSet(&nextEventTimer, TIME_INFINITE, NextEventTimer_Callback, nextEventCallbackDummyArg);
-//
-//    return S_OK;
-//}
-//
-// HRESULT Time_Uninitialize()
-//{
-//    chVTReset(&nextEventTimer);
-//
-//    // nothing to do here has time management is handled by ChibiOS
-//    return S_OK;
-//}
-//
-// void Time_SetCompare ( uint64_t compareValueTicks )
-//{
-//    if(compareValueTicks == 0)
-//    {
-//        // compare value is 0 so dequeue and schedule immediately
-//        // can't call chVTSet with 'immediate delay value', so use value 1 to get it executed ASAP
-//        chVTSet(&nextEventTimer, 1, NextEventTimer_Callback, nextEventCallbackDummyArg);
-//    }
-//    else if(compareValueTicks == HAL_COMPLETION_IDLE_VALUE)
-//    {
-//        // wait for infinity, don't need to do anything here
-//    }
-//    else
-//    {
-//        if (HAL_Time_CurrentSysTicks() >= compareValueTicks)
-//        {
-//            // already missed the event, dequeue and execute immediately
-//            // can't call chVTSet with 'immediate delay value', so use value 1 to get it executed ASAP
-//            chVTSet(&nextEventTimer, 1, NextEventTimer_Callback, nextEventCallbackDummyArg);
-//        }
-//        else
-//        {
-//            // compareValueTicks is the time (in sys ticks) that is being requested to fire an
-//            HAL_COMPLETION::DequeueAndExec()
-//            // need to subtract the current system time to set when the timer will fire
-//        	// compareValueTicks is in CMSIS ticks (which equals to ms), so we use TIME_MS2I only to round
-//        	compareValueTicks -= HAL_Time_CurrentSysTicks();
-//            uint64_t delay = TIME_MS2I(compareValueTicks);
-//
-//            // make sure that chVTSet does not get called with zero delay
-//            if (delay == 0)
-//            {
-//                // compare value is 0 so dequeue and execute immediately
-//                // no need to call the timer
-//                HAL_COMPLETION::DequeueAndExec();
-//                return;
-//            }
-//
-//            // no need to stop the timer if it's running because the API does it anyway
-//            chVTSet(&nextEventTimer, delay, NextEventTimer_Callback, nextEventCallbackDummyArg);
-//        }
-//    }
-//}
+    if (compareMs == 0)
+    {
+        TimerCallback();
+    }
+    else
+    {
+        pCompletionsTimer = std::make_unique<Microsoft::Win32::Timer>((UINT32)compareMs, TimerCallback);
+    }
+}


### PR DESCRIPTION
## Description
- Replace HAL_COMPLETION implementation with timer.

## Motivation and Context
- Bool timers wheren't working on WIN32.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
