### PR TITLE
Implement native support for new Network Information calls

### DIFF
--- a/CMake/Modules/FindSystem.Net.cmake
+++ b/CMake/Modules/FindSystem.Net.cmake
@@ -16,6 +16,7 @@ set(System.Net_SRCS
 
     # System.Net.NetworkInformation
     sys_net_native_System_Net_NetworkInformation_NetworkInterface.cpp
+    sys_net_native_System_Net_NetworkInformation_IPGlobalProperties.cpp
     sys_net_native_System_Net_NetworkInformation_Wireless80211Configuration.cpp
     sys_net_native_System_Net_NetworkInformation_WirelessAPConfiguration.cpp
 

--- a/src/DeviceInterfaces/System.Net/sys_net_native.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native.cpp
@@ -6,6 +6,7 @@
 
 #include "sys_net_native.h"
 
+// clang-format off
 
 static const CLR_RT_MethodHandler method_lookup[] =
 {
@@ -39,6 +40,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface::InitializeNetworkInterfaceSettings___VOID,
     Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface::UpdateConfiguration___VOID__I4,
+    Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface::GetIsNetworkAvailable___STATIC__BOOLEAN,
     NULL,
     Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface::GetNetworkInterfaceCount___STATIC__I4,
     Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface::GetNetworkInterface___STATIC__SystemNetNetworkInformationNetworkInterface__U4,
@@ -66,6 +68,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    Library_sys_net_native_System_Net_NetworkInformation_IPGlobalProperties::GetIPAddress___STATIC__SystemNetIPAddress,
     NULL,
     NULL,
     NULL,
@@ -299,7 +302,9 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_System_Net =
 {
     "System.Net",
-    0x1118F266,
+    0x06699AEA,
     method_lookup,
-    { 100, 1, 3, 1 }
+    { 100, 1, 3, 2 }
 };
+
+// clang-format on

--- a/src/DeviceInterfaces/System.Net/sys_net_native.h
+++ b/src/DeviceInterfaces/System.Net/sys_net_native.h
@@ -134,6 +134,7 @@ struct Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface
 
     NANOCLR_NATIVE_DECLARE(InitializeNetworkInterfaceSettings___VOID);
     NANOCLR_NATIVE_DECLARE(UpdateConfiguration___VOID__I4);
+    NANOCLR_NATIVE_DECLARE(GetIsNetworkAvailable___STATIC__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(GetNetworkInterfaceCount___STATIC__I4);
     NANOCLR_NATIVE_DECLARE(GetNetworkInterface___STATIC__SystemNetNetworkInformationNetworkInterface__U4);
     NANOCLR_NATIVE_DECLARE(IPAddressFromString___STATIC__U4__STRING);
@@ -165,6 +166,13 @@ struct Library_sys_net_native_System_Net_IPHostEntry
 {
     static const int FIELD__hostName = 1;
     static const int FIELD__addressList = 2;
+
+    //--//
+};
+
+struct Library_sys_net_native_System_Net_NetworkInformation_IPGlobalProperties
+{
+    NANOCLR_NATIVE_DECLARE(GetIPAddress___STATIC__SystemNetIPAddress);
 
     //--//
 };

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_IPGlobalProperties.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_IPGlobalProperties.cpp
@@ -6,7 +6,8 @@
 #include "sys_net_native.h"
 #include <nanoPAL_Sockets.h>
 
-HRESULT Library_sys_net_native_System_Net_NetworkInformation_IPGlobalProperties::GetIPAddress___STATIC__SystemNetIPAddress(CLR_RT_StackFrame &stack)
+HRESULT Library_sys_net_native_System_Net_NetworkInformation_IPGlobalProperties::
+    GetIPAddress___STATIC__SystemNetIPAddress(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
 
@@ -41,7 +42,7 @@ HRESULT Library_sys_net_native_System_Net_NetworkInformation_IPGlobalProperties:
 
     // loop through all the network interface and check if any is up
     for (int interfaceIndex = 0; interfaceIndex < g_TargetConfiguration.NetworkInterfaceConfigs->Count;
-        interfaceIndex++)
+         interfaceIndex++)
     {
         NANOCLR_CLEAR(config);
 

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_IPGlobalProperties.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_IPGlobalProperties.cpp
@@ -1,0 +1,80 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include "sys_net_native.h"
+#include <nanoPAL_Sockets.h>
+
+HRESULT Library_sys_net_native_System_Net_NetworkInformation_IPGlobalProperties::GetIPAddress___STATIC__SystemNetIPAddress(CLR_RT_StackFrame &stack)
+{
+    NANOCLR_HEADER();
+
+    HAL_Configuration_NetworkInterface config;
+
+    CLR_RT_TypeDef_Index ipAddressTypeDef;
+    CLR_RT_HeapBlock *ipAddressHbObj;
+    CLR_RT_HeapBlock ipAddress;
+    CLR_INT64 *pRes;
+
+    CLR_RT_HeapBlock &top = stack.PushValue();
+
+    // find <IPAddress> type, don't bother checking the result as it exists for sure
+    g_CLR_RT_TypeSystem.FindTypeDef("IPAddress", "System.Net", ipAddressTypeDef);
+
+    // create an instance of <IPAddress>
+    NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(ipAddress, ipAddressTypeDef));
+
+    // dereference the object in order to reach its fields
+    ipAddressHbObj = ipAddress.Dereference();
+
+    {
+        // IPAddress _address field
+        // CLR_INT64 fields need to be accessed by pointer
+        CLR_RT_HeapBlock &addressFieldRef =
+            ipAddressHbObj[Library_sys_net_native_System_Net_IPAddress::FIELD___address];
+        pRes = (CLR_INT64 *)&addressFieldRef.NumericByRef().s8;
+
+        // default to IP Any Address
+        *pRes = 0;
+    }
+
+    // loop through all the network interface and check if any is up
+    for (int interfaceIndex = 0; interfaceIndex < g_TargetConfiguration.NetworkInterfaceConfigs->Count;
+        interfaceIndex++)
+    {
+        NANOCLR_CLEAR(config);
+
+        // load network interface configuration from storage
+        if (!ConfigurationManager_GetConfigurationBlock(
+                (void *)&config,
+                DeviceConfigurationOption_Network,
+                interfaceIndex))
+        {
+            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
+        }
+        _ASSERTE(config.StartupAddressMode > 0);
+
+        // load adapter configuration on top of the stored config
+        NANOCLR_CHECK_HRESULT(SOCK_CONFIGURATION_LoadConfiguration(&config, interfaceIndex));
+
+        // has IP v4?
+        if (config.IPv4Address > 0)
+        {
+            *pRes = config.IPv4Address;
+
+            // IPAddress _family field
+            // IP v4: AddressFamily.InterNetwork
+            ipAddressHbObj[Library_sys_net_native_System_Net_IPAddress::FIELD___family].NumericByRef().s4 =
+                SOCK_AF_INET;
+
+            // set address field with IPAddress heap block object
+            top.SetObjectReference(ipAddressHbObj);
+
+            // we have an IP, no need to check any other
+            break;
+        }
+    }
+
+    NANOCLR_NOCLEANUP();
+}

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_NetworkInterface.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_NetworkInterface.cpp
@@ -207,6 +207,32 @@ HRESULT Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface::U
     NANOCLR_NOCLEANUP();
 }
 
+HRESULT Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface::GetIsNetworkAvailable___STATIC__BOOLEAN(
+    CLR_RT_StackFrame &stack)
+{
+    NATIVE_PROFILE_CLR_NETWORK();
+    NANOCLR_HEADER();
+
+    bool networkIsAvailable = false;
+
+    // loop through all the network interface and check if any is up
+    for (int interfaceIndex = 0; interfaceIndex < g_TargetConfiguration.NetworkInterfaceConfigs->Count;
+         interfaceIndex++)
+    {
+        NANOCLR_CHECK_HRESULT(SOCK_CONFIGURATION_LinkStatus(interfaceIndex, &networkIsAvailable));
+
+        if (networkIsAvailable)
+        {
+            // network interface is UP, no need to check any other
+            break;
+        }
+    }
+
+    stack.SetResult_Boolean(networkIsAvailable);
+
+    NANOCLR_NOCLEANUP();
+}
+
 HRESULT Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface::GetNetworkInterfaceCount___STATIC__I4(
     CLR_RT_StackFrame &stack)
 {

--- a/src/PAL/COM/sockets/sockets_lwip.cpp
+++ b/src/PAL/COM/sockets/sockets_lwip.cpp
@@ -199,13 +199,13 @@ HRESULT SOCK_CONFIGURATION_LoadConfiguration(HAL_Configuration_NetworkInterface 
 HRESULT SOCK_CONFIGURATION_LinkStatus(uint32_t interfaceIndex, bool *status)
 {
     NATIVE_PROFILE_PAL_COM();
-    
-    return HAL_SOCK_CONFIGURATION_Link_status(interfaceIndex, status);
-} 
 
-#define SOCKET_SHUTDOWN_READ         0
-#define SOCKET_SHUTDOWN_WRITE        1
-#define SOCKET_SHUTDOWN_READ_WRITE   2
+    return HAL_SOCK_CONFIGURATION_Link_status(interfaceIndex, status);
+}
+
+#define SOCKET_SHUTDOWN_READ       0
+#define SOCKET_SHUTDOWN_WRITE      1
+#define SOCKET_SHUTDOWN_READ_WRITE 2
 
 #define ISSET_SOCKET_FLAG(x, y) ((y) == ((y) & (x).m_flags))
 #define SET_SOCKET_FLAG(x, y)   (x).m_flags |= (y)

--- a/src/PAL/COM/sockets/sockets_lwip.cpp
+++ b/src/PAL/COM/sockets/sockets_lwip.cpp
@@ -196,9 +196,16 @@ HRESULT SOCK_CONFIGURATION_LoadConfiguration(HAL_Configuration_NetworkInterface 
     return hr;
 }
 
-#define SOCKET_SHUTDOWN_READ       0
-#define SOCKET_SHUTDOWN_WRITE      1
-#define SOCKET_SHUTDOWN_READ_WRITE 2
+HRESULT SOCK_CONFIGURATION_LinkStatus(uint32_t interfaceIndex, bool *status)
+{
+    NATIVE_PROFILE_PAL_COM();
+    
+    return HAL_SOCK_CONFIGURATION_Link_status(interfaceIndex, status);
+} 
+
+#define SOCKET_SHUTDOWN_READ         0
+#define SOCKET_SHUTDOWN_WRITE        1
+#define SOCKET_SHUTDOWN_READ_WRITE   2
 
 #define ISSET_SOCKET_FLAG(x, y) ((y) == ((y) & (x).m_flags))
 #define SET_SOCKET_FLAG(x, y)   (x).m_flags |= (y)

--- a/src/PAL/Include/nanoPAL_Sockets.h
+++ b/src/PAL/Include/nanoPAL_Sockets.h
@@ -634,6 +634,7 @@ HRESULT SOCK_CONFIGURATION_UpdateAdapterConfiguration(
     uint32_t interfaceIndex,
     uint32_t updateFlags);
 HRESULT SOCK_CONFIGURATION_LoadConfiguration(HAL_Configuration_NetworkInterface *config, uint32_t interfaceIndex);
+HRESULT SOCK_CONFIGURATION_LinkStatus(uint32_t interfaceIndex, bool *status);
 
 //--// SSL
 
@@ -725,6 +726,7 @@ HRESULT HAL_SOCK_CONFIGURATION_UpdateAdapterConfiguration(
     HAL_Configuration_NetworkInterface *config,
     uint32_t interfaceIndex,
     uint32_t updateFlags);
+HRESULT HAL_SOCK_CONFIGURATION_Link_status(uint32_t interfaceIndex, bool *status);
 
 void *HAL_SOCK_GlobalLockContext();
 void HAL_SOCK_EventsSet(uint32_t events);

--- a/src/PAL/Lwip/lwIP_Sockets.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets.cpp
@@ -79,6 +79,21 @@ void LWIP_SOCKETS_Driver::PostAvailabilityOff(void *arg)
         0);
 }
 
+HRESULT LWIP_SOCKETS_Driver::Link_status(uint32_t interfaceIndex, bool *status)
+{
+    struct netif *networkInterface =
+        netif_find_interface(g_LWIP_SOCKETS_Driver.m_interfaces[interfaceIndex].m_interfaceNumber);
+
+    if (NULL == networkInterface)
+    {
+        return CLR_E_FAIL;
+    }
+
+    *status = netif_is_link_up(networkInterface);
+
+    return S_OK;
+}
+
 #if LWIP_NETIF_LINK_CALLBACK == 1
 void LWIP_SOCKETS_Driver::Link_callback(struct netif *netif)
 {

--- a/src/PAL/Lwip/lwIP_Sockets.h
+++ b/src/PAL/Lwip/lwIP_Sockets.h
@@ -97,14 +97,14 @@ struct LWIP_SOCKETS_Driver
 
     static int SendTo(SOCK_SOCKET s, const char *buf, int len, int flags, const SOCK_sockaddr *to, int tolen);
 
+    static HRESULT Link_status(uint32_t interfaceIndex, bool *status);
+
     static HRESULT LoadAdapterConfiguration(HAL_Configuration_NetworkInterface *config, uint32_t interfaceIndex);
 
     static HRESULT UpdateAdapterConfiguration(
         uint32_t interfaceIndex,
         uint32_t updateFlags,
         HAL_Configuration_NetworkInterface *config);
-
-    static HRESULT LoadWirelessConfiguration(uint32_t interfaceIndex, HAL_Configuration_Wireless80211 *wirelessConfig);
 
   private:
     static void Status_callback(struct netif *netif);

--- a/src/PAL/Lwip/lwIP_Sockets_functions.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets_functions.cpp
@@ -150,6 +150,12 @@ HRESULT HAL_SOCK_CONFIGURATION_UpdateAdapterConfiguration(
     return LWIP_SOCKETS_Driver::UpdateAdapterConfiguration(interfaceIndex, updateFlags, config);
 }
 
+HRESULT HAL_SOCK_CONFIGURATION_Link_status(uint32_t interfaceIndex, bool *status)
+{
+    NATIVE_PROFILE_PAL_NETWORK();
+    return LWIP_SOCKETS_Driver::Link_status(interfaceIndex, status);
+}
+
 void HAL_SOCK_EventsSet(uint32_t events)
 {
     NATIVE_PROFILE_PAL_NETWORK();

--- a/targets/TI-SimpleLink/common/simplelink_sockets_functions.cpp
+++ b/targets/TI-SimpleLink/common/simplelink_sockets_functions.cpp
@@ -177,6 +177,12 @@ HRESULT HAL_SOCK_CONFIGURATION_UpdateAdapterConfiguration(
     return S_OK;
 }
 
+HRESULT HAL_SOCK_CONFIGURATION_Link_status(uint32_t interfaceIndex, bool *status)
+{
+    NATIVE_PROFILE_PAL_NETWORK();
+    return LWIP_SOCKETS_Driver::Link_status(interfaceIndex, status);
+}
+
 void HAL_SOCK_EventsSet(uint32_t events)
 {
     NATIVE_PROFILE_PAL_NETWORK();

--- a/targets/TI-SimpleLink/common/sockets_simplelink.cpp
+++ b/targets/TI-SimpleLink/common/sockets_simplelink.cpp
@@ -903,6 +903,13 @@ HRESULT SOCK_CONFIGURATION_LoadConfiguration(HAL_Configuration_NetworkInterface 
     return hr;
 }
 
+HRESULT SOCK_CONFIGURATION_LinkStatus(uint32_t interfaceIndex, bool *status)
+{
+    NATIVE_PROFILE_PAL_COM();
+
+    return HAL_SOCK_CONFIGURATION_Link_status(interfaceIndex, status);
+}
+
 bool SOCKETS_DbgInitialize(int ComPortNum)
 {
     NATIVE_PROFILE_PAL_COM();


### PR DESCRIPTION
## Description
- Add implementation for GetIsNetworkAvailable.
- Add implementation for IPGlobalProperties::GetIPAddress.
- Add low level code in lwIP to support these.
- Add stubs in TI SimpleLink to support these.
- Update CMake accordingly.
- Update System.Net assembly declaration.

## Motivation and Context
- Native support for nanoframework/lib-nanoFramework.System.Net#162.

## How Has This Been Tested?<!-- (if applicable) -->
- Network sample from samples repo.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
