### PR TITLE
Fix FileStream memory leak

### DIFF
--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
@@ -75,10 +75,9 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::OpenFileNative___VOID
 
     // setup file path
     filePath = (char *)platform_malloc(2 * FF_LFN_BUF + 1);
-    vfsPath = (char *)platform_malloc(2 * FF_LFN_BUF + 1);
-
+    
     // sanity check for successfull malloc
-    if (filePath == NULL || vfsPath == NULL)
+    if (filePath == NULL)
     {
         // failed to allocate memory
         NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
@@ -212,10 +211,9 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::ReadNative___I4__STRI
 
     // setup file path
     filePath = (char *)platform_malloc(2 * FF_LFN_BUF + 1);
-    vfsPath = (char *)platform_malloc(2 * FF_LFN_BUF + 1);
-
+  
     // sanity check for successfull malloc
-    if (filePath == NULL || vfsPath == NULL)
+    if (filePath == NULL)
     {
         // failed to allocate memory
         NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
@@ -305,10 +303,9 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::WriteNative___VOID__S
 
     // setup file path
     filePath = (char *)platform_malloc(2 * FF_LFN_BUF + 1);
-    vfsPath = (char *)platform_malloc(2 * FF_LFN_BUF + 1);
-
+    
     // sanity check for successfull mallocs
-    if (filePath == NULL || vfsPath == NULL)
+    if (filePath == NULL)
     {
         // failed to allocate memory
         NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);

--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
@@ -24,6 +24,9 @@ void CombinePathAndName(char *outpath, const char *path1, const char *path2)
 //  Converts from windows type path       "c:\folder\folder\file.ext"
 //  to linux type path used in ESP32 VFS  "/c/folder/folder/file.exe
 //  where /c is the mount point
+////////////////////////////////////////////
+// MAKE SURE TO FREE THE RETURNED POINTER //
+////////////////////////////////////////////
 //
 char *ConvertToVfsPath(const char *filepath)
 {
@@ -31,7 +34,18 @@ char *ConvertToVfsPath(const char *filepath)
     char *path = NULL;
 
     int pathlen = hal_strlen_s(filepath);
+    
+    /////////////////////////////////
+    // MAKE SURE TO FREE THIS POINTER
     startPath = (char *)platform_malloc(pathlen + 1);
+    
+    // sanity check for successfull malloc
+    if (startPath == NULL)
+    {
+        // failed to allocate memory
+        return NULL;
+    }
+    
     path = startPath;
     hal_strcpy_s(path, pathlen + 1, filepath);
 


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
1) Remove the vfsPath platform_malloc.
2) Remove check for vfsPath == NULL;

## Motivation and Context
- Leak native memory very time a file is opened or written to.
- Fixes https://github.com/nanoframework/Home/issues/895

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
loop 100 times.
[https://github.com/alberk8/nanoFramework-SDCard-Test/tree/main/nanoFrameworkSDCard](url)

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
