### PR TITLE
Fix WireProtocol Receive processing

### DIFF
--- a/src/CLR/Include/WireProtocol.h
+++ b/src/CLR/Include/WireProtocol.h
@@ -58,13 +58,13 @@ typedef enum WP_Flags
 // enum with machine states for Wire Procotol receiver
 typedef enum ReceiveState
 {
-    ReceiveState_Idle             = 1,
-    ReceiveState_Initialize       = 2,
-    ReceiveState_WaitingForHeader = 3,
-    ReceiveState_ReadingHeader    = 4,
-    ReceiveState_CompleteHeader   = 5,
-    ReceiveState_ReadingPayload   = 6,
-    ReceiveState_CompletePayload  = 7,
+    ReceiveState_Idle             = (uint8_t)1,
+    ReceiveState_Initialize       = (uint8_t)2,
+    ReceiveState_WaitingForHeader = (uint8_t)3,
+    ReceiveState_ReadingHeader    = (uint8_t)4,
+    ReceiveState_CompleteHeader   = (uint8_t)5,
+    ReceiveState_ReadingPayload   = (uint8_t)6,
+    ReceiveState_CompletePayload  = (uint8_t)7,
 }ReceiveState;
 
 // enum with CLR monitor commands

--- a/src/CLR/Include/WireProtocol_HAL_Interface.h
+++ b/src/CLR/Include/WireProtocol_HAL_Interface.h
@@ -15,9 +15,8 @@
 ///
 /// @param ptr Pointer to the buffer that will hold the received bytes.
 /// @param size Number of bytes to read. On return it will have the number of bytes actually received.
-/// @return bool true if any bytes where received, false otherwise.
 ///
-uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size);
+void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size);
 
 ///
 /// @brief Sends a message through the Wire Protocol channel.

--- a/src/CLR/WireProtocol/WireProtocol_HAL_Interface.c
+++ b/src/CLR/WireProtocol/WireProtocol_HAL_Interface.c
@@ -16,13 +16,10 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 // provided as weak to be replaced by actual implementation by HAL interface
-__nfweak uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
+__nfweak void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
 {
     (void)(ptr);
     (void)(size);
-
-    // default to false
-    return false;
 }
 
 // provided as weak to be replaced by actual implementation by HAL interface

--- a/targets/ChibiOS/_common/WireProtocol_HAL_Interface.c
+++ b/targets/ChibiOS/_common/WireProtocol_HAL_Interface.c
@@ -18,7 +18,7 @@
 
 #if (HAL_USE_SERIAL_USB == TRUE)
 
-uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
+void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
 {
     // save for later comparison
     uint32_t requestedSize = *size;
@@ -28,28 +28,18 @@ uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
     if (*size)
     {
         // read from serial stream with 100ms timeout
-        size_t read = chnReadTimeout(&SDU1, ptr, requestedSize, TIME_MS2I(100));
+        size_t read = chnReadTimeout(&SDU1, *ptr, requestedSize, TIME_MS2I(100));
 
-        // check if any bytes where read
-        if (read == 0)
-        {
-            return false;
-        }
-
-        ptr += read;
+        *ptr += read;
         *size -= read;
 
         TRACE(TRACE_STATE, "RXMSG: Expecting %d bytes, received %d.\n", requestedSize, read);
     }
-
-    return true;
 }
 #elif (HAL_USE_SERIAL == TRUE)
 
-uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
+void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
 {
-    volatile uint32_t read;
-
     // save for later comparison
     uint32_t requestedSize = *size;
     (void)requestedSize;
@@ -58,21 +48,13 @@ uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
     if (*size)
     {
         // non blocking read from serial port with 100ms timeout
-        read = chnReadTimeout(&SERIAL_DRIVER, ptr, requestedSize, TIME_MS2I(20));
+        size_t read = chnReadTimeout(&SERIAL_DRIVER, *ptr, requestedSize, TIME_MS2I(100));
 
         TRACE(TRACE_STATE, "RXMSG: Expecting %d bytes, received %d.\n", requestedSize, read);
 
-        // check if any bytes where read
-        if (read == 0)
-        {
-            return false;
-        }
-
-        ptr += read;
+        *ptr += read;
         *size -= read;
     }
-
-    return true;
 }
 
 #else

