### PR TITLE
Improve time sensitive WP requests

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -442,6 +442,8 @@ bool CLR_DBG_Debugger::Monitor_Ping(WP_Message *msg)
         fStopOnBoot = (cmdReply != NULL) && (cmdReply->Flags & Monitor_Ping_c_Ping_DbgFlag_Stop);
     }
 
+    Events_WaitForEvents(0, 50);
+
     if (CLR_EE_DBG_IS_MASK(StateInitialize, StateMask))
     {
         if (fStopOnBoot)
@@ -1285,9 +1287,15 @@ bool CLR_DBG_Debugger::Debugging_Execution_ChangeConditions(WP_Message *msg)
         WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
     }
 
-    // set & reset new conditions
-    g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions |= cmd->FlagsToSet;
-    g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions &= ~cmd->FlagsToReset;
+    // if there is anything to change, need to wait and apply the changes 
+    if(conditionsCopy)
+    {
+        Events_WaitForEvents(0, 50);
+
+        // set & reset new conditions
+        g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions |= cmd->FlagsToSet;
+        g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions &= ~cmd->FlagsToReset;
+    }
 
     return true;
 }

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1287,8 +1287,8 @@ bool CLR_DBG_Debugger::Debugging_Execution_ChangeConditions(WP_Message *msg)
         WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
     }
 
-    // if there is anything to change, need to wait and apply the changes 
-    if(conditionsCopy)
+    // if there is anything to change, need to wait and apply the changes
+    if (conditionsCopy)
     {
         Events_WaitForEvents(0, 50);
 


### PR DESCRIPTION
## Description
- Add delay to WP requests that change execution flags to allow a safe reply before flags are commited.

## Motivation and Context
- Improves responsiveness and reliability in VS debugger interaction,

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
