### PR TITLE
Add Get Native Memory Info on ESP32

### DIFF
--- a/CMake/Modules/FindnanoFramework.Hardware.Esp32.cmake
+++ b/CMake/Modules/FindnanoFramework.Hardware.Esp32.cmake
@@ -22,6 +22,7 @@ set(nanoFramework.Hardware.Esp32_SRCS
     nanoFramework_hardware_esp32_native_Hardware_Esp32_Logging.cpp
     nanoFramework_hardware_esp32_native_Hardware_Esp32_HighResTimer.cpp
 	nanoFramework_hardware_esp32_native_Hardware_Esp32_Configuration.cpp
+    nanoFramework_hardware_esp32_native_Hardware_Esp32_NativeMemory.cpp
 )
 
 foreach(SRC_FILE ${nanoFramework.Hardware.Esp32_SRCS})

--- a/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native.cpp
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native.cpp
@@ -50,6 +50,11 @@ static const CLR_RT_MethodHandler method_lookup[] =
     Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Logging::NativeSetLogLevel___STATIC__VOID__STRING__I4,
     NULL,
     NULL,
+    Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_NativeMemory::NativeGetMemoryTotalSize___STATIC__U4__I4,
+    Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_NativeMemory::NativeGetMemoryTotalFreeSize___STATIC__U4__I4,
+    Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_NativeMemory::NativeGetMemoryLargestFreeBlock___STATIC__U4__I4,
+    NULL,
+    NULL,
     NULL,
     NULL,
     NULL,
@@ -72,7 +77,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_Hardware_Esp32 =
 {
     "nanoFramework.Hardware.Esp32",
-    0x1B75B894,
+    0xBE7FF253,
     method_lookup,
     { 100, 0, 7, 2 }
 };

--- a/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native.h
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native.h
@@ -12,6 +12,13 @@
 #include <nanoCLR_Checks.h>
 #include <corlib_native.h>
 
