### PR TITLE
initial meset of  npf__format_spec_t fs; to all zeros

### DIFF
--- a/src/CLR/Helpers/nanoprintf/nanoprintf.c
+++ b/src/CLR/Helpers/nanoprintf/nanoprintf.c
@@ -32,6 +32,7 @@
 */
 
 #include "nanoprintf.h"
+#include <string.h>
 
 #if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
 #include <math.h>
@@ -558,6 +559,9 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list vlist)
     npf__format_spec_t fs;
     char const *cur = format;
     int n = 0, sign = 0, i;
+
+    // inialise structure
+    memset(&fs, 0, sizeof(npf__format_spec_t));
 
     while (*cur)
     {


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
memset all of  'npf__format_spec_t fs;' instanct to zero when entering  npf_vpprintf(...) method.

## Motivation and Context
Build is correctly failing as the structure  npf__format_spec_t fs;  has not been initialised before being used. 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Built and run on ST_B_L475E_IOT01A in develop-azurertos branch

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
