### PR TITLE
Add build option to set XTAL frequency to 26MHz

### DIFF
--- a/.vscode/cmake-variants.TEMPLATE.json
+++ b/.vscode/cmake-variants.TEMPLATE.json
@@ -59,6 +59,7 @@
           "FATFS_SOURCE": "<path-to-local-FATFS-source-mind-the-forward-slash>",
           "LWIP_VERSION": "<valid-lwip-version-if-empty-use-default-set-cmake>",
           "ESP32_IDF_PATH": "<absolute-path-to-the-IDF-folder-mind-the-forward-slashes>",
+          "ESP32_XTAL_FREQ_26": "OFF-default-ON-to-enable-XTAL-frequency-to-26M",
           "SDK_CONFIG_FILE": "<absolute-path-to-the-IDF-SDK-CONFIG-file-mind-the-forward-slashes-leave-empty-to-use-series-default>",
           "ETH_PHY_ADDR": "<Address-of-the-PHY-chip-leave-empty-to-use-default>",
           "ETH_MDC_GPIO": "<GPIO-number-for-SMI-MDC-pin-leave-empty-to-use-default>",

--- a/CMake/binutils.ESP32.cmake
+++ b/CMake/binutils.ESP32.cmake
@@ -528,6 +528,37 @@ macro(nf_add_idf_as_library)
 
     endif()
 
