### PR TITLE
Fixed ESP32 GPIO Uninitialize

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
@@ -147,18 +147,14 @@ bool CPU_GPIO_Initialize()
 
 bool CPU_GPIO_Uninitialize()
 {
-    gpio_input_state *pGpio;
-
-    pGpio = gpioInputList.FirstNode();
-
-    // Clean up input state list
-    while (pGpio->Next() != NULL)
+    NANOCLR_FOREACH_NODE(gpio_input_state,pGpio,gpioInputList)
     {
         UnlinkInputState(pGpio);
-        pGpio = pGpio->Next();
     }
+    NANOCLR_FOREACH_NODE_END();
 
     gpio_uninstall_isr_service();
+
     return true;
 }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
The way CPU_GPIO_Uninitialize was implemented, a linked list itteration fails after the current item in the linked list gets removed during the itteration. 
A better coding pattern, macro NANOCLR_FOREACH_NODE is now used which allows removal of the item while itterating.

## Motivation and Context
As part of solving issue #705 it was noticed that, if any INPUT pins are defined, the application raises an unhandled exception when entering deep sleep state.
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Leftover fix to nanoFramework/Home#705

## How Has This Been Tested?<!-- (if applicable) -->
Tested on a cloned build using the same test app using for Issue #705


## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
