### PR TITLE
Add macro to clean-up build artifacts

### DIFF
--- a/CMake/binutils.ChibiOS.cmake
+++ b/CMake/binutils.ChibiOS.cmake
@@ -329,3 +329,17 @@ macro(nf_setup_target_build)
     nf_setup_target_build_common(${ARGN})
 
 endmacro()
+
+# macro to clear binary files related with nanoBooter from output
+# to make sure that the build file it's up to date
+macro(nf_clear_output_files_nanobooter)
+    nf_clear_common_output_files_nanobooter()
+    # other files specific to this platform should go here
+endmacro()
+
+# macro to clear binary files related with nanoCLR from output
+# to make sure that the build file it's up to date
+macro(nf_clear_output_files_nanoclr)
+    nf_clear_common_output_files_nanoclr()
+    # other files specific to this platform should go here
+endmacro()

--- a/CMake/binutils.ESP32.cmake
+++ b/CMake/binutils.ESP32.cmake
@@ -134,3 +134,17 @@ macro(nf_add_platform_sources target)
     endif()
 
 endmacro()
+
+# macro to clear binary files related with nanoBooter from output
+# to make sure that the build file it's up to date
+macro(nf_clear_output_files_nanobooter)
+    nf_clear_common_output_files_nanobooter()
+    # other files specific to this platform should go here
+endmacro()
+
+# macro to clear binary files related with nanoCLR from output
+# to make sure that the build file it's up to date
+macro(nf_clear_output_files_nanoclr)
+    nf_clear_common_output_files_nanoclr()
+    # other files specific to this platform should go here
+endmacro()

--- a/CMake/binutils.FreeRTOS.cmake
+++ b/CMake/binutils.FreeRTOS.cmake
@@ -281,3 +281,17 @@ macro(nf_setup_target_build)
     nf_setup_target_build_common(${ARGN})
 
 endmacro()
+
+# macro to clear binary files related with nanoBooter from output
+# to make sure that the build file it's up to date
+macro(nf_clear_output_files_nanobooter)
+    nf_clear_common_output_files_nanobooter()
+    # other files specific to this platform should go here
+endmacro()
+
+# macro to clear binary files related with nanoCLR from output
+# to make sure that the build file it's up to date
+macro(nf_clear_output_files_nanoclr)
+    nf_clear_common_output_files_nanoclr()
+    # other files specific to this platform should go here
+endmacro()

--- a/CMake/binutils.TI_SimpleLink.cmake
+++ b/CMake/binutils.TI_SimpleLink.cmake
@@ -358,3 +358,17 @@ macro(nf_setup_target_build)
     nf_setup_target_build_common(${ARGN})
 
 endmacro()
+
+# macro to clear binary files related with nanoBooter from output
+# to make sure that the build file it's up to date
+macro(nf_clear_output_files_nanobooter)
+    nf_clear_common_output_files_nanobooter()
+    # other files specific to this platform should go here
+endmacro()
+
+# macro to clear binary files related with nanoCLR from output
+# to make sure that the build file it's up to date
+macro(nf_clear_output_files_nanoclr)
+    nf_clear_common_output_files_nanoclr()
+    # other files specific to this platform should go here
+endmacro()

--- a/CMake/binutils.common.cmake
+++ b/CMake/binutils.common.cmake
@@ -523,6 +523,8 @@ macro(nf_setup_target_build_common)
                 ${NANOBOOTER_PROJECT_NAME}.elf
             EXTRA_LINKMAP_PROPERTIES ${NFSTBC_BOOTER_EXTRA_LINKMAP_PROPERTIES})
 
+        nf_clear_output_files_nanobooter()
+
     endif()
 
     #######################
@@ -575,5 +577,41 @@ macro(nf_setup_target_build_common)
     endif()
 
     nf_generate_build_output_files(${NANOCLR_PROJECT_NAME}.elf)
+   
+    nf_clear_output_files_nanoclr()
+
+endmacro()
+
+# macro to clear binary files related with nanoBooter from output
+# to make sure that the build file it's up to date
+macro(nf_clear_common_output_files_nanobooter)
+    list(APPEND BOOTER_BUILD_FILES_TO_REMOVE ${CMAKE_BINARY_DIR}/${NANOBOOTER_PROJECT_NAME}.bin)
+    list(APPEND BOOTER_BUILD_FILES_TO_REMOVE ${CMAKE_BINARY_DIR}/${NANOBOOTER_PROJECT_NAME}.elf)
+    list(APPEND BOOTER_BUILD_FILES_TO_REMOVE ${CMAKE_BINARY_DIR}/${NANOBOOTER_PROJECT_NAME}.hex)
+
+    add_custom_command(
+        TARGET ${NANOBOOTER_PROJECT_NAME}.elf
+        PRE_BUILD
+        COMMAND ${CMAKE_COMMAND} -E remove -f ${BOOTER_BUILD_FILES_TO_REMOVE}
+        COMMAND_EXPAND_LISTS
+        COMMENT "Removing nanoBooter bin and elf files from build folder"
+    )
+    
+endmacro()
+
+# macro to clear binary files related with nanoCLR from output
+# to make sure that the build file it's up to date
+macro(nf_clear_common_output_files_nanoclr)
+    list(APPEND CLR_BUILD_FILES_TO_REMOVE ${CMAKE_BINARY_DIR}/${NANOCLR_PROJECT_NAME}.bin)
+    list(APPEND CLR_BUILD_FILES_TO_REMOVE ${CMAKE_BINARY_DIR}/${NANOCLR_PROJECT_NAME}.elf)
+    list(APPEND CLR_BUILD_FILES_TO_REMOVE ${CMAKE_BINARY_DIR}/${NANOCLR_PROJECT_NAME}.hex)
+
+    add_custom_command(
+        TARGET ${NANOCLR_PROJECT_NAME}.elf
+        PRE_BUILD
+        COMMAND ${CMAKE_COMMAND} -E remove -f ${CLR_BUILD_FILES_TO_REMOVE}
+        COMMAND_EXPAND_LISTS
+        COMMENT "Removing nanoCLR bin and elf files from build folder"
+    )
 
 endmacro()


### PR DESCRIPTION
## Description
- Add macros to make sure the build artifacts files are deleted before building.

## Motivation and Context
- Need to be 200% sure that local builds do generate artifacts all the time. On random occasions, the compiler fails to generate/link/update the build artifacts. This causes that old artifacts are used in debug sessions unnoticed causing frustration.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
