### PR TITLE
Rework of WireProtocol

### DIFF
--- a/src/CLR/Include/WireProtocol.h
+++ b/src/CLR/Include/WireProtocol.h
@@ -125,11 +125,6 @@ typedef struct WP_Message
     WP_Packet      m_header;
     uint8_t*       m_payload;
 
-    uint8_t*       m_pos;
-    uint16_t       m_size;
-    uint64_t       m_payloadTicks;
-    int            m_rxState;
-
     void (*Initialize)(WP_Controller* parent);
     void (*PrepareReception)(void);
     void (*PrepareRequest)(unsigned int cmd, unsigned int flags, unsigned int payloadSize, unsigned char* payload);

--- a/src/CLR/Include/WireProtocol_HAL_Interface.h
+++ b/src/CLR/Include/WireProtocol_HAL_Interface.h
@@ -10,24 +10,23 @@
 
 //////////////////////////////////////////
 
-/// 
+///
 /// @brief Receives n bytes from the Wire Protocol channel.
-/// 
+///
 /// @param ptr Pointer to the buffer that will hold the received bytes.
 /// @param size Number of bytes to read. On return it will have the number of bytes actually received.
 /// @return bool true if any bytes where received, false otherwise.
 ///
-bool WP_ReceiveBytes(uint8_t* ptr, uint16_t *size);
+bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size);
 
-/// 
+///
 /// @brief Sends a message through the Wire Protocol channel.
-/// 
+///
 /// @param message Message to send
 /// @return bool true for transmition succesfull, false otherwise.
 ///
-bool WP_TransmitMessage(WP_Message* message);
+bool WP_TransmitMessage(WP_Message *message);
 
 void WP_CheckAvailableIncomingData();
 
 #endif // _WIREPROTOCOL_HAL_INTERFACE_H_
-

--- a/src/CLR/Include/WireProtocol_HAL_Interface.h
+++ b/src/CLR/Include/WireProtocol_HAL_Interface.h
@@ -9,8 +9,24 @@
 #include "WireProtocol.h"
 
 //////////////////////////////////////////
-int WP_ReceiveBytes(uint8_t* ptr, unsigned short* size);
-int WP_TransmitMessage(WP_Message* message);
+
+/// 
+/// @brief Receives n bytes from the Wire Protocol channel.
+/// 
+/// @param ptr Pointer to the buffer that will hold the received bytes.
+/// @param size Number of bytes to read. On return it will have the number of bytes actually received.
+/// @return bool true if any bytes where received, false otherwise.
+///
+bool WP_ReceiveBytes(uint8_t* ptr, uint16_t *size);
+
+/// 
+/// @brief Sends a message through the Wire Protocol channel.
+/// 
+/// @param message Message to send
+/// @return bool true for transmition succesfull, false otherwise.
+///
+bool WP_TransmitMessage(WP_Message* message);
+
 void WP_CheckAvailableIncomingData();
 
 #endif // _WIREPROTOCOL_HAL_INTERFACE_H_

--- a/src/CLR/Include/WireProtocol_Message.h
+++ b/src/CLR/Include/WireProtocol_Message.h
@@ -12,36 +12,51 @@
 #include "WireProtocol_HAL_Interface.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-#define TRACE_ERRORS 1
+#define TRACE_ERRORS  1
 #define TRACE_HEADERS 2
-#define TRACE_STATE 4
-#define TRACE_NODATA 8
+#define TRACE_STATE   4
+#define TRACE_NODATA  8
 
 #if TRACE_MASK != 0
-#define TRACE0( f, msg ) if((f) & TRACE_MASK ) debug_printf( msg ) 
-#define TRACE( f, msg, ...) if((f) & TRACE_MASK ) debug_printf( msg, __VA_ARGS__ ) 
+#define TRACE0(f, msg)                                                                                                 \
+    if ((f)&TRACE_MASK)                                                                                                \
+    debug_printf(msg)
+#define TRACE(f, msg, ...)                                                                                             \
+    if ((f)&TRACE_MASK)                                                                                                \
+    debug_printf(msg, __VA_ARGS__)
 #else
