### PR TITLE
Skip CLR_DBG_Monitor_Message while reading payload

### DIFF
--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -425,6 +425,13 @@ void WP_PrepareAndSendProtocolMessage(uint32_t cmd, uint32_t payloadSize, uint8_
 {
     WP_Message message;
 
+    if (_rxState == ReceiveState_ReadingPayload && cmd == CLR_DBG_Commands_c_Monitor_Message)
+    {
+        // skip the outgoing Monitor message while we are busy receiving a packet payload
+        TRACE0(TRACE_ERRORS, "Skip CLR_DBG_Commands_c_Monitor_Message\n");
+        return;
+    }
+
     WP_Message_Initialize(&message);
 
     WP_Message_PrepareRequest(&message, cmd, flags, payloadSize, payload);


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Add check and skip sending CLR Debugger Monitor_Message from nF if, and only if, it is busy receiving a payload of an incoming Wire Protocol packet. 
The change only impacts:
```
void WP_PrepareAndSendProtocolMessage(uint32_t cmd, uint32_t payloadSize, uint8_t *payload, uint32_t flags)
```

## Motivation and Context
The Monitor_Message is sent continuously approximately every 1.2 seconds from nF to the PC host after a Debugger has connected with the firmware. The message is transmitted regardless of what else is going on. If by chance it is send when nF is in the middle of receiving a payload that is larger than the low-level hardware buffers, there is a risk the WP_Process loop reading the incoming payload will be delayed during the setup and transmission process of the Monitor Message and the low-level RX  buffer can overflow if it is small. Example buffer needs to be more than 300 bytes to avoid overflow. 

The problem is easiest to demonstrate if there is a deployed application (e.g. nBlinky) currently being executed by nF, when at the same time one is trying to send large payloads via WP.

I have not been able to reproduce the problem when the deployment area is erased. 

## How Has This Been Tested?
Build nF with the following settings:
mcuconf.h :
```
#define STM32_SERIAL_USE_UART4              TRUE
#define STM32_UART_USE_UART4                FALSE
```
with cmake-variants.json enabled Stdio trace on for errors. 
```
                    "NF_TRACE_TO_STDIO": "ON",
                    "NF_WP_TRACE_ERRORS": "ON",
```
Deploy nBlinky and leave it running. 
Connect with modified nanoFramework.Tools.Debugger test application with button that performs RAM "ERASE" (memset to 0xFF), Read & Write WP operations of 1024 bytes in a loop. Read used to check "Erase" and Write successful. [Used RAM for testing to avoid harm to flash with WR/ERASE.]

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
