### PR TITLE
Fix COM port enumeration for ESP32

### DIFF
--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1237,8 +1237,22 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetDeviceSelector_
     NANOCLR_HEADER();
 
     // declare the device selector string whose max size is "COM1,COM2,COM3" + terminator
-    // COM1 is being used for VS debug, so it's not available
-    char deviceSelectorString[10] = "COM2,COM3";
+    // and init with the terminator
+    char deviceSelectorString[14 + 1] = {0};
+
+    // unless the build is configure to use USB CDC, COM1 is being used for VS debug, so it's not available
+#if defined(CONFIG_USB_CDC_ENABLED)
+    strcat(deviceSelectorString, "COM1,");
+#endif
+#if defined(UART_NUM_1)
+    strcat(deviceSelectorString, "COM2,");
+#endif
+#if defined(UART_NUM_2)
+    strcat(deviceSelectorString, "COM3,");
+#endif
+
+    // replace the last comma with a terminator
+    deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
 
     // because the caller is expecting a result to be returned
     // we need set a return result in the stack argument using the appropriate SetResult according to the variable

--- a/targets/ESP32/_nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
+++ b/targets/ESP32/_nanoCLR/Windows.Devices.SerialCommunication/win_dev_serial_native_Windows_Devices_SerialCommunication_SerialDevice.cpp
@@ -1026,15 +1026,26 @@ HRESULT Library_win_dev_serial_native_Windows_Devices_SerialCommunication_Serial
     GetDeviceSelector___STATIC__STRING(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
-    {
-        // declare the device selector string whose max size is "COM1,COM2,COM3" + terminator
-        // COM1 is being used for VS debug, so it's not available
-        char deviceSelectorString[15] = "COM2,COM3";
 
-        // because the caller is expecting a result to be returned
-        // we need set a return result in the stack argument using the appropriate SetResult according to the variable
-        // type (a string here)
-        stack.SetResult_String(deviceSelectorString);
-    }
+    // declare the device selector string whose max size is "COM1,COM2,COM3" + terminator
+    // and init with the terminator
+    char deviceSelectorString[14 + 1] = {0};
+
+    // unless the build is configure to use USB CDC, COM1 is being used for VS debug, so it's not available
+#if defined(CONFIG_USB_CDC_ENABLED)
+    strcat(deviceSelectorString, "COM1,");
+#endif
+#if defined(UART_NUM_1)
+    strcat(deviceSelectorString, "COM2,");
+#endif
+#if defined(UART_NUM_2)
+    strcat(deviceSelectorString, "COM3,");
+#endif
+
+    // because the caller is expecting a result to be returned
+    // we need set a return result in the stack argument using the appropriate SetResult according to the variable
+    // type (a string here)
+    stack.SetResult_String(deviceSelectorString);
+
     NANOCLR_NOCLEANUP_NOLABEL();
 }


### PR DESCRIPTION
## Description
- String for device selector is now build according to configuration.
- Allowing UART0 to be available for C# on targets using the embedded USB CDC.

## Motivation and Context
- Fixes issue with wrong COM port enumeration on some ESP32-S2 targets.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
