### PR TITLE
Move IP conversions to sockets driver

### DIFF
--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_IPAddress.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_IPAddress.cpp
@@ -4,16 +4,17 @@
 //
 
 #include "sys_net_native.h"
-#include <ip4_addr.h>
 
 HRESULT Library_sys_net_native_System_Net_IPAddress::IPv4ToString___STATIC__STRING__U4(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
 
-    // get IP v4 address in numeric format
-    const ip4_addr_t ip4Address = {stack.Arg0().NumericByRef().u4};
+    // // get IP v4 address in numeric format
+    // const ip4_addr_t ip4Address = {stack.Arg0().NumericByRef().u4};
 
-    NANOCLR_CHECK_HRESULT(stack.SetResult_String(ip4addr_ntoa(&ip4Address)));
+    // NANOCLR_CHECK_HRESULT(stack.SetResult_String(ip4addr_ntoa(&ip4Address)));
+
+    NANOCLR_CHECK_HRESULT(stack.SetResult_String(SOCK_IPAddressToString(stack.Arg0().NumericByRef().u4)));
 
     NANOCLR_NOCLEANUP();
 }

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_NetworkInterface.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_NetworkInformation_NetworkInterface.cpp
@@ -307,35 +307,13 @@ HRESULT Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface::I
     NATIVE_PROFILE_CLR_NETWORK();
     NANOCLR_HEADER();
 
-    LPCSTR szName = stack.Arg0().RecoverString();
-    struct SOCK_addrinfo hints;
-    struct SOCK_addrinfo *addr = NULL;
-    struct SOCK_sockaddr_in *addr_in;
-    int ret;
+    CLR_UINT64 address;
 
-    memset(&hints, 0, sizeof(hints));
+    LPCSTR ipString = stack.Arg0().RecoverString();
 
-    ret = SOCK_getaddrinfo(szName, NULL, &hints, &addr);
+    NANOCLR_CHECK_HRESULT(SOCK_IPAddressFromString(ipString, &address));
 
-    // getaddrinfo returns a winsock error code rather than SOCK_SOCKET_ERROR, so pass this on to the exception handling
-    if (ret != 0 || addr == NULL || addr->ai_family != SOCK_AF_INET)
-    {
-        NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
-    }
+    stack.PushValue().SetInteger((CLR_UINT64)address);
 
-    _ASSERTE(addr->ai_addr != NULL);
-    _ASSERTE(addr->ai_addrlen >= sizeof(SOCK_sockaddr_in));
-
-    addr_in = (struct SOCK_sockaddr_in *)addr->ai_addr;
-
-    stack.PushValue().SetInteger((CLR_UINT64)addr_in->sin_addr.S_un.S_addr);
-
-    NANOCLR_CLEANUP();
-
-    if (addr)
-    {
-        SOCK_freeaddrinfo(addr);
-    }
-
-    NANOCLR_CLEANUP_END();
+    NANOCLR_NOCLEANUP();
 }

--- a/src/PAL/COM/sockets/sockets_lwip.cpp
+++ b/src/PAL/COM/sockets/sockets_lwip.cpp
@@ -203,6 +203,20 @@ HRESULT SOCK_CONFIGURATION_LinkStatus(uint32_t interfaceIndex, bool *status)
     return HAL_SOCK_CONFIGURATION_Link_status(interfaceIndex, status);
 }
 
+HRESULT SOCK_IPAddressFromString(const char *ipString, uint64_t *address)
+{
+    NATIVE_PROFILE_PAL_COM();
+
+    return HAL_SOCK_IPAddressFromString(ipString, address);
+}
+
+const char *SOCK_IPAddressToString(uint32_t address)
+{
+    NATIVE_PROFILE_PAL_COM();
+
+    return HAL_SOCK_IPAddressToString(address);
+}
+
 #define SOCKET_SHUTDOWN_READ       0
 #define SOCKET_SHUTDOWN_WRITE      1
 #define SOCKET_SHUTDOWN_READ_WRITE 2

