### PR TITLE
Fix Bluetooth options in cmake-variants

### DIFF
--- a/.vscode/cmake-variants-DEVCONTAINER.json
+++ b/.vscode/cmake-variants-DEVCONTAINER.json
@@ -334,7 +334,8 @@
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
           "API_nanoFramework.Devices.OneWire": "ON",
-          "API_nanoFramework.Graphics": "OFF"
+          "API_nanoFramework.Graphics": "OFF",
+          "API_nanoFramework.Device.Bluetooth": "OFF"
         }
       },
       "ESP32_REV0_BLE": {
@@ -381,7 +382,7 @@
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
           "API_nanoFramework.Devices.OneWire": "ON",
           "API_nanoFramework.Graphics": "OFF",
-          "API_nanoFramework.Hardware.Esp32.Ble": "ON"
+          "API_nanoFramework.Device.Bluetooth": "ON"
         }
       },
       "ESP32_PICO": {
@@ -429,7 +430,7 @@
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
           "API_nanoFramework.Devices.OneWire": "ON",
           "API_nanoFramework.Graphics": "OFF",
-          "API_nanoFramework.Hardware.Esp32.Ble": "ON"
+          "API_nanoFramework.Device.Bluetooth": "OFF"
         }
       },
       "ESP_WROVER_KIT": {
@@ -474,6 +475,7 @@
           "API_Windows.Storage": "ON",
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
+          "API_nanoFramework.Device.Bluetooth": "OFF",
           "API_nanoFramework.Graphics": "ON",
           "GRAPHICS_DISPLAY": "ILI9341_240x320_SPI.cpp",
           "TOUCHPANEL_DEVICE": "XPT2046.cpp",
@@ -525,7 +527,8 @@
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
           "API_nanoFramework.Devices.OneWire": "OFF",
-          "API_nanoFramework.Graphics": "OFF"
+          "API_nanoFramework.Graphics": "OFF",
+          "API_nanoFramework.Device.Bluetooth": "OFF"
         }
       },
       "KALUGA_1": {
@@ -570,6 +573,7 @@
           "API_System.Device.Spi": "ON",
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
+          "API_nanoFramework.Device.Bluetooth": "OFF",
           "API_nanoFramework.Devices.OneWire": "OFF",
           "API_nanoFramework.Graphics": "ON",
           "GRAPHICS_DISPLAY": "ILI9341_240x320_SPI.cpp",
@@ -620,6 +624,7 @@
           "API_Windows.Storage": "ON",
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
+          "API_nanoFramework.Device.Bluetooth": "OFF",
           "API_nanoFramework.Graphics": "ON",
           "GRAPHICS_DISPLAY": "ILI9341_240x320_SPI.cpp",
           "TOUCHPANEL_DEVICE": "XPT2046.cpp",
@@ -673,7 +678,7 @@
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
           "API_nanoFramework.Devices.OneWire": "ON",
           "API_nanoFramework.Graphics": "OFF",
-          "API_nanoFramework.Hardware.Esp32.Ble": "OFF"
+          "API_nanoFramework.Device.Bluetooth": "OFF"
         }
       },
       "TI_CC1352R1_LAUNCHXL": {

--- a/targets/ESP32/ESP32/cmake-variants.json
+++ b/targets/ESP32/ESP32/cmake-variants.json
@@ -65,7 +65,8 @@
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
           "API_nanoFramework.Devices.OneWire": "ON",
-          "API_nanoFramework.Graphics": "OFF"
+          "API_nanoFramework.Graphics": "OFF",
+          "API_nanoFramework.Device.Bluetooth": "OFF"
         }
       },
       "ESP32_REV0": {
@@ -111,7 +112,8 @@
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
           "API_nanoFramework.Devices.OneWire": "ON",
-          "API_nanoFramework.Graphics": "OFF"
+          "API_nanoFramework.Graphics": "OFF",
+          "API_nanoFramework.Device.Bluetooth": "OFF"
         }
       },
       "ESP32_BLE_REV0": {
@@ -208,7 +210,7 @@
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
           "API_nanoFramework.Devices.OneWire": "ON",
           "API_nanoFramework.Graphics": "OFF",
-          "API_nanoFramework.Device.Bluetooth": "ON"
+          "API_nanoFramework.Device.Bluetooth": "OFF"
         }
       },
       "ESP_WROVER_KIT": {
@@ -253,6 +255,7 @@
           "API_Windows.Storage": "ON",
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
+          "API_nanoFramework.Device.Bluetooth": "OFF",
           "API_nanoFramework.Graphics": "ON",
           "GRAPHICS_DISPLAY": "ILI9341_240x320_SPI.cpp",
           "TOUCHPANEL_DEVICE": "XPT2046.cpp",
@@ -302,6 +305,7 @@
           "API_Windows.Storage": "ON",
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
+          "API_nanoFramework.Device.Bluetooth": "OFF",
           "API_nanoFramework.Graphics": "ON",
           "GRAPHICS_DISPLAY": "ILI9341_240x320_SPI.cpp",
           "TOUCHPANEL_DEVICE": "XPT2046.cpp",
@@ -356,7 +360,7 @@
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
           "API_nanoFramework.Devices.OneWire": "ON",
           "API_nanoFramework.Graphics": "OFF",
-          "API_nanoFramework.Hardware.Esp32.Ble": "OFF"
+          "API_nanoFramework.Device.Bluetooth": "OFF"
         }
       }
     }

--- a/targets/ESP32/ESP32_S2/cmake-variants.json
+++ b/targets/ESP32/ESP32_S2/cmake-variants.json
@@ -69,7 +69,8 @@
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
           "API_nanoFramework.Devices.OneWire": "OFF",
-          "API_nanoFramework.Graphics": "OFF"
+          "API_nanoFramework.Graphics": "OFF",
+          "API_nanoFramework.Device.Bluetooth": "OFF"
         }
       },
       "KALUGA_1": {
@@ -113,6 +114,7 @@
           "API_System.Device.Spi": "ON",
           "API_Hardware.Esp32": "ON",
           "API_nanoFramework.Hardware.Esp32.Rmt": "ON",
+          "API_nanoFramework.Device.Bluetooth": "OFF",
           "API_nanoFramework.Devices.OneWire": "OFF",
           "API_nanoFramework.Graphics": "ON",
           "GRAPHICS_DISPLAY": "ILI9341_240x320_SPI.cpp",


### PR DESCRIPTION
## Description
- Fix Bluetooth options in cmake-variants.

## Motivation and Context
- Options misaligned between templates and pipelines.
- Wrong CMake option.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
