### PR TITLE
Fix potential memory leaks in S.IO.Ports code

### DIFF
--- a/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -432,7 +432,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadExisting___STR
 
     NF_PAL_UART *palUart = NULL;
 
-    uint8_t *buffer;
+    uint8_t *buffer = NULL;
     uint32_t bufferLength;
 
     CLR_RT_HeapBlock &top = stack.PushValue();
@@ -462,7 +462,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadExisting___STR
         buffer = (uint8_t *)platform_malloc(bufferLength);
 
         // sanity check
-        if (buffer)
+        if (buffer == NULL)
         {
             NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
         }
@@ -471,8 +471,6 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadExisting___STR
         palUart->RxRingBuffer.Pop(buffer, bufferLength);
 
         NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_String::CreateInstance(top, (const char *)buffer, bufferLength));
-
-        platform_free(buffer);
     }
     else
     {
@@ -480,7 +478,14 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadExisting___STR
         NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_String::CreateInstance(top, (const char *)NULL));
     }
 
-    NANOCLR_NOCLEANUP();
+    NANOCLR_CLEANUP();
+
+    if (buffer != NULL)
+    {
+        platform_free(buffer);
+    }
+
+    NANOCLR_CLEANUP_END();
 }
 
 HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(CLR_RT_StackFrame &stack)
@@ -716,72 +721,48 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeDispose___VO
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_USART1) && (NF_SERIAL_COMM_STM32_UART_USE_USART1 == TRUE)
         case 1:
             UnInit_UART1();
-            // stop UART
-            uartStop(&UARTD1);
-            Uart1_PAL.UartDriver = NULL;
             break;
 #endif
 
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_USART2) && (NF_SERIAL_COMM_STM32_UART_USE_USART2 == TRUE)
         case 2:
             UnInit_UART2();
-            // stop UART
-            uartStop(&UARTD2);
-            Uart2_PAL.UartDriver = NULL;
             break;
 #endif
 
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_USART3) && (NF_SERIAL_COMM_STM32_UART_USE_USART3 == TRUE)
         case 3:
             UnInit_UART3();
-            // stop UART
-            uartStop(&UARTD3);
-            Uart3_PAL.UartDriver = NULL;
             break;
 #endif
 
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_UART4) && (NF_SERIAL_COMM_STM32_UART_USE_UART4 == TRUE)
         case 4:
             UnInit_UART4();
-            // stop UART
-            uartStop(&UARTD4);
-            Uart4_PAL.UartDriver = NULL;
             break;
 #endif
 
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_UART5) && (NF_SERIAL_COMM_STM32_UART_USE_UART5 == TRUE)
         case 5:
             UnInit_UART5();
-            // stop UART
-            uartStop(&UARTD5);
-            Uart5_PAL.UartDriver = NULL;
             break;
 #endif
 
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_USART6) && (NF_SERIAL_COMM_STM32_UART_USE_USART6 == TRUE)
         case 6:
             UnInit_UART6();
-            // stop UART
-            uartStop(&UARTD6);
-            Uart6_PAL.UartDriver = NULL;
             break;
 #endif
 
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_UART7) && (NF_SERIAL_COMM_STM32_UART_USE_UART7 == TRUE)
         case 7:
             UnInit_UART7();
-            // stop UART
-            uartStop(&UARTD7);
-            Uart7_PAL.UartDriver = NULL;
             break;
 #endif
 
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_UART8) && (NF_SERIAL_COMM_STM32_UART_USE_UART8 == TRUE)
         case 8:
             UnInit_UART8();
-            // stop UART
-            uartStop(&UARTD8);
-            Uart8_PAL.UartDriver = NULL;
             break;
 #endif
 

--- a/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_target.h
+++ b/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_target.h
@@ -154,6 +154,10 @@ void Init_UART8();
 #define UART_UNINIT(num)                                                                                               \
     void UnInit_UART##num()                                                                                            \
     {                                                                                                                  \
+        Uart##num##_PAL.TxBuffer = NULL;                                                                               \
+        Uart##num##_PAL.RxBuffer = NULL;                                                                               \
+        uartStop(&UARTD##num##);                                                                                       \
+        Uart##num##_PAL.UartDriver = NULL;                                                                             \
         return;                                                                                                        \
     }
 


### PR DESCRIPTION
## Description
- Move some calls to cleanup ending block.
- Fix check of buffer allocation on all ReadExisting functions.
- Also removed wrong calls to platform_free on TxBuffer that isn't allocated.
- Add missing calls to null buffer pointers in uart de-init code.
- Improve uart de-init macro for ChibiOS.

## Motivation and Context
- Improves memory allocation/free on S.IO.Ports code.
- Addresses code review of #2080.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