--- a/src/PAL/Include/nanoPAL_Sockets.h
+++ b/src/PAL/Include/nanoPAL_Sockets.h
@@ -635,6 +635,8 @@ HRESULT SOCK_CONFIGURATION_UpdateAdapterConfiguration(
     uint32_t updateFlags);
 HRESULT SOCK_CONFIGURATION_LoadConfiguration(HAL_Configuration_NetworkInterface *config, uint32_t interfaceIndex);
 HRESULT SOCK_CONFIGURATION_LinkStatus(uint32_t interfaceIndex, bool *status);
+HRESULT SOCK_IPAddressFromString(const char *ipString, uint64_t *address);
+const char *SOCK_IPAddressToString(uint32_t address);
 
 //--// SSL
 
@@ -727,6 +729,8 @@ HRESULT HAL_SOCK_CONFIGURATION_UpdateAdapterConfiguration(
     uint32_t interfaceIndex,
     uint32_t updateFlags);
 HRESULT HAL_SOCK_CONFIGURATION_Link_status(uint32_t interfaceIndex, bool *status);
+HRESULT HAL_SOCK_IPAddressFromString(const char *ipString, uint64_t *address);
+const char *HAL_SOCK_IPAddressToString(uint32_t address);
 
 void *HAL_SOCK_GlobalLockContext();
 void HAL_SOCK_EventsSet(uint32_t events);

--- a/src/PAL/Lwip/lwIP_Sockets.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets.cpp
@@ -94,6 +94,37 @@ HRESULT LWIP_SOCKETS_Driver::Link_status(uint32_t interfaceIndex, bool *status)
     return S_OK;
 }
 
