### PR TITLE
Secure sockets now can use stored device certificate

### DIFF
--- a/src/DeviceInterfaces/System.Net/sys_net_native.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native.cpp
@@ -155,8 +155,8 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     Library_sys_net_native_System_Net_Security_CertificateManager::AddCaCertificateBundle___STATIC__BOOLEAN__SZARRAY_U1,
-    Library_sys_net_native_System_Net_Security_SslNative::SecureServerInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate,
-    Library_sys_net_native_System_Net_Security_SslNative::SecureClientInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate,
+    Library_sys_net_native_System_Net_Security_SslNative::SecureServerInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate__BOOLEAN,
+    Library_sys_net_native_System_Net_Security_SslNative::SecureClientInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate__BOOLEAN,
     Library_sys_net_native_System_Net_Security_SslNative::SecureAccept___STATIC__VOID__I4__OBJECT,
     Library_sys_net_native_System_Net_Security_SslNative::SecureConnect___STATIC__VOID__I4__STRING__OBJECT,
     Library_sys_net_native_System_Net_Security_SslNative::SecureRead___STATIC__I4__OBJECT__SZARRAY_U1__I4__I4__I4,
@@ -243,6 +243,8 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
+    NULL,
     Library_sys_net_native_System_Net_Sockets_NativeSocket::socket___STATIC__I4__I4__I4__I4,
     Library_sys_net_native_System_Net_Sockets_NativeSocket::bind___STATIC__VOID__OBJECT__SystemNetEndPoint,
     Library_sys_net_native_System_Net_Sockets_NativeSocket::connect___STATIC__VOID__OBJECT__SystemNetEndPoint__BOOLEAN,
@@ -302,9 +304,9 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_System_Net =
 {
     "System.Net",
-    0xEECB2218,
+    0x76BCAD4E,
     method_lookup,
-    { 100, 1, 3, 3 }
+    { 100, 1, 3, 4 }
 };
 
 // clang-format on

--- a/src/DeviceInterfaces/System.Net/sys_net_native.h
+++ b/src/DeviceInterfaces/System.Net/sys_net_native.h
@@ -275,9 +275,9 @@ struct Library_sys_net_native_System_Net_Security_CertificateManager
 struct Library_sys_net_native_System_Net_Security_SslNative
 {
     NANOCLR_NATIVE_DECLARE(
-        SecureServerInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate);
+        SecureServerInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(
-        SecureClientInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate);
+        SecureClientInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(SecureAccept___STATIC__VOID__I4__OBJECT);
     NANOCLR_NATIVE_DECLARE(SecureConnect___STATIC__VOID__I4__STRING__OBJECT);
     NANOCLR_NATIVE_DECLARE(SecureRead___STATIC__I4__OBJECT__SZARRAY_U1__I4__I4__I4);
@@ -329,8 +329,9 @@ struct Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509
 struct Library_sys_net_native_System_Net_Security_SslStream
 {
     static const int FIELD___sslVerification = 6;
-    static const int FIELD___sslContext = 7;
-    static const int FIELD___isServer = 8;
+    static const int FIELD___useStoredDeviceCertificate = 7;
+    static const int FIELD___sslContext = 8;
+    static const int FIELD___isServer = 9;
 
     //--//
 };

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
@@ -32,7 +32,7 @@ void Time_GetDateTime(DATE_TIME_INFO *dt)
 
 // Initalise SSL as a server
 HRESULT Library_sys_net_native_System_Net_Security_SslNative::
-    SecureServerInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate(
+    SecureServerInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate__BOOLEAN(
         CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_NETWORK();
@@ -41,7 +41,7 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::
 
 // Initalise SSL as a client
 HRESULT Library_sys_net_native_System_Net_Security_SslNative::
-    SecureClientInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate(
+    SecureClientInit___STATIC__I4__I4__I4__SystemSecurityCryptographyX509CertificatesX509Certificate__SystemSecurityCryptographyX509CertificatesX509Certificate__BOOLEAN(
         CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_NETWORK();
@@ -414,6 +414,7 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
     CLR_INT32 sslVerify = stack.Arg1().NumericByRef().s4;
     CLR_RT_HeapBlock *hbCert = stack.Arg2().Dereference();
     CLR_RT_HeapBlock *caCert = stack.Arg3().Dereference();
+    bool useDeviceCertificate = (bool)stack.Arg4().NumericByRef().u1;
     CLR_RT_HeapBlock_Array *arrCert = NULL;
     CLR_RT_HeapBlock_Array *privateKey = NULL;
     CLR_UINT8 *sslCert = NULL;
@@ -466,7 +467,8 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
                  pk == NULL ? 0 : privateKey->m_numOfElements,
                  password,
                  hal_strlen_s(password),
-                 sslContext)
+                 sslContext,
+                 useDeviceCertificate)
                  ? 0
                  : -1);
     }
@@ -482,7 +484,8 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
                  pk == NULL ? 0 : privateKey->m_numOfElements,
                  password,
                  hal_strlen_s(password),
-                 sslContext)
+                 sslContext,
+                 useDeviceCertificate)
                  ? 0
                  : -1);
     }

