### PR TITLE
Fix exception thrown on Timer constructor

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapBlock_Timer.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Timer.cpp
@@ -7,52 +7,55 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
- HRESULT CLR_RT_HeapBlock_Timer::CreateInstance( CLR_UINT32 flags, CLR_RT_HeapBlock& owner, CLR_RT_HeapBlock& tmRef )
+HRESULT CLR_RT_HeapBlock_Timer::CreateInstance(CLR_UINT32 flags, CLR_RT_HeapBlock &owner, CLR_RT_HeapBlock &tmRef)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock_Timer* timer = NULL;
+    CLR_RT_HeapBlock_Timer *timer = NULL;
 
     //
     // Create a request and stop the calling thread.
     //
-    timer = EVENTCACHE_EXTRACT_NODE(g_CLR_RT_EventCache,CLR_RT_HeapBlock_Timer,DATATYPE_TIMER_HEAD); CHECK_ALLOCATION(timer);
+    timer = EVENTCACHE_EXTRACT_NODE(g_CLR_RT_EventCache, CLR_RT_HeapBlock_Timer, DATATYPE_TIMER_HEAD);
+    CHECK_ALLOCATION(timer);
 
     {
-        CLR_RT_ProtectFromGC gc( *timer );
+        CLR_RT_ProtectFromGC gc(*timer);
 
         timer->Initialize();
 
-        timer->m_flags               = flags;
-        timer->m_timeExpire          = TIMEOUT_INFINITE;
-        timer->m_timeFrequency       = TIMEOUT_INFINITE;
-        timer->m_timeLastExpiration  = 0;
+        timer->m_flags = flags;
+        timer->m_timeExpire = TIMEOUT_INFINITE;
+        timer->m_timeFrequency = TIMEOUT_INFINITE;
+        timer->m_timeLastExpiration = 0;
         timer->m_ticksLastExpiration = 0;
 
-        g_CLR_RT_ExecutionEngine.m_timers.LinkAtBack( timer );
+        g_CLR_RT_ExecutionEngine.m_timers.LinkAtBack(timer);
 
-        NANOCLR_SET_AND_LEAVE(CLR_RT_ObjectToEvent_Source::CreateInstance( timer, owner, tmRef ));
+        NANOCLR_SET_AND_LEAVE(CLR_RT_ObjectToEvent_Source::CreateInstance(timer, owner, tmRef));
     }
 
     NANOCLR_CLEANUP();
 
-    if(FAILED(hr))
+    if (FAILED(hr))
     {
-        if(timer) timer->ReleaseWhenDead();
+        if (timer)
+            timer->ReleaseWhenDead();
     }
 
     NANOCLR_CLEANUP_END();
 }
 
-HRESULT CLR_RT_HeapBlock_Timer::ExtractInstance( CLR_RT_HeapBlock& ref, CLR_RT_HeapBlock_Timer*& timer )
+HRESULT CLR_RT_HeapBlock_Timer::ExtractInstance(CLR_RT_HeapBlock &ref, CLR_RT_HeapBlock_Timer *&timer)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_ObjectToEvent_Source* src = CLR_RT_ObjectToEvent_Source::ExtractInstance( ref ); FAULT_ON_NULL(src);
+    CLR_RT_ObjectToEvent_Source *src = CLR_RT_ObjectToEvent_Source::ExtractInstance(ref);
+    FAULT_ON_NULL(src);
 
-    timer = (CLR_RT_HeapBlock_Timer*)src->m_eventPtr;
+    timer = (CLR_RT_HeapBlock_Timer *)src->m_eventPtr;
 
     NANOCLR_NOCLEANUP();
 }
@@ -64,7 +67,7 @@ void CLR_RT_HeapBlock_Timer::RecoverFromGC()
     NATIVE_PROFILE_CLR_CORE();
     CheckAll();
 
-    ReleaseWhenDead();  
+    ReleaseWhenDead();
 }
 
 //--//
