### PR TITLE
Bump AzureRTOS version from 6.1.7 to 6.1.8

### DIFF
--- a/targets/AzureRTOS/CMakeLists.txt
+++ b/targets/AzureRTOS/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 # check if build was requested with a specifc AzureRTOS version
 if(RTOS_VERSION_EMPTY)
     # no AzureRTOS version actualy specified, must be empty which is fine, we'll default to a known good version
-    set(RTOS_VERSION "v6.1.7_rel")
+    set(RTOS_VERSION "v6.1.8_rel")
 endif()
 
 if(NO_RTOS_SOURCE_FOLDER)


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Change the default version of Azure RTOS included to v6.1.8_rel

## Motivation and Context
Keep nanoFramework using the latest AzureRTOS sources. No changes to nF sources needed.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Build ST_B_L475E_IOT01A successfully. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
