### PR TITLE
Enable SmartConfig

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Esp32_Wireless.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Esp32_Wireless.cpp
@@ -217,12 +217,8 @@ int Esp32_Wireless_Open(int index, HAL_Configuration_NetworkInterface *pConfig)
 
     if (pWireless->Options & Wireless80211Configuration_ConfigurationOptions_SmartConfig)
     {
-        // FIXME
-        // Disable for now, When the smart_config starts it scans for wireless AP
-        // If it doesn't find any AP it ends up with a exception which causes the device to restart
-
         // Start Smart config (if enabled)
-        // Start_wifi_smart_config();
+        Start_wifi_smart_config();
     }
 
     return Esp32_Wait_NetNumber(ESP_IF_WIFI_STA);


### PR DESCRIPTION
## Description

This was disabled a long time ago due to bug in IDF where the smartconfig would crash if no AP where found.  This problem is fixed in current release v3.3.1


## Motivation and Context
Reported on Discord channel

## How Has This Been Tested?<!-- (if applicable) -->
Tested using the Esp Touch for Esp8622, ESP32 on Android 

With logging enabled

```
NFPKTV1[00][00][00][00][00][00][00][00][00][00][00][00][00]ÿÿ[00][00][01] [00][00][00][00][00][00]I (423) smartconfig: SC version: V2.8.0
NFPKTV1[00][00][00][00][00][00][00][00][00]	[00][00][00][00][00][00][00][01][00][00][00][00][00][00][00]I (4533) wifi: ic_enable_sniffer
[1B][0;32mI (4533) sc: SC_STATUS_FINDING_CHANNEL[1B][0m
I (19023) smartconfig: TYPE: ESPTOUCH
I (19023) smartconfig: T|PHONE MAC:66:e4:98:97:81:c5
I (19023) smartconfig: T|AP MAC:84:c9:b2:a9:88:16
[1B][0;32mI (19023) sc: SC_STATUS_GETTING_SSID_PSWD[1B][0m
I (21913) smartconfig: T|pswd: <REMOVED>
I (21913) smartconfig: T|ssid: <REMOVED>
I (21913) smartconfig: T|bssid: 84:c9:b2:a9:88:16
I (21913) wifi: ic_disable_sniffer
[1B][0;32mI (21913) sc: SC_STATUS_LINK[1B][0m
[1B][0;32mI (21913) sc: SSID:<REMOVED>[1B][0m
[1B][0;32mI (21913) sc: PASSWORD:<REMOVED>[1B][0m
[1B][0;32mI (21953) wifi: WiFi Connect to <REMOVED> result 0[1B][0m
I (22073) wifi: new:<1,1>, old:<1,0>, ap:<255,255>, sta:<1,1>, prof:1
I (22863) wifi: state: init -> auth (b0)
I (22873) wifi: state: auth -> assoc (0)
I (22883) wifi: state: assoc -> run (10)
I (22993) wifi: connected with <REMOVED>, aid = 6, channel 1, 40U, bssid = 84:c9:b2:a9:88:16
I (22993) wifi: security type: 4, phy: bgn, rssi: -84
I (23003) wifi: pm start, type: 1

I (24323) wifi: AP's beacon interval = 102400 us, DTIM period = 1
[1B][0;32mI (27243) event: sta ip: 192.168.2.122, mask: 255.255.255.0, gw: 192.168.2.1[1B][0m
[1B][0;32mI (30273) sc: SC_STATUS_LINK_OVER[1B][0m
[1B][0;32mI (30273) sc: Phone ip: 192.168.2.123
[1B][0m
[1B][0;32mI (30273) sc: smartconfig over[1B][0m
I (43013) wifi: bcn_timout,ap_probe_send_start
I (229083) wifi: bcn_timout,ap_probe_send_start
```
Credentials <REMOVED>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