+typedef enum __nfpack NativeMemory_MemoryType
+{
+    NativeMemory_MemoryType_All = 0,
+    NativeMemory_MemoryType_Internal = 1,
+    NativeMemory_MemoryType_SpiRam = 2,
+} NativeMemory_MemoryType;
+
 struct Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Configuration
 {
     NANOCLR_NATIVE_DECLARE(NativeSetPinFunction___STATIC__VOID__I4__I4);
@@ -51,8 +58,8 @@ struct Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_
 
 struct Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_HighResTimerEvent
 {
-    static const int FIELD__EventType = 1;
-    static const int FIELD__TimerHandle = 2;
+    static const int FIELD__EventType = 3;
+    static const int FIELD__TimerHandle = 4;
 
     //--//
 
@@ -61,6 +68,16 @@ struct Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_
 struct Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Logging
 {
     NANOCLR_NATIVE_DECLARE(NativeSetLogLevel___STATIC__VOID__STRING__I4);
+
+    //--//
+
+};
+
+struct Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_NativeMemory
+{
+    NANOCLR_NATIVE_DECLARE(NativeGetMemoryTotalSize___STATIC__U4__I4);
+    NANOCLR_NATIVE_DECLARE(NativeGetMemoryTotalFreeSize___STATIC__U4__I4);
+    NANOCLR_NATIVE_DECLARE(NativeGetMemoryLargestFreeBlock___STATIC__U4__I4);
 
     //--//
 

--- a/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_NativeMemory.cpp
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_NativeMemory.cpp
@@ -1,0 +1,58 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+#include "nanoFramework_hardware_esp32_native.h"
+#include <esp32_idf.h>
+
+
+uint32_t GetCaps(CLR_RT_StackFrame &stack)
+{
+    uint32_t caps = MALLOC_CAP_32BIT | MALLOC_CAP_8BIT;
+    int memoryType = (int)stack.Arg0().NumericByRef().u4;
+
+    if ( memoryType == NativeMemory_MemoryType::NativeMemory_MemoryType_All )
+    {
+        caps | = (MALLOC_CAP_INTERNAL + MALLOC_CAP_SPIRAM);
+    }
+    else if (memoryType == NativeMemory_MemoryType::NativeMemory_MemoryType_Internal)
+    {
+         caps | = MALLOC_CAP_INTERNAL;
+    }
+    else
+    {
+         caps | = MALLOC_CAP_SPIRAM;
+    }
+    
+    return caps;
+}
+
+
+HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_NativeMemory::NativeGetMemoryTotalSize___STATIC__U4__I4( CLR_RT_StackFrame &stack )
+{
+    NANOCLR_HEADER();
+    {
+        stack.SetResult_U4((uint32_t)heap_caps_get_total_size(GetCaps(stack)));
+    }
+    NANOCLR_NOCLEANUP_NOLABEL();
+}
+
+HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_NativeMemory::NativeGetMemoryTotalFreeSize___STATIC__U4__I4( CLR_RT_StackFrame &stack )
+{
+    NANOCLR_HEADER();
+    {
+        stack.SetResult_U4((uint32_t)heap_caps_get_free_size(GetCaps(stack)));
+    }
+    NANOCLR_NOCLEANUP_NOLABEL();
+}
+
+HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_NativeMemory::NativeGetMemoryLargestFreeBlock___STATIC__U4__I4( CLR_RT_StackFrame &stack )
+{
+    NANOCLR_HEADER();
+    {
+        stack.SetResult_U4((uint32_t)heap_caps_get_largest_free_blockcaps(GetCaps(stack)));
+    }
+    NANOCLR_NOCLEANUP_NOLABEL();
+}

--- a/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_NativeMemory.cpp
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_NativeMemory.cpp
@@ -5,7 +5,7 @@
 //
 
 #include "nanoFramework_hardware_esp32_native.h"
-#include <esp32_idf.h>
+#include <nanoHAL.h>
 
 
 uint32_t GetCaps(CLR_RT_StackFrame &stack)
@@ -13,23 +13,21 @@ uint32_t GetCaps(CLR_RT_StackFrame &stack)
     uint32_t caps = MALLOC_CAP_32BIT | MALLOC_CAP_8BIT;
     int memoryType = (int)stack.Arg0().NumericByRef().u4;
 
-    if ( memoryType == NativeMemory_MemoryType::NativeMemory_MemoryType_All )
+    if (memoryType == NativeMemory_MemoryType::NativeMemory_MemoryType_Internal)
     {
-        caps | = (MALLOC_CAP_INTERNAL + MALLOC_CAP_SPIRAM);
+         caps |= MALLOC_CAP_INTERNAL;
     }
-    else if (memoryType == NativeMemory_MemoryType::NativeMemory_MemoryType_Internal)
+    else if (memoryType == NativeMemory_MemoryType::NativeMemory_MemoryType_SpiRam)
     {
-         caps | = MALLOC_CAP_INTERNAL;
-    }
-    else
-    {
-         caps | = MALLOC_CAP_SPIRAM;
+         caps |= MALLOC_CAP_SPIRAM;
     }
     
     return caps;
 }
 
-
+//
+// Get the total size of all the regions. 
+//
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_NativeMemory::NativeGetMemoryTotalSize___STATIC__U4__I4( CLR_RT_StackFrame &stack )
 {
     NANOCLR_HEADER();
@@ -39,6 +37,9 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
     NANOCLR_NOCLEANUP_NOLABEL();
 }
 
+//
+// Get the total free size of all the regions. 
+//
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_NativeMemory::NativeGetMemoryTotalFreeSize___STATIC__U4__I4( CLR_RT_StackFrame &stack )
 {
     NANOCLR_HEADER();
@@ -48,11 +49,14 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
     NANOCLR_NOCLEANUP_NOLABEL();
 }
 
+//
+// Get the largest free block of memory able to be allocated.
+// 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_NativeMemory::NativeGetMemoryLargestFreeBlock___STATIC__U4__I4( CLR_RT_StackFrame &stack )
 {
     NANOCLR_HEADER();
     {
-        stack.SetResult_U4((uint32_t)heap_caps_get_largest_free_blockcaps(GetCaps(stack)));
+        stack.SetResult_U4((uint32_t)heap_caps_get_largest_free_block(GetCaps(stack)));
     }
     NANOCLR_NOCLEANUP_NOLABEL();
 }


### PR DESCRIPTION
## Description
Allows the information about amount native memory to queried from Managed code
Using nanoFramework.Hardware.Esp32

## Motivation and Context
To allow testing of memory leaks in unit tests

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Simple test app

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
