### PR TITLE
Fix bug in unreserving GPIO pins for SD Card

### DIFF
--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_nanoFramework_System_IO_FileSystem_SDCard.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_nanoFramework_System_IO_FileSystem_SDCard.cpp
@@ -53,7 +53,7 @@ void GetMMCPins(bool _1bit, int *count, int8_t **pPins)
 
 void UnReservePins(int count, int8_t *pPins)
 {
-    for (int index = count; index <= count; index++)
+    for (int index = count-1; index >= 0; index--)
     {
         CPU_GPIO_ReservePin((GPIO_PIN)pPins[index], false);
     }

--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_nanoFramework_System_IO_FileSystem_SDCard.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_nanoFramework_System_IO_FileSystem_SDCard.cpp
@@ -53,7 +53,7 @@ void GetMMCPins(bool _1bit, int *count, int8_t **pPins)
 
 void UnReservePins(int count, int8_t *pPins)
 {
-    for (int index = count-1; index >= 0; index--)
+    for (int index = count - 1; index >= 0; index--)
     {
         CPU_GPIO_ReservePin((GPIO_PIN)pPins[index], false);
     }


### PR DESCRIPTION
## Description
Not correctly un-reserving SDIO pins when SDCARD disposed

## Motivation and Context
- Fixes nanoFramework/Home#894

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Run test from issue 894 in loop

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
