### PR TITLE
Fix debugger discovery

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -99,8 +99,8 @@ void CLR_DBG_Debugger::Debugger_Discovery()
             break;
         }
 
-        // pause for 250ms so this is not flooding the channel with PING packets
-        Events_WaitForEvents(0, loopCounter * 500);
+        // pause for multiples of 250ms so this is not flooding the channel with PING packets
+        PLATFORM_DELAY(loopCounter * 250);
 
         loopCounter++;
     }

--- a/targets/win32/Include/targetHAL.h
+++ b/targets/win32/Include/targetHAL.h
@@ -8,6 +8,8 @@
 
 // #include <nanoHAL_Power.h>
 
+#define PLATFORM_DELAY(milliSecs) Sleep(milliSecs);
+
 // set min possible number of sockets
 #define PLATFORM_DEPENDENT__SOCKETS_MAX_COUNT 1
 


### PR DESCRIPTION
## Description
- Replace Events_WaitForEvents with PLATFORM_DELAY.

## Motivation and Context
- Resolves issues with debugger discovery on less performant platforms. The call to wait events was bailing out because of UART activity (which triggered an early return) or when the time base isn't yet setup. On these situations the previous fix wasn't working and the UART was being completly flooded with ping packets.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Deployment tests with various apps.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
