### PR TITLE
Fix TLS issue with ESP32 builds

### DIFF
--- a/CMake/Modules/FindNF_Network.cmake
+++ b/CMake/Modules/FindNF_Network.cmake
@@ -9,6 +9,16 @@ list(APPEND NF_Network_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/PAL/COM/sockets/ssl)
 list(APPEND NF_Network_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/PAL/Lwip)
 list(APPEND NF_Network_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/DeviceInterfaces/Networking.Sntp)
 
+if(USE_SECURITY_MBEDTLS_OPTION)
+    list(APPEND NF_Network_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/PAL/COM/sockets/ssl/mbedTLS)
+endif()
+
+if(USE_ENC28J60_DRIVER_OPTION)
+    list(APPEND NF_Network_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/DeviceInterfaces/Network/Enc28j60)
+    list(APPEND NF_Network_Driver_Path ${CMAKE_SOURCE_DIR}/src/DeviceInterfaces/Network/Enc28j60)
+    set(Use_Networking_Extra_Driver TRUE)
+endif()
+
 # source files for nanoFramework Networking
 set(NF_Network_SRCS
 
@@ -166,6 +176,11 @@ macro(nf_add_lib_network)
 
     # add this has a library
     set(LIB_NAME NF_Network)
+
+    if(RTOS_FREERTOS_ESP32_CHECK)
+        # IDF it's using tweaked version of mbedTLS, so clear ours
+        unset(mbedTLS_SOURCES)
+    endif()
 
     add_library(
         ${LIB_NAME} STATIC 

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/CMakeLists.txt
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/CMakeLists.txt
@@ -60,7 +60,11 @@ if(USE_NETWORKING_OPTION)
             ${CMAKE_CURRENT_SOURCE_DIR}
             ${CMAKE_CURRENT_SOURCE_DIR}/Include
             ${TARGET_ESP32_IDF_INCLUDES}
-        EXTRA_COMPILE_OPTIONS -mfix-esp32-psram-cache-issue)
+    )
+
+    if(USE_PSRAM_FIX)
+        target_compile_options(NF_Network PUBLIC "-mfix-esp32-psram-cache-issue")
+    endif()
 
 endif()
 
@@ -139,7 +143,7 @@ foreach( IDF_libraries ${PROJECT_LINK_LIBS} )
 endforeach( IDF_libraries )
 
 if(USE_NETWORKING_OPTION)
-    set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_FLAGS " -L${CMAKE_CURRENT_BINARY_DIR} -lNF_Network " )
+    set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_FLAGS " -Wl,--whole-archive -L${CMAKE_CURRENT_BINARY_DIR} -lNF_Network -Wl,--no-whole-archive " )
 endif()
 
 set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_FLAGS " -Wl,--whole-archive -L${CMAKE_CURRENT_BINARY_DIR} -lNanoApiLib -Wl,--no-whole-archive " )
@@ -149,7 +153,6 @@ set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf    APPEND_STRING PROPERTY LINK_F
 # Set Includes & compile definition for Network library
 if(USE_NETWORKING_OPTION)
 
-    # target_compile_definitions(NetworkLib PUBLIC -DPLATFORM_ESP32)
     set (EXTRA_LIBS ${EXTRA_LIBS} nano::NF_Network)
     target_link_libraries(${NANOCLR_PROJECT_NAME}.elf ${EXTRA_LIBS})
     SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}" )
@@ -158,7 +161,7 @@ if(USE_NETWORKING_OPTION)
     set_target_properties(NF_Network PROPERTIES COMPILE_FLAGS " -w " )
 endif()
 
- target_include_directories(NanoApiLib PUBLIC
+target_include_directories(NanoApiLib PUBLIC
     # directories for nanoFramework libraries
     ${CMAKE_CURRENT_BINARY_DIR}/nanoCLR
     ${CMAKE_CURRENT_SOURCE_DIR}/Include

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Memory.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Memory.cpp
@@ -30,7 +30,7 @@ static const char *TAG = "Memory";
 
 // You can't go much bigger than this when allocating in normal memory to
 // get memory in one continuous lump.
-#define NORMAL_MEMORY_SIZE (90 * 1024)
+#define NORMAL_MEMORY_SIZE (84 * 1024)
 
 // Saved memory allocation for when heap is reset so we can return same value.
 unsigned char *pManagedHeap = NULL;


### PR DESCRIPTION
## Description
- Remove official mbedTLS sources from build for ESP32.
- Adjusted inclusion on network library in ESP32 build.
- Decrease managed heap size for ESP32 variants without PSRAM.

## Motivation and Context
- Fixes (again) issues with low memory available for TLS operation.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
