### PR TITLE
Fix ChibiOS HAL build

### DIFF
--- a/CMake/Modules/FindChibiOS_F0_HAL.cmake
+++ b/CMake/Modules/FindChibiOS_F0_HAL.cmake
@@ -6,9 +6,8 @@
 include(FetchContent)
 FetchContent_GetProperties(chibios)
 
-include(binutils.ChibiOS)
-
 # set include directories for ChibiOS HAL
+list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${CHIBIOS_BOARD_DEFINITIONS_PATH})
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/common/ARMCMx)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/include)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/STM32/STM32F0xx)
@@ -119,6 +118,8 @@ set(CHIBIOS_HAL_SRCS
 
     # OSAL 
     osal.c
+
+    board.c
 )
 
 foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
@@ -154,6 +155,8 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
 
             ${OSHAL_PATH}
 
+            ${CHIBIOS_BOARD_DEFINITIONS_PATH}
+
         CMAKE_FIND_ROOT_PATH_BOTH
     )
 
@@ -165,8 +168,6 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
 
 endforeach()
 
-NF_ADD_BOARD_CONFIG_FILE()
-
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(CHIBIOS_F0_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(ChibiOS_F0_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)

--- a/CMake/Modules/FindChibiOS_F4_HAL.cmake
+++ b/CMake/Modules/FindChibiOS_F4_HAL.cmake
@@ -6,9 +6,8 @@
 include(FetchContent)
 FetchContent_GetProperties(chibios)
 
-include(binutils.ChibiOS)
-
 # set include directories for ChibiOS HAL
+list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${CHIBIOS_BOARD_DEFINITIONS_PATH})
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/common/ARMCMx)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/include)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/STM32/STM32F4xx)
@@ -132,6 +131,8 @@ set(CHIBIOS_HAL_SRCS
 
     # OSAL 
     osal.c
+
+    board.c
 )
 
 foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
@@ -171,6 +172,8 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
             ${chibios_SOURCE_DIR}/os/hal/ports/STM32/LLD/xWDGv1
 
             ${OSHAL_PATH}
+            
+            ${CHIBIOS_BOARD_DEFINITIONS_PATH}
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )
@@ -183,8 +186,6 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
 
 endforeach()
 
-NF_ADD_BOARD_CONFIG_FILE()
-
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(CHIBIOS_F4_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(ChibiOS_F4_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)

--- a/CMake/Modules/FindChibiOS_F7_HAL.cmake
+++ b/CMake/Modules/FindChibiOS_F7_HAL.cmake
@@ -6,9 +6,8 @@
 include(FetchContent)
 FetchContent_GetProperties(chibios)
 
-include(binutils.ChibiOS)
-
 # set include directories for ChibiOS HAL
+list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${CHIBIOS_BOARD_DEFINITIONS_PATH})
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/common/ARMCMx)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/include)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/STM32/STM32F7xx)
@@ -133,6 +132,8 @@ set(CHIBIOS_HAL_SRCS
 
     # OSAL 
     osal.c
+
+    board.c
 )
 
 foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
@@ -172,6 +173,8 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
 
             ${OSHAL_PATH}
 
+            ${CHIBIOS_BOARD_DEFINITIONS_PATH}
+
         CMAKE_FIND_ROOT_PATH_BOTH
     )
 
@@ -183,8 +186,6 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
 
 endforeach()
 
-NF_ADD_BOARD_CONFIG_FILE()
-
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(CHIBIOS_F7_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(ChibiOS_F7_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)

--- a/CMake/Modules/FindChibiOS_H7_HAL.cmake
+++ b/CMake/Modules/FindChibiOS_H7_HAL.cmake
@@ -6,9 +6,8 @@
 include(FetchContent)
 FetchContent_GetProperties(chibios)
 
-include(binutils.ChibiOS)
-
 # set include directories for ChibiOS HAL
+list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${CHIBIOS_BOARD_DEFINITIONS_LOCATION})
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/common/ARMCMx)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/include)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/STM32/STM32H7xx)
@@ -134,6 +133,8 @@ set(CHIBIOS_HAL_SRCS
 
     # OSAL 
     osal.c
+
+    board.c
 )
 
 foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
@@ -175,6 +176,8 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
 
             ${OSHAL_PATH}
 
+            ${CHIBIOS_BOARD_DEFINITIONS_PATH}
+
         CMAKE_FIND_ROOT_PATH_BOTH
     )
 
@@ -186,8 +189,6 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
 
 endforeach()
 
