### PR TITLE
Improvements in TRACE for Wire Protocol

### DIFF
--- a/.vscode/cmake-variants.TEMPLATE.json
+++ b/.vscode/cmake-variants.TEMPLATE.json
@@ -66,6 +66,7 @@
           "NF_WP_TRACE_HEADERS": "OFF-default-ON-to-enable-trace-header-messages-wire-protocol",
           "NF_WP_TRACE_STATE": "OFF-default-ON-to-enable-trace-state-messages-wire-protocol",
           "NF_WP_TRACE_NODATA": "OFF-default-ON-to-enable-trace-no-data-messages-wire-protocol",
+          "NF_WP_TRACE_VERBOSE": "OFF-default-ON-to-enable-trace-verbose-state-messages-wire-protocol",
           "NF_WP_TRACE_ALL": "OFF-default-ON-to-enable-trace-all-messages-wire-protocol",
           "NF_WP_IMPLEMENTS_CRC32": "OFF-default-OFF-to-disable-CRC32-wire-protocol",
           "NF_FEATURE_DEBUGGER": "OFF-default-ON-to-include-managed-app-debugging-capability",

--- a/CMake/Modules/FindWireProtocol.cmake
+++ b/CMake/Modules/FindWireProtocol.cmake
@@ -24,8 +24,11 @@ endif()
 if(NF_WP_TRACE_NODATA)
     math(EXPR WP_TRACE_MASK "${WP_TRACE_MASK} + 8")
 endif()
+if(NF_WP_TRACE_VERBOSE)
+    math(EXPR WP_TRACE_MASK "${WP_TRACE_MASK} + 16")
+endif()
 if(NF_WP_TRACE_ALL)
-    math(EXPR WP_TRACE_MASK "8 + 4 + 2 + 1")
+    math(EXPR WP_TRACE_MASK "16 + 8 + 4 + 2 + 1")
 endif()
 
 message(STATUS "Wire Protocol TRACE_MASK is '${WP_TRACE_MASK}'") # debug helper

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,7 +438,8 @@ option(NF_WP_TRACE_ERRORS "option to Trace errors with Wire Protocol")
 option(NF_WP_TRACE_HEADERS "option to Trace headers with Wire Protocol")
 option(NF_WP_TRACE_STATE "option to Trace state with Wire Protocol")
 option(NF_WP_TRACE_NODATA "option to Trace empty packets with Wire Protocol")
-option(NF_WP_TRACE_ALL "option to Trace  with Wire Protocol")
+option(NF_WP_TRACE_VERBOSE "option to Trace more detailed state with Wire Protocol. ")
+option(NF_WP_TRACE_ALL "option to Trace ALL information with Wire Protocol.")
 
 # reports Wire Protocol CRC32 implementation
 if(NF_WP_IMPLEMENTS_CRC32)

--- a/CMakeSettings.SAMPLE.json
+++ b/CMakeSettings.SAMPLE.json
@@ -114,6 +114,11 @@
           "type": "BOOL"
         },
         {
+          "name": "NF_WP_TRACE_VERBOSE",
+          "value": "OFF",
+          "type": "BOOL"
+        },
+        {
           "name": "NF_WP_TRACE_ALL",
           "value": "OFF",
           "type": "BOOL"
@@ -385,6 +390,11 @@
         },
         {
           "name": "NF_WP_TRACE_NODATA",
+          "value": "OFF",
+          "type": "BOOL"
+        },
+        {
+          "name": "NF_WP_TRACE_VERBOSE",
           "value": "OFF",
           "type": "BOOL"
         },

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -319,6 +319,10 @@
           "value": "OFF"
         },
         {
+          "name": "NF_WP_TRACE_VERBOSE:BOOL", //OFF-default-ON-to-enable-trace-verbose-state-messages-wire-protocol
+          "value": "OFF"
+        },
+        {
           "name": "NF_WP_TRACE_ALL:BOOL", //OFF-default-ON-to-enable-trace-all-messages-wire-protocol
           "value": "OFF"
         },

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -15,20 +15,6 @@
 
 #define __min(a, b) (((a) < (b)) ? (a) : (b))
 
-#if 0
-#define TRACE0(msg, ...) debug_printf(msg)
-#define TRACE(msg, ...)  debug_printf(msg, __VA_ARGS__) 
-char const* const AccessMemoryModeNames[] = {
-"AccessMemory_Check",
-"AccessMemory_Read", 
-"AccessMemory_Write",
-"AccessMemory_Erase"
-};
-#else
-#define TRACE0(msg, ...)
-#define TRACE(msg, ...)
-#endif
-
 //--//
 
 extern const CLR_RT_NativeAssemblyData *g_CLR_InteropAssembliesNativeData[];
