### PR TITLE
Add missing macros for Azure CMake

### DIFF
--- a/CMake/binutils.AzureRTOS.cmake
+++ b/CMake/binutils.AzureRTOS.cmake
@@ -371,3 +371,17 @@ macro(nf_setup_target_build)
     nf_setup_target_build_common(${ARGN})
 
 endmacro()
+
+# macro to clear binary files related with nanoBooter from output
+# to make sure that the build file it's up to date
+macro(nf_clear_output_files_nanobooter)
+    nf_clear_common_output_files_nanobooter()
+    # other files specific to this platform should go here
+endmacro()
+
+# macro to clear binary files related with nanoCLR from output
+# to make sure that the build file it's up to date
+macro(nf_clear_output_files_nanoclr)
+    nf_clear_common_output_files_nanoclr()
+    # other files specific to this platform should go here
+endmacro()


### PR DESCRIPTION
## Description
- Add definition for nf_clear_output_files_nanoclr in AzureRTOS.cmake, copied macro definition from ChibiOS.

## Motivation and Context
- Required by updated build as per develop branch.

## How Has This Been Tested?
- Configuration of AzureRTOS project

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
