### PR TITLE
Increase priority of network threads for STM32 targets

### DIFF
--- a/targets/ChibiOS/_Include/lwipopts.h
+++ b/targets/ChibiOS/_Include/lwipopts.h
@@ -578,7 +578,7 @@
  * sys_thread_new() when the thread is created.
  */
 #ifndef TCPIP_THREAD_PRIO
-#define TCPIP_THREAD_PRIO (NORMALPRIO)
+#define TCPIP_THREAD_PRIO (NORMALPRIO + 2)
 #endif
 
 /**

--- a/targets/ChibiOS/_Lwip/nf_lwipthread.h
+++ b/targets/ChibiOS/_Lwip/nf_lwipthread.h
@@ -35,7 +35,7 @@
  * @brief   lwIP thread priority.
  */
 #ifndef LWIP_THREAD_PRIORITY
-#define LWIP_THREAD_PRIORITY NORMALPRIO
+#define LWIP_THREAD_PRIORITY (NORMALPRIO + 2)
 #endif
 
 /**


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->

- The priority of the TCP/IP thread has been increased from osPriorityNormal to osPriorityHigh.
- The priority of the LWIP thread has been increased from osPriorityNormal to osPriorityHigh.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
The TCP/IP and the LWIP threads have the same priority as the CLR thread. If the CLR is busy, it's possible that the network communication is interrupted. This leads to a lot of tcp retransmissions and timeout problems.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We have tested this on a custom STM32F427 based target with network capabilities, running an application with a modbus over TCP implementation. If the CLR is busy (e.g. during SD-card write or similar), we can see that the low_level_input function is no longer called regularly, which makes that the read function runs into a timeout.
![LWIP_blocked](https://user-images.githubusercontent.com/54800166/123767641-eb239000-d8c7-11eb-870d-95162230d7b6.PNG)
After increasing the priorities, this problem does no longer occur.
![Scheduling_ok](https://user-images.githubusercontent.com/54800166/123767783-08f0f500-d8c8-11eb-8d05-407b3f9f3bd0.PNG)
We also verified with a stress test, that no problems occur if the data is not read out immediately and the receive buffer is going to be full. The window update mechanism works very well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
