### PR TITLE
Fix Wire Protocol build options

### DIFF
--- a/CMake/Modules/FindWireProtocol.cmake
+++ b/CMake/Modules/FindWireProtocol.cmake
@@ -3,14 +3,6 @@
 # See LICENSE file in the project root for full license information.
 #
 
-# handle Wire Protocol _TRACE_ preferences, if any
-option(NF_WP_TRACE_ERRORS "option to Trace errors with Wire Protocol")
-option(NF_WP_TRACE_HEADERS "option to Trace headers with Wire Protocol")
-option(NF_WP_TRACE_STATE "option to Trace state with Wire Protocol")
-option(NF_WP_TRACE_NODATA "option to Trace empty packets with Wire Protocol")
-option(NF_WP_TRACE_ALL "option to Trace  with Wire Protocol")
-option(NF_WP_IMPLEMENTS_CRC32 "option to report if target implements CRC32 in Wire Protocol")
-
 # this one has to follow the declaration on src\CLR\Include\WireProtocol_Message.h
 # #define TRACE_ERRORS 1
 # #define TRACE_HEADERS 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,15 @@ if(RTOS_CHIBIOS_CHECK)
 endif()
 
 #################################################################
+# Wire Protocol options
+option(NF_WP_IMPLEMENTS_CRC32 "option to report if target implements CRC32 in Wire Protocol" ON)
+
+# handle Wire Protocol _TRACE_ preferences, if any
+option(NF_WP_TRACE_ERRORS "option to Trace errors with Wire Protocol")
+option(NF_WP_TRACE_HEADERS "option to Trace headers with Wire Protocol")
+option(NF_WP_TRACE_STATE "option to Trace state with Wire Protocol")
+option(NF_WP_TRACE_NODATA "option to Trace empty packets with Wire Protocol")
+option(NF_WP_TRACE_ALL "option to Trace  with Wire Protocol")
 
 # reports Wire Protocol CRC32 implementation
 if(NF_WP_IMPLEMENTS_CRC32)


### PR DESCRIPTION
## Description
- Build options moved upwards in the build sequence, otherwise they aren't properly picked up.

## Motivation and Context
- The defaults for these build options couldn't be picked up at the location they where.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
