### PR TITLE
Fix managed heap size for non BLE versions

### DIFF
--- a/targets/ESP32/_nanoCLR/Memory.cpp
+++ b/targets/ESP32/_nanoCLR/Memory.cpp
@@ -25,7 +25,7 @@ static const char *TAG = "Memory";
 
 // You can't go much bigger than this when allocating in internal memory to
 // get memory in one continuous lump.
-#if defined(HAL_USE_BLE)
+#if (HAL_USE_BLE == TRUE)
 #define INTERNAL_MEMORY_SIZE (54 * 1024) // Reduce Managed heap if using BLE without spiram
 #else
 #define INTERNAL_MEMORY_SIZE (84 * 1024)


### PR DESCRIPTION

## Description
A mistake in BLE firmware cause non BLE firmware version to use small managed heap size

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes/Closes/Resolves nanoFramework/Home#NNNN

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

Built ESP32_rev0 & ESP32_BLE_REV0 version and checked managed heap size with GC.Run

- ESP32_rev0 = 79K
- ESP32_BLE_REV0 = 49K


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