-NF_ADD_BOARD_CONFIG_FILE()
-
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(CHIBIOS_H7_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(ChibiOS_H7_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)

--- a/CMake/Modules/FindChibiOS_L0_HAL.cmake
+++ b/CMake/Modules/FindChibiOS_L0_HAL.cmake
@@ -6,9 +6,8 @@
 include(FetchContent)
 FetchContent_GetProperties(chibios)
 
-include(binutils.ChibiOS)
-
 # set include directories for ChibiOS HAL
+list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${CHIBIOS_BOARD_DEFINITIONS_PATH})
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/common/ARMCMx)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/include)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/STM32/STM32L0xx)
@@ -123,6 +122,8 @@ set(CHIBIOS_HAL_SRCS
 
     # OSAL 
     osal.c
+
+    board.c
 )
 
 foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
@@ -157,6 +158,8 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
 
             ${OSHAL_PATH}
 
+            ${CHIBIOS_BOARD_DEFINITIONS_PATH}
+
         CMAKE_FIND_ROOT_PATH_BOTH
     )
 
@@ -168,8 +171,6 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
 
 endforeach()
 
-NF_ADD_BOARD_CONFIG_FILE()
-
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(CHIBIOS_L0_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(ChibiOS_L0_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)

--- a/CMake/Modules/FindChibiOS_L4_HAL.cmake
+++ b/CMake/Modules/FindChibiOS_L4_HAL.cmake
@@ -7,6 +7,7 @@ include(FetchContent)
 FetchContent_GetProperties(chibios)
 
 # set include directories for ChibiOS HAL
+list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${CHIBIOS_BOARD_DEFINITIONS_PATH})
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/common/ARMCMx)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/ports/STM32/STM32L4xx)
 list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os/hal/include)
@@ -133,6 +134,8 @@ set(CHIBIOS_HAL_SRCS
 
     # OSAL 
     osal.c
+
+    board.c
 )
 
 foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
@@ -171,8 +174,9 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
             ${chibios_SOURCE_DIR}/os/hal/ports/STM32/LLD/USARTv2
             ${chibios_SOURCE_DIR}/os/hal/ports/STM32/LLD/xWDGv1
 
-
             ${OSHAL_PATH}
+            
+            ${CHIBIOS_BOARD_DEFINITIONS_PATH}
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )
@@ -185,8 +189,6 @@ foreach(SRC_FILE ${CHIBIOS_HAL_SRCS})
 
 endforeach()
 
-NF_ADD_BOARD_CONFIG_FILE()
-
 include(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(CHIBIOS_L4_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(ChibiOS_L4_HAL DEFAULT_MSG CHIBIOS_HAL_INCLUDE_DIRS CHIBIOS_HAL_SOURCES)

--- a/CMake/binutils.ChibiOS.cmake
+++ b/CMake/binutils.ChibiOS.cmake
@@ -140,8 +140,8 @@ macro(NF_ADD_PLATFORM_INCLUDE_DIRECTORIES TARGET)
 
     target_include_directories(${TARGET}.elf PUBLIC
 
-        ${CHIBIOS_INCLUDE_DIRS}
         ${CHIBIOS_HAL_INCLUDE_DIRS}
+        ${CHIBIOS_INCLUDE_DIRS}
         ${ChibiOSnfOverlay_INCLUDE_DIRS}
         ${CHIBIOS_CONTRIB_INCLUDE_DIRS}
         ${${TARGET_STM32_CUBE_PACKAGE}_CubePackage_INCLUDE_DIRS}
@@ -191,8 +191,8 @@ macro(NF_ADD_PLATFORM_SOURCES TARGET)
 
         ${${TARGET_STM32_CUBE_PACKAGE}_CubePackage_SOURCES}
 
-        ${CHIBIOS_SOURCES}
         ${CHIBIOS_HAL_SOURCES}
+        ${CHIBIOS_SOURCES}
         ${ChibiOSnfOverlay_SOURCES}
     )
 
@@ -237,62 +237,5 @@ macro(NF_ADD_PLATFORM_SOURCES TARGET)
         SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMBEDTLS_CONFIG_FILE=\"<${CMAKE_SOURCE_DIR}/src/PAL/COM/sockets/ssl/mbedTLS/nf_mbedtls_config.h>\"")
         SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMBEDTLS_CONFIG_FILE=\"<${CMAKE_SOURCE_DIR}/src/PAL/COM/sockets/ssl/mbedTLS/nf_mbedtls_config.h>\"")
     endif()
