### PR TITLE
Fix PWM deviceSelectorString

### DIFF
--- a/targets/ChibiOS/_nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmController.cpp
+++ b/targets/ChibiOS/_nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmController.cpp
@@ -125,7 +125,7 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmController::GetDeviceS
     NANOCLR_HEADER();
     {
     // declare the device selector string whose max size is "TIM1,TIM3,TIM4,TIM5,TIM8,TIM9," + terminator and init with the terminator
-       char deviceSelectorString[ 30 + 1] = { 0 };
+       char deviceSelectorString[7 * 5 + 1] = { 0 };
 
    #if STM32_PWM_USE_TIM1
        strcat(deviceSelectorString, "TIM1,");

--- a/targets/ChibiOS/_nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmController.cpp
+++ b/targets/ChibiOS/_nanoCLR/Windows.Devices.Pwm/win_dev_pwm_native_Windows_Devices_Pwm_PwmController.cpp
@@ -130,31 +130,29 @@ HRESULT Library_win_dev_pwm_native_Windows_Devices_Pwm_PwmController::GetDeviceS
     {
         // declare the device selector string whose max size is "TIM1,TIM3,TIM4,TIM5,TIM8,TIM9," + terminator and init
         // with the terminator
-        char deviceSelectorString[7 * 5 + 1] = {0};
-
+        static char deviceSelectorString[] =
 #if STM32_PWM_USE_TIM1
-        strcat(deviceSelectorString, "TIM1,");
+            "TIM1,"
 #endif
 #if STM32_PWM_USE_TIM2
-        strcat(deviceSelectorString, "TIM2,");
+            "TIM2,"
 #endif
 #if STM32_PWM_USE_TIM3
-        strcat(deviceSelectorString, "TIM3,");
+            "TIM3,"
 #endif
-#ifndef STM32F0XX
 #if STM32_PWM_USE_TIM4
-        strcat(deviceSelectorString, "TIM4,");
+            "TIM4,"
 #endif
 #if STM32_PWM_USE_TIM5
-        strcat(deviceSelectorString, "TIM5,");
+            "TIM5,"
 #endif
 #if STM32_PWM_USE_TIM8
-        strcat(deviceSelectorString, "TIM8,");
+            "TIM8,"
 #endif
 #if STM32_PWM_USE_TIM9
-        strcat(deviceSelectorString, "TIM9,");
+            "TIM9,"
 #endif
-#endif
+            ;
         // replace the last comma with a terminator
         deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
 


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Insufficient space allocated when char deviceSelectorString[30] #ifndef STM32F0XX is true as there will be 7 timer strings "TIM1,TIM2,TIM3,TIM4,TIM5,TIM8,TIM9", each 5 char long. Current allocation is 30 when 35 is required. 

I suggest we let the compiler figure out the maths and suggest  char deviceSelectorString[7 * 5 + 1] = { 0 };

## Motivation and Context
Fix bug.

## How Has This Been Tested?
Source code review. 

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
