### PR TITLE
Replace wrong path with CMake variable in binutils.AzureRTOS

### DIFF
--- a/CMake/binutils.AzureRTOS.cmake
+++ b/CMake/binutils.AzureRTOS.cmake
@@ -175,7 +175,7 @@ macro(nf_add_platform_dependencies target)
                 ${CHIBIOS_HAL_INCLUDE_DIRS}
                 ${ChibiOSnfOverlay_INCLUDE_DIRS}
                 ${azure_rtos_SOURCE_DIR}/common/inc
-                ${CMAKE_SOURCE_DIR}/targets/AzureChibiOS/${TARGET_BOARD}
+                ${TARGET_BASE_LOCATION}
                 ${AZRTOS_INCLUDES})
         
         add_dependencies(NF_NativeAssemblies azrtos::threadx)


### PR DESCRIPTION
## Description
Replace
```${CMAKE_SOURCE_DIR}/targets/AzureChibiOS/${TARGET_BOARD}```
 With
```${TARGET_BASE_LOCATION}```

## Motivation and Context
Replace hard coded target with CMake variable. 

This is a good example why we should avoid hardcoded paths in global cmakelists.txt as they can be forgotten. There should be documentation that defines the base must have cmake variables all platforms can depend on being initialised correctly. 

## How Has This Been Tested?
Build AzureRTOS target.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
