### PR TITLE
Added monitor parent pid param to the RUN command

### DIFF
--- a/targets/netcore/nanoFramework.nanoCLR.CLI/RunCommandLineOptions.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/RunCommandLineOptions.cs
@@ -37,6 +37,10 @@ namespace nanoFramework.nanoCLR.CLI
         [Option("clrversion", Required = false, HelpText = "Get nanoCLR version running on the virtual device")]
         public bool CLRVersion { get; set; }
 
+        [Option('m', "monitorparentpid", Required = false, HelpText = "Parent process id to monitor - exit if the parent exits")]
+        public int? MonitorParentPid { get; set; }
+
+
         /// <summary>
         /// Allowed values:
         /// q[uiet]

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/RunCommandProcessor.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/RunCommandProcessor.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
@@ -104,9 +105,29 @@ namespace nanoFramework.nanoCLR.CLI
                 hostBuilder.UsePortTrace();
             }
 
+            if (options.MonitorParentPid != null)
+            {
+                try
+                {
+                    Process parentProcess = Process.GetProcessById((int)options.MonitorParentPid);
+                    parentProcess.EnableRaisingEvents = true;
+                    parentProcess.Exited += ParentProcess_Exited;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to find parent process with pid: {options.MonitorParentPid} message: {ex.Message}");
+                }
+            }
+
             hostBuilder.Build().Run();
 
             return 0;
+        }
+
+        private static void ParentProcess_Exited(object sender, EventArgs e)
+        {
+            Console.WriteLine("Exiting due to parent process ending");
+            Environment.Exit(0);        // force exit of this process since the parent has exited/died
         }
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Added monitor parent pid parm to the RUN command.  The caller passes their PID into the CLI and the CLI will force exit if the parent exits before the child.  This prevents children from being left abandoned if VS or VSTest exits abnormally.
- New parm: monitorparentpid [integer] - the parent callers process id
- New callback if the parent process exits then the CLR.CLI.exe process will force exit

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Prevents abandoned CLR.CLI processes from being left around when VS or VSTest exit abnormally

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using an experimental version of the nanoFramework extension and Visual Studio.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
