### PR TITLE
Add support to generate DAPLink files

### DIFF
--- a/CMake/Modules/FindBuildUtils.cmake
+++ b/CMake/Modules/FindBuildUtils.cmake
@@ -48,6 +48,30 @@ function(NF_GENERATE_HEX_PACKAGE FILE1 FILE2 OUTPUTFILENAME)
 
 endfunction()
 
+# generates a binary file with nanoBooter + nanoCLR at the proper addresses
+# ready to be drag & drop on targets that feature DAPLink 
+function(NF_GENERATE_BIN_PACKAGE FILE1 FILE2 OFFSET OUTPUTFILENAME)
+
+    add_custom_command(
+            
+        TARGET ${NANOCLR_PROJECT_NAME}.elf POST_BUILD
+
+        COMMAND ${TOOL_SRECORD_PREFIX}/srec_cat
+
+        ${FILE1} -Binary
+        ${FILE2} -Binary -offset 0x${OFFSET}
+        -o ${OUTPUTFILENAME} -Binary
+
+        WORKING_DIRECTORY ${TOOL_SRECORD_PREFIX} 
+
+        COMMENT "exporting hex files to one binary file" 
+    )
+
+    # need to add a dependency of NANOCLR to NANOBOOTER because SRECORD util needs hex outputs of both targets
+    add_dependencies(${NANOCLR_PROJECT_NAME}.elf ${NANOBOOTER_PROJECT_NAME}.elf)
+
+endfunction()
+
 function(NF_GENERATE_BUILD_OUTPUT_FILES TARGET)
 
     # need to remove the .elf suffix from target name

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -284,11 +284,13 @@ jobs:
         BuildOptions: -DTARGET_SERIES=STM32F0xx -DRTOS=CHIBIOS -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DUSE_RNG=OFF -DNF_PLATFORM_NO_CLR_TRACE=ON -DNF_CLR_NO_IL_INLINE=ON -DAPI_Hardware.Stm32=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_System.Device.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_System.Device.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_System.Device.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_nanoFramework.System.Text=ON
         GccArm_Version:
         NeedsDFU: false
+        NeedsSRECORD: true
       ST_STM32F769I_DISCOVERY:
         TargetBoard: ST_STM32F769I_DISCOVERY
         BuildOptions: -DTARGET_SERIES=STM32F7xx -DRTOS=CHIBIOS -DSUPPORT_ANY_BASE_CONVERSION=ON -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DNF_FEATURE_HAS_SDCARD=ON -DAPI_System.Math=ON -DAPI_Hardware.Stm32=ON -DNF_FEATURE_HAS_CONFIG_BLOCK=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_System.Device.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_System.Device.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_System.Device.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Device.Dac=ON -DAPI_System.Net=ON -DNF_SECURITY_MBEDTLS=ON -DAPI_nanoFramework.Devices.OneWire=ON -DAPI_nanoFramework.Devices.Can=ON -DAPI_System.IO.FileSystem=ON -DAPI_nanoFramework.ResourceManager=ON -DAPI_nanoFramework.System.Collections=ON -DAPI_nanoFramework.System.Text=ON -DAPI_nanoFramework.Graphics=ON -DGRAPHICS_MEMORY=Graphics_Memory.cpp -DGRAPHICS_DISPLAY=Otm8009a_DSI_Video_Mode.cpp  -DGRAPHICS_DISPLAY_INTERFACE=DSI_To_Display_Video_Mode.cpp -DTOUCHPANEL_DEVICE=ft6x06_I2C.cpp -DTOUCHPANEL_INTERFACE=I2C_To_TouchPanel.cpp
         GccArm_Version:
-        NeedsDFU: false 
+        NeedsDFU: false
+        NeedsSRECORD: true
 
   variables:
     # creates a counter and assigns it to the revision variable
@@ -301,6 +303,7 @@ jobs:
   - template: azure-pipelines-templates/nb-gitversioning.yml
   - template: azure-pipelines-templates/download-install-arm-gcc-toolchain.yml
   - template: azure-pipelines-templates/download-install-ninja.yml