@@ -652,7 +638,6 @@ void CLR_DBG_Debugger::AccessMemory(
     uint32_t *errorCode)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
-    TRACE("AccessMemory( 0x%08X, 0x%08x, 0x%08X, %s)\n", location, lengthInBytes, buf, AccessMemoryModeNames[mode]);
 
     bool proceed = false;
 
@@ -706,7 +691,7 @@ void CLR_DBG_Debugger::AccessMemory(
                 // AccessMemory_Check to free memory.
                 if (!CheckPermission(accessAddress, mode))
                 {
-                    TRACE0("=> Permission check failed!\n");
+                    // Permission check failed
 
                     // set error code
                     *errorCode = AccessMemoryErrorCode_PermissionDenied;
@@ -746,7 +731,7 @@ void CLR_DBG_Debugger::AccessMemory(
 
                                 if (!bufPtr)
                                 {
-                                    TRACE0("=> Failed to allocate data buffer\n");
+                                    // Failed to allocate data buffer
 
                                     // set error code
                                     *errorCode = AccessMemoryErrorCode_FailedToAllocateReadBuffer;
@@ -858,12 +843,7 @@ void CLR_DBG_Debugger::AccessMemory(
 
         if ((sectAddr < ramStartAddress) || (sectAddr >= ramEndAddress) || (sectAddrEnd > ramEndAddress))
         {
-            TRACE(
-                " Invalid address %x and range %x Ram Start %x, Ram end %x\r\n",
-                sectAddr,
-                lengthInBytes,
-                ramStartAddress,
-                ramEndAddress);
+            // Invalid address and range
             return;
         }
         else
@@ -895,8 +875,6 @@ void CLR_DBG_Debugger::AccessMemory(
             }
         }
     }
-
-    TRACE0("=> SUCCESS\n");
 
     *errorCode = AccessMemoryErrorCode_NoError;
 }

--- a/src/CLR/Include/WireProtocol_Message.h
+++ b/src/CLR/Include/WireProtocol_Message.h
@@ -16,6 +16,7 @@
 #define TRACE_HEADERS 2
 #define TRACE_STATE   4
 #define TRACE_NODATA  8
+#define TRACE_VERBOSE 16
 
 #if defined(TRACE_MASK) && TRACE_MASK != 0
 #define TRACE0(f, msg)                                                                                                 \
@@ -24,9 +25,33 @@
 #define TRACE(f, msg, ...)                                                                                             \
     if ((f)&TRACE_MASK)                                                                                                \
     debug_printf(msg, __VA_ARGS__)
+
+#if defined(TRACE_MASK) && (TRACE_MASK & TRACE_VERBOSE) != 0
+#define TRACE0_LIMIT(f, modCount, msg)                                                                                 \
+    if (((traceLoopCounter++) % modCount == 0) && (f)&TRACE_MASK)                                                      \
+    debug_printf(msg)
+#define TRACE_LIMIT(f, modCount, msg, ...)                                                                             \
+    if (((traceLoopCounter++) % modCount == 0) && (f)&TRACE_MASK)                                                      \
+    debug_printf(msg, __VA_ARGS__)
+#endif
+
 #else
 #define TRACE0(msg, ...)
 #define TRACE(msg, ...)
+#define TRACE0_LIMIT(...)
+#define TRACE_LIMIT(...)
+#endif
+
+#if defined(TRACE_MASK) && TRACE_MASK & TRACE_HEADERS != 0
+#define WP_TXMSG            "TXMSG: "
+#define WP_RXMSG            "RXMSG: "
+#define WP_RXMSG_Hdr_OK     "RXHOK: "
+#define WP_RXMSG_Payload_Ok "RXPOK: "
+#define WP_RXMSG_NAK        "RXNAK: "
+void WP_TraceHeader(const char *pstrLabel, WP_Message *message);
+#define TRACE_WP_HEADER(l, m) WP_TraceHeader(l, m)
+#else
+#define TRACE_WP_HEADER(l, m)
 #endif
 
 ////////////////////////////////////////////////////

--- a/src/CLR/Messaging/Messaging.cpp
+++ b/src/CLR/Messaging/Messaging.cpp
@@ -197,7 +197,7 @@ bool CLR_Messaging::App_ProcessHeader(void *state, WP_Message *msg)
 
     if (!pThis->ProcessHeader(msg))
     {
-        TRACE0("ProcessHeader() indicated invalid header!\n");
+        TRACE0(TRACE_HEADERS, "ProcessHeader() indicated invalid header!\n");
         return false;
     }
 
@@ -207,7 +207,7 @@ bool CLR_Messaging::App_ProcessHeader(void *state, WP_Message *msg)
 
         if (ptr == NULL)
         {
-            TRACE0("Failed to allocate 0x%08X bytes for message payload!\n");
+            TRACE0(TRACE_HEADERS, "Failed to allocate 0x%08X bytes for message payload!\n");
             return false;
         }
 
@@ -331,7 +331,7 @@ bool CLR_Messaging::ProcessHeader(WP_Message *msg)
     (void)msg;
 
     NATIVE_PROFILE_CLR_MESSAGING();
-    TRACE("MSG: 0x%08X\n", msg->m_header.m_cmd);
+    TRACE(TRACE_HEADERS, "MSG: 0x%08X\n", msg->m_header.m_cmd);
     return true;
 }
 

--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -20,6 +20,11 @@ static uint8_t *_pos;
 static uint32_t _size;
 static WP_Message _inboundMessage;
 
+#if defined(TRACE_MASK) && (TRACE_MASK & TRACE_VERBOSE) != 0
+// used WP_Message_Process() and methods it calls to avoid flooding TRACE
+static uint32_t traceLoopCounter = 0;
+#endif
+
 #ifdef DEBUG
 volatile uint8_t _rxStatePrev;
 #endif
@@ -246,7 +251,9 @@ void WP_Message_Process()
                 break;
 
             case ReceiveState_WaitingForHeader:
-                TRACE0(TRACE_STATE, "RxState==WaitForHeader\n");
+                // Warning: Includeing TRACE_VERBOSE will NOT output the following TRACE on every loop
+                //          of the statemachine to avoid flooding the trace.
+                TRACE0_LIMIT(TRACE_VERBOSE, 100, "RxState==WaitForHeader\n");
 
                 WP_ReceiveBytes(&_pos, &_size);
 
@@ -319,16 +326,11 @@ void WP_Message_Process()
 
             case ReceiveState_CompleteHeader:
 
-                TRACE0(TRACE_STATE, "RxState=CompleteHeader\n");
+                TRACE0(TRACE_STATE, "RxState==CompleteHeader\n");
 
                 if (WP_Message_VerifyHeader(&_inboundMessage))
                 {
-                    TRACE(
-                        TRACE_HEADERS,
-                        "RXMSG: 0x%08X, 0x%08X, 0x%08X\n",
-                        _inboundMessage.m_header.m_cmd,
-                        _inboundMessage.m_header.m_flags,
-                        _inboundMessage.m_header.m_size);
+                    TRACE_WP_HEADER(WP_RXMSG_Hdr_OK, &_inboundMessage);
 
                     if (WP_App_ProcessHeader(&_inboundMessage))
                     {
@@ -364,7 +366,7 @@ void WP_Message_Process()
 
             case ReceiveState_ReadingPayload:
 
-                TRACE(TRACE_STATE, "RxState=ReadingPayload. Expecting %d bytes.\n", _inboundMessage.m_header.m_size);
+                TRACE(TRACE_STATE, "RxState==ReadingPayload. Expecting %d bytes.\n", _inboundMessage.m_header.m_size);
 
                 // If the time between consecutive payload bytes exceeds the timeout threshold then assume that
                 // the rest of the payload is not coming. Reinitialize to sync with the next header.
@@ -391,10 +393,15 @@ void WP_Message_Process()
                 break;
 
             case ReceiveState_CompletePayload:
-                TRACE0(TRACE_STATE, "RxState=CompletePayload\n");
+                TRACE0(TRACE_STATE, "RxState==CompletePayload\n");
                 if (WP_Message_VerifyPayload(&_inboundMessage))
                 {
+                    TRACE_WP_HEADER(WP_RXMSG_Payload_Ok, &_inboundMessage);
                     WP_App_ProcessPayload(&_inboundMessage);
+                }
+                else
+                {
+                    TRACE_WP_HEADER(WP_RXMSG_NAK, &_inboundMessage);
                 }
 
                 _rxState = ReceiveState_Initialize;
@@ -403,7 +410,7 @@ void WP_Message_Process()
 
             default:
                 // unknown state
-                TRACE0(TRACE_ERRORS, "RxState=UNKNOWN!!\n");
+                TRACE0(TRACE_ERRORS, "RxState==UNKNOWN!!\n");
                 return;
         }
     }
@@ -411,12 +418,6 @@ void WP_Message_Process()
 
 void WP_SendProtocolMessage(WP_Message *message)
 {
-    TRACE(
-        TRACE_HEADERS,
-        "TXMSG: 0x%08X, 0x%08X, 0x%08X\n",
-        message->m_header.m_cmd,
-        message->m_header.m_flags,
-        message->m_header.m_size);
     WP_TransmitMessage(message);
 }
 
@@ -427,13 +428,6 @@ void WP_PrepareAndSendProtocolMessage(uint32_t cmd, uint32_t payloadSize, uint8_
     WP_Message_Initialize(&message);
 
     WP_Message_PrepareRequest(&message, cmd, flags, payloadSize, payload);
-
-    TRACE(
-        TRACE_HEADERS,
-        "TXMSG: 0x%08X, 0x%08X, 0x%08X\n",
-        message.m_header.m_cmd,
-        message.m_header.m_flags,
-        message.m_header.m_size);
 
     WP_TransmitMessage(&message);
 }
@@ -449,3 +443,20 @@ __nfweak void debug_printf(const char *format, ...)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#if defined(TRACE_MASK) && TRACE_MASK & TRACE_HEADERS != 0
+void WP_TraceHeader(const char *pstrLabel, WP_Message *message)
+{
+    TRACE(
+        TRACE_HEADERS,
+        "%scmd=0x%08X, flags=0x%08X, hCRC=0x%08X, pCRC=0x%08X, seq=0x%04X replySeq=0x%04X len=%d\n",
+        pstrLabel,
+        message->m_header.m_cmd,
+        message->m_header.m_flags,
+        message->m_header.m_crcHeader,
+        message->m_header.m_crcData,
+        message->m_header.m_seq,
+        message->m_header.m_seqReply,
+        message->m_header.m_size);
+}
+#endif

--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -328,7 +328,7 @@ void WP_Message_Process()
                         "RXMSG: 0x%08X, 0x%08X, 0x%08X\n",
                         _inboundMessage.m_header.m_cmd,
                         _inboundMessage.m_header.m_flags,
-                        _inboundMessage.m_header._size);
+                        _inboundMessage.m_header.m_size);
 
                     if (WP_App_ProcessHeader(&_inboundMessage))
                     {
@@ -364,7 +364,7 @@ void WP_Message_Process()
 
             case ReceiveState_ReadingPayload:
 
-                TRACE(TRACE_STATE, "RxState=ReadingPayload. Expecting %d bytes.\n", message->_size);
+                TRACE(TRACE_STATE, "RxState=ReadingPayload. Expecting %d bytes.\n", _inboundMessage.m_header.m_size);
 
                 // If the time between consecutive payload bytes exceeds the timeout threshold then assume that
                 // the rest of the payload is not coming. Reinitialize to sync with the next header.
@@ -416,7 +416,7 @@ void WP_SendProtocolMessage(WP_Message *message)
         "TXMSG: 0x%08X, 0x%08X, 0x%08X\n",
         message->m_header.m_cmd,
         message->m_header.m_flags,
-        message->m_header._size);
+        message->m_header.m_size);
     WP_TransmitMessage(message);
 }
 