@@ -72,63 +75,66 @@ void CLR_RT_HeapBlock_Timer::RecoverFromGC()
 void CLR_RT_HeapBlock_Timer::Trigger()
 {
     NATIVE_PROFILE_CLR_CORE();
-    if(m_references.IsEmpty()) return;
-    
-    if(m_flags & CLR_RT_HeapBlock_Timer::c_Executing)
-    {        
+    if (m_references.IsEmpty())
+        return;
+
+    if (m_flags & CLR_RT_HeapBlock_Timer::c_Executing)
+    {
         return;
     }
 
     m_flags |= CLR_RT_HeapBlock_Timer::c_Triggered;
 }
 
-void CLR_RT_HeapBlock_Timer::SpawnTimer( CLR_RT_Thread* th )
-{   
+void CLR_RT_HeapBlock_Timer::SpawnTimer(CLR_RT_Thread *th)
+{
     NATIVE_PROFILE_CLR_CORE();
-     //Only one managed timer max
+    // Only one managed timer max
     _ASSERTE(m_references.NumOfNodes() == 1);
 
-    CLR_RT_ObjectToEvent_Source* ref          = (CLR_RT_ObjectToEvent_Source*)m_references.FirstValidNode();
-    CLR_RT_HeapBlock*            managedTimer = ref->m_objectPtr;
-    CLR_RT_HeapBlock*            callback     = &managedTimer[ Library_corlib_native_System_Threading_Timer::FIELD___callback ];
-    CLR_RT_HeapBlock*            state        = &managedTimer[ Library_corlib_native_System_Threading_Timer::FIELD___state    ];
-    CLR_RT_HeapBlock_Delegate*   delegate     = callback->DereferenceDelegate();
-    CLR_RT_ProtectFromGC         gc( *managedTimer );
+    CLR_RT_ObjectToEvent_Source *ref = (CLR_RT_ObjectToEvent_Source *)m_references.FirstValidNode();
+    CLR_RT_HeapBlock *managedTimer = ref->m_objectPtr;
+    CLR_RT_HeapBlock *callback = &managedTimer[Library_corlib_native_System_Threading_Timer::FIELD___callback];
+    CLR_RT_HeapBlock *state = &managedTimer[Library_corlib_native_System_Threading_Timer::FIELD___state];
+    CLR_RT_HeapBlock_Delegate *delegate = callback->DereferenceDelegate();
+    CLR_RT_ProtectFromGC gc(*managedTimer);
 
-    _ASSERTE(delegate != NULL);  if(delegate == NULL) return;
+    _ASSERTE(delegate != NULL);
+    if (delegate == NULL)
+        return;
     _ASSERTE(delegate->DataType() == DATATYPE_DELEGATE_HEAD);
 
     m_ticksLastExpiration = HAL_Time_CurrentTime();
-    m_timeLastExpiration  = m_timeExpire;
-    m_timeExpire          = TIMEOUT_INFINITE;
+    m_timeLastExpiration = m_timeExpire;
+    m_timeExpire = TIMEOUT_INFINITE;
 
-    if(SUCCEEDED(th->PushThreadProcDelegate( delegate )))
+    if (SUCCEEDED(th->PushThreadProcDelegate(delegate)))
     {
-        CLR_RT_StackFrame* stack = th->FirstFrame();
-        if(stack->Next() != NULL)
+        CLR_RT_StackFrame *stack = th->FirstFrame();
+        if (stack->Next() != NULL)
         {
             int numArgs = stack->m_call.m_target->numArgs;
-            if(numArgs > 0)
+            if (numArgs > 0)
             {
-                stack->m_arguments[ numArgs-1 ].Assign( *state );
+                stack->m_arguments[numArgs - 1].Assign(*state);
             }
         }
 
         //
         // Associate the timer with the thread.
         //
-        m_flags |=  CLR_RT_HeapBlock_Timer::c_Executing;
+        m_flags |= CLR_RT_HeapBlock_Timer::c_Executing;
         m_flags &= ~CLR_RT_HeapBlock_Timer::c_Triggered;
 
-        th->m_terminationCallback  = CLR_RT_HeapBlock_Timer::ThreadTerminationCallback;
+        th->m_terminationCallback = CLR_RT_HeapBlock_Timer::ThreadTerminationCallback;
         th->m_terminationParameter = this;
     }
 }
 
-void CLR_RT_HeapBlock_Timer::ThreadTerminationCallback( void* param )
+void CLR_RT_HeapBlock_Timer::ThreadTerminationCallback(void *param)
 {
     NATIVE_PROFILE_CLR_CORE();
-    CLR_RT_HeapBlock_Timer* pThis = (CLR_RT_HeapBlock_Timer*)param;
+    CLR_RT_HeapBlock_Timer *pThis = (CLR_RT_HeapBlock_Timer *)param;
 
     pThis->m_flags &= ~CLR_RT_HeapBlock_Timer::c_Executing;
 
@@ -140,8 +146,7 @@ void CLR_RT_HeapBlock_Timer::ThreadTerminationCallback( void* param )
 void CLR_RT_HeapBlock_Timer::Reschedule()
 {
     NATIVE_PROFILE_CLR_CORE();
-    if((m_flags & CLR_RT_HeapBlock_Timer::c_Recurring   ) &&
-       (m_flags & CLR_RT_HeapBlock_Timer::c_EnabledTimer)  )
+    if ((m_flags & CLR_RT_HeapBlock_Timer::c_Recurring) && (m_flags & CLR_RT_HeapBlock_Timer::c_EnabledTimer))
     {
         CLR_UINT64 expire = m_timeLastExpiration + m_timeFrequency;
 
@@ -150,52 +155,70 @@ void CLR_RT_HeapBlock_Timer::Reschedule()
         //
         // If we fall back too much, we need to compute the next expiration in the future, to avoid an avalanche effect.
         //
-        if(expire < HAL_Time_CurrentTime())
+        if (expire < HAL_Time_CurrentTime())
         {
             expire = HAL_Time_CurrentTime() - ((HAL_Time_CurrentTime() - expire) % m_timeFrequency) + m_timeFrequency;
         }
 
-        m_timeExpire = expire; CLR_RT_ExecutionEngine::InvalidateTimerCache();
+        m_timeExpire = expire;
+        CLR_RT_ExecutionEngine::InvalidateTimerCache();
     }
 }
 
 //--//
 
-void CLR_RT_HeapBlock_Timer::AdjustNextFixedExpire( const SYSTEMTIME& systemTime, bool fNext )
+void CLR_RT_HeapBlock_Timer::AdjustNextFixedExpire(const SYSTEMTIME &systemTime, bool fNext)
 {
     NATIVE_PROFILE_CLR_CORE();
     SYSTEMTIME st = systemTime;
-    CLR_INT64  baseTime;
-    CLR_INT64  add;
+    CLR_INT64 baseTime;
+    CLR_INT64 add;
 
     CLR_RT_ExecutionEngine::InvalidateTimerCache();
 
-    switch(m_flags & CLR_RT_HeapBlock_Timer::c_AnyChange)
+    switch (m_flags & CLR_RT_HeapBlock_Timer::c_AnyChange)
     {
-    case CLR_RT_HeapBlock_Timer::c_SecondChange: add = TIME_CONVERSION__ONESECOND * (CLR_INT64)TIME_CONVERSION__TO_SECONDS;                                               break;
-    case CLR_RT_HeapBlock_Timer::c_MinuteChange: add = TIME_CONVERSION__ONEMINUTE * (CLR_INT64)TIME_CONVERSION__TO_SECONDS; st.wSecond = 0;                               break;
-    case CLR_RT_HeapBlock_Timer::c_HourChange  : add = TIME_CONVERSION__ONEHOUR   * (CLR_INT64)TIME_CONVERSION__TO_SECONDS; st.wSecond = 0; st.wMinute = 0;               break;
-    case CLR_RT_HeapBlock_Timer::c_DayChange   : add = TIME_CONVERSION__ONEDAY    * (CLR_INT64)TIME_CONVERSION__TO_SECONDS; st.wSecond = 0; st.wMinute = 0; st.wHour = 0; break;
+        case CLR_RT_HeapBlock_Timer::c_SecondChange:
+            add = TIME_CONVERSION__ONESECOND * (CLR_INT64)TIME_CONVERSION__TO_SECONDS;
+            break;
+        case CLR_RT_HeapBlock_Timer::c_MinuteChange:
+            add = TIME_CONVERSION__ONEMINUTE * (CLR_INT64)TIME_CONVERSION__TO_SECONDS;
+            st.wSecond = 0;
+            break;
+        case CLR_RT_HeapBlock_Timer::c_HourChange:
+            add = TIME_CONVERSION__ONEHOUR * (CLR_INT64)TIME_CONVERSION__TO_SECONDS;
+            st.wSecond = 0;
+            st.wMinute = 0;
+            break;
+        case CLR_RT_HeapBlock_Timer::c_DayChange:
+            add = TIME_CONVERSION__ONEDAY * (CLR_INT64)TIME_CONVERSION__TO_SECONDS;
+            st.wSecond = 0;
+            st.wMinute = 0;
+            st.wHour = 0;
+            break;
 
-    default                                    : return;
+        default:
+            return;
     }
 
     st.wMilliseconds = 0;
-    baseTime = HAL_Time_ConvertFromSystemTime( &st );
+    baseTime = HAL_Time_ConvertFromSystemTime(&st);
 
-    m_timeExpire     = fNext ? baseTime + add : baseTime;
-    m_timeFrequency  = add;
-    m_flags         |= CLR_RT_HeapBlock_Timer::c_Recurring;
+    m_timeExpire = fNext ? baseTime + add : baseTime;
+    m_timeFrequency = add;
+    m_flags |= CLR_RT_HeapBlock_Timer::c_Recurring;
 }
 
-bool CLR_RT_HeapBlock_Timer::CheckDisposed( CLR_RT_StackFrame& stack )
+bool CLR_RT_HeapBlock_Timer::CheckDisposed(CLR_RT_StackFrame &stack)
 {
-    CLR_RT_HeapBlock*       pThis =   stack.This();
-    CLR_RT_HeapBlock_Timer* timer;
-    
-    if(!FAILED(CLR_RT_HeapBlock_Timer::ExtractInstance( pThis[ Library_corlib_native_System_Threading_Timer::FIELD___timer ], timer )))
+    CLR_RT_HeapBlock *pThis = stack.This();
+    CLR_RT_HeapBlock_Timer *timer;
+
+    if (!FAILED(CLR_RT_HeapBlock_Timer::ExtractInstance(
+            pThis[Library_corlib_native_System_Threading_Timer::FIELD___timer],
+            timer)))
     {
-        if((timer->m_flags & CLR_RT_HeapBlock_Timer::c_ACTION_Destroy) == 0)
+        if ((timer->m_flags & CLR_RT_HeapBlock_Timer::c_ACTION_Destroy) == 0)
         {
             return false;
         }
@@ -204,43 +227,49 @@ bool CLR_RT_HeapBlock_Timer::CheckDisposed( CLR_RT_StackFrame& stack )
     return true;
 }
 
-HRESULT CLR_RT_HeapBlock_Timer::ConfigureObject( CLR_RT_StackFrame& stack, CLR_UINT32 flags )
+HRESULT CLR_RT_HeapBlock_Timer::ConfigureObject(CLR_RT_StackFrame &stack, CLR_UINT32 flags)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock*       pThis =   stack.This();
-    CLR_RT_HeapBlock*       args  = &(stack.Arg1());
-    CLR_RT_HeapBlock_Timer* timer;
-    
+    CLR_RT_HeapBlock *pThis = stack.This();
+    CLR_RT_HeapBlock *args = &(stack.Arg1());
+    CLR_RT_HeapBlock_Timer *timer;
+
     const CLR_INT64 maxTime = (CLR_INT64)0x7FFFFFFF * (CLR_INT64)TIME_CONVERSION__TO_MILLISECONDS;
     const CLR_INT64 minTime = 0;
 
-    if(flags & CLR_RT_HeapBlock_Timer::c_ACTION_Create)
+    if (flags & CLR_RT_HeapBlock_Timer::c_ACTION_Create)
     {
-        FAULT_ON_NULL(args[ 0 ].DereferenceDelegate());
+        FAULT_ON_NULL_ARG(args[0].DereferenceDelegate());
 
-        NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Timer::CreateInstance( 0, *pThis, pThis[ Library_corlib_native_System_Threading_Timer::FIELD___timer ] ));
+        NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Timer::CreateInstance(
+            0,
+            *pThis,
+            pThis[Library_corlib_native_System_Threading_Timer::FIELD___timer]));
 
-        pThis[ Library_corlib_native_System_Threading_Timer::FIELD___callback ].Assign( args[ 0 ] );
-        pThis[ Library_corlib_native_System_Threading_Timer::FIELD___state    ].Assign( args[ 1 ] );
+        pThis[Library_corlib_native_System_Threading_Timer::FIELD___callback].Assign(args[0]);
+        pThis[Library_corlib_native_System_Threading_Timer::FIELD___state].Assign(args[1]);
 
         args += 2;
     }
 
-    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Timer::ExtractInstance( pThis[ Library_corlib_native_System_Threading_Timer::FIELD___timer ], timer ));
+    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Timer::ExtractInstance(
+        pThis[Library_corlib_native_System_Threading_Timer::FIELD___timer],
+        timer));
 
