### PR TITLE
Improvements in ESP32 I2C

### DIFF
--- a/targets/ESP32/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -5,7 +5,11 @@
 
 #include "sys_dev_i2c_native_target.h"
 
-static const char *TAG = "I2C";
+// copied from esp-idf\components\driver\test\test_i2c.c because they aren't made available on a header
+#define I2C_MASTER_TX_BUF_DISABLE 0
+#define I2C_MASTER_RX_BUF_DISABLE 0
+// I2C master will check ack from slave
+#define ACK_CHECK_EN 0x1
 
 typedef Library_sys_dev_i2c_native_System_Device_I2c_I2cConnectionSettings I2cConnectionSettings;
 typedef Library_sys_dev_i2c_native_System_Device_I2c_I2cTransferResult I2cTransferResult;
@@ -16,7 +20,7 @@ static char Esp_I2C_Initialised_Flag[I2C_NUM_MAX] = {0, 0};
 // need to declare these as external
 // TODO move them here after Windows.Devices.I2c is removed
 extern void Esp32_I2c_UnitializeAll();
-extern void SetConfig(i2c_port_t bus, CLR_RT_HeapBlock *config);
+extern bool SetConfig(i2c_port_t bus, CLR_RT_HeapBlock *config);
 
 HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::NativeInit___VOID(CLR_RT_StackFrame &stack)
 {
@@ -41,18 +45,28 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::NativeInit___VOI
         }
 
         // Set the Bus parameters