+    # option for automatic XTAL frequency detection
+    # (default is OFF which means that fixed default frequency will be used)
+    option(ESP32_XTAL_FREQ_26 "option to enable support for automatic XTAL frequency detection")
+    
+    if(ESP32_XTAL_FREQ_26)
+
+        message(STATUS "Support for automatic XTAL frequency detection is enabled")
+                
+        # need to read the supplied SDK CONFIG file and replace the appropriate options            
+        file(READ
+            "${SDKCONFIG_DEFAULTS_FILE}"
+            SDKCONFIG_DEFAULT_CONTENTS)
+
+        string(REPLACE
+            "CONFIG_ESP32_XTAL_FREQ_40"
+            "CONFIG_ESP32_XTAL_FREQ_26"
+            SDKCONFIG_DEFAULT_FINAL_CONTENTS
+            "${SDKCONFIG_DEFAULT_CONTENTS}")
+
+        # need to temporarilly allow changes in source files
+        set(CMAKE_DISABLE_SOURCE_CHANGES OFF)
+
+        file(WRITE 
+            ${SDKCONFIG_DEFAULTS_FILE} 
+            ${SDKCONFIG_DEFAULT_FINAL_CONTENTS})
+
+        set(CMAKE_DISABLE_SOURCE_CHANGES ON)
+    else()
+        message(STATUS "Using default XTAL frequency")
+    endif()
+
     # create IDF static libraries
     idf_build_process(${TARGET_SERIES_SHORT}
         COMPONENTS 

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -240,6 +240,14 @@ jobs:
         IDF_Target: esp32
         TargetName: ESP32
         PackageName: ESP32_PSRAM_REV3
+      ESP32_PSRAM_XTAL26_REV0:
+        TargetBoard: ESP32
+        BuildOptions: -DTARGET_SERIES=ESP32 -DRTOS=ESP32 -DESP32_XTAL_FREQ_26=ON -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DNF_FEATURE_HAS_CONFIG_BLOCK=ON -DNF_SECURITY_MBEDTLS=ON -DSUPPORT_ANY_BASE_CONVERSION=ON -DNF_FEATURE_HAS_SDCARD=ON -DAPI_System.IO.FileSystem=ON -DAPI_System.Math=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_System.Device.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_System.Device.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_System.Device.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_System.IO.Ports=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=ON -DAPI_Windows.Devices.Wifi=ON -DAPI_Hardware.Esp32=ON -DAPI_nanoFramework.Devices.OneWire=ON -DAPI_nanoFramework.ResourceManager=ON -DAPI_nanoFramework.System.Collections=ON -DAPI_nanoFramework.System.Text=ON -DAPI_nanoFramework.Hardware.Esp32.Rmt=ON -DAPI_System.Device.Dac=ON
+        ToolchainFile: toolchain.xtensa-esp32-elf.cmake
+        SDK_config: 
+        IDF_Target: esp32
+        TargetName: ESP32
+        PackageName: ESP32_PSRAM_REV0
       ESP32_REV3:
         TargetBoard: ESP32
         BuildOptions: -DTARGET_SERIES=ESP32 -DRTOS=ESP32 -DNF_FEATURE_DEBUGGER=ON -DNF_FEATURE_RTC=ON -DNF_FEATURE_HAS_CONFIG_BLOCK=ON -DNF_SECURITY_MBEDTLS=ON -DSUPPORT_ANY_BASE_CONVERSION=ON -DNF_FEATURE_HAS_SDCARD=ON -DAPI_System.IO.FileSystem=ON -DAPI_System.Math=ON -DAPI_Windows.Devices.Gpio=ON -DAPI_System.Device.Gpio=ON -DAPI_Windows.Devices.Spi=ON -DAPI_System.Device.Spi=ON -DAPI_Windows.Devices.I2c=ON -DAPI_System.Device.I2c=ON -DAPI_Windows.Devices.Pwm=ON -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_System.IO.Ports=ON -DAPI_Windows.Devices.Adc=ON -DAPI_System.Net=ON -DAPI_Windows.Devices.Wifi=ON -DAPI_Hardware.Esp32=ON -DAPI_nanoFramework.Devices.OneWire=ON -DAPI_nanoFramework.ResourceManager=ON -DAPI_nanoFramework.System.Collections=ON -DAPI_nanoFramework.System.Text=ON -DAPI_nanoFramework.Hardware.Esp32.Rmt=ON -DAPI_System.Device.Dac=ON

--- a/targets/ESP32/_IDF/sdkconfig.default
+++ b/targets/ESP32/_IDF/sdkconfig.default
@@ -238,6 +238,10 @@ CONFIG_ESP_TLS_USE_DS_PERIPHERAL=y
 #
 # end of ADC-Calibration
 
+# config for XTAL freq
+# adding it here, so it can be overriden by our CMake
+CONFIG_ESP32_XTAL_FREQ_40=y
+
 #
 # Common ESP-related
 #

--- a/targets/ESP32/_IDF/sdkconfig.default.esp32
+++ b/targets/ESP32/_IDF/sdkconfig.default.esp32
@@ -332,6 +332,10 @@ CONFIG_ESP32S2_RTC_CLK_CAL_CYCLES=576
 #
 # end of ADC-Calibration
 
+# config for XTAL freq
+# adding it here, so it can be overriden by our CMake
+CONFIG_ESP32_XTAL_FREQ_40=y
+
 #
 # Common ESP-related
 #

--- a/targets/ESP32/_IDF/sdkconfig.default.esp32s2
+++ b/targets/ESP32/_IDF/sdkconfig.default.esp32s2
@@ -333,6 +333,10 @@ CONFIG_ESP32S2_RTC_CLK_CAL_CYCLES=576
 #
 # end of ADC-Calibration
 
+# config for XTAL freq
+# adding it here, so it can be overriden by our CMake
+CONFIG_ESP32_XTAL_FREQ_40=y
+
 #
 # Common ESP-related
 #

--- a/targets/ESP32/_IDF/sdkconfig.default_ble _rev3.esp32
+++ b/targets/ESP32/_IDF/sdkconfig.default_ble _rev3.esp32
@@ -338,6 +338,10 @@ CONFIG_ESP32S2_RTC_CLK_CAL_CYCLES=576
 #
 # end of ADC-Calibration
 
+# config for XTAL freq
+# adding it here, so it can be overriden by our CMake
+CONFIG_ESP32_XTAL_FREQ_40=y
+
 #
 # Common ESP-related
 #

--- a/targets/ESP32/_IDF/sdkconfig.default_ble.esp32
+++ b/targets/ESP32/_IDF/sdkconfig.default_ble.esp32
@@ -335,6 +335,10 @@ CONFIG_ESP32S2_RTC_CLK_CAL_CYCLES=576
 #
 # end of ADC-Calibration
 
+# config for XTAL freq
+# adding it here, so it can be overriden by our CMake
+CONFIG_ESP32_XTAL_FREQ_40=y
+
 #
 # Common ESP-related
 #

--- a/targets/ESP32/_IDF/sdkconfig.default_nopsram.esp32
+++ b/targets/ESP32/_IDF/sdkconfig.default_nopsram.esp32
@@ -309,6 +309,10 @@ CONFIG_ESP32S2_RTC_CLK_CAL_CYCLES=576
 #
 # end of ADC-Calibration
 
+# config for XTAL freq
+# adding it here, so it can be overriden by our CMake
+CONFIG_ESP32_XTAL_FREQ_40=y
+
 #
 # Common ESP-related
 #

--- a/targets/ESP32/_IDF/sdkconfig.default_nopsram_rev3.esp32
+++ b/targets/ESP32/_IDF/sdkconfig.default_nopsram_rev3.esp32
@@ -310,6 +310,10 @@ CONFIG_ESP32S2_RTC_CLK_CAL_CYCLES=576
 #
 # end of ADC-Calibration
 
+# config for XTAL freq
+# adding it here, so it can be overriden by our CMake
+CONFIG_ESP32_XTAL_FREQ_40=y
+
 #
 # Common ESP-related
 #

--- a/targets/ESP32/_IDF/sdkconfig.default_pico
+++ b/targets/ESP32/_IDF/sdkconfig.default_pico
@@ -309,6 +309,10 @@ CONFIG_ESP32S2_RTC_CLK_CAL_CYCLES=576
 #
 # end of ADC-Calibration
 
+# config for XTAL freq
+# adding it here, so it can be overriden by our CMake
+CONFIG_ESP32_XTAL_FREQ_40=y
+
 #
 # Common ESP-related
 #

--- a/targets/ESP32/_IDF/sdkconfig.default_rev3.esp32
+++ b/targets/ESP32/_IDF/sdkconfig.default_rev3.esp32
@@ -334,6 +334,10 @@ CONFIG_ESP32S2_RTC_CLK_CAL_CYCLES=576
 #
 # end of ADC-Calibration
 
+# config for XTAL freq
+# adding it here, so it can be overriden by our CMake
+CONFIG_ESP32_XTAL_FREQ_40=y
+
 #
 # Common ESP-related
 #


### PR DESCRIPTION
## Description
- Add config option to sdk config files.
- Add build option to CMake and template file
- Add variant to nightly build yaml.

## Motivation and Context
- Adds new variant for boards that use 26MHz crystal.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
