### PR TITLE
Fix RX in TI SimpleLink

### DIFF
--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_common.h.in
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_common.h.in
@@ -50,9 +50,9 @@
 
 /////////////////////////////////////
 #if defined(DEBUG)
-    #define MANAGED_HEAP_SIZE       (28*1024)
+    #define MANAGED_HEAP_SIZE       (23*1024)
 #else
-    #define MANAGED_HEAP_SIZE       (37*1024)
+    #define MANAGED_HEAP_SIZE       (36*1024)
 #endif
 /////////////////////////////////////
 

--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_system_io_serial_config.cpp
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_system_io_serial_config.cpp
@@ -17,6 +17,6 @@ __attribute__((aligned(32)))
 uint8_t Uart1_TxBuffer[UART1_TX_SIZE];
 
 #if defined(__GNUC__)
-__attribute__((aligned (32)))
+__attribute__((aligned(32)))
 #endif
 uint8_t Uart1_RxBuffer[UART1_RX_SIZE];

--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_system_io_serial_config.cpp
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_system_io_serial_config.cpp
@@ -15,3 +15,8 @@
 __attribute__((aligned(32)))
 #endif
 uint8_t Uart1_TxBuffer[UART1_TX_SIZE];
+
+#if defined(__GNUC__)
+__attribute__((aligned (32)))
+#endif
+uint8_t Uart1_RxBuffer[UART1_RX_SIZE];

--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_system_io_serial_config.h
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_system_io_serial_config.h
@@ -11,5 +11,5 @@
 #define NF_SERIAL_COMM_TI_USE_UART1 TRUE
 
 // buffers size
-#define UART1_TX_SIZE  256
-#define UART1_RX_SIZE  256
+#define UART1_TX_SIZE 256
+#define UART1_RX_SIZE 256

--- a/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_system_io_serial_config.h
+++ b/targets/TI-SimpleLink/TI_CC1352R1_LAUNCHXL/target_system_io_serial_config.h
@@ -11,4 +11,5 @@
 #define NF_SERIAL_COMM_TI_USE_UART1 TRUE
 
 // buffers size
-#define UART1_TX_SIZE 256
+#define UART1_TX_SIZE  256
+#define UART1_RX_SIZE  256

--- a/targets/TI-SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_target.h
+++ b/targets/TI-SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_target.h
@@ -19,10 +19,14 @@ typedef struct
     UART2_Params UartParams;
     uint8_t UartNum;
 
+    Task_Handle WorkingTask;
+
     HAL_RingBuffer<uint8_t> TxRingBuffer;
     uint8_t *TxBuffer;
     uint16_t TxOngoingCount;
 
+    HAL_RingBuffer<uint8_t> RxRingBuffer;
+    uint8_t *RxBuffer;
     uint16_t RxBytesToRead;
 
     bool IsLongRunning;
@@ -37,12 +41,7 @@ typedef struct
 extern NF_PAL_UART Uart1_PAL;
 #endif
 
-/////////////////////////////////////
-// UART Tx buffers                 //
-// these live in the target folder //
-/////////////////////////////////////
-extern uint8_t Uart1_TxBuffer[];
-
 #define UART_TX_BUFFER_SIZE(num) UART##num##_TX_SIZE
+#define UART_RX_BUFFER_SIZE(num) UART##num##_RX_SIZE
 
 #endif //_SYS_IO_SER_NATIVE_TARGET_H_


### PR DESCRIPTION
## Description
- Add RX ring buffer.
- Update declarations and target config files.
- Fix initialization of UART PAL struct.
- Replace implementation of RX with blocking task because SimpleLink UART2 API doesn't have an RX event.

## Motivation and Context
- Resolves issues cause by poor with TI SimpleLink UART2 API.
- Until their UART2 API has a proper RX event this workaround has to be here. 
- For reference reported [here](https://e2e.ti.com/support/wireless-connectivity/sub-1-ghz-group/sub-1-ghz/f/sub-1-ghz-forum/1019108/launchxl-cc1352r1-uart-receive-interrupt/).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Serial sample from samples repo.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