+  - template: azure-pipelines-templates/download-srecord.yml
   - template: azure-pipelines-templates/download-hexdfu.yml
   - template: azure-pipelines-templates/build-chibios-stm32.yml
   - template: azure-pipelines-templates/pack-publish-artifacts.yml

--- a/targets/ChibiOS/CMakeLists.txt
+++ b/targets/ChibiOS/CMakeLists.txt
@@ -27,6 +27,21 @@ if(DEFINED TOOL_HEX2DFU_PREFIX)
     endif()
 endif()
 
+########################################################
+# check availability of SRecord tool, if specified
+if(DEFINED TOOL_SRECORD_PREFIX)
+    if(NOT ((EXISTS ${TOOL_SRECORD_PREFIX}/srec_cat.exe) OR (EXISTS ${TOOL_SRECORD_PREFIX}/srec_cat)))
+        message(STATUS "")
+        message(STATUS "Couldn't find the srec_cat tool at the specified path: ${TOOL_SRECORD_PREFIX}/srec_cat.exe")
+        message(STATUS "Make sure that the CMake option TOOL_SRECORD_PREFIX has the correct path.")
+        message(STATUS "If you don't have this tool download it from https://sourceforge.net/projects/srecord/files/srecord-win32/")
+        message(STATUS "")
+        message(FATAL_ERROR "srec_cat tool not found")
+    else()
+        set(SRECORD_TOOL_AVAILABLE TRUE CACHE INTERNAL "srec_cat tool available")
+    endif()
+endif()
+
 # check if RTOS_SOURCE_FOLDER was specified or if it's empty (default is empty)
 set(NO_RTOS_SOURCE_FOLDER TRUE)
 if(RTOS_SOURCE_FOLDER)

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
@@ -82,3 +82,27 @@ set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAG
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)
 nf_generate_build_output_files(${NANOCLR_PROJECT_NAME}.elf)
+
+# generate bin file for deployment
+if(SRECORD_TOOL_AVAILABLE)
+
+    ############################################################################################################
+    ## when changing the linker file make sure to update the addresses below with the offset of the CLR image ##
+    ## DO NOT use the leading 0x notation, just the address in plain hexadecimal formating                    ##
+    ############################################################################################################
+
+    if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+        NF_GENERATE_BIN_PACKAGE(
+            ${CMAKE_SOURCE_DIR}/build/${NANOBOOTER_PROJECT_NAME}.bin
+            ${CMAKE_SOURCE_DIR}/build/${NANOCLR_PROJECT_NAME}.bin
+            5000
+            ${CMAKE_SOURCE_DIR}/build/nanobooter-nanoclr.bin)
+    else()
+        NF_GENERATE_BIN_PACKAGE(
+            ${CMAKE_SOURCE_DIR}/build/${NANOBOOTER_PROJECT_NAME}.bin
+            ${CMAKE_SOURCE_DIR}/build/${NANOCLR_PROJECT_NAME}.bin
+            2800
+            ${CMAKE_SOURCE_DIR}/build/nanobooter-nanoclr.bin)
+    endif()
+
+endif()

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/cmake-variants.json
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/cmake-variants.json
@@ -30,6 +30,7 @@
           "CMAKE_TOOLCHAIN_FILE": "CMake/toolchain.arm-none-eabi.cmake",
           "TOOLCHAIN_PREFIX": "<absolute-path-to-the-toolchain-folder-mind-the-forward-slashes>",
           "TOOL_HEX2DFU_PREFIX": "<absolute-path-to-hex2dfu-mind-the-forward-slashes>",
+          "TOOL_SRECORD_PREFIX": "<absolute-path-to-srecord-folder-mind-the-forward-slashes>",
           "TARGET_SERIES": "STM32F0xx",
           "RTOS": "CHIBIOS",
           "RTOS_SOURCE_FOLDER": "",

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/STM32F091xC_CLR-DEBUG.ld
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/STM32F091xC_CLR-DEBUG.ld
@@ -10,6 +10,11 @@
 /*
  * STM32F091xC memory setup.
  */
