### PR TITLE
Fix double implementation for GCC

### DIFF
--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -431,66 +431,20 @@ struct CLR_RT_HeapBlock
 
                 operator double() const
                 {
-                    double ret_val;
+                    double ret_val = 0;
 
-#if defined(__GNUC__)
-                    ///
-                    /// UNDONE: FIXME: This code fixes an optimization problem with the gcc compiler.
-                    /// When the optimization level is greater than zero, the gcc compiler
-                    /// code will not work with the unsigned int* conversion, it requires you
-                    /// to copy byte by byte.
-                    ///
-                    CLR_UINT8 *tmp = (CLR_UINT8 *)&ret_val;
-                    CLR_UINT8 *src = (CLR_UINT8 *)&LL;
-                    uint32_t i;
-
-                    for (i = 0; i < sizeof(CLR_UINT32); i++)
-                    {
-                        *tmp++ = *src++;
-                    }
-
-                    src = (CLR_UINT8 *)&HH;
-                    for (i = 0; i < sizeof(CLR_UINT32); i++)
-                    {
-                        *tmp++ = *src++;
-                    }
-#else
                     CLR_UINT32 *tmp = (CLR_UINT32 *)&ret_val;
                     tmp[0] = LL;
                     tmp[1] = HH;
-#endif // defined(__GNUC__)
 
                     return ret_val;
                 }
 
                 R8 &operator=(const double num)
                 {
-#if defined(__GNUC__)
-                    ///
-                    /// UNDONE: FIXME: This code fixes an optimization problem with the gcc compiler.
-                    /// When the optimization level is greater than zero, the gcc compiler
-                    /// code will not work with the unsigned int* conversion, it requires you
-                    /// to copy byte by byte.
-                    ///
-                    CLR_UINT8 *src = (CLR_UINT8 *)&num;
-                    CLR_UINT8 *dst = (CLR_UINT8 *)&LL;
-                    uint32_t i;
-
-                    for (i = 0; i < sizeof(CLR_UINT32); i++)
-                    {
-                        *dst++ = *src++;
-                    }
-
-                    dst = (CLR_UINT8 *)&HH;
-                    for (i = 0; i < sizeof(CLR_UINT32); i++)
-                    {
-                        *dst++ = *src++;
-                    }
-#else
                     CLR_UINT32 *tmp = (CLR_UINT32 *)&num;
                     LL = (CLR_UINT32)tmp[0];
                     HH = (CLR_UINT32)tmp[1];
-#endif
 
                     return *this;
                 }

--- a/src/CLR/System.Math/nf_native_system_math_System_Math.cpp
+++ b/src/CLR/System.Math/nf_native_system_math_System_Math.cpp
@@ -19,13 +19,9 @@ HRESULT Library_nf_native_system_math_System_Math::Max___STATIC__R8__R8__R8(CLR_
     double y = stack.Arg1().NumericByRefConst().r8;
 
     // from .NET spec: If val1, val2, or both val1 and val2 are equal to NaN, NaN is returned.
-    if (System::Double::IsNaN(x))
+    if (System::Double::IsNaN(x) || System::Double::IsNaN(y))
     {
-        stack.SetResult_R8(x);
-    }
-    else if (System::Double::IsNaN(y))
-    {
-        stack.SetResult_R8(y);
+        stack.SetResult_R8(NAN);
     }
     else
     {
@@ -40,13 +36,9 @@ HRESULT Library_nf_native_system_math_System_Math::Max___STATIC__R8__R8__R8(CLR_
     float y = (float)stack.Arg1().NumericByRefConst().r8;
 
     // from .NET spec: If val1, val2, or both val1 and val2 are equal to NaN, NaN is returned.
-    if (System::Double::IsNaN(x))
+    if (System::Double::IsNaN(x) || System::Double::IsNaN(y))
     {
-        stack.SetResult_R8(x);
-    }
-    else if (System::Double::IsNaN(y))
-    {
-        stack.SetResult_R8(y);
+        stack.SetResult_R8(NAN);
     }
     else
     {


### PR DESCRIPTION
## Description
- Remove ancient code with an workaround for an old bug with GCC.
- Improve code handling Math.Max to use C constant for NaN.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
