### PR TITLE
Work on WP and messaging

### DIFF
--- a/src/CLR/Include/WireProtocol_Message.h
+++ b/src/CLR/Include/WireProtocol_Message.h
@@ -94,7 +94,7 @@ extern "C"
 {
 #endif
 
-    void WP_ReplyToCommand(WP_Message *message, int fSuccess, int fCritical, void *ptr, int size);
+    void WP_ReplyToCommand(WP_Message *message, uint8_t fSuccess, uint8_t fCritical, void *ptr, uint32_t size);
     void WP_SendProtocolMessage(WP_Message *message);
     void WP_PrepareAndSendProtocolMessage(uint32_t cmd, uint32_t payloadSize, uint8_t *payload, uint32_t flags);
 

--- a/src/CLR/Include/nanoCLR_Messaging.h
+++ b/src/CLR/Include/nanoCLR_Messaging.h
@@ -9,6 +9,9 @@
 #include <nanoCLR_Types.h>
 #include <WireProtocol.h>
 
+// definition for the table size of the messaging lookup table
+#define CMD_HANDLER_LOOKUP_TABLE_SIZE 2
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 typedef bool (*CLR_Messaging_CommandHandler)(WP_Message *msg);
@@ -84,8 +87,8 @@ struct CLR_Messaging
 
     //--//
 
-    CLR_Messaging_CommandHandlerLookups m_Lookup_Requests[2];
-    CLR_Messaging_CommandHandlerLookups m_Lookup_Replies[2];
+    CLR_Messaging_CommandHandlerLookups m_Lookup_Requests[CMD_HANDLER_LOOKUP_TABLE_SIZE];
+    CLR_Messaging_CommandHandlerLookups m_Lookup_Replies[CMD_HANDLER_LOOKUP_TABLE_SIZE];
 
     COM_HANDLE m_port;
 

--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -41,7 +41,7 @@ extern void debug_printf(const char *format, ...);
 //////////////////////////////////////////
 // helper functions
 
-void WP_ReplyToCommand(WP_Message *message, int fSuccess, int fCritical, void *ptr, int size)
+void WP_ReplyToCommand(WP_Message *message, uint8_t fSuccess, uint8_t fCritical, void *ptr, uint32_t size)
 {
     WP_Message msgReply;
     uint32_t flags = 0;


### PR DESCRIPTION
## Description
- Fix param types on some calls.
- Improve GetInteropNativeAssemblies and call.
- Remove old code that was used to wrokaround old gcc issue.
- Rework CLR_Messaging CreateInstance and DeleteInstance to use dynamic memory allocation.
- Rework CLR_Messaging::ProcessPayload to improve processing.

## Motivation and Context
- Fix issues with messaging and device discovery on some targets.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