+
+/*
+* When updating the flash0 address below make sure to update the address in NF_GENERATE_BIN_PACKAGE 
+*/
+
 MEMORY
 {
     flash0     (rx) : org = 0x08005000, len = 256k - 20k - 46k   /* flash size less the space reserved for nanoBooter and application deployment*/

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/STM32F091xC_CLR.ld
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/STM32F091xC_CLR.ld
@@ -10,6 +10,11 @@
 /*
  * STM32F091xC memory setup.
  */
+ 
+/*
+* When updating the flash0 address below make sure to update the address in NF_GENERATE_BIN_PACKAGE 
+*/
+
 MEMORY
 {
     flash0     (rx) : org = 0x08002800, len = 256k - 10k - 88k   /* flash size less the space reserved for nanoBooter and application deployment*/

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/CMakeLists.txt
@@ -88,3 +88,27 @@ set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAG
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)
 nf_generate_build_output_files(${NANOCLR_PROJECT_NAME}.elf)
+
+# generate bin file for deployment
+if(SRECORD_TOOL_AVAILABLE)
+
+    ############################################################################################################
+    ## when changing the linker file make sure to update the addresses below with the offset of the CLR image ##
+    ## DO NOT use the leading 0x notation, just the address in plain hexadecimal formating                    ##
+    ############################################################################################################
+
+    if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+        NF_GENERATE_BIN_PACKAGE(
+            ${CMAKE_SOURCE_DIR}/build/${NANOBOOTER_PROJECT_NAME}.bin
+            ${CMAKE_SOURCE_DIR}/build/${NANOCLR_PROJECT_NAME}.bin
+            10000
+            ${CMAKE_SOURCE_DIR}/build/nanobooter-nanoclr.bin)
+    else()
+        NF_GENERATE_BIN_PACKAGE(
+            ${CMAKE_SOURCE_DIR}/build/${NANOBOOTER_PROJECT_NAME}.bin
+            ${CMAKE_SOURCE_DIR}/build/${NANOCLR_PROJECT_NAME}.bin
+            10000
+            ${CMAKE_SOURCE_DIR}/build/nanobooter-nanoclr.bin)
+    endif()
+
+endif()

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/cmake-variants.json
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/cmake-variants.json
@@ -30,6 +30,7 @@
           "CMAKE_TOOLCHAIN_FILE": "CMake/toolchain.arm-none-eabi.cmake",
           "TOOLCHAIN_PREFIX": "<absolute-path-to-the-toolchain-folder-mind-the-forward-slashes>",
           "TOOL_HEX2DFU_PREFIX": "<absolute-path-to-hex2dfu-mind-the-forward-slashes>",
+          "TOOL_SRECORD_PREFIX": "<absolute-path-to-srecord-folder-mind-the-forward-slashes>",
           "RTOS": "CHIBIOS",
           "TARGET_SERIES": "STM32F7xx",
           "RTOS_SOURCE_FOLDER": "",

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/STM32F76xx_CLR-DEBUG.ld
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/STM32F76xx_CLR-DEBUG.ld
@@ -14,6 +14,7 @@
  *
  * Notes:
  * BSS is placed in DTCM RAM in order to simplify DMA buffers management.
+ * When updating the flash0 address below make sure to update the address in NF_GENERATE_BIN_PACKAGE 
  */
 MEMORY
 {

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/STM32F76xx_CLR.ld
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/STM32F76xx_CLR.ld
@@ -14,6 +14,7 @@
  *
  * Notes:
  * BSS is placed in DTCM RAM in order to simplify DMA buffers management.
+ * When updating the flash0 address below make sure to update the address in NF_GENERATE_BIN_PACKAGE 
  */
 MEMORY
 {


### PR DESCRIPTION
## Description
- Add new function to bin utils that generates DAPLink file.
- Add SRecord util to ChibiOS ST platform.
- Update ST_NUCLEO64_F091RC and ST_STM32F769I_DISCOVERY CMakelists to generate file.
- Update Azure yaml to generate file on build for these targets.

## Motivation and Context
- Adds support to generate DAPLink files.

## How Has This Been Tested?<!-- (if applicable) -->
- Deploying to blank ST_STM32F769I_DISCOVERY using this method. 

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