-        SetConfig(bus, pConfig);
+        if (!SetConfig(bus, pConfig))
+        {
+            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
+        }
 
         // If this is first device on Bus then init driver
         if (Esp_I2C_Initialised_Flag[bus] == 0)
         {
-            esp_err_t res = i2c_driver_install(bus, I2C_MODE_MASTER, 0, 0, 0);
+            // install driver in RAM to prevent issues with PSRAM cache
+            esp_err_t res = i2c_driver_install(
+                bus,
+                I2C_MODE_MASTER,
+                I2C_MASTER_RX_BUF_DISABLE,
+                I2C_MASTER_TX_BUF_DISABLE,
+                ESP_INTR_FLAG_IRAM);
+
             if (res != ESP_OK)
             {
                 NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
             }
 
-            // Ensure driver gets unitialized during soft reboot
+            // Ensure driver gets uninitialized during soft reboot
             HAL_AddSoftRebootHandler(Esp32_I2c_UnitializeAll);
 
             Esp_I2C_Initialised_Flag[bus]++;
@@ -64,29 +78,30 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::NativeInit___VOI
 HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::NativeDispose___VOID(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
+
+    CLR_RT_HeapBlock *pConfig;
+    i2c_port_t bus;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock *pThis = stack.This();
+    FAULT_ON_NULL(pThis);
+
+    // get a pointer to the managed I2C connectionSettings object instance
+    pConfig = pThis[FIELD___connectionSettings].Dereference();
+
+    // get bus index
+    // subtract 1 to get ESP32 bus number
+    bus = (i2c_port_t)(pConfig[I2cConnectionSettings::FIELD___busId].NumericByRef().s4 - 1);
+
+    Esp_I2C_Initialised_Flag[bus]--;
+
+    if (Esp_I2C_Initialised_Flag[bus] <= 0)
     {
-        CLR_RT_HeapBlock *pConfig;
+        i2c_driver_delete(bus);
 
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock *pThis = stack.This();
-        FAULT_ON_NULL(pThis);
-
-        // get a pointer to the managed spi connectionSettings object instance
-        pConfig = pThis[FIELD___connectionSettings].Dereference();
-
-        // get bus index
-        // subtract 1 to get ESP32 bus number
-        i2c_port_t bus = (i2c_port_t)(pConfig[I2cConnectionSettings::FIELD___busId].NumericByRef().s4 - 1);
-
-        Esp_I2C_Initialised_Flag[bus]--;
-
-        if (Esp_I2C_Initialised_Flag[bus] <= 0)
-        {
-            i2c_driver_delete(bus);
-
-            Esp_I2C_Initialised_Flag[bus] = 0;
-        }
+        Esp_I2C_Initialised_Flag[bus] = 0;
     }
+
     NANOCLR_NOCLEANUP();
 }
 
@@ -94,136 +109,167 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
     NativeTransmit___SystemDeviceI2cI2cTransferResult__SystemSpanByte__SystemSpanByte(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
+
+    uint8_t *writeBuffer = NULL;
+    uint8_t *readBuffer = NULL;
+    int writeOffset = 0;
+    int writeSize = 0;
+    int readOffset = 0;
+    int readSize = 0;
+    esp_err_t opResult;
+    uint32_t transferResult;
+    i2c_port_t bus;
+    int slaveAddress;
+    i2c_cmd_handle_t cmd;
+
+    CLR_RT_HeapBlock *result;
+    CLR_RT_HeapBlock *writeSpanByte;
+    CLR_RT_HeapBlock *readSpanByte;
+    CLR_RT_HeapBlock_Array *writeData = NULL;
+    CLR_RT_HeapBlock_Array *readData = NULL;
+    CLR_RT_HeapBlock *pConfig = NULL;
+
+    // create the return object (I2cTransferResult)
+    CLR_RT_HeapBlock &top = stack.PushValueAndClear();
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock *pThis = stack.This();
+    FAULT_ON_NULL(pThis);
+
+    // get a pointer to the managed I2C connectionSettings object instance
+    pConfig = pThis[FIELD___connectionSettings].Dereference();
+
+    // get bus index
+    // subtract 1 to get ESP32 bus number
+    bus = (i2c_port_t)(pConfig[I2cConnectionSettings::FIELD___busId].NumericByRef().s4 - 1);
+
+    slaveAddress = pConfig[I2cConnectionSettings::FIELD___deviceAddress].NumericByRef().s4;
+
+    // dereference the write and read SpanByte from the arguments
+    writeSpanByte = stack.Arg1().Dereference();
+    if (writeSpanByte != NULL)
     {
-        unsigned char *writeData = NULL;
-        unsigned char *readData = NULL;
-        int writeOffset = 0;
-        int writeSize = 0;
-        int readOffset = 0;
-        int readSize = 0;
-        esp_err_t i2cStatus;
+        writeData = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
 
-        CLR_RT_HeapBlock *result;
-        CLR_RT_HeapBlock *writeSpanByte;
-        CLR_RT_HeapBlock *readSpanByte;
-        CLR_RT_HeapBlock_Array *writeBuffer = NULL;
-        CLR_RT_HeapBlock_Array *readBuffer = NULL;
-
-        // create the return object (I2cTransferResult)
-        CLR_RT_HeapBlock &top = stack.PushValueAndClear();
-
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock *pThis = stack.This();
-        FAULT_ON_NULL(pThis);
-
-        // get a pointer to the managed spi connectionSettings object instance
-        CLR_RT_HeapBlock *pConfig = pThis[FIELD___connectionSettings].Dereference();
-
-        // get bus index
-        // subtract 1 to get ESP32 bus number
-        i2c_port_t bus = (i2c_port_t)(pConfig[I2cConnectionSettings::FIELD___busId].NumericByRef().s4 - 1);
-
-        int slaveAddress = pConfig[I2cConnectionSettings::FIELD___deviceAddress].NumericByRef().s4;
-
-        // dereference the write and read SpanByte from the arguments
-        writeSpanByte = stack.Arg1().Dereference();
-        if (writeSpanByte != NULL)
+        if (writeData != NULL)
         {
-            writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
-            if (writeBuffer != NULL)
-            {
-                // Get the write offset, only the elements defined by the span must be written, not the whole array
-                writeOffset = writeSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+            // Get the write offset, only the elements defined by the span must be written, not the whole array
+            writeOffset = writeSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
 
-                // grab the pointer to the array by starting and the offset specified in the span
-                writeData = writeBuffer->GetElement(writeOffset);
+            // use the span length as write size, only the elements defined by the span must be written
+            writeSize = writeSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
 
-                // use the span length as write size, only the elements defined by the span must be written
-                writeSize = writeSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
-            }
+            // grab the pointer to the array by starting and the offset specified in the span
+            writeBuffer = (uint8_t *)writeData->GetElement(writeOffset);
         }
+    }
 
-        readSpanByte = stack.Arg2().Dereference();
-        if (readSpanByte != 0)
+    readSpanByte = stack.Arg2().Dereference();
+    if (readSpanByte != 0)
+    {
+        readData = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
+
+        if (readData != NULL)
         {
-            readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
-            if (readBuffer != NULL)
+            // Get the read offset, only the elements defined by the span must be read, not the whole array
+            readOffset = readSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+
+            // use the span length as read size, only the elements defined by the span must be read
+            readSize = readSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
+
+            // need to allocate buffer from internal memory to prevent
+            readBuffer = (uint8_t *)heap_caps_malloc(readSize, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
+
+            if (readBuffer == NULL)
             {
-                // Get the read offset, only the elements defined by the span must be read, not the whole array
-                readOffset = readSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
-
-                // grab the pointer to the array by starting and the offset specified in the span
-                readData = readBuffer->GetElement(readOffset);
-
-                // use the span length as read size, only the elements defined by the span must be read
-                readSize = readSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
+                NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
             }
+
+            memset(readBuffer, 0, readSize);
         }
+    }
 
-        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    cmd = i2c_cmd_link_create();
 
-        if (writeSize != 0) // Write
+    // handle write transaction,if any
+    if (writeSize != 0)
+    {
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (slaveAddress << 1) | I2C_MASTER_WRITE, ACK_CHECK_EN);
+        opResult = i2c_master_write(cmd, &writeBuffer[0], writeSize, true);
+
+        ASSERT(opResult == ESP_OK);
+    }
+
+    // setup read transaction, if any
+    if (readSize != 0)
+    {
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (slaveAddress << 1) | I2C_MASTER_READ, ACK_CHECK_EN);
+
+        // read all bytes with ACK except the last one
+        opResult = i2c_master_read(cmd, readBuffer, readSize, I2C_MASTER_LAST_NACK);
+
+        ASSERT(opResult == ESP_OK);
+    }
+
+    i2c_master_stop(cmd);
+
+    opResult = i2c_master_cmd_begin(bus, cmd, 1000 / portTICK_RATE_MS);
+    i2c_cmd_link_delete(cmd);
+
+    // create return object
+    NANOCLR_CHECK_HRESULT(
+        g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+
+    result = top.Dereference();
+
+    FAULT_ON_NULL(result);
+
+    if (opResult != ESP_OK)
+    {
+        transferResult = I2cTransferStatus_FullTransfer;
+
+        // set the result field
+        if (opResult == ESP_FAIL)
         {
-            i2c_master_start(cmd);
-            i2c_master_write_byte(cmd, (slaveAddress << 1) | I2C_MASTER_WRITE, 1);
-            i2cStatus = i2c_master_write(cmd, &writeData[0], writeSize, true);
-            if (i2cStatus != ESP_OK)
-                ESP_LOGE(TAG, "i2c_master_write error:%d", i2cStatus);
+            transferResult = I2cTransferStatus_SlaveAddressNotAcknowledged;
         }
-        if (readSize != 0) // Read
+        else if (opResult == ESP_ERR_TIMEOUT)
         {
-            i2c_master_start(cmd);
-            i2c_master_write_byte(cmd, (slaveAddress << 1) | I2C_MASTER_READ, 1);
-            if (readSize > 1)
-            {
-                // Additional read bytes with ACK
-                i2c_master_read(cmd, &readData[0], readSize - 1, I2C_MASTER_ACK);
-            }
-            // Last read byte with NACK
-            i2c_master_read_byte(cmd, &readData[readSize - 1], I2C_MASTER_NACK);
-        }
-
-        i2c_master_stop(cmd);
-
-        i2cStatus = i2c_master_cmd_begin(bus, cmd, 1000 / portTICK_RATE_MS);
-        i2c_cmd_link_delete(cmd);
-
-        // create return object
-        NANOCLR_CHECK_HRESULT(
-            g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
-        result = top.Dereference();
-        FAULT_ON_NULL(result);
-
-        if (i2cStatus != ESP_OK)
-        {
-            uint32_t transferResult = I2cTransferStatus_FullTransfer;
-
-            // set the result field
-            if (i2cStatus == ESP_FAIL)
-            {
-                transferResult = I2cTransferStatus_SlaveAddressNotAcknowledged;
-            }
-            else if (i2cStatus == ESP_ERR_TIMEOUT)
-            {
-                transferResult = I2cTransferStatus_ClockStretchTimeout;
-            }
-            else
-            {
-                transferResult = I2cTransferStatus_UnknownError;
-            }
-
-            result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)transferResult);
-
-            // set the bytes transferred field
-            result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(0);
+            transferResult = I2cTransferStatus_ClockStretchTimeout;
         }
         else
         {
-            result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
-
-            // set the bytes transferred field
-            result[I2cTransferResult::FIELD___bytesTransferred].SetInteger((CLR_UINT32)(writeSize + readSize));
+            transferResult = I2cTransferStatus_UnknownError;
         }
+
+        result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)transferResult);
+
+        // set the bytes transferred field
+        result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(0);
     }
-    NANOCLR_NOCLEANUP();
+    else
+    {
+        // was there a read operation?
+        if (readSize > 0)
+        {
+            // grab the pointer to the array by starting and the offset specified in the span
+            memcpy(readData->GetElement(readOffset), readBuffer, readSize);
+        }
+
+        result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
+
+        // set the bytes transferred field
+        result[I2cTransferResult::FIELD___bytesTransferred].SetInteger((CLR_UINT32)(writeSize + readSize));
+    }
+
+    NANOCLR_CLEANUP();
+
+    if (readBuffer)
+    {
+        platform_free(readBuffer);
+    }
+
+    NANOCLR_CLEANUP_END();
 }


### PR DESCRIPTION
## Description
- Driver is now installed in RAM.
- Read buffer is now allocated from RAM.
- Rework SetConfig to assert call to IDF.
- Add assert to returns from calls to IDF.
- Improvements in I2C handling code for efficiency.

## Motivation and Context
- When PSRAM is used or when the I2C is time sensitive it's advisable to install the driver in RAM and have the read buffer allocated from internal RAM. This is to prevent issues and delays caused with caching and PSRAM access when serving the I2C interrupt.
- Fixes nanoFramework/Home#871.
- Resolves nanoFramework/Home#756.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