-#define TRACE0(msg,...)
-#define TRACE(msg,...)
+#define TRACE0(msg, ...)
+#define TRACE(msg, ...)
 #endif
 
 ////////////////////////////////////////////////////
 // function declarations (related with WP_Message)
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-void WP_Message_PrepareReception();
-void WP_Message_Initialize(WP_Message *message);
-void WP_Message_PrepareRequest(WP_Message* message, uint32_t cmd, uint32_t flags, uint32_t payloadSize, uint8_t* payload);
-void WP_Message_PrepareReply(WP_Message* message, const WP_Packet* req, uint32_t flags, uint32_t payloadSize,  uint8_t* payload);
-void WP_Message_SetPayload(WP_Message* message, uint8_t* payload);
-void WP_Message_Release(WP_Message* message);
-int  WP_Message_VerifyHeader(WP_Message* message);
-int  WP_Message_VerifyPayload(WP_Message* message);
-void WP_Message_ReplyBadPacket(uint32_t flags);
-int  WP_Message_Process();
+    void WP_Message_PrepareReception();
+    void WP_Message_Initialize(WP_Message *message);
+    void WP_Message_PrepareRequest(
+        WP_Message *message,
+        uint32_t cmd,
+        uint32_t flags,
+        uint32_t payloadSize,
+        uint8_t *payload);
+    void WP_Message_PrepareReply(
+        WP_Message *message,
+        const WP_Packet *req,
+        uint32_t flags,
+        uint32_t payloadSize,
+        uint8_t *payload);
+    void WP_Message_SetPayload(WP_Message *message, uint8_t *payload);
+    void WP_Message_Release(WP_Message *message);
+    int WP_Message_VerifyHeader(WP_Message *message);
+    int WP_Message_VerifyPayload(WP_Message *message);
+    void WP_Message_ReplyBadPacket(uint32_t flags);
+    int WP_Message_Process();
 
 #ifdef __cplusplus
 }
@@ -51,12 +66,13 @@ int  WP_Message_Process();
 // helper functions
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-void WP_ReplyToCommand(WP_Message* message, int fSuccess, int fCritical, void* ptr, int size);
-void WP_SendProtocolMessage(WP_Message *message);
-void WP_PrepareAndSendProtocolMessage(uint32_t cmd, uint32_t payloadSize, uint8_t* payload, uint32_t flags);
+    void WP_ReplyToCommand(WP_Message *message, int fSuccess, int fCritical, void *ptr, int size);
+    void WP_SendProtocolMessage(WP_Message *message);
+    void WP_PrepareAndSendProtocolMessage(uint32_t cmd, uint32_t payloadSize, uint8_t *payload, uint32_t flags);
 
 #ifdef __cplusplus
 }

--- a/src/CLR/Include/WireProtocol_Message.h
+++ b/src/CLR/Include/WireProtocol_Message.h
@@ -32,8 +32,8 @@
 extern "C" {
 #endif
 
-void WP_Message_Initialize(WP_Message* message);
-void WP_Message_PrepareReception(WP_Message* message);
+void WP_Message_PrepareReception();
+void WP_Message_Initialize(WP_Message *message);
 void WP_Message_PrepareRequest(WP_Message* message, uint32_t cmd, uint32_t flags, uint32_t payloadSize, uint8_t* payload);
 void WP_Message_PrepareReply(WP_Message* message, const WP_Packet* req, uint32_t flags, uint32_t payloadSize,  uint8_t* payload);
 void WP_Message_SetPayload(WP_Message* message, uint8_t* payload);
@@ -41,7 +41,7 @@ void WP_Message_Release(WP_Message* message);
 int  WP_Message_VerifyHeader(WP_Message* message);
 int  WP_Message_VerifyPayload(WP_Message* message);
 void WP_Message_ReplyBadPacket(uint32_t flags);
-int  WP_Message_Process(WP_Message* message);
+int  WP_Message_Process();
 
 #ifdef __cplusplus
 }

--- a/src/CLR/WireProtocol/WireProtocol_HAL_Interface.c
+++ b/src/CLR/WireProtocol/WireProtocol_HAL_Interface.c
@@ -16,7 +16,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 // provided as weak to be replaced by actual implementation by HAL interface
-__nfweak int WP_ReceiveBytes(uint8_t* ptr, unsigned short* size)
+__nfweak bool WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
 {
     (void)(ptr);
     (void)(size);
@@ -26,7 +26,7 @@ __nfweak int WP_ReceiveBytes(uint8_t* ptr, unsigned short* size)
 }
 
 // provided as weak to be replaced by actual implementation by HAL interface
