### PR TITLE
Remove GenericPort_Write for SimpleLink

### DIFF
--- a/targets/TI-SimpleLink/_common/GenericPort.cpp
+++ b/targets/TI-SimpleLink/_common/GenericPort.cpp
@@ -39,20 +39,3 @@ extern "C" uint32_t DebuggerPort_WriteProxy(const char *format, ...)
 
     return chars;
 }
-
-uint32_t GenericPort_Write(int portNum, const char *data, size_t size)
-{
-    (void)portNum;
-    size_t bytesWritten;
-
-    if (CLR_EE_DBG_IS_NOT(Enabled))
-    {
-        // debugger port is NOT in use, OK to output to UART
-        // send characters directly to the UART port
-        UART2_writeTimeout(uart, data, size, &bytesWritten, UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod);
-
-        return bytesWritten;
-    }
-
-    return (uint32_t)size;
-}


### PR DESCRIPTION
## Description
- Remove GenericPort_Write for SimpleLink.

## Motivation and Context
- Despite the check for the debugger flag, this is prone to causing issues during transitory conditions when the debugger flag is being set and the device could sending data over the UART, thus potentially causing issues with the Wire Protocol decoding in VS.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