-    if(flags & CLR_RT_HeapBlock_Timer::c_ACTION_Create)
+    if (flags & CLR_RT_HeapBlock_Timer::c_ACTION_Create)
     {
         CLR_UINT32 anyChange = (flags & CLR_RT_HeapBlock_Timer::c_AnyChange);
 
-        if(anyChange)
+        if (anyChange)
         {
-            SYSTEMTIME systemTime; HAL_Time_ToSystemTime( HAL_Time_CurrentTime(), &systemTime );
+            SYSTEMTIME systemTime;
+            HAL_Time_ToSystemTime(HAL_Time_CurrentTime(), &systemTime);
 
             timer->m_flags |= anyChange | CLR_RT_HeapBlock_Timer::c_EnabledTimer;
 
-            timer->AdjustNextFixedExpire( systemTime, true );
+            timer->AdjustNextFixedExpire(systemTime, true);
         }
         else
         {
@@ -248,46 +277,56 @@ HRESULT CLR_RT_HeapBlock_Timer::ConfigureObject( CLR_RT_StackFrame& stack, CLR_U
         }
     }
 
-    if(flags & CLR_RT_HeapBlock_Timer::c_ACTION_Destroy)
+    if (flags & CLR_RT_HeapBlock_Timer::c_ACTION_Destroy)
     {
         timer->m_flags &= ~CLR_RT_HeapBlock_Timer::c_EnabledTimer;
     }
 
-    if(flags & CLR_RT_HeapBlock_Timer::c_ACTION_Change)
+    if (flags & CLR_RT_HeapBlock_Timer::c_ACTION_Change)
     {
         //
         // You cannot change a fixed timer after creation.
         //
-        if(timer->m_flags & CLR_RT_HeapBlock_Timer::c_AnyChange) NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        if (timer->m_flags & CLR_RT_HeapBlock_Timer::c_AnyChange)
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
 
-        if(flags & CLR_RT_HeapBlock_Timer::c_INPUT_Int32)
+        if (flags & CLR_RT_HeapBlock_Timer::c_INPUT_Int32)
         {
-            timer->m_timeExpire    = args[ 0 ].NumericByRef().s4;
-            timer->m_timeFrequency = args[ 1 ].NumericByRef().s4;
+            timer->m_timeExpire = args[0].NumericByRef().s4;
+            timer->m_timeFrequency = args[1].NumericByRef().s4;
 
-            if (timer->m_timeExpire    == -1) timer->m_timeExpire    = TIMEOUT_INFINITE;
-            if (timer->m_timeFrequency == -1) timer->m_timeFrequency = TIMEOUT_INFINITE;
+            if (timer->m_timeExpire == -1)
+                timer->m_timeExpire = TIMEOUT_INFINITE;
+            if (timer->m_timeFrequency == -1)
+                timer->m_timeFrequency = TIMEOUT_INFINITE;
         }
-        else if(flags & CLR_RT_HeapBlock_Timer::c_INPUT_TimeSpan)
+        else if (flags & CLR_RT_HeapBlock_Timer::c_INPUT_TimeSpan)
         {
-            CLR_INT64* pVal;
+            CLR_INT64 *pVal;
 
-            pVal = Library_corlib_native_System_TimeSpan::GetValuePtr( args[ 0 ] ); FAULT_ON_NULL(pVal); 
-            if (*pVal == -c_TickPerMillisecond) timer->m_timeExpire = TIMEOUT_INFINITE;
-            else timer->m_timeExpire    = *pVal;
-            
-            pVal = Library_corlib_native_System_TimeSpan::GetValuePtr( args[ 1 ] ); FAULT_ON_NULL(pVal); 
-            if (*pVal == -c_TickPerMillisecond) timer->m_timeFrequency = TIMEOUT_INFINITE;
-            else timer->m_timeFrequency    = *pVal;
+            pVal = Library_corlib_native_System_TimeSpan::GetValuePtr(args[0]);
+            FAULT_ON_NULL(pVal);
+            if (*pVal == -c_TickPerMillisecond)
+                timer->m_timeExpire = TIMEOUT_INFINITE;
+            else
+                timer->m_timeExpire = *pVal;
+
+            pVal = Library_corlib_native_System_TimeSpan::GetValuePtr(args[1]);
+            FAULT_ON_NULL(pVal);
+            if (*pVal == -c_TickPerMillisecond)
+                timer->m_timeFrequency = TIMEOUT_INFINITE;
+            else
+                timer->m_timeFrequency = *pVal;
         }
 
-        if(timer->m_timeExpire == TIMEOUT_INFINITE) 
+        if (timer->m_timeExpire == TIMEOUT_INFINITE)
         {
             timer->m_flags &= ~CLR_RT_HeapBlock_Timer::c_EnabledTimer;
         }
         else
         {
-            if(flags & CLR_RT_HeapBlock_Timer::c_INPUT_Int32) timer->m_timeExpire *= TIME_CONVERSION__TO_MILLISECONDS;
+            if (flags & CLR_RT_HeapBlock_Timer::c_INPUT_Int32)
+                timer->m_timeExpire *= TIME_CONVERSION__TO_MILLISECONDS;
 
             if (minTime <= timer->m_timeExpire && timer->m_timeExpire <= maxTime)
             {
@@ -301,15 +340,16 @@ HRESULT CLR_RT_HeapBlock_Timer::ConfigureObject( CLR_RT_StackFrame& stack, CLR_U
             }
         }
 
-        if(timer->m_timeFrequency == 0 || timer->m_timeFrequency == TIMEOUT_INFINITE) 
+        if (timer->m_timeFrequency == 0 || timer->m_timeFrequency == TIMEOUT_INFINITE)
         {
             timer->m_flags &= ~CLR_RT_HeapBlock_Timer::c_Recurring;
         }
         else
         {
-            if(flags & CLR_RT_HeapBlock_Timer::c_INPUT_Int32) timer->m_timeFrequency *= TIME_CONVERSION__TO_MILLISECONDS;
-            
-            if(minTime <= timer->m_timeFrequency && timer->m_timeFrequency <= maxTime )
+            if (flags & CLR_RT_HeapBlock_Timer::c_INPUT_Int32)
+                timer->m_timeFrequency *= TIME_CONVERSION__TO_MILLISECONDS;
+
+            if (minTime <= timer->m_timeFrequency && timer->m_timeFrequency <= maxTime)
             {
                 timer->m_flags |= CLR_RT_HeapBlock_Timer::c_Recurring;
             }
@@ -324,4 +364,3 @@ HRESULT CLR_RT_HeapBlock_Timer::ConfigureObject( CLR_RT_StackFrame& stack, CLR_U
 
     NANOCLR_NOCLEANUP();
 }
-


### PR DESCRIPTION
## Description
- Change check macro to throw correct exceptio: was NullReferenceException instead of ArgumentNullException.

## Motivation and Context
- Fixes nanoFramework/Home#713.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