-__nfweak int WP_TransmitMessage(WP_Message* message)
+__nfweak bool WP_TransmitMessage(WP_Message* message)
 {
     (void)(message);
 

--- a/src/CLR/WireProtocol/WireProtocol_HAL_Interface.c
+++ b/src/CLR/WireProtocol/WireProtocol_HAL_Interface.c
@@ -16,7 +16,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 // provided as weak to be replaced by actual implementation by HAL interface
-__nfweak bool WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
+__nfweak bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
 {
     (void)(ptr);
     (void)(size);
@@ -26,7 +26,7 @@ __nfweak bool WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
 }
 
 // provided as weak to be replaced by actual implementation by HAL interface
-__nfweak bool WP_TransmitMessage(WP_Message* message)
+__nfweak bool WP_TransmitMessage(WP_Message *message)
 {
     (void)(message);
 

--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -323,7 +323,7 @@ int WP_Message_Process()
 
                         if (_inboundMessage.m_header.m_size)
                         {
-                            if (_inboundMessage.m_payload == NULL) 
+                            if (_inboundMessage.m_payload == NULL)
                             {
                                 // Bad, no buffer...
                                 _rxState = ReceiveState_Initialize;

--- a/targets/ChibiOS/_common/WireProtocol_HAL_Interface.c
+++ b/targets/ChibiOS/_common/WireProtocol_HAL_Interface.c
@@ -87,8 +87,7 @@ bool WP_TransmitMessage(WP_Message *message)
         message->m_header.m_size);
 
     // write header to output stream
-    writeResult =
-        chnWriteTimeout(&SDU1, (const uint8_t *)&message->m_header, sizeof(message->m_header), TIME_MS2I(10));
+    writeResult = chnWriteTimeout(&SDU1, (const uint8_t *)&message->m_header, sizeof(message->m_header), TIME_MS2I(10));
 
     if (writeResult == sizeof(message->m_header))
     {

--- a/targets/ChibiOS/_common/WireProtocol_HAL_Interface.c
+++ b/targets/ChibiOS/_common/WireProtocol_HAL_Interface.c
@@ -23,6 +23,7 @@ bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
 {
     // save for latter comparison
     uint16_t requestedSize = *size;
+    (void)requestedSize;
 
     // check for request with 0 size
     if (*size)

--- a/targets/ChibiOS/_common/WireProtocol_HAL_Interface.c
+++ b/targets/ChibiOS/_common/WireProtocol_HAL_Interface.c
@@ -17,129 +17,96 @@
 
 WP_Message inboundMessage;
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////
-// The functions below are the ones that need to be ported to new channels/HALs when required
-// These are to be considered as a reference implementations when working on new ports
-// 
-// This reference implementation provides communication through:
-// - serial port (UART/USART) 
-// - serial over USB (USB CDC class device)
-//
-////////////////////////////////////////////////////////////////////////////////////////////////
-
 #if (HAL_USE_SERIAL_USB == TRUE)
 
-int WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
+bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
 {
     // save for latter comparison
     uint16_t requestedSize = *size;
 
-    // sanity check for request of 0 size
-    if(*size)
+    // check for request with 0 size
+    if (*size)
     {
-        //////////////////////////////////////////////////////////
-        //               PORTING CHANGE REQUIRED HERE           //
-        //////////////////////////////////////////////////////////
-        // change here to read (size) bytes from the input stream
-        // preferably with read timeout and being able to check 
-        // if the requested number of bytes was actually read
-        //////////////////////////////////////////////////////////
-
         // read from serial stream with 250ms timeout
-        size_t read = chnReadTimeout(&SDU1, ptr, *size, TIME_MS2I(250)); 
+        size_t read = chnReadTimeout(&SDU1, ptr, *size, TIME_MS2I(250));
 
-        ptr  += read;
+        ptr += read;
         *size -= read;
 
-        TRACE( TRACE_STATE, "RXMSG: Expecting %d bytes, received %d.\n",requestedSize, read);
-        
-        // check if the requested read matches the actual read count
-        return (requestedSize == read);
+        TRACE(TRACE_STATE, "RXMSG: Expecting %d bytes, received %d.\n", requestedSize, read);
+
+        // check if any bytes where read
+        return read > 0;
     }
 
     return true;
 }
 #elif (HAL_USE_SERIAL == TRUE)
 
-int WP_ReceiveBytes(uint8_t* ptr, uint16_t* size)
+bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
 {
     // save for latter comparison
     uint16_t requestedSize = *size;
+    (void)requestedSize;
 
-    // sanity check for request of 0 size
-    if(*size)
+    // check for request with 0 size
+    if (*size)
     {
-        //////////////////////////////////////////////////////////
-        //               PORTING CHANGE REQUIRED HERE           //
-        //////////////////////////////////////////////////////////
-        // change here to read (size) bytes from the input stream
-        // preferably with read timeout and being able to check 
-        // if the requested number of bytes was actually read
-        //////////////////////////////////////////////////////////
-        
-        // non blocking read from serial port with 250ms timeout
-        volatile size_t read = chnReadTimeout(&SERIAL_DRIVER, ptr, *size, TIME_MS2I(250));
+        // non blocking read from serial port with 10ms timeout
+        volatile size_t read = chnReadTimeout(&SERIAL_DRIVER, ptr, *size, TIME_MS2I(10));
 
-        ptr  += read;
+        ptr += read;
         *size -= read;
-        
-        TRACE( TRACE_STATE, "RXMSG: Expecting %d bytes, received %d.\n",requestedSize, read);
 
-        // check if the requested read matches the actual read count
-        return (requestedSize == read);
+        TRACE(TRACE_STATE, "RXMSG: Expecting %d bytes, received %d.\n", requestedSize, read);
+
+        // check if any bytes where read
+        return read > 0;
     }
 
     return true;
 }
 
 #else
-#error "Wire Protocol needs a transport. Please make sure that HAL_USE_SERIAL and/or HAL_USE_SERIAL_USB are set to TRUE in 'halconf.h'"
+#error                                                                                                                 \
+    "Wire Protocol needs a transport. Please make sure that HAL_USE_SERIAL and/or HAL_USE_SERIAL_USB are set to TRUE in 'halconf.h'"
 #endif
 
 #if (HAL_USE_SERIAL_USB == TRUE)
 
-int WP_TransmitMessage(WP_Message* message)
+bool WP_TransmitMessage(WP_Message *message)
 {
     uint32_t writeResult;
     bool operationResult = false;
 
-    ///////////////////////////////////////////////////////////
-    //              PORTING CHANGE REQUIRED HERE             //
-    ///////////////////////////////////////////////////////////
-    // change here to write (size) bytes to the output stream
-    // preferably with timeout and being able to check 
-    // if the write was successful or at least buffered
-    //////////////////////////////////////////////////////////
-
-    TRACE( TRACE_HEADERS, "TXMSG: 0x%08X, 0x%08X, 0x%08X\n", message->m_header.m_cmd, message->m_header.m_flags, message->m_header.m_size );
+    TRACE(
+        TRACE_HEADERS,
+        "TXMSG: 0x%08X, 0x%08X, 0x%08X\n",
+        message->m_header.m_cmd,
+        message->m_header.m_flags,
+        message->m_header.m_size);
 
     // write header to output stream
-    writeResult = chnWriteTimeout(&SDU1, (const uint8_t *)&message->m_header, sizeof(message->m_header), TIME_MS2I(250));
+    writeResult =
+        chnWriteTimeout(&SDU1, (const uint8_t *)&message->m_header, sizeof(message->m_header), TIME_MS2I(10));
 
-    if(writeResult == sizeof(message->m_header))
+    if (writeResult == sizeof(message->m_header))
     {
         operationResult = true;
 
         // if there is anything on the payload send it to the output stream
-        if(message->m_header.m_size && message->m_payload)
+        if (message->m_header.m_size && message->m_payload)
         {
-            ///////////////////////////////////////////////////////////
-            //              PORTING CHANGE REQUIRED HERE             //
-            ///////////////////////////////////////////////////////////
-            // see description above
-            //////////////////////////////////////////////////////////
-
             // reset flag
             operationResult = false;
 
-            writeResult = chnWriteTimeout(&SDU1, message->m_payload, message->m_header.m_size, TIME_MS2I(250));
+            writeResult = chnWriteTimeout(&SDU1, message->m_payload, message->m_header.m_size, TIME_MS2I(50));
 
-            if(writeResult == message->m_header.m_size)
+            if (writeResult == message->m_header.m_size)
             {
                 operationResult = true;
 
-                TRACE0( TRACE_ERRORS, "TXMSG: OK\n");                    
+                TRACE0(TRACE_ERRORS, "TXMSG: OK\n");
             }
         }
     }
@@ -148,47 +115,39 @@ int WP_TransmitMessage(WP_Message* message)
 }
 #elif (HAL_USE_SERIAL == TRUE)
 
-int WP_TransmitMessage(WP_Message* message)
+bool WP_TransmitMessage(WP_Message *message)
 {
     uint32_t writeResult;
     bool operationResult = false;
-    
-    ///////////////////////////////////////////////////////////
-    //              PORTING CHANGE REQUIRED HERE             //
-    ///////////////////////////////////////////////////////////
-    // change here to write (size) bytes to the output stream
-    // preferably with timeout and being able to check 
-    // if the write was sucessfull or at least buffered
-    //////////////////////////////////////////////////////////
-    
-    TRACE( TRACE_HEADERS, "TXMSG: 0x%08X, 0x%08X, 0x%08X\n", message->m_header.m_cmd, message->m_header.m_flags, message->m_header.m_size );
+
+    TRACE(
+        TRACE_HEADERS,
+        "TXMSG: 0x%08X, 0x%08X, 0x%08X\n",
+        message->m_header.m_cmd,
+        message->m_header.m_flags,
+        message->m_header.m_size);
 
     // write header to output stream
-    writeResult = chnWriteTimeout(&SERIAL_DRIVER, (const uint8_t *)&message->m_header, sizeof(message->m_header), TIME_MS2I(250));
+    writeResult =
+        chnWriteTimeout(&SERIAL_DRIVER, (const uint8_t *)&message->m_header, sizeof(message->m_header), TIME_MS2I(10));
 
-    if(writeResult == sizeof(message->m_header))
+    if (writeResult == sizeof(message->m_header))
     {
         operationResult = true;
 
         // if there is anything on the payload send it to the output stream
-        if(message->m_header.m_size && message->m_payload)
+        if (message->m_header.m_size && message->m_payload)
         {
-            ///////////////////////////////////////////////////////////
-            //              PORTING CHANGE REQUIRED HERE             //
-            ///////////////////////////////////////////////////////////
-            // see description above
-            //////////////////////////////////////////////////////////
-
             // reset flag
             operationResult = false;
 
-            writeResult = chnWriteTimeout(&SERIAL_DRIVER, message->m_payload, message->m_header.m_size, TIME_MS2I(250));
+            writeResult = chnWriteTimeout(&SERIAL_DRIVER, message->m_payload, message->m_header.m_size, TIME_MS2I(50));
 
-            if(writeResult == message->m_header.m_size)
+            if (writeResult == message->m_header.m_size)
             {
                 operationResult = true;
 
-                TRACE0( TRACE_ERRORS, "TXMSG: OK\n");                    
+                TRACE0(TRACE_ERRORS, "TXMSG: OK\n");
             }
         }
     }
@@ -197,5 +156,6 @@ int WP_TransmitMessage(WP_Message* message)
 }
 
 #else
-#error "Wire Protocol needs a transport. Please make sure that HAL_USE_SERIAL and/or HAL_USE_SERIAL_USB are set to TRUE in 'halconf.h'"
+#error                                                                                                                 \
+    "Wire Protocol needs a transport. Please make sure that HAL_USE_SERIAL and/or HAL_USE_SERIAL_USB are set to TRUE in 'halconf.h'"
 #endif

--- a/targets/ChibiOS/_common/WireProtocol_ReceiverThread.c
+++ b/targets/ChibiOS/_common/WireProtocol_ReceiverThread.c
@@ -8,8 +8,6 @@
 #include <cmsis_os.h>
 #include <WireProtocol_Message.h>
 
-extern WP_Message inboundMessage;
-
 #if (HAL_USE_SERIAL_USB == TRUE)
 extern SerialUSBDriver SDU1;
 #endif
@@ -17,42 +15,40 @@ extern SerialUSBDriver SDU1;
 // This thread needs to be implemented at ChibiOS level because it has to include a call to chThdShouldTerminateX()
 // in case the thread is requested to terminate by the CMSIS call osThreadTerminate()
 
-__attribute__((noreturn))
-void ReceiverThread(void const * argument)
+__attribute__((noreturn)) void ReceiverThread(void const *argument)
 {
-  (void)argument;
+    (void)argument;
 
-  osDelay(500);
+    osDelay(500);
 
-  // loop until thread receives a request to terminate
-  while (1) {
+    WP_Message_PrepareReception();
 
-  #if (HAL_USE_SERIAL_USB == TRUE)
-    // only bother to wait for WP message is USB is connected
-    if (SDU1.config->usbp->state == USB_ACTIVE)
+    // loop until thread receives a request to terminate
+    while (1)
     {
-  #endif
 
-      WP_Message_Initialize(&inboundMessage);
-      WP_Message_PrepareReception(&inboundMessage);
+#if (HAL_USE_SERIAL_USB == TRUE)
+        // only bother to wait for WP message is USB is connected
+        if (SDU1.config->usbp->state == USB_ACTIVE)
+        {
+#endif
 
-      WP_Message_Process(&inboundMessage);
+            WP_Message_Process();
 
-  #if (HAL_USE_SERIAL_USB == TRUE)
-      // pass control to the OS
-      osThreadYield();
+#if (HAL_USE_SERIAL_USB == TRUE)
+            // pass control to the OS
+            osThreadYield();
+        }
+        else
+        {
+            osDelay(1000);
+        }
+
+#elif (HAL_USE_SERIAL == TRUE)
+        // delay here to give other threads a chance to run
+        osDelay(100);
+#endif
     }
-    else
-    {
-      osDelay(1000);
-    }
 
-  #elif (HAL_USE_SERIAL == TRUE)
-    // delay here to give other threads a chance to run
-    osDelay(100);
-  #endif
-
-  }
-
-  // this function never returns
+    // this function never returns
 }

--- a/targets/FreeRTOS/NXP/_common/WireProtocol_HAL_Interface.c
+++ b/targets/FreeRTOS/NXP/_common/WireProtocol_HAL_Interface.c
@@ -58,6 +58,7 @@ bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
 
     // save for latter comparison
     uint16_t requestedSize = *size;
+    (void)requestedSize;
 
     // check for request with 0 size
     if (*size)
@@ -69,7 +70,7 @@ bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
         *size -= read;
 
         // check if any bytes where read
-        return receivedBytes > 0;
+        return read > 0;
     }
 
     return true;

--- a/targets/FreeRTOS/NXP/_common/WireProtocol_HAL_Interface.c
+++ b/targets/FreeRTOS/NXP/_common/WireProtocol_HAL_Interface.c
@@ -32,7 +32,6 @@ lpuart_rtos_config_t lpuart_config = {
 
 bool WP_Initialise()
 {
-
     NVIC_SetPriority(BOARD_UART_IRQ, 5);
 
     lpuart_config.srcclk = BOARD_DebugConsoleSrcFreq();
@@ -49,17 +48,18 @@ bool WP_Initialise()
     return WP_Port_Intitialised;
 }
 
-int WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
+bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
 {
     // TODO: Initialise Port if not already done, Wire Protocol should be calling this directly at startup
     if (!WP_Port_Intitialised)
+    {
         WP_Initialise();
+    }
 
     // save for latter comparison
     uint16_t requestedSize = *size;
 
-    // int readData = 0;
-    // sanity check for request of 0 size
+    // check for request with 0 size
     if (*size)
     {
         size_t read = 0;
@@ -68,18 +68,19 @@ int WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
         ptr += read;
         *size -= read;
 
-        // check if the requested read matches the actual read count
-        return (requestedSize == read);
+        // check if any bytes where read
+        return receivedBytes > 0;
     }
 
     return true;
 }
 
-int WP_TransmitMessage(WP_Message *message)
+bool WP_TransmitMessage(WP_Message *message)
 {
-
     if (!WP_Port_Intitialised)
+    {
         WP_Initialise();
+    }
 
     if (kStatus_Success != LPUART_RTOS_Send(&handle, (uint8_t *)&message->m_header, sizeof(message->m_header)))
     {

--- a/targets/FreeRTOS/_common/WireProtocol_ReceiverThread.c
+++ b/targets/FreeRTOS/_common/WireProtocol_ReceiverThread.c
@@ -5,30 +5,24 @@
 
 #include "FreeRTOS.h"
 #include "task.h"
-#include "WireProtocol_HAL_Interface.h"
+#include <WireProtocol_HAL_Interface.h>
+#include <WireProtocol_Message.h>
 
-extern WP_Message inboundMessage;
-
-void WP_Message_Initialize(WP_Message* a);
-void WP_Message_PrepareReception(WP_Message* a);
-void WP_Message_Process(WP_Message* a);
-
-
-void ReceiverThread(void * argument)
+void ReceiverThread(void *argument)
 {
-  (void)argument;
+    (void)argument;
 
-  // loop forever
-  while (1) {
+    WP_Message_PrepareReception();
 
-    WP_Message_Initialize(&inboundMessage);
-    WP_Message_PrepareReception(&inboundMessage);
+    // loop forever
+    while (1)
+    {
 
-    WP_Message_Process(&inboundMessage);
+        WP_Message_Process();
 
-    // Allow other tasks a chance to run
-    taskYIELD();
-  }
+        // Allow other tasks a chance to run
+        taskYIELD();
+    }
 
-  // nothing to deinitialize or cleanup, so it's safe to return
+    // nothing to deinitialize or cleanup, so it's safe to return
 }

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/WireProtocol_HAL_Interface.c
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/WireProtocol_HAL_Interface.c
@@ -84,27 +84,20 @@ bool WP_Initialise(COM_HANDLE port)
     return true;
 }
 
-int WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
+bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
 {
     // TODO: Initialise Port if not already done, Wire Protocol should be calling this directly at startup
     if (!WP_Port_Intitialised)
+    {
         WP_Initialise(WP_Port);
+    }
 
     // save for latter comparison
     uint16_t requestedSize = *size;
 
-    // int readData = 0;
-    // sanity check for request of 0 size
+    // check for request with 0 size
     if (*size)
     {
-        //////////////////////////////////////////////////////////
-        //               PORTING CHANGE REQUIRED HERE           //
-        //////////////////////////////////////////////////////////
-        // change here to read (size) bytes from the input stream
-        // preferably with read timeout and being able to check
-        // if the requested number of bytes was actually read
-        //////////////////////////////////////////////////////////
-
         // non blocking read from serial port with 100ms timeout
         volatile size_t read =
             uart_read_bytes(WP_Port, ptr, (uint32_t)requestedSize, (TickType_t)100 / portTICK_PERIOD_MS);
@@ -112,44 +105,37 @@ int WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
         ptr += read;
         *size -= read;
 
-        // check if the requested read matches the actual read count
-        return (requestedSize == read);
+        // check if any bytes where read
+        return receivedBytes > 0;
     }
 
     return true;
 }
 
-int WP_TransmitMessage(WP_Message *message)
+bool WP_TransmitMessage(WP_Message *message)
 {
-    ///////////////////////////////////////////////////////////
-    //              PORTING CHANGE REQUIRED HERE             //
-    ///////////////////////////////////////////////////////////
-    // change here to write (size) bytes to the output stream
-    // preferably with timeout and being able to check
-    // if the write was sucessfull or at least buffered
-    //////////////////////////////////////////////////////////
-
     if (!WP_Port_Intitialised)
+    {
         WP_Initialise(WP_Port);
+    }
 
     // TODO Check if timeout required
     // write header to output stream
-
     if (uart_write_bytes(WP_Port, (const char *)&message->m_header, sizeof(message->m_header)) !=
         sizeof(message->m_header))
-        return false;
+        ~
+        {
+            return false;
+        }
 
     // if there is anything on the payload send it to the output stream
     if (message->m_header.m_size && message->m_payload)
     {
-        ///////////////////////////////////////////////////////////
-        //              PORTING CHANGE REQUIRED HERE             //
-        ///////////////////////////////////////////////////////////
-        // see description above
-        //////////////////////////////////////////////////////////
         if (uart_write_bytes(WP_Port, (const char *)message->m_payload, message->m_header.m_size) !=
             (int)message->m_header.m_size)
+        {
             return false;
+        }
     }
 
     return true;

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/WireProtocol_HAL_Interface.c
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/WireProtocol_HAL_Interface.c
@@ -99,14 +99,13 @@ bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
     if (*size)
     {
         // non blocking read from serial port with 100ms timeout
-        volatile size_t read =
-            uart_read_bytes(WP_Port, ptr, (uint32_t)requestedSize, (TickType_t)100 / portTICK_PERIOD_MS);
+        size_t read = uart_read_bytes(WP_Port, ptr, (uint32_t)requestedSize, (TickType_t)100 / portTICK_PERIOD_MS);
 
         ptr += read;
         *size -= read;
 
         // check if any bytes where read
-        return receivedBytes > 0;
+        return read > 0;
     }
 
     return true;
@@ -123,10 +122,9 @@ bool WP_TransmitMessage(WP_Message *message)
     // write header to output stream
     if (uart_write_bytes(WP_Port, (const char *)&message->m_header, sizeof(message->m_header)) !=
         sizeof(message->m_header))
-        ~
-        {
-            return false;
-        }
+    {
+        return false;
+    }
 
     // if there is anything on the payload send it to the output stream
     if (message->m_header.m_size && message->m_payload)

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/WireProtocol_ReceiverThread.c
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/WireProtocol_ReceiverThread.c
@@ -4,30 +4,24 @@
 //
 
 #include <esp32_os.h>
-#include "WireProtocol_HAL_Interface.h"
+#include <WireProtocol_HAL_Interface.h>
+#include <WireProtocol_Message.h>
 
-extern WP_Message inboundMessage;
-
-void WP_Message_Initialize(WP_Message* a);
-void WP_Message_PrepareReception(WP_Message* a);
-void WP_Message_Process(WP_Message* a);
-
-
-void ReceiverThread(void const * argument)
+void ReceiverThread(void const *argument)
 {
-  (void)argument;
+    (void)argument;
 
-  // loop forever
-  while (1) {
+    WP_Message_PrepareReception();
 
-    WP_Message_Initialize(&inboundMessage);
-    WP_Message_PrepareReception(&inboundMessage);
+    // loop forever
+    while (1)
+    {
 
-    WP_Message_Process(&inboundMessage);
+        WP_Message_Process();
 
-    // Allow other tasks a chance to run
-    vTaskDelay(0);
-  }
+        // Allow other tasks a chance to run
+        vTaskDelay(0);
+    }
 
-  // nothing to deinitialize or cleanup, so it's safe to return
+    // nothing to deinitialize or cleanup, so it's safe to return
 }

--- a/targets/TI-SimpleLink/_common/WireProtocol_HAL_Interface.c
+++ b/targets/TI-SimpleLink/_common/WireProtocol_HAL_Interface.c
@@ -35,7 +35,7 @@ bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
         *size -= read;
 
         // check if any bytes where read
-        return receivedBytes > 0;
+        return read > 0;
     }
 
     return true;

--- a/targets/TI-SimpleLink/_common/WireProtocol_HAL_Interface.c
+++ b/targets/TI-SimpleLink/_common/WireProtocol_HAL_Interface.c
@@ -19,59 +19,32 @@ UART2_Handle uart = NULL;
 
 WP_Message inboundMessage;
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////
-// The functions below are the ones that need to be ported to new channels/HALs when required
-// These are to be considered as a reference implementations when working on new ports
-//
-// This reference implementation provides communication through:
-// - serial port (UART/USART)
-//
-////////////////////////////////////////////////////////////////////////////////////////////////
-
-int WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
+bool WP_ReceiveBytes(uint8_t *ptr, uint16_t *size)
 {
     // save for latter comparison
     uint16_t requestedSize = *size;
     size_t read;
 
-    // int readData = 0;
-    // sanity check for request of 0 size
+    // check for request with 0 size
     if (*size)
     {
-        //////////////////////////////////////////////////////////
-        //               PORTING CHANGE REQUIRED HERE           //
-        //////////////////////////////////////////////////////////
-        // change here to read (size) bytes from the input stream
-        // preferably with read timeout and being able to check
-        // if the requested number of bytes was actually read
-        //////////////////////////////////////////////////////////
-
         // non blocking read from serial port with 500ms timeout
         UART2_readTimeout(uart, ptr, requestedSize, &read, UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod);
 
         ptr += read;
         *size -= read;
 
-        // check if the requested read matches the actual read count
-        return (requestedSize == read);
+        // check if any bytes where read
+        return receivedBytes > 0;
     }
 
     return true;
 }
 
-int WP_TransmitMessage(WP_Message *message)
+bool WP_TransmitMessage(WP_Message *message)
 {
     uint32_t writeResult;
     bool operationResult = false;
-
-    ///////////////////////////////////////////////////////////
-    //              PORTING CHANGE REQUIRED HERE             //
-    ///////////////////////////////////////////////////////////
-    // change here to write (size) bytes to the output stream
-    // preferably with timeout and being able to check
-    // if the write was successfull or at least buffered
-    //////////////////////////////////////////////////////////
 
     TRACE(
         TRACE_HEADERS,
@@ -95,12 +68,6 @@ int WP_TransmitMessage(WP_Message *message)
         // if there is anything on the payload send it to the output stream
         if (message->m_header.m_size && message->m_payload)
         {
-            ///////////////////////////////////////////////////////////
-            //              PORTING CHANGE REQUIRED HERE             //
-            ///////////////////////////////////////////////////////////
-            // see description above
-            //////////////////////////////////////////////////////////
-
             // reset flag
             operationResult = false;
 

--- a/targets/TI-SimpleLink/_common/WireProtocol_ReceiverThread.c
+++ b/targets/TI-SimpleLink/_common/WireProtocol_ReceiverThread.c
@@ -3,28 +3,22 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#include "WireProtocol_HAL_Interface.h"
+#include <WireProtocol_HAL_Interface.h>
+#include <WireProtocol_Message.h>
 #include <ti/sysbios/knl/Task.h>
 #include <xdc/std.h>
-
-extern WP_Message inboundMessage;
-
-void WP_Message_Initialize(WP_Message* a);
-void WP_Message_PrepareReception(WP_Message* a);
-void WP_Message_Process(WP_Message* a);
 
 void ReceiverThread(UArg arg0, UArg arg1)
 {
     (void)arg0;
     (void)arg1;
 
-    // loop forever
-    while (1) 
-    {
-        WP_Message_Initialize(&inboundMessage);
-        WP_Message_PrepareReception(&inboundMessage);
+    WP_Message_PrepareReception();
 
-        WP_Message_Process(&inboundMessage);
+    // loop forever
+    while (1)
+    {
+        WP_Message_Process();
 
         // Allow other tasks a chance to run
         Task_yield();


### PR DESCRIPTION
## Description
- Simplification of WP Message: remove unnecessary parameter passing.
- Improvement of message processing: now it's possible to actually find the header marker on an message
- Significate refactor the WP Message moving vars inside when possible, rename several, simplification on several of the state machine states.
- Simplification of receiver thread on targets: prepare reception is now called only once, process message is now the only call in the loop.
- HAL interface calls now return bool.
- Fix WP_ReceiveBytes to adjust to expected outcome and workflow of process message state machine.

## Motivation and Context
- Global improvement of WP processing and responsiveness.

## How Has This Been Tested?<!-- (if applicable) -->
- Debugger test app.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
