### PR TITLE
Fix call to data available in SSL stream

### DIFF
--- a/src/PAL/COM/sockets/ssl/mbedTLS/ssl_available_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/mbedTLS/ssl_available_internal.cpp
@@ -24,7 +24,7 @@ int ssl_available_internal(int sd)
     // It won't work because we are using blockign sockets.
     // Even if we unblock it temporarily, it will still won't return until there is something to be read.
     // That call will block the execution and the watchdog will eventually kick in.
-    // Bottom line: take the information provided by this call as informational. 
+    // Bottom line: take the information provided by this call as informational.
 
     int availableBytes = mbedtls_ssl_check_pending(ssl);
 

--- a/src/PAL/COM/sockets/ssl/mbedTLS/ssl_available_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/mbedTLS/ssl_available_internal.cpp
@@ -18,14 +18,22 @@ int ssl_available_internal(int sd)
         return SOCK_SOCKET_ERROR;
     }
 
-    mbedtls_ssl_read(ssl, NULL, 0);
+    // Developer note
+    // Ideally we should be making a call to read passing a NULL pointer and requesting 0 bytes
+    // Like this: mbedtls_ssl_read(ssl, NULL, 0)
+    // It won't work because we are using blockign sockets.
+    // Even if we unblock it temporarily, it will still won't return until there is something to be read.
+    // That call will block the execution and the watchdog will eventually kick in.
+    // Bottom line: take the information provided by this call as informational. 
 
-    if (mbedtls_ssl_check_pending(ssl))
+    int availableBytes = mbedtls_ssl_check_pending(ssl);
+
+    if (availableBytes > 0)
     {
         return mbedtls_ssl_get_bytes_avail(ssl);
     }
     else
     {
-        return 0;
+        return availableBytes;
     }
 }


### PR DESCRIPTION
## Description
- Can't call the read on a blocking socket.
- Even if unblock it temporarily it will still won't return until there is something to be read.

## Motivation and Context
- Calling this is blocking the execution until there is something to read in the socket.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
