### PR TITLE
Fix potential memory leak in System.IO

### DIFF
--- a/src/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_File.cpp
+++ b/src/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_File.cpp
@@ -24,78 +24,79 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_File::ExistsNative___STATIC__BOOL
     CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
+    
+    const char *workingPath = stack.Arg0().RecoverString();
+    const char *fileName = stack.Arg1().RecoverString();
+
+    bool exists = false;
+    FRESULT operationResult;
+    char *filePath = NULL;
+
+    FAULT_ON_NULL(workingPath);
+    FAULT_ON_NULL(fileName);
+
+    // setup file path
+    filePath = (char *)platform_malloc(2 * FF_LFN_BUF + 1);
+
+    // sanity check for successfull malloc
+    if (filePath == NULL)
     {
-        const char *workingPath = stack.Arg0().RecoverString();
-        FAULT_ON_NULL(workingPath);
-        const char *fileName = stack.Arg1().RecoverString();
-        FAULT_ON_NULL(fileName);
+        // failed to allocate memory
+        NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
+    }
 
-        bool exists = false;
+    // clear working buffer
+    memset(filePath, 0, 2 * FF_LFN_BUF + 1);
 
-        FRESULT operationResult;
-        char *filePath = NULL;
+    // compose file path
+    CombinePathAndName2(filePath, workingPath, fileName);
 
-        // setup file path
-        filePath = (char *)platform_malloc(2 * FF_LFN_BUF + 1);
+    // change directory
+    operationResult = f_chdir(workingPath);
 
-        // sanity check for successfull malloc
-        if (filePath == NULL)
+    if (operationResult != FR_OK)
+    {
+        if (operationResult == FR_INVALID_DRIVE)
         {
-            // failed to allocate memory
-            NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
-        }
-
-        // clear working buffer
-        memset(filePath, 0, 2 * FF_LFN_BUF + 1);
-
-        // compose file path
-        CombinePathAndName2(filePath, workingPath, fileName);
-
-        // change directory
-        operationResult = f_chdir(workingPath);
-
-        if (operationResult != FR_OK)
-        {
-            if (operationResult == FR_INVALID_DRIVE)
-            {
-                // invalid drive
-                NANOCLR_SET_AND_LEAVE(CLR_E_VOLUME_NOT_FOUND);
-            }
-            else
-            {
-                // error opening the directoty
-                NANOCLR_SET_AND_LEAVE(CLR_E_DIRECTORY_NOT_FOUND);
-            }
+            // invalid drive
+            NANOCLR_SET_AND_LEAVE(CLR_E_VOLUME_NOT_FOUND);
         }
         else
         {
-            FILINFO fno;
-
-            operationResult = f_stat(filePath, &fno);
-
-            if (operationResult == FR_OK)
-            {
-                exists = true;
-            }
-            else if (operationResult == FR_NO_FILE)
-            {
-                exists = false;
-            }
-            else
-            {
-                exists = false;
-            }
+            // error opening the directoty
+            NANOCLR_SET_AND_LEAVE(CLR_E_DIRECTORY_NOT_FOUND);
         }
-
-        // free buffer memory, if allocated
-        if (filePath != NULL)
-        {
-            platform_free(filePath);
-        }
-
-        stack.SetResult_Boolean(exists);
     }
-    NANOCLR_NOCLEANUP();
+    else
+    {
+        FILINFO fno;
+
+        operationResult = f_stat(filePath, &fno);
+
+        if (operationResult == FR_OK)
+        {
+            exists = true;
+        }
+        else if (operationResult == FR_NO_FILE)
+        {
+            exists = false;
+        }
+        else
+        {
+            exists = false;
+        }
+    }
+    stack.SetResult_Boolean(exists);
+    
+    NANOCLR_CLEANUP();
+    
+    // free buffer memory, if allocated
+    if (filePath != NULL)
+    {
+        platform_free(filePath);
+    }
+
+    NANOCLR_CLEANUP_END();
 }
 
 HRESULT Library_nf_sys_io_filesystem_System_IO_File::MoveNative___STATIC__VOID__STRING__STRING(CLR_RT_StackFrame &stack)

--- a/src/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
+++ b/src/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
@@ -117,6 +117,12 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::OpenFileNative___VOID
             // file doesn't exist
             NANOCLR_SET_AND_LEAVE(CLR_E_FILE_NOT_FOUND);
         }
+        if (operationResult == FR_OK)
+            {
+                // file created (or opened) succesfully
+                // OK to close it
+                f_close(&file);
+            }
         else
         {
             // failed to create the file
@@ -130,10 +136,6 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::OpenFileNative___VOID
     if (filePath != NULL)
     {
         platform_free(filePath);
-    }
-    if (file != NULL)
-    {
-        f_close(&file);
     }
 
     NANOCLR_CLEANUP_END();
@@ -221,6 +223,9 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::ReadNative___I4__STRI
                 // failed to create the file
                 NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
             }
+            
+            // OK to close it
+            f_close(&file);
         }
         else
         {
@@ -236,10 +241,6 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::ReadNative___I4__STRI
     if (filePath != NULL)
     {
         platform_free(filePath);
-    }
-    if (file != NULL)
-    {
-        f_close(&file);
     }
 
     NANOCLR_CLEANUP_END();
@@ -321,6 +322,9 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::WriteNative___VOID__S
                 // Failed to write to file
                 NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
             }
+
+            // OK to close it
+            f_close(&file);
         }
         else
         {
@@ -335,10 +339,6 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::WriteNative___VOID__S
     if (filePath != NULL)
     {
         platform_free(filePath);
-    }
-    if (file != NULL)
-    {
-        f_close(&file);
     }
 
     NANOCLR_CLEANUP_END();
@@ -402,6 +402,9 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::GetLengthNative___I8_
         {
             // file opened succesfully
             length = f_size(&file);
+
+            // OK to close it
+            f_close(&file);
         }
         else
         {
@@ -417,10 +420,6 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::GetLengthNative___I8_
     if (filePath != NULL)
     {
         platform_free(filePath);
-    }
-    if (file != NULL)
-    {
-        f_close(&file);
     }
 
     NANOCLR_CLEANUP_END();

--- a/src/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
+++ b/src/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
@@ -220,7 +220,7 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::ReadNative___I4__STRI
             operationResult = f_read(&file, buffer, length, &readCount);
             if (operationResult != FR_OK)
             {
-                // failed to create the file
+                // failed to read the file
                 NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
             }
             


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New implementation of System.IO allocates memory and frees it only if fatfs methods return without error. This can lead to memory leak, if for example f_open method fails. I added CLEANUP() sections in native methods for freeing memory allocated on heap and closing file handles.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes memory leak in System.IO
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
