### PR TITLE
Memory allocation is now using heap_caps API

### DIFF
--- a/targets/ESP32/_common/platform_heap.c
+++ b/targets/ESP32/_common/platform_heap.c
@@ -6,38 +6,20 @@
 #include <esp32_idf.h>
 #include <nanoHAL_v2.h>
 
+// setting here the default malloc capabilities that will be used when performing malloc operations
+#define DEFAULT_MALLOC_CAPS MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL
+
 void *platform_malloc(size_t size)
 {
-
-    // need to undef in order to call the real function
-#undef malloc
-
-    return malloc(size);
-
-    // define back
-#define malloc YOU_SHALL_NOT_USE_malloc
+    return heap_caps_malloc(size, DEFAULT_MALLOC_CAPS);
 }
 
 void platform_free(void *ptr)
 {
-
-// need to undef in order to call the real function
-#undef free
-
-    free(ptr);
-
-    // define back
-#define free YOU_SHALL_NOT_USE_free
+    heap_caps_free(ptr);
 }
 
 void *platform_realloc(void *ptr, size_t size)
 {
-
-// need to undef in order to call the real function
-#undef realloc
-
-    return realloc(ptr, size);
-
-    // define back
-#define realloc YOU_SHALL_NOT_USE_realloc
+    return heap_caps_realloc(ptr, size, DEFAULT_MALLOC_CAPS);
 }


### PR DESCRIPTION
## Description
- Memory allocation is now using heap_caps API and always requesting memory from internal RAM.

## Motivation and Context
- This is required to make use that malloc and free call the correct API for targets with and without PSRAM.
- Also this ensures that there are no cache or other issues in memory allocated dynamically in targets with PSRAM.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
