### PR TITLE
Update nanoFramework_hardware_esp32_native_Hardware_Esp32_Sleep.cpp

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native.cpp
@@ -72,5 +72,5 @@ const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_Hardware_Esp3
     "nanoFramework.Hardware.Esp32",
     0x1B75B894,
     method_lookup,
-    { 100, 0, 7, 1 }
+    { 100, 0, 7, 2 }
 };

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_Sleep.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_Sleep.cpp
@@ -29,14 +29,28 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
 {
     NANOCLR_HEADER();
     {
-        gpio_num_t gpio_num = (gpio_num_t)stack.Arg0().NumericByRef().s4;
+        uint64_t mask = (uint64_t)stack.Arg0().NumericByRef().s8;
         int  level = stack.Arg1().NumericByRef().s4;
-        
-        esp_err_t err = esp_sleep_enable_ext0_wakeup( gpio_num, level);
+
+        // Extract pin number from mask value
+        gpio_num_t gpio_num = GPIO_NUM_0;
+        esp_err_t err = 0;
+        if (mask)   // Only enable pin if other than Pin.None
+        {          
+            for (size_t i = 0; i < GPIO_NUM_MAX; i++)
+            {               
+                if (mask & 0x01)
+                {
+                    gpio_num = (gpio_num_t) i;
+                } 
+                mask >>= 1;              
+            }
+            err = esp_sleep_enable_ext0_wakeup( gpio_num, level);
+        }      
 
         // Return err to the managed application
         stack.SetResult_I4( (int)err ) ;
- }
+    }
     NANOCLR_NOCLEANUP_NOLABEL();
 }
 


### PR DESCRIPTION
Fixes the bug that causes EnableWakeupByPin not waking up an ESP32



<!--- Provide a general summary of your changes in the Title above -->

## Description
Corrected method &lt;&lt;NativeEnableWakeupByPin&gt;&gt; not to directly use the pin mask value, but to firstly extracting the gpio pin number from the mask value.
The &lt;&lt;esp_sleep_enable_ext0_wakeup&gt;&gt; method requires a pin number as a parameter, not the mask value.

## Motivation and Context
- Fixes nanoFramework/Home#705

## How Has This Been Tested?<!-- (if applicable) -->
Tested by:
- Building the target and uploading into ESP32.
- Running a nanoFramework test app which execises the EnableWakeupByPin functionality.

This is a simple fix which does not affect other areas of code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
