### PR TITLE
Add System.Device.Pwm to ESP32

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -335,7 +335,7 @@ jobs:
           -DAPI_Windows.Devices.Gpio=ON -DAPI_System.Device.Gpio=ON
           -DAPI_Windows.Devices.Spi=ON -DAPI_System.Device.Spi=ON
           -DAPI_Windows.Devices.I2c=ON -DAPI_System.Device.I2c=ON
-          -DAPI_Windows.Devices.Pwm=ON
+          -DAPI_Windows.Devices.Pwm=ON -DAPI_System.Device.Pwm=ON
           -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_System.IO.Ports=ON
           -DAPI_Windows.Devices.Adc=ON -DAPI_System.Device.Adc=ON
           -DAPI_System.Net=ON
@@ -367,10 +367,10 @@ jobs:
           -DNF_FEATURE_HAS_SDCARD=ON
           -DAPI_System.IO.FileSystem=ON
           -DAPI_System.Math=ON
-          -DAPI_Windows.Devices.Gpio=ON  -DAPI_System.Device.Gpio=ON
+          -DAPI_Windows.Devices.Gpio=ON -DAPI_System.Device.Gpio=ON
           -DAPI_Windows.Devices.Spi=ON -DAPI_System.Device.Spi=ON
           -DAPI_Windows.Devices.I2c=ON -DAPI_System.Device.I2c=ON
-          -DAPI_Windows.Devices.Pwm=ON
+          -DAPI_Windows.Devices.Pwm=ON -DAPI_System.Device.Pwm=ON
           -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_System.IO.Ports=ON
           -DAPI_Windows.Devices.Adc=ON -DAPI_System.Device.Adc=ON
           -DAPI_System.Net=ON
@@ -403,7 +403,7 @@ jobs:
           -DAPI_Windows.Devices.Gpio=ON -DAPI_System.Device.Gpio=ON
           -DAPI_Windows.Devices.Spi=ON -DAPI_System.Device.Spi=ON
           -DAPI_Windows.Devices.I2c=ON -DAPI_System.Device.I2c=ON
-          -DAPI_Windows.Devices.Pwm=ON
+          -DAPI_Windows.Devices.Pwm=ON -DAPI_System.Device.Pwm=ON
           -DAPI_Windows.Devices.SerialCommunication=ON -DAPI_System.IO.Ports=ON
           -DAPI_Windows.Devices.Adc=ON -DAPI_System.Device.Adc=ON
           -DAPI_System.Net=ON


### PR DESCRIPTION
## Description
Where missing.

## Motivation and Context
System.Device.Pwm was missing from some ESP32 targets. This adds it (where Windows.Devices.Pwm was already on).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->


## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