--- a/src/PAL/COM/sockets/Sockets_debugger.cpp
+++ b/src/PAL/COM/sockets/Sockets_debugger.cpp
@@ -456,7 +456,8 @@ bool Sockets_LWIP_Driver::UpgradeToSsl(
                 0,
                 NULL,
                 0,
-                g_DebuggerPort_SslCtx_Handle))
+                g_DebuggerPort_SslCtx_Handle,
+                false))
         {
             int32_t ret;
 

--- a/src/PAL/COM/sockets/ssl/mbedTLS/ssl_generic_init_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/mbedTLS/ssl_generic_init_internal.cpp
@@ -19,6 +19,7 @@ bool ssl_generic_init_internal(
     const char *password,
     int passwordLength,
     int &contextHandle,
+    bool useDeviceCertificate,
     bool isServer)
 {
     (void)sslMode;
@@ -183,6 +184,24 @@ bool ssl_generic_init_internal(
             context->x509_crt,
             (const unsigned char *)g_TargetConfiguration.CertificateStore->Certificates[configIndex]->Certificate,
             g_TargetConfiguration.CertificateStore->Certificates[configIndex]->CertificateSize);
+    }
+
+    // check if the device certificate is to be used
+    if (useDeviceCertificate)
+    {
+        // check if there is a device certificate stored
+        if (g_TargetConfiguration.DeviceCertificates->Count > 0)
+        {
+            // there is!
+            // fill in the parameters like if it was supplied by the caller
+            // OK to override, that's the intended behaviour
+            certificate = (const char *)g_TargetConfiguration.DeviceCertificates->Certificates[0]->Certificate;
+            certLength = g_TargetConfiguration.DeviceCertificates->Certificates[0]->CertificateSize;
+
+            // clear private keys, just in case
+            privateKey = NULL;
+            privateKeyLength = 0;
+        }
     }
 
     // parse "own" certificate if passed

--- a/src/PAL/COM/sockets/ssl/ssl.cpp
+++ b/src/PAL/COM/sockets/ssl/ssl.cpp
@@ -50,6 +50,7 @@ static bool SSL_GenericInit(
     const char *password,
     int passwordLength,
     int &contextHandle,
+    bool useDeviceCertificate,
     bool isServer)
 {
     if (!s_InitDone)
@@ -67,6 +68,7 @@ static bool SSL_GenericInit(
         password,
         passwordLength,
         contextHandle,
+        useDeviceCertificate,
         isServer);
 }
 
@@ -103,7 +105,8 @@ bool SSL_ServerInit(
     int privateKeyLength,
     const char *password,
     int passwordLength,
-    int &contextHandle)
+    int &contextHandle,
+    bool useDeviceCertificate)
 {
     NATIVE_PROFILE_PAL_COM();
 
@@ -117,6 +120,7 @@ bool SSL_ServerInit(
         password,
         passwordLength,
         contextHandle,
+        useDeviceCertificate,
         true);
 }
 