--- a/targets/FreeRTOS/NXP/_common/WireProtocol_HAL_Interface.c
+++ b/targets/FreeRTOS/NXP/_common/WireProtocol_HAL_Interface.c
@@ -46,7 +46,7 @@ bool WP_Initialise()
     return WP_Port_Intitialised;
 }
 
-uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
+void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
 {
     // TODO: Initialise Port if not already done, Wire Protocol should be calling this directly at startup
     if (!WP_Port_Intitialised)
@@ -61,19 +61,11 @@ uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
     if (*size)
     {
         size_t read = 0;
-        LPUART_RTOS_Receive(&handle, ptr, requestedSize, &read);
+        LPUART_RTOS_Receive(&handle, *ptr, requestedSize, &read);
 
-        // check if any bytes where read
-        if (read == 0)
-        {
-            return false;
-        }
-
-        ptr += read;
+        *ptr += read;
         *size -= read;
     }
-
-    return true;
 }
 
 uint8_t WP_TransmitMessage(WP_Message *message)

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/WireProtocol_HAL_Interface.c
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/common/WireProtocol_HAL_Interface.c
@@ -82,7 +82,7 @@ bool WP_Initialise(COM_HANDLE port)
     return true;
 }
 
-uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
+void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
 {
     // TODO: Initialise Port if not already done, Wire Protocol should be calling this directly at startup
     if (!WP_Port_Intitialised)
@@ -97,25 +97,11 @@ uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
     if (*size)
     {
         // non blocking read from serial port with 100ms timeout
-        size_t read = uart_read_bytes(WP_Port, ptr, (uint32_t)requestedSize, (TickType_t)100 / portTICK_PERIOD_MS);
+        size_t read = uart_read_bytes(WP_Port, *ptr, (uint32_t)requestedSize, (TickType_t)100 / portTICK_PERIOD_MS);
 
-        // check if any bytes where read
-        if (read == 0)
-        {
-            return false;
-        }
-
-        // check if any bytes where read
-        if (read == 0)
-        {
-            return false;
-        }
-
-        ptr += read;
+        *ptr += read;
         *size -= read;
     }
-
-    return true;
 }
 
 uint8_t WP_TransmitMessage(WP_Message *message)

--- a/targets/TI-SimpleLink/_common/WireProtocol_HAL_Interface.c
+++ b/targets/TI-SimpleLink/_common/WireProtocol_HAL_Interface.c
@@ -17,7 +17,7 @@
 
 UART2_Handle uart = NULL;
 
-uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
+void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
 {
     // save for later comparison
     uint32_t requestedSize = *size;
@@ -27,19 +27,11 @@ uint8_t WP_ReceiveBytes(uint8_t *ptr, uint32_t *size)
     if (*size)
     {
         // non blocking read from serial port with 500ms timeout
-        UART2_readTimeout(uart, ptr, requestedSize, &read, UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod);
+        UART2_readTimeout(uart, *ptr, requestedSize, &read, UART_TIMEOUT_MILLISECONDS / Clock_tickPeriod);
 
-        // check if any bytes where read
-        if (read == 0)
-        {
-            return false;
-        }
-
-        ptr += read;
+        *ptr += read;
         *size -= read;
     }
-
-    return true;
 }
 
 uint8_t WP_TransmitMessage(WP_Message *message)


### PR DESCRIPTION
## Description
- Update declaration of WP_ReceiveBytes to pass position argument by reference and remove return.
- Update code and declarations on all platform implementations.
- Remove unnused globals in WP Message.
- Fix code in ReceiveState_ReadingHeader state.
- Add cast to ReceiveState enum to make sure of correct type.

## Motivation and Context
- Resolves nanoFramework/Home#785.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
