### PR TITLE
Fix ADC2 and tidy up

### DIFF
--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Esp32_Wireless.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/Network/Esp32_Wireless.cpp
@@ -108,6 +108,12 @@ esp_err_t Esp32_InitaliseWifi()
         }
     }
 
+    // Don't init if Wifi Mode null (Disabled)
+    if ( wifi_mode == WIFI_MODE_NULL)
+    {
+        return ESP_FAIL;
+    }
+
     if (!WifiInitialised)
     {
         // Init WiFi Alloc resource for WiFi driver, such as WiFi control structure,

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcChannel.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcChannel.cpp
@@ -42,13 +42,19 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcChannel::NativeReadVal
         }
         else if (adcNumber == 2)
         {
-            channelNumber -= 10; // Adjust channel number for ADC2
+            // Adjust channel number for ADC2
+            channelNumber -= 10;
             result = adc2_get_raw((adc2_channel_t)channelNumber, ADC_WIDTH_12Bit, &reading);
+
             if (result != ESP_OK)
+            {
                 NANOCLR_SET_AND_LEAVE(CLR_E_PIN_UNAVAILABLE);
+            }
         }
         else
+        {
             NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        }
 
         stack.SetResult_I4(reading);
     }

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcChannel.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcChannel.cpp
@@ -21,12 +21,7 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcChannel::NativeReadVal
         // Get channel from _channelNumber field
         int channelNumber = pThis[FIELD___channelNumber].NumericByRef().s4;
 
-        // need to get the controllerId for the ADC controller of this channel
-        // get pointer to AdcController field
-        //CLR_RT_HeapBlock* adcController = pThis[FIELD___adcController].Dereference();
-
-        // get pointer to _controllerId field
-//       int adcNumber = adcController[Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::FIELD___controllerId].NumericByRef().s4;
+        // Calculate internal ADC number based on channel number
         int adcNumber = channelNumber <= 9 ? 1 : 2;
 
         if ( adcNumber == 1)
@@ -43,6 +38,7 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcChannel::NativeReadVal
         }
         else if ( adcNumber == 2)
         {
+            channelNumber -= 10; // Adjust channel number for ADC2
             result = adc2_get_raw( (adc2_channel_t)channelNumber, ADC_WIDTH_12Bit, &reading); 
             if ( result != ESP_OK)
                 NANOCLR_SET_AND_LEAVE(CLR_E_PIN_UNAVAILABLE);

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcController.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcController.cpp
@@ -46,7 +46,9 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeOpen
         int channelNumber = stack.Arg1().NumericByRef().s4;
 
         if (channelNumber < ADC_CHANNEL_0 || channelNumber > 19)
+        {
             NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        }
 
         // Get ADC device number from channel
         int adcUnit = channelNumber <= 9 ? 1 : 2;
@@ -70,8 +72,10 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeOpen
                 break;
 
             case 2:
-                channelNumber -= 10; // Adjust for ADC2
+                // Adjust for ADC2
+                channelNumber -= 10;
                 result = adc2_config_channel_atten((adc2_channel_t)channelNumber, atten);
+                
                 if (result != ESP_OK)
                 {
                     NANOCLR_SET_AND_LEAVE(CLR_E_PIN_UNAVAILABLE);

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcController.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcController.cpp
@@ -75,7 +75,7 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeOpen
                 // Adjust for ADC2
                 channelNumber -= 10;
                 result = adc2_config_channel_atten((adc2_channel_t)channelNumber, atten);
-                
+
                 if (result != ESP_OK)
                 {
                     NANOCLR_SET_AND_LEAVE(CLR_E_PIN_UNAVAILABLE);

--- a/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcController.cpp
+++ b/targets/FreeRTOS_ESP32/ESP32_WROOM_32/nanoCLR/Windows.Devices.Adc/win_dev_adc_native_Windows_Devices_Adc_AdcController.cpp
@@ -41,12 +41,12 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeOpen
         CLR_RT_HeapBlock* pThis = stack.This();  FAULT_ON_NULL(pThis);
 
         // Get channel from argument
-        int channel = stack.Arg1().NumericByRef().s4;
+        int channelNumber = stack.Arg1().NumericByRef().s4;
 
-        if ( channel < ADC_CHANNEL_0 || channel > 19 ) NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        if ( channelNumber < ADC_CHANNEL_0 || channelNumber > 19 ) NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
 
         // Get ADC device number from channel
-        int adcUnit = channel <= 9 ? 1 : 2;
+        int adcUnit = channelNumber <= 9 ? 1 : 2;
 
         adc_power_acquire();         // Make sure powered on
 
@@ -54,11 +54,11 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeOpen
         {
             case 1:
                 // Normal channel 0-7 ?
-                if ( channel <= 7 )
+                if ( channelNumber <= 7 )
                 {
                     adc1_config_width( width_bit );
 
-                    result =  adc1_config_channel_atten( (adc1_channel_t)channel, atten);
+                    result =  adc1_config_channel_atten( (adc1_channel_t)channelNumber, atten);
                     if ( result != ESP_OK )
                     {
                         NANOCLR_SET_AND_LEAVE(CLR_E_PIN_UNAVAILABLE);
@@ -67,7 +67,8 @@ HRESULT Library_win_dev_adc_native_Windows_Devices_Adc_AdcController::NativeOpen
                 break;
 
             case 2:
-                result = adc2_config_channel_atten( (adc2_channel_t)channel, atten );
+                channelNumber -= 10; // Adjust for ADC2
+                result = adc2_config_channel_atten( (adc2_channel_t)channelNumber, atten );
                 if ( result != ESP_OK )
                 {
                     NANOCLR_SET_AND_LEAVE(CLR_E_PIN_UNAVAILABLE);


### PR DESCRIPTION
## Description
Tidy up code and fix channel number used for internal ADC2 (ADC1 channels 10 to 19)
Make sure WiFi is not initted if disabled so that ADC2 can work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Resolves nanoFramework/Home#822

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Modified ADC sample

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