-
-endmacro()
-
-# Add board.c file and path for board.h to ChibiOS HAL
-# To be called from target series HAL CMake module
-macro(NF_ADD_BOARD_CONFIG_FILE)
-
-    # adjust search path here
-    if(RTOS_CHIBIOS_CHECK)
-
-        set(RTOS_PATH ${CMAKE_SOURCE_DIR}/targets/ChibiOS)
-        set(RTOS_COMMUNITY_PATH ${CMAKE_SOURCE_DIR}/targets-community/ChibiOS)
-
-    elseif(RTOS_AZURERTOS_CHECK)
-
-        set(RTOS_PATH ${CMAKE_SOURCE_DIR}/targets/AzureRTOS/ST)
-        set(RTOS_COMMUNITY_PATH ${CMAKE_SOURCE_DIR}/targets-community/AzureRTOS/ST)
-
-    else()
-        message(FATAL_ERROR "Unsuported RTOS using ChibiOS HAL")
-    endif()
-
-    set(CHIBIOS_SRC_FILE SRC_FILE -NOTFOUND)
-
-    find_file(CHIBIOS_SRC_FILE board.c
-        PATHS 
-
-            # the following hint order is for the board.c file, it has to match the search order of the main CMake otherwise we'll pick one that is the pair
-            # this path hint is for OEM boards for which the board file(s) are probably located directly in the "target" folder along with remaining files
-            ${RTOS_PATH}/${TARGET_BOARD}
-        
-            # this path hint is for the alternative boards folder in the nanoFramework ChibiOS 'overlay'
-            ${RTOS_PATH}/_nf-overlay/os/hal/boards/${TARGET_BOARD}
-            
-            # this path hint is for the usual location of the board.c file
-            ${chibios_SOURCE_DIR}/os/hal/boards/${TARGET_BOARD}
-
-            # this path hint is for the alternative boards folder in the nanoFramework ChibiOS 'overlay' provideded by the community
-            ${RTOS_COMMUNITY_PATH}/_nf-overlay/os/hal/boards/${TARGET_BOARD}
-
-            # this path hint is for Community provided boards that are located directly in the "targets-community" folder
-            ${RTOS_COMMUNITY_PATH}/${TARGET_BOARD}
-
-        CMAKE_FIND_ROOT_PATH_BOTH
-    )
-
-    if (BUILD_VERBOSE)
-        message("board.c >> ${CHIBIOS_SRC_FILE}")
-    endif()
-
-    # get path to board.h file
-    string(REPLACE "/board.c" "" BOARD_HEADER_PATH "${CHIBIOS_SRC_FILE}")
-    
-    # include path for board.h
-    list(APPEND CHIBIOS_HAL_INCLUDE_DIRS ${BOARD_HEADER_PATH})
-
-    list(APPEND CHIBIOS_HAL_SOURCES ${CHIBIOS_SRC_FILE})
 
 endmacro()

--- a/targets/ChibiOS/CMakeLists.txt
+++ b/targets/ChibiOS/CMakeLists.txt
@@ -313,6 +313,7 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/targets/ChibiOS/_nf-overlay/os/hal/boards/${TARGET
     # board found
     # if it's on nF overlay board.c and board.h exist there for sure
     set(CHIBIOS_BOARD_DEFINITIONS_LOCATION "Board definition files taken from nanoFramework overlay" CACHE INTERNAL "Location of board definition files")
+    set(CHIBIOS_BOARD_DEFINITIONS_PATH ${CMAKE_SOURCE_DIR}/targets/ChibiOS/_nf-overlay/os/hal/boards/${TARGET_BOARD} CACHE INTERNAL "Path of board definition files")
 else()
     # board NOT found in ChibiOS 'overlay'
 
@@ -324,6 +325,7 @@ else()
             EXISTS ${CMAKE_SOURCE_DIR}/targets/ChibiOS/${TARGET_BOARD}/board.h)
             # definition files found
             set(CHIBIOS_BOARD_DEFINITIONS_LOCATION "Board definition files taken from target folder" CACHE INTERNAL "Location of board definition files")
+            set(CHIBIOS_BOARD_DEFINITIONS_PATH ${CMAKE_SOURCE_DIR}/targets/ChibiOS/${TARGET_BOARD} CACHE INTERNAL "Path of board definition files")
 
         else()
             # board.c and board.h are NOT in the target folder, try to find them in the official distribution
@@ -332,6 +334,7 @@ else()
                 # board found
                 # if it's on the ChibiOS official distribution board.c and board.h exist here for sure
                 set(CHIBIOS_BOARD_DEFINITIONS_LOCATION "Board definition files taken from official ChibiOS distribution" CACHE INTERNAL "Location of board definition files")
+                set(CHIBIOS_BOARD_DEFINITIONS_PATH ${chibios_SOURCE_DIR}/os/hal/boards/${TARGET_BOARD} CACHE INTERNAL "Path of board definition files")
 
             else()
                 # board NOT found in official distribution


### PR DESCRIPTION
## Description
- Board header file was being fetched from wrong location on some targets.
- Simplification of the board definitions finding.

## Motivation and Context
- Fixes build of ChibiOS targets.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
