### PR TITLE
Fix implementation of GetCertificateStore and GetDeviceCertificate

### DIFF
--- a/src/HAL/Include/nanoHAL_ConfigurationManager.h
+++ b/src/HAL/Include/nanoHAL_ConfigurationManager.h
@@ -186,15 +186,18 @@ extern "C"
     HAL_Configuration_Wireless80211 *ConfigurationManager_GetWirelessConfigurationFromId(uint32_t configurationId);
 
     // gets the HAL_Configuration_WirelessAP configuration block that has the specified Id, if that exists
-    // defined as weak needs to be free to implement the storage of the configuration block as they see fit
+    // memory is allocated for the configuration block, has to be free by the caller
+    // defined as weak to allow replacement at platform/target level to allow different storage management
     HAL_Configuration_WirelessAP *ConfigurationManager_GetWirelessAPConfigurationFromId(uint32_t configurationId);
 
     // gets the HAL_Configuration_X509CaRootBundle certificate store, if that exists
-    // defined as weak needs to be free to implement the storage of the configuration block as they see fit
+    // memory is allocated for the configuration block, has to be free by the caller
+    // defined as weak to allow replacement at platform/target level to allow different storage management
     HAL_Configuration_X509CaRootBundle *ConfigurationManager_GetCertificateStore();
 
     // gets the HAL_Configuration_X509DeviceCertificate device certificate, if that exists
-    // defined as weak needs to be free to implement the storage of the configuration block as they see fit
+    // memory is allocated for the configuration block, has to be free by the caller
+    // defined as weak to allow replacement at platform/target level to allow different storage management
     HAL_Configuration_X509DeviceCertificate *ConfigurationManager_GetDeviceCertificate();
 
 #ifdef __cplusplus

--- a/src/HAL/nanoHAL_ConfigurationManager.c
+++ b/src/HAL/nanoHAL_ConfigurationManager.c
@@ -223,7 +223,20 @@ __nfweak HAL_Configuration_Wireless80211 *ConfigurationManager_GetWirelessConfig
     {
         if (g_TargetConfiguration.Wireless80211Configs->Configs[i]->Id == configurationId)
         {
-            return g_TargetConfiguration.Wireless80211Configs->Configs[i];
+            // need to make a copy
+            HAL_Configuration_Wireless80211 *configBlock =
+                (HAL_Configuration_Wireless80211 *)platform_malloc(sizeof(HAL_Configuration_Wireless80211));
+
+            // check allocation
+            if (configBlock)
+            {
+                memcpy(
+                    configBlock,
+                    g_TargetConfiguration.Wireless80211Configs->Configs[i],
+                    sizeof(HAL_Configuration_Wireless80211));
+
+                return configBlock;
+            }
         }
     }
 
@@ -237,7 +250,20 @@ __nfweak HAL_Configuration_WirelessAP *ConfigurationManager_GetWirelessAPConfigu
     {
         if (g_TargetConfiguration.WirelessAPConfigs->Configs[i]->Id == configurationId)
         {
-            return g_TargetConfiguration.WirelessAPConfigs->Configs[i];
+            // need to make a copy
+            HAL_Configuration_WirelessAP *configBlock =
+                (HAL_Configuration_WirelessAP *)platform_malloc(sizeof(HAL_Configuration_WirelessAP));
+
+            // check allocation
+            if (configBlock)
+            {
+                memcpy(
+                    configBlock,
+                    g_TargetConfiguration.WirelessAPConfigs->Configs[i],
+                    sizeof(HAL_Configuration_WirelessAP));
+
+                return configBlock;
+            }
         }
     }
 
@@ -249,7 +275,21 @@ __nfweak HAL_Configuration_X509CaRootBundle *ConfigurationManager_GetCertificate
 {
     if (g_TargetConfiguration.CertificateStore->Count)
     {
-        return g_TargetConfiguration.CertificateStore->Certificates[0];
+        // need to make a copy
+        // need to compute size as the cert size is variable
+        int32_t blockSize = offsetof(HAL_Configuration_X509CaRootBundle, Certificate) +
+                            g_TargetConfiguration.CertificateStore->Certificates[0]->CertificateSize;
+
+        HAL_Configuration_X509CaRootBundle *configBlock =
+            (HAL_Configuration_X509CaRootBundle *)platform_malloc(blockSize);
+
+        // check allocation
+        if (configBlock)
+        {
+            memcpy(configBlock, g_TargetConfiguration.CertificateStore->Certificates[0], blockSize);
+
+            return configBlock;
+        }
     }
 
     // not found
@@ -260,7 +300,21 @@ __nfweak HAL_Configuration_X509DeviceCertificate *ConfigurationManager_GetDevice
 {
     if (g_TargetConfiguration.DeviceCertificates->Count)
     {
-        return g_TargetConfiguration.DeviceCertificates->Certificates[0];
+        // need to make a copy
+        // need to compute size as the cert size is variable
+        int32_t blockSize = offsetof(HAL_Configuration_X509DeviceCertificate, Certificate) +
+                            g_TargetConfiguration.DeviceCertificates->Certificates[0]->CertificateSize;
+
+        HAL_Configuration_X509DeviceCertificate *configBlock =
+            (HAL_Configuration_X509DeviceCertificate *)platform_malloc(blockSize);
+
+        // check allocation
+        if (configBlock)
+        {
+            memcpy(configBlock, g_TargetConfiguration.DeviceCertificates->Certificates[0], blockSize);
+
+            return configBlock;
+        }
     }
 
     // not found


### PR DESCRIPTION
## Description
- A config block is now created from heap in order to return the cert store and the device certificate.

## Motivation and Context
- The recent changes in #2093 assumed that memory allocation was happening inside there functions. For memory mapped storage, that's not the case, thus, trying to free this memory, causes an hard fault. With this fix, for memory mapped storage, a copy of the bundle/certificate is now performed. The extra memory penalty is not an issue because this happens very briefly when the certs are being parsed to be added to mbedTLS context.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