@@ -433,7 +433,7 @@ void WP_PrepareAndSendProtocolMessage(uint32_t cmd, uint32_t payloadSize, uint8_
         "TXMSG: 0x%08X, 0x%08X, 0x%08X\n",
         message.m_header.m_cmd,
         message.m_header.m_flags,
-        message.m_header._size);
+        message.m_header.m_size);
 
     WP_TransmitMessage(&message);
 }

--- a/targets/TI_SimpleLink/_common/WireProtocol_HAL_Interface.c
+++ b/targets/TI_SimpleLink/_common/WireProtocol_HAL_Interface.c
@@ -39,12 +39,7 @@ uint8_t WP_TransmitMessage(WP_Message *message)
     uint32_t writeResult;
     bool operationResult = false;
 
-    TRACE(
-        TRACE_HEADERS,
-        "TXMSG: 0x%08X, 0x%08X, 0x%08X\n",
-        message->m_header.m_cmd,
-        message->m_header.m_flags,
-        message->m_header.m_size);
+    TRACE_WP_HEADER(WP_TXMSG, message);
 
     // write header to uart
     UART2_writeTimeout(


### PR DESCRIPTION
## Description
- Define single method used to TRACE WP headers and replace the copy-paste with single macro to call the method and ensure uniform traced output when debugging WP message exchanges.
- Remove TRACE calls from debugger class. 

## Motivation and Context
- Uniform trace data that matches data traced by Debugger on PC. Additional data formatting in a way that is easier to read.
- On debugger class the TRACE usage wasn't bringing much value.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
