### PR TITLE
ChibiOS is now fetched from official SVN repo

### DIFF
--- a/targets/ChibiOS/CMakeLists.txt
+++ b/targets/ChibiOS/CMakeLists.txt
@@ -80,12 +80,12 @@ endif()
 
 if(NO_RTOS_SOURCE_FOLDER)
     # no CHIBIOS source specified, download it from it's repo
-    message(STATUS "RTOS is: ChibiOS ${RTOS_VERSION} from nanoFramework GitHub repo")
+    message(STATUS "RTOS is: ChibiOS ${RTOS_VERSION} from SVN official repo")
 
     FetchContent_Declare(
         chibios
-        GIT_REPOSITORY https://github.com/nanoframework/ChibiOS_mirror
-        GIT_TAG ${RTOS_VERSION}
+        SVN_REPOSITORY https://svn.osdn.net/svnroot/chibios/branches/${RTOS_VERSION}
+        SVN_REVISION -rHEAD
     )
 
 else()
@@ -93,12 +93,13 @@ else()
 
     # sanity check is source path exists
     if(EXISTS ${RTOS_SOURCE_FOLDER}/)
+    
         message(STATUS "RTOS is: ChibiOS ${RTOS_VERSION} (source from: ${RTOS_SOURCE_FOLDER})")
 
         FetchContent_Declare(
             chibios
-            GIT_REPOSITORY ${RTOS_SOURCE_FOLDER}
-            GIT_TAG ${RTOS_VERSION}
+            SVN_REPOSITORY ${RTOS_SOURCE_FOLDER}
+            SVN_REVISION -rHEAD
         )
 
     else()


### PR DESCRIPTION
## Description

## Motivation and Context
- ChibiOS "official" github mirror is no updated and it's missing the latest 21.6.x branch for a month not. After several attempts to have a proper github mirror it was considered not worth the effort to setup and maintain. As a result the CMake was changed to fetch the sources from the official SVN repository. The option to source from a local folder keeps being valid.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
