### PR TITLE
Fix SerialPort dispose

### DIFF
--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -63,6 +63,7 @@ void UnitializePalUart_sys(NF_PAL_UART *palUart)
         uart_event_t event;
         event.type = UART_EVENT_MAX;
         xQueueSend(palUart->UartEventQueue, &event, (portTickType)0);
+        palUart->UartEventTask = NULL;
 
         // free buffer memory
         platform_free(palUart->RxBuffer);
@@ -74,14 +75,6 @@ void UnitializePalUart_sys(NF_PAL_UART *palUart)
 
         // delete driver
         uart_driver_delete((uart_port_t)palUart->UartNum);
-
-        // delete task, if any
-        if (palUart->UartEventTask)
-        {
-            vTaskDelete(palUart->UartEventTask);
-        }
-
-        palUart->UartEventTask = NULL;
     }
 }
 


### PR DESCRIPTION
## Description
If you tried to dispose a open serialport object the firmware crashes due to it killing a task that's already ended.

Native Dispose sent a message to event task causing it to close but also tried to delete task. 

Removed delete task as unnecessary. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
