### PR TITLE
Fix TRACE calls

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -15,20 +15,6 @@
 
 #define __min(a, b) (((a) < (b)) ? (a) : (b))
 
-#if 0
-#define TRACE0(msg, ...) debug_printf(msg)
-#define TRACE(msg, ...)  debug_printf(msg, __VA_ARGS__) 
-char const* const AccessMemoryModeNames[] = {
-"AccessMemory_Check",
-"AccessMemory_Read", 
-"AccessMemory_Write",
-"AccessMemory_Erase"
-};
-#else
-#define TRACE0(msg, ...)
-#define TRACE(msg, ...)
-#endif
-
 //--//
 
 extern const CLR_RT_NativeAssemblyData *g_CLR_InteropAssembliesNativeData[];
@@ -652,7 +638,6 @@ void CLR_DBG_Debugger::AccessMemory(
     uint32_t *errorCode)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    TRACE("AccessMemory( 0x%08X, 0x%08x, 0x%08X, %s)\n", location, lengthInBytes, buf, AccessMemoryModeNames[mode]);
 
     bool proceed = false;
 
@@ -706,7 +691,7 @@ void CLR_DBG_Debugger::AccessMemory(
                 // AccessMemory_Check to free memory.
                 if (!CheckPermission(accessAddress, mode))
                 {
-                    TRACE0("=> Permission check failed!\n");
+                    // Permission check failed
 
                     // set error code
                     *errorCode = AccessMemoryErrorCode_PermissionDenied;
@@ -746,7 +731,7 @@ void CLR_DBG_Debugger::AccessMemory(
 
                                 if (!bufPtr)
                                 {
-                                    TRACE0("=> Failed to allocate data buffer\n");
+                                    // Failed to allocate data buffer
 
                                     // set error code
                                     *errorCode = AccessMemoryErrorCode_FailedToAllocateReadBuffer;
@@ -858,12 +843,7 @@ void CLR_DBG_Debugger::AccessMemory(
 
         if ((sectAddr < ramStartAddress) || (sectAddr >= ramEndAddress) || (sectAddrEnd > ramEndAddress))
         {
-            TRACE(
-                " Invalid address %x and range %x Ram Start %x, Ram end %x\r\n",
-                sectAddr,
-                lengthInBytes,
-                ramStartAddress,
-                ramEndAddress);
+            // Invalid address and range
             return;
         }
         else
@@ -895,8 +875,6 @@ void CLR_DBG_Debugger::AccessMemory(
             }
         }
     }
-
-    TRACE0("=> SUCCESS\n");
 
     *errorCode = AccessMemoryErrorCode_NoError;
 }

--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -328,7 +328,7 @@ void WP_Message_Process()
                         "RXMSG: 0x%08X, 0x%08X, 0x%08X\n",
                         _inboundMessage.m_header.m_cmd,
                         _inboundMessage.m_header.m_flags,
-                        _inboundMessage.m_header._size);
+                        _inboundMessage.m_header.m_size);
 
                     if (WP_App_ProcessHeader(&_inboundMessage))
                     {
@@ -364,7 +364,7 @@ void WP_Message_Process()
 
             case ReceiveState_ReadingPayload:
 
-                TRACE(TRACE_STATE, "RxState=ReadingPayload. Expecting %d bytes.\n", message->_size);
+                TRACE(TRACE_STATE, "RxState=ReadingPayload. Expecting %d bytes.\n", _inboundMessage.m_header.m_size);
 
                 // If the time between consecutive payload bytes exceeds the timeout threshold then assume that
                 // the rest of the payload is not coming. Reinitialize to sync with the next header.
@@ -416,7 +416,7 @@ void WP_SendProtocolMessage(WP_Message *message)
         "TXMSG: 0x%08X, 0x%08X, 0x%08X\n",
         message->m_header.m_cmd,
         message->m_header.m_flags,
-        message->m_header._size);
+        message->m_header.m_size);
     WP_TransmitMessage(message);
 }
 
@@ -433,7 +433,7 @@ void WP_PrepareAndSendProtocolMessage(uint32_t cmd, uint32_t payloadSize, uint8_
         "TXMSG: 0x%08X, 0x%08X, 0x%08X\n",
         message.m_header.m_cmd,
         message.m_header.m_flags,
-        message.m_header._size);
+        message.m_header.m_size);
 
     WP_TransmitMessage(&message);
 }


### PR DESCRIPTION
## Description
- Remove TRACE entirely from debugger class.
- Fix calls to trace in WP_Message_Process.

## Motivation and Context
- Current TRACE use in debugger class is pretty useless and the defines there are conflicting with the ones in Wire Protocol header.
- Fixed TRACE in Wire Protocol (far more important).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