+HRESULT LWIP_SOCKETS_Driver::IPAddressFromString(const char *ipString, uint64_t *address)
+{
+    ip4_addr_t ipv4Address;
+    // FIXME IPV6
+    // ip6_addr_t ipv6Address
+
+    if (ip4addr_aton(ipString, &ipv4Address))
+    {
+        *address = ipv4Address.addr;
+    }
+    // FIXME IPV6
+    // else if(ip6addr_aton(ipString, &ipv6Address))
+    // {
+    // }
+    else
+    {
+        return CLR_E_INVALID_PARAMETER;
+    }
+
+    return S_OK;
+}
+
+const char *LWIP_SOCKETS_Driver::IPAddressToString(uint32_t address)
+{
+    // get IP v4 address in numeric format
+    // FIXME IPV6
+    const ip4_addr_t ip4Address = {address};
+
+    return ip4addr_ntoa(&ip4Address);
+}
+
 #if LWIP_NETIF_LINK_CALLBACK == 1
 void LWIP_SOCKETS_Driver::Link_callback(struct netif *netif)
 {

--- a/src/PAL/Lwip/lwIP_Sockets.h
+++ b/src/PAL/Lwip/lwIP_Sockets.h
@@ -99,6 +99,10 @@ struct LWIP_SOCKETS_Driver
 
     static HRESULT Link_status(uint32_t interfaceIndex, bool *status);
 
+    static HRESULT IPAddressFromString(const char *ipString, uint64_t *address);
+
+    static const char *IPAddressToString(uint32_t address);
+
     static HRESULT LoadAdapterConfiguration(HAL_Configuration_NetworkInterface *config, uint32_t interfaceIndex);
 
     static HRESULT UpdateAdapterConfiguration(

--- a/src/PAL/Lwip/lwIP_Sockets_functions.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets_functions.cpp
@@ -156,6 +156,18 @@ HRESULT HAL_SOCK_CONFIGURATION_Link_status(uint32_t interfaceIndex, bool *status
     return LWIP_SOCKETS_Driver::Link_status(interfaceIndex, status);
 }
 
+HRESULT HAL_SOCK_IPAddressFromString(const char *ipString, uint64_t *address)
+{
+    NATIVE_PROFILE_PAL_NETWORK();
+    return LWIP_SOCKETS_Driver::IPAddressFromString(ipString, address);
+}
+
+const char *HAL_SOCK_IPAddressToString(uint32_t address)
+{
+    NATIVE_PROFILE_PAL_NETWORK();
+    return LWIP_SOCKETS_Driver::IPAddressToString(address);
+}
+
 void HAL_SOCK_EventsSet(uint32_t events)
 {
     NATIVE_PROFILE_PAL_NETWORK();

--- a/targets/TI-SimpleLink/common/simplelink_sockets.cpp
+++ b/targets/TI-SimpleLink/common/simplelink_sockets.cpp
@@ -6,13 +6,13 @@
 
 #include "simplelink_sockets.h"
 
-//--// 
+//--//
 
 #if defined(DEBUG)
-#define DEBUG_HANDLE_SOCKET_ERROR(t,a) 
+#define DEBUG_HANDLE_SOCKET_ERROR(t, a)
 // assume there is something to add in later??
 #else
-#define DEBUG_HANDLE_SOCKET_ERROR(t,a) 
+#define DEBUG_HANDLE_SOCKET_ERROR(t, a)
 #endif
 
 //--//
@@ -22,39 +22,45 @@ static HAL_CONTINUATION PostAddressChangedContinuation;
 static HAL_CONTINUATION PostAvailabilityOnContinuation;
 static HAL_CONTINUATION PostAvailabilityOffContinuation;
 
-void PostAddressChanged(void* arg)
+void PostAddressChanged(void *arg)
 {
     (void)arg;
 
-	Network_PostEvent(NetworkChange_NetworkEventType_AddressChanged, 0, 0);
+    Network_PostEvent(NetworkChange_NetworkEventType_AddressChanged, 0, 0);
 }
 
-void PostAvailabilityOn(void* arg)
+void PostAvailabilityOn(void *arg)
 {
     (void)arg;
 
-	Network_PostEvent(NetworkChange_NetworkEventType_AvailabilityChanged, NetworkChange_NetworkEvents_NetworkAvailable, 0);
+    Network_PostEvent(
+        NetworkChange_NetworkEventType_AvailabilityChanged,
+        NetworkChange_NetworkEvents_NetworkAvailable,
+        0);
 }
 
-void PostAvailabilityOff(void* arg)
+void PostAvailabilityOff(void *arg)
 {
     (void)arg;
 
-	Network_PostEvent(NetworkChange_NetworkEventType_AvailabilityChanged, NetworkChange_NetworkEvents_NetworkNOTAvailable, 0);
+    Network_PostEvent(
+        NetworkChange_NetworkEventType_AvailabilityChanged,
+        NetworkChange_NetworkEvents_NetworkNOTAvailable,
+        0);
 }
 
 void Link_callback(bool linkUp)
 {
-	if (linkUp)
-	{
-		if (!PostAvailabilityOnContinuation.IsLinked())
-			PostAvailabilityOnContinuation.Enqueue();
-	}
-	else
-	{
-		if (!PostAvailabilityOffContinuation.IsLinked())
-			PostAvailabilityOffContinuation.Enqueue();
-	}
+    if (linkUp)
+    {
+        if (!PostAvailabilityOnContinuation.IsLinked())
+            PostAvailabilityOnContinuation.Enqueue();
+    }
+    else
+    {
+        if (!PostAvailabilityOffContinuation.IsLinked())
+            PostAvailabilityOffContinuation.Enqueue();
+    }
 
     Events_Set(SYSTEM_EVENT_FLAG_SOCKET);
     Events_Set(SYSTEM_EVENT_FLAG_NETWORK);
@@ -62,44 +68,44 @@ void Link_callback(bool linkUp)
 
 void Status_callback()
 {
-	if (!PostAddressChangedContinuation.IsLinked())
-		PostAddressChangedContinuation.Enqueue();
+    if (!PostAddressChangedContinuation.IsLinked())
+        PostAddressChangedContinuation.Enqueue();
 
 #if !defined(BUILD_RTM)
-	// lcd_printf("\f\n\n\n\n\n\nLink Update: %s\n", (netif_is_up(netif) ? "UP  " : "DOWN"));
-	// lcd_printf("         IP: %d.%d.%d.%d\n", (netif->ip_addr.addr >> 0) & 0xFF,
-	// 	(netif->ip_addr.addr >> 8) & 0xFF,
-	// 	(netif->ip_addr.addr >> 16) & 0xFF,
-	// 	(netif->ip_addr.addr >> 24) & 0xFF);
-	// lcd_printf("         SM: %d.%d.%d.%d\n", (netif->netmask.addr >> 0) & 0xFF,
-	// 	(netif->netmask.addr >> 8) & 0xFF,
-	// 	(netif->netmask.addr >> 16) & 0xFF,
-	// 	(netif->netmask.addr >> 24) & 0xFF);
-	// lcd_printf("         GW: %d.%d.%d.%d\n", (netif->gw.addr >> 0) & 0xFF,
-	// 	(netif->gw.addr >> 8) & 0xFF,
-	// 	(netif->gw.addr >> 16) & 0xFF,
-	// 	(netif->gw.addr >> 24) & 0xFF);
+        // lcd_printf("\f\n\n\n\n\n\nLink Update: %s\n", (netif_is_up(netif) ? "UP  " : "DOWN"));
+        // lcd_printf("         IP: %d.%d.%d.%d\n", (netif->ip_addr.addr >> 0) & 0xFF,
+        // 	(netif->ip_addr.addr >> 8) & 0xFF,
+        // 	(netif->ip_addr.addr >> 16) & 0xFF,
+        // 	(netif->ip_addr.addr >> 24) & 0xFF);
+        // lcd_printf("         SM: %d.%d.%d.%d\n", (netif->netmask.addr >> 0) & 0xFF,
+        // 	(netif->netmask.addr >> 8) & 0xFF,
+        // 	(netif->netmask.addr >> 16) & 0xFF,
+        // 	(netif->netmask.addr >> 24) & 0xFF);
+        // lcd_printf("         GW: %d.%d.%d.%d\n", (netif->gw.addr >> 0) & 0xFF,
+        // 	(netif->gw.addr >> 8) & 0xFF,
+        // 	(netif->gw.addr >> 16) & 0xFF,
+        // 	(netif->gw.addr >> 24) & 0xFF);
 
-//FIXME debug_printf("IP Address: %d.%d.%d.%d\n", (netif->ip_addr.u_addr.ip4.addr >> 0) & 0xFF,
+// FIXME debug_printf("IP Address: %d.%d.%d.%d\n", (netif->ip_addr.u_addr.ip4.addr >> 0) & 0xFF,
 // 	(netif->ip_addr.u_addr.ip4.addr >> 8) & 0xFF,
 // 	(netif->ip_addr.u_addr.ip4.addr >> 16) & 0xFF,
 // 	(netif->ip_addr.u_addr.ip4.addr >> 24) & 0xFF);
 #if LWIP_DNS
-	if (netif->flags & NETIF_FLAG_ETHARP)
-	{
-		//ip_addr_t * dns1 = dns_getserver(0);
-		//ip_addr_t * dns2 = dns_getserver(1);
+    if (netif->flags & NETIF_FLAG_ETHARP)
+    {
+        // ip_addr_t * dns1 = dns_getserver(0);
+        // ip_addr_t * dns2 = dns_getserver(1);
 
-		// lcd_printf("         dns1: %d.%d.%d.%d\n", (dns1.addr >> 0) & 0xFF,
-		// 	(dns1.addr >> 8) & 0xFF,
-		// 	(dns1.addr >> 16) & 0xFF,
-		// 	(dns1.addr >> 24) & 0xFF);
+        // lcd_printf("         dns1: %d.%d.%d.%d\n", (dns1.addr >> 0) & 0xFF,
+        // 	(dns1.addr >> 8) & 0xFF,
+        // 	(dns1.addr >> 16) & 0xFF,
+        // 	(dns1.addr >> 24) & 0xFF);
 
-		// lcd_printf("         dns2: %d.%d.%d.%d\n", (dns2.addr >> 0) & 0xFF,
-		// 	(dns2.addr >> 8) & 0xFF,
-		// 	(dns2.addr >> 16) & 0xFF,
-		// 	(dns2.addr >> 24) & 0xFF);
-	}
+        // lcd_printf("         dns2: %d.%d.%d.%d\n", (dns2.addr >> 0) & 0xFF,
+        // 	(dns2.addr >> 8) & 0xFF,
+        // 	(dns2.addr >> 16) & 0xFF,
+        // 	(dns2.addr >> 24) & 0xFF);
+    }
 #endif
     Events_Set(SYSTEM_EVENT_FLAG_SOCKET);
     Events_Set(SYSTEM_EVENT_FLAG_NETWORK);
@@ -107,7 +113,7 @@ void Status_callback()
 #endif
 
 bool SimpleLink_SOCKETS_Initialize()
-{   
+{
     NATIVE_PROFILE_PAL_NETWORK();
 
     PostAddressChangedContinuation.InitializeCallback(PostAddressChanged, NULL);

--- a/targets/TI-SimpleLink/common/simplelink_sockets_functions.cpp
+++ b/targets/TI-SimpleLink/common/simplelink_sockets_functions.cpp
@@ -183,6 +183,18 @@ HRESULT HAL_SOCK_CONFIGURATION_Link_status(uint32_t interfaceIndex, bool *status
     return LWIP_SOCKETS_Driver::Link_status(interfaceIndex, status);
 }
 
+HRESULT HAL_SOCK_IPAddressFromString(const char *ipString, uint64_t *address)
+{
+    NATIVE_PROFILE_PAL_NETWORK();
+    return LWIP_SOCKETS_Driver::IPAddressFromString(ipString, address);
+}
+
+const char *HAL_SOCK_IPAddressToString(uint32_t address)
+{
+    NATIVE_PROFILE_PAL_NETWORK();
+    return LWIP_SOCKETS_Driver::IPAddressToString(address);
+}
+
 void HAL_SOCK_EventsSet(uint32_t events)
 {
     NATIVE_PROFILE_PAL_NETWORK();

--- a/targets/TI-SimpleLink/common/sockets_simplelink.cpp
+++ b/targets/TI-SimpleLink/common/sockets_simplelink.cpp
@@ -910,6 +910,20 @@ HRESULT SOCK_CONFIGURATION_LinkStatus(uint32_t interfaceIndex, bool *status)
     return HAL_SOCK_CONFIGURATION_Link_status(interfaceIndex, status);
 }
 
+HRESULT SOCK_IPAddressFromString(const char *ipString, uint64_t *address)
+{
+    NATIVE_PROFILE_PAL_COM();
+
+    return HAL_SOCK_IPAddressFromString(ipString, address);
+}
+
+const char *SOCK_IPAddressToString(uint32_t address)
+{
+    NATIVE_PROFILE_PAL_COM();
+
+    return HAL_SOCK_IPAddressToString(address);
+}
+
 bool SOCKETS_DbgInitialize(int ComPortNum)
 {
     NATIVE_PROFILE_PAL_COM();


### PR DESCRIPTION
## Description
- Move IP conversions to sockets driver.
- Simplify NetworkInterface::IPAddressFromString.

## Motivation and Context
- Previous implementation was wrongly making direct calls to lwIP API.

## How Has This Been Tested?<!-- (if applicable) -->
- Networking sample.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