@@ -129,7 +133,8 @@ bool SSL_ClientInit(
     int privateKeyLength,
     const char *password,
     int passwordLength,
-    int &contextHandle)
+    int &contextHandle,
+    bool useDeviceCertificate)
 {
     NATIVE_PROFILE_PAL_COM();
 
@@ -143,6 +148,7 @@ bool SSL_ClientInit(
         password,
         passwordLength,
         contextHandle,
+        useDeviceCertificate,
         false);
 }
 

--- a/src/PAL/COM/sockets/ssl/ssl_functions.h
+++ b/src/PAL/COM/sockets/ssl/ssl_functions.h
@@ -57,6 +57,7 @@ bool ssl_generic_init_internal(
     const char *password,
     int passwordLength,
     int &contextHandle,
+    bool useDeviceCertificate,
     bool isServer);
 bool ssl_initialize_internal();
 bool ssl_uninitialize_internal();

--- a/src/PAL/COM/sockets/ssl/ssl_stubs.cpp
+++ b/src/PAL/COM/sockets/ssl/ssl_stubs.cpp
@@ -29,7 +29,8 @@ __nfweak bool SSL_ServerInit(
     int privateKeyLength,
     const char *password,
     int passwordLength,
-    int &contextHandle)
+    int &contextHandle,
+    bool useDeviceCertificate)
 {
     (void)sslMode;
     (void)sslVerify;
@@ -40,6 +41,7 @@ __nfweak bool SSL_ServerInit(
     (void)password;
     (void)passwordLength;
     (void)contextHandle;
+    (void)useDeviceCertificate;
 
     NATIVE_PROFILE_PAL_COM();
 
@@ -55,7 +57,8 @@ __nfweak bool SSL_ClientInit(
     int privateKeyLength,
     const char *password,
     int passwordLength,
-    int &contextHandle)
+    int &contextHandle,
+    bool useDeviceCertificate)
 {
     (void)sslMode;
     (void)sslVerify;
@@ -66,6 +69,7 @@ __nfweak bool SSL_ClientInit(
     (void)password;
     (void)passwordLength;
     (void)contextHandle;
+    (void)useDeviceCertificate;
 
     NATIVE_PROFILE_PAL_COM();
 

--- a/src/PAL/Include/nanoPAL_Sockets.h
+++ b/src/PAL/Include/nanoPAL_Sockets.h
@@ -655,7 +655,9 @@ bool SSL_ServerInit(
     int privateKeyLength,
     const char *password,
     int passwordLength,
-    int &sslContextHandle);
+    int &sslContextHandle,
+    bool useDeviceCertificate);
+
 bool SSL_ClientInit(
     int sslMode,
     int sslVerify,
@@ -665,7 +667,9 @@ bool SSL_ClientInit(
     int privateKeyLength,
     const char *password,
     int passwordLength,
-    int &sslContextHandle);
+    int &sslContextHandle,
+    bool useDeviceCertificate);
+
 bool SSL_AddCertificateAuthority(
     int sslContextHandle,
     const char *certificate,

--- a/targets/TI-SimpleLink/common/ssl_simplelink.cpp
+++ b/targets/TI-SimpleLink/common/ssl_simplelink.cpp
@@ -79,6 +79,7 @@ bool ssl_generic_init_internal(
     const char *password,
     int passwordLength,
     int &contextHandle,
+    bool useDeviceCertificate,
     bool isServer)
 {
     (void)password;


### PR DESCRIPTION
## Description
- Update TLS drivers and System.Net native interface to use stored device certificate on demand.
- Update System.Net assembly declaration.

## Motivation and Context
- Last piece of the puzzle to allow using device certificates.
- Supports nanoframework/lib-nanoFramework.System.Net#165.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [x] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
