### PR TITLE
Remove need for source control in chibios

### DIFF
--- a/targets/ChibiOS/CMakeLists.txt
+++ b/targets/ChibiOS/CMakeLists.txt
@@ -92,16 +92,14 @@ else()
     # ChibiOS source was specified
 
     # sanity check is source path exists
-    if(EXISTS ${RTOS_SOURCE_FOLDER}/)
+    if(EXISTS ${RTOS_SOURCE_FOLDER}/) # TODO: should also check content!
         if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
-            message(STATUS "RTOS is: ChibiOS ${RTOS_VERSION} (source from: ${RTOS_SOURCE_FOLDER}) and has to be cloned with svn.")
-
+            message(STATUS "RTOS is: ChibiOS ${RTOS_VERSION} (source from: ${RTOS_SOURCE_FOLDER})")
             FetchContent_Declare(
                 chibios
-                SVN_REPOSITORY ${RTOS_SOURCE_FOLDER}
-                SVN_REVISION -rHEAD
-            )     
-        else()
+                SOURCE_DIR ${RTOS_SOURCE_FOLDER}
+            )
+        else() # Probably not required (currently used by dev container!)
             message(STATUS "RTOS is: ChibiOS ${RTOS_VERSION} (source from: ${RTOS_SOURCE_FOLDER}) and has to be cloned with: git svn clone RUL -rHEAD.")
 
             FetchContent_Declare(
@@ -135,13 +133,12 @@ if(CHIBIOS_CONTRIB_REQUIRED)
         # ChibiOS-Contrib source was specified
 
         # sanity check is source path exists
-        if(EXISTS ${CHIBIOS_CONTRIB_SOURCE}/)
+        if(EXISTS ${CHIBIOS_CONTRIB_SOURCE}/) # TODO: should also check content!
             message(STATUS "ChibiOS-Contrib (source from: ${CHIBIOS_CONTRIB_SOURCE})")
 
             FetchContent_Declare(
                 chibios-contrib
-                GIT_REPOSITORY ${CHIBIOS_CONTRIB_SOURCE}
-                GIT_TAG nanoframework
+                SOURCE_DIR ${CHIBIOS_CONTRIB_SOURCE}
             )
 
         else()
@@ -200,13 +197,12 @@ if(NF_FEATURE_HAS_SDCARD OR NF_FEATURE_HAS_USB_MSD)
         # FatFS source was specified
 
         # sanity check is source path exists
-        if(EXISTS ${FATFS_SOURCE}/)
+        if(EXISTS ${FATFS_SOURCE}/) # TODO: should also check content!
             message(STATUS "FatFS ${FATFS_VERSION_TAG} source from: ${FATFS_SOURCE})")
 
             FetchContent_Declare(
                 fatfs
-                GIT_REPOSITORY ${FATFS_SOURCE}
-                GIT_TAG ${FATFS_VERSION_TAG}
+                SOURCE_DIR ${FATFS_SOURCE}
             )
 
         else()
@@ -259,14 +255,13 @@ if(NF_SECURITY_MBEDTLS)
         # message(FATAL_ERROR ${mbedtls_SOURCE_DIR}") 
 
         # sanity check is source path exists
-        if(EXISTS ${MBEDTLS_SOURCE}/)
+        if(EXISTS ${MBEDTLS_SOURCE}/) # TODO: should also check content!
 
-            message(STATUS "mbedTLS ${FATFS_VERSION_TAG} (source from: ${MBEDTLS_SOURCE})")
+            message(STATUS "mbedTLS source from: ${MBEDTLS_SOURCE}")
             
             FetchContent_Declare(
                 mbedtls
-                GIT_REPOSITORY ${MBEDTLS_SOURCE}
-                GIT_TAG ${MBEDTLS_GIT_TAG}
+                SOURCE_DIR ${MBEDTLS_SOURCE}
             )
 
         else()

--- a/targets/ChibiOS/CMakeLists.txt
+++ b/targets/ChibiOS/CMakeLists.txt
@@ -92,21 +92,26 @@ else()
     # ChibiOS source was specified
 
     # sanity check is source path exists
-    if(EXISTS ${RTOS_SOURCE_FOLDER}/) # TODO: should also check content!
+    if(EXISTS ${RTOS_SOURCE_FOLDER}/)
         if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
+
             message(STATUS "RTOS is: ChibiOS ${RTOS_VERSION} (source from: ${RTOS_SOURCE_FOLDER})")
             FetchContent_Declare(
                 chibios
                 SOURCE_DIR ${RTOS_SOURCE_FOLDER}
             )
-        else() # Probably not required (currently used by dev container!)
-            message(STATUS "RTOS is: ChibiOS ${RTOS_VERSION} (source from: ${RTOS_SOURCE_FOLDER}) and has to be cloned with: git svn clone RUL -rHEAD.")
+
+        else()
+            # running on *nix requires setting up a local git repo from SVN
+            # with git svn clone https://svn.osdn.net/svnroot/chibios/branches/${RTOS_VERSION} -rHEAD
+            message(STATUS "RTOS is: ChibiOS ${RTOS_VERSION} (source from: ${RTOS_SOURCE_FOLDER})")
 
             FetchContent_Declare(
                 chibios
                 GIT_REPOSITORY ${RTOS_SOURCE_FOLDER}
                 GIT_TAG master
             )
+
         endif()
     else()
         message(FATAL_ERROR "Couldn't find ChibiOS source at ${RTOS_SOURCE_FOLDER}/")
@@ -133,7 +138,7 @@ if(CHIBIOS_CONTRIB_REQUIRED)
         # ChibiOS-Contrib source was specified
 
         # sanity check is source path exists
-        if(EXISTS ${CHIBIOS_CONTRIB_SOURCE}/) # TODO: should also check content!
+        if(EXISTS ${CHIBIOS_CONTRIB_SOURCE}/)
             message(STATUS "ChibiOS-Contrib (source from: ${CHIBIOS_CONTRIB_SOURCE})")
 
             FetchContent_Declare(
@@ -197,7 +202,7 @@ if(NF_FEATURE_HAS_SDCARD OR NF_FEATURE_HAS_USB_MSD)
         # FatFS source was specified
 
         # sanity check is source path exists
-        if(EXISTS ${FATFS_SOURCE}/) # TODO: should also check content!
+        if(EXISTS ${FATFS_SOURCE}/)
             message(STATUS "FatFS ${FATFS_VERSION_TAG} source from: ${FATFS_SOURCE})")
 
             FetchContent_Declare(
@@ -255,9 +260,9 @@ if(NF_SECURITY_MBEDTLS)
         # message(FATAL_ERROR ${mbedtls_SOURCE_DIR}") 
 
         # sanity check is source path exists
-        if(EXISTS ${MBEDTLS_SOURCE}/) # TODO: should also check content!
+        if(EXISTS ${MBEDTLS_SOURCE}/)
 
-            message(STATUS "mbedTLS source from: ${MBEDTLS_SOURCE}")
+        message(STATUS "mbedTLS ${MBEDTLS_GIT_TAG} (source from: ${MBEDTLS_SOURCE})")
             
             FetchContent_Declare(
                 mbedtls


### PR DESCRIPTION
when using local source versions of libs.


## Description


## Motivation and Context
When using local source folders for chibios (or libs) it currently requires the folders to already be initialized by Git or SVN.
This PR removes that need.

TODO: (if required to make it better):
* As a fallback, download the sources from the latest release bin,
* Remove the linux (dev container) difference.

## How Has This Been Tested?
Tested using a local source folder of chibios on an OrgPal3.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
