### PR TITLE
Remove serial configuration from ST_NUCLEO64_F091RC

### DIFF
--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/main.c
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/main.c
@@ -17,12 +17,6 @@
 // need to declare the Receiver thread here
 osThreadDef(ReceiverThread, osPriorityHigh, 512, "ReceiverThread");
 
-// configuration for debugger serial port
-// dev notes:
-// conservative baud rate value as 921600 has a high error percentage on baud rate clocking
-// OVER8 bit on CR1 to further decrease baud rate clocking error
-static const SerialConfig uartConfig = {460800, USART_CR1_OVER8, USART_CR2_STOP1_BITS, 0};
-
 // Application entry point.
 int main(void)
 {
@@ -63,7 +57,7 @@ int main(void)
 #endif
 
     // starts the serial driver
-    sdStart(&SERIAL_DRIVER, &uartConfig);
+    sdStart(&SERIAL_DRIVER, NULL);
 
     // create the receiver thread
     osThreadCreate(osThread(ReceiverThread), NULL);

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/main.c
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/main.c
@@ -31,12 +31,6 @@ osThreadDef(ReceiverThread, osPriorityHigh, 512, "ReceiverThread");
 // declare CLRStartup thread here
 osThreadDef(CLRStartupThread, osPriorityNormal, 4096, "CLRStartupThread");
 
-// configuration for debugger serial port
-// dev notes:
-// conservative baud rate value as 921600 has a high error percentage on baud rate clocking
-// OVER8 bit on CR1 to further decrease baud rate clocking error
-static const SerialConfig uartConfig = {460800, USART_CR1_OVER8, USART_CR2_STOP1_BITS, 0};
-
 //  Application entry point.
 int main(void)
 {
@@ -76,7 +70,7 @@ int main(void)
 #endif
 
     // starts the serial driver
-    sdStart(&SERIAL_DRIVER, &uartConfig);
+    sdStart(&SERIAL_DRIVER, NULL);
 
     // create the receiver thread
     osThreadCreate(osThread(ReceiverThread), NULL);


### PR DESCRIPTION
## Description
- Remove serial configuration from ST_NUCLEO64_F091RC.

## Motivation and Context
- Not required anymore after ChibiOS v21.6.x.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
