### PR TITLE
Fix storage of certificates in ESP32

### DIFF
--- a/src/CLR/WireProtocol/WireProtocol_MonitorCommands.c
+++ b/src/CLR/WireProtocol/WireProtocol_MonitorCommands.c
@@ -219,6 +219,7 @@ int Monitor_UpdateConfiguration(WP_Message *message)
         case DeviceConfigurationOption_Network:
         case DeviceConfigurationOption_Wireless80211Network:
         case DeviceConfigurationOption_X509CaRootBundle:
+        case DeviceConfigurationOption_X509DeviceCertificates:
         case DeviceConfigurationOption_All:
             if (ConfigurationManager_StoreConfigurationBlock(
                     cmd->Data,

--- a/src/HAL/Include/nanoHAL_ConfigurationManager.h
+++ b/src/HAL/Include/nanoHAL_ConfigurationManager.h
@@ -131,6 +131,8 @@ extern "C"
 
     // StoreConfigurationBlock() is defined in targetHAL_ConfigurationManager.cpp at target level because the target
     // needs to be free to implement the storage of the configuration block as they see fit
+    // X509 certs can be large and are usually received in chunks. In this case, the block size parameter is the size of
+    // the current chunck.
     bool ConfigurationManager_StoreConfigurationBlock(
         void *configurationBlock,
         DeviceConfigurationOption configuration,

--- a/targets/ESP32/_IDF/esp32/app_main.c
+++ b/targets/ESP32/_IDF/esp32/app_main.c
@@ -61,7 +61,7 @@ void app_main()
     ESP_ERROR_CHECK(nvs_flash_init());
 
     // start receiver task pinned to core 1
-    xTaskCreatePinnedToCore(&receiver_task, "ReceiverThread", 2048, NULL, 5, NULL, 1);
+    xTaskCreatePinnedToCore(&receiver_task, "ReceiverThread", 3072, NULL, 5, NULL, 1);
 
     // start the CLR main task pinned to core 0
     xTaskCreatePinnedToCore(&main_task, "main_task", 15000, NULL, 5, NULL, 0);

--- a/targets/ESP32/_Include/targetHAL_ConfigStorage.h
+++ b/targets/ESP32/_Include/targetHAL_ConfigStorage.h
@@ -26,13 +26,14 @@ extern "C"
     // Parameters:-
     //   configuration      : Type of configuration block to open
     //   configurationIndex : Index of type to open
-    //   write              : True to create/overwrite file
+    //   isWrite            : flag to signal writting to the file
+    //   isAppend           : flag to signal appending to the file
     //
     // Return :-
     //    true  : returns handle
     //    false -1
     //
-    FILE *ConfigStorage_OpenFile(DeviceConfigurationOption configuration, uint32_t configurationIndex, bool write);
+    FILE *ConfigStorage_OpenFile(DeviceConfigurationOption configuration, uint32_t configurationIndex, bool isWrite, bool isAppend);
 
     //
     //  ConfigStorage_CloseFile - Close opened file / NVS system
@@ -71,6 +72,20 @@ extern "C"
     //    false- Error/Not found
     //
     bool ConfigStorage_WriteFile(FILE *handle, uint8_t *pData, int32_t writeSize);
+
+    //
+    //  ConfigStorage_AppendFile -  Append data to file system
+    //
+    // Parameters:-
+    //   handle    : Handle returned from ConfigStorage_OpenFile
+    //   pData     : Pointer data to write
+    //   writeSize : Size of data to write
+    //
+    // return:-
+    //    true - OK
+    //    false- Error/Not found
+    //
+    bool ConfigStorage_AppendFile(FILE *handle, uint8_t *pData, int32_t writeSize);
 
     //
     // ConfigStorage_ReadFile - Read the data from opened file

--- a/targets/ESP32/_common/targetHAL_ConfigStorageSPIFFS.c
+++ b/targets/ESP32/_common/targetHAL_ConfigStorageSPIFFS.c
@@ -21,7 +21,8 @@ typedef enum ConfigIoType
 {
     ConfigIoType_Read,
     ConfigIoType_Write,
-    ConfigIoType_GetSize
+    ConfigIoType_GetSize,
+    ConfigIoType_Append,
 } ConfigIoType;
 
 // Initialise SPIFFS
@@ -136,10 +137,12 @@ void ConfigStorage_GetConfigFileName(
 // Parameters:-
 //   configuration      : Type of configuration block to open
 //   configurationIndex : Index of type to open
+//   isWrite            : flag to signal writting to the file
+//   isAppend           : flag to signal appending to the file
 //
 // Return :handle
 //
-FILE *ConfigStorage_OpenFile(DeviceConfigurationOption configuration, uint32_t configurationIndex, bool write)
+FILE *ConfigStorage_OpenFile(DeviceConfigurationOption configuration, uint32_t configurationIndex, bool isWrite, bool isAppend)
 {
     // buffer for file name
     // add extra position for terminator
@@ -148,7 +151,7 @@ FILE *ConfigStorage_OpenFile(DeviceConfigurationOption configuration, uint32_t c
     ConfigStorage_GetConfigFileName(configuration, configurationIndex, fileName);
 
     // Open SPIFFS config storage
-    FILE *file = fopen(fileName, write ? "wb" : "rb");
+    FILE *file = fopen(fileName, isWrite ? (isAppend ? "a" : "w") : "r");
 
     if (file != NULL)
     {
@@ -250,6 +253,16 @@ int32_t Config_IO(FILE *handle, ConfigIoType ioType, uint8_t *pData, int32_t siz
 
             break;
         }
+        else if (ioType == ConfigIoType_Append)
+        {
+            // get to the end of the file
+            fseek(file, 0, SEEK_END);
+
+            // append more data
+            result = fwrite((const void *)pData, 1, (size_t)size, file);
+
+            break;
+        }
         else
         {
             break;
@@ -289,6 +302,23 @@ int32_t ConfigStorage_FileSize(FILE *handle)
 bool ConfigStorage_WriteFile(FILE *handle, uint8_t *pData, int32_t writeSize)
 {
     return (Config_IO(handle, ConfigIoType_Write, pData, writeSize) == writeSize);
+}
+
+//
+//  ConfigStorage_AppendFile -  Append data to NVS system
+//
+// Parameters:-
+//   handle    : Handle returned from ConfigStorage_OpenFile
+//   pData     : Pointer data to write
+//   writeSize : Size of data to write
+//
+// return:-
+//    true - OK
+//    false- Error/Not found
+//
+bool ConfigStorage_AppendFile(FILE *handle, uint8_t *pData, int32_t writeSize)
+{
+    return (Config_IO(handle, ConfigIoType_Append, pData, writeSize) == writeSize);
 }
 
 //
@@ -449,7 +479,7 @@ HAL_CONFIGURATION_X509_CERTIFICATE *ConfigStorage_FindX509CertificateConfigurati
     DIR *dir = opendir(NANO_SPIFFS_BASE_PATH);
     struct dirent *dirInfo = {0};
 
-    uint32_t configCount = 0;
+    uint32_t certCount = 0;
 
     // 1st pass, count the config files
     for (;;)
@@ -464,7 +494,7 @@ HAL_CONFIGURATION_X509_CERTIFICATE *ConfigStorage_FindX509CertificateConfigurati
 
         if (strstr(dirInfo->d_name, (const char *)c_MARKER_CONFIGURATION_X509CAROOTBUNDLE_V1))
         {
-            configCount++;
+            certCount++;
 
             // there is only one CA root bundle, so we're good here
             break;
@@ -472,7 +502,8 @@ HAL_CONFIGURATION_X509_CERTIFICATE *ConfigStorage_FindX509CertificateConfigurati
     }
 
     // allocate config struct
-    int32_t allocationSize = sizeof(HAL_Configuration_X509CaRootBundle);
+    int32_t allocationSize = offsetof(HAL_CONFIGURATION_X509_CERTIFICATE, Certificates) +
+                             certCount * sizeof(HAL_Configuration_X509CaRootBundle *);
 
     // allocate config struct
     HAL_CONFIGURATION_X509_CERTIFICATE *certificateStore =
@@ -488,17 +519,45 @@ HAL_CONFIGURATION_X509_CERTIFICATE *ConfigStorage_FindX509CertificateConfigurati
     memset(certificateStore, 0, allocationSize);
 
     // set collection count
-    certificateStore->Count = configCount;
+    certificateStore->Count = certCount;
+
+    if (certCount > 0)
+    {
+        // allocate cert struct
+        HAL_Configuration_X509CaRootBundle *certificate =
+            (HAL_Configuration_X509CaRootBundle *)platform_malloc(sizeof(HAL_Configuration_X509CaRootBundle));
+
+        // check allocation
+        if (certificate == NULL)
+        {
+            return NULL;
+        }
+
+        // clear memory
+        memset(certificate, 0, sizeof(HAL_Configuration_X509CaRootBundle));
+
+        // make sure the config block marker is set
+        memcpy(
+            certificate,
+            c_MARKER_CONFIGURATION_X509CAROOTBUNDLE_V1,
+            sizeof(c_MARKER_CONFIGURATION_X509CAROOTBUNDLE_V1));
+
+        // get size of certificate
+        certificate->CertificateSize =
+            ConfigurationManager_GetConfigurationBlockSize(DeviceConfigurationOption_X509CaRootBundle, 0);
+
+        certificateStore->Certificates[0] = certificate;
+    }
 
     return certificateStore;
 }
 
-HAL_CONFIGURATION_X509_DEVICE_CERTIFICATE *ConfigStorage_FindX509DeviceCertificatesConfigurationBlocks()
+HAL_CONFIGURATION_X509_DEVICE_CERTIFICATE *IRAM_ATTR ConfigStorage_FindX509DeviceCertificatesConfigurationBlocks()
 {
     DIR *dir = opendir(NANO_SPIFFS_BASE_PATH);
     struct dirent *dirInfo = {0};
 
-    uint32_t configCount = 0;
+    uint32_t certCount = 0;
 
     // 1st pass, count the config files
     for (;;)
@@ -513,7 +572,7 @@ HAL_CONFIGURATION_X509_DEVICE_CERTIFICATE *ConfigStorage_FindX509DeviceCertifica
 
         if (strstr(dirInfo->d_name, (const char *)c_MARKER_CONFIGURATION_X509DEVICECERTIFICATE_V1))
         {
-            configCount++;
+            certCount++;
 
             // there is only one device cert, so we're good here
             break;
@@ -521,7 +580,8 @@ HAL_CONFIGURATION_X509_DEVICE_CERTIFICATE *ConfigStorage_FindX509DeviceCertifica
     }
 
     // allocate config struct
-    int32_t allocationSize = sizeof(HAL_Configuration_X509DeviceCertificate);
+    int32_t allocationSize = offsetof(HAL_CONFIGURATION_X509_DEVICE_CERTIFICATE, Certificates) +
+                             certCount * sizeof(HAL_Configuration_X509DeviceCertificate *);
 
     // allocate config struct
     HAL_CONFIGURATION_X509_DEVICE_CERTIFICATE *deviceCertificate =
@@ -537,7 +597,35 @@ HAL_CONFIGURATION_X509_DEVICE_CERTIFICATE *ConfigStorage_FindX509DeviceCertifica
     memset(deviceCertificate, 0, allocationSize);
 
     // set collection count
-    deviceCertificate->Count = configCount;
+    deviceCertificate->Count = certCount;
+
+    if (certCount > 0)
+    {
+        // allocate cert struct
+        HAL_Configuration_X509DeviceCertificate *certificate =
+            (HAL_Configuration_X509DeviceCertificate *)platform_malloc(sizeof(HAL_Configuration_X509DeviceCertificate));
+
+        // check allocation
+        if (certificate == NULL)
+        {
+            return NULL;
+        }
+
+        // clear memory
+        memset(certificate, 0, sizeof(HAL_Configuration_X509DeviceCertificate));
+
+        // make sure the config block marker is set
+        memcpy(
+            certificate,
+            c_MARKER_CONFIGURATION_X509DEVICECERTIFICATE_V1,
+            sizeof(c_MARKER_CONFIGURATION_X509DEVICECERTIFICATE_V1));
+
+        // get size of certificate
+        certificate->CertificateSize =
+            ConfigurationManager_GetConfigurationBlockSize(DeviceConfigurationOption_X509DeviceCertificates, 0);
+
+        deviceCertificate->Certificates[0] = certificate;
+    }
 
     return deviceCertificate;
 }
@@ -555,7 +643,7 @@ bool ConfigurationManager_GetConfigurationBlockFromStorage(
     ets_printf("GetConfigFromStorage %d, %d\n", (int)configuration, configurationIndex);
 #endif
 
-    handle = ConfigStorage_OpenFile(configuration, configurationIndex, false);
+    handle = ConfigStorage_OpenFile(configuration, configurationIndex, false, false);
 
     if (handle != NULL)
     {
@@ -578,7 +666,7 @@ int32_t ConfigurationManager_GetConfigurationBlockSize(
     FILE *handle;
     int32_t readSize = 0;
 
-    handle = ConfigStorage_OpenFile(configuration, configurationIndex, false);
+    handle = ConfigStorage_OpenFile(configuration, configurationIndex, false, false);
 
     if (handle != NULL)
     {

--- a/targets/ESP32/_common/targetHAL_ConfigurationManager.cpp
+++ b/targets/ESP32/_common/targetHAL_ConfigurationManager.cpp
@@ -15,11 +15,6 @@
 
 // #define DEBUG_CONFIG        1
 
-// Saves the remaining bundle size for multiple block cert configs
-static int32_t savedBundleSize;
-static int32_t remainingBundleSize;
-static int32_t savedBundleOffset;
-
 #ifdef DEBUG_CONFIG
 void PrintBlock(char *pBlock, int bsize)
 {
@@ -77,7 +72,7 @@ int32_t ConfigurationManager_FindConfigurationBlockSize(
     FILE *handle;
     int32_t configSize = 0;
 
-    handle = ConfigStorage_OpenFile(configuration, configurationIndex, false);
+    handle = ConfigStorage_OpenFile(configuration, configurationIndex, false, false);
     if (handle != NULL)
     {
         configSize = ConfigStorage_FileSize(handle);
@@ -99,7 +94,7 @@ bool StoreConfigBlock(
     bool result = false;
     FILE *fileHandle;
 
-    fileHandle = ConfigStorage_OpenFile(configType, configurationIndex, true);
+    fileHandle = ConfigStorage_OpenFile(configType, configurationIndex, true, false);
     if (fileHandle != NULL)
     {
         result = ConfigStorage_WriteFile(fileHandle, (uint8_t *)configBlock, writeSize);
@@ -111,6 +106,36 @@ bool StoreConfigBlock(
             writeSize,
             (int)result);
 #endif
+        ConfigStorage_CloseFile(fileHandle);
+    }
+
+    return result;
+}
+
+bool AppendConfigBlock(
+    DeviceConfigurationOption configType,
+    uint32_t configurationIndex,
+    void *configBlock,
+    size_t writeSize)
+{
+    bool result = false;
+    FILE *fileHandle;
+
+    fileHandle = ConfigStorage_OpenFile(configType, configurationIndex, true, true);
+
+    if (fileHandle != NULL)
+    {
+        result = ConfigStorage_AppendFile(fileHandle, (uint8_t *)configBlock, writeSize);
+
+#ifdef DEBUG_CONFIG
+        ets_printf(
+            "store type %d index %d, length %d result %d\n",
+            (int)configType,
+            configurationIndex,
+            writeSize,
+            (int)result);
+#endif
+
         ConfigStorage_CloseFile(fileHandle);
     }
 
@@ -445,260 +470,45 @@ bool ConfigurationManager_GetConfigurationBlock(
         sizeOfBlock);
 }
 
-DeviceConfigurationOption GetConfigOption(char *config)
+bool ConfigurationManager_StoreConfigurationBlockCertificate(
+    DeviceConfigurationOption configuration,
+    uint32_t configurationIndex,
+    void *configurationBlock,
+    uint32_t blockSize,
+    uint32_t offset)
 {
-    if (!memcmp(c_MARKER_CONFIGURATION_NETWORK_V1, config, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1)))
+    if (offset == 0)
     {
-        return DeviceConfigurationOption_Network;
-    }
-    else if (!memcmp(c_MARKER_CONFIGURATION_WIRELESS80211_V1, config, sizeof(c_MARKER_CONFIGURATION_WIRELESS80211_V1)))
-    {
-        return DeviceConfigurationOption_Wireless80211Network;
-    }
-    else if (!memcmp(c_MARKER_CONFIGURATION_WIRELESS_AP_V1, config, sizeof(c_MARKER_CONFIGURATION_WIRELESS_AP_V1)))
-    {
-        return DeviceConfigurationOption_WirelessNetworkAP;
-    }
-    else if (!memcmp(
-                 c_MARKER_CONFIGURATION_X509CAROOTBUNDLE_V1,
-                 config,
-                 sizeof(c_MARKER_CONFIGURATION_X509CAROOTBUNDLE_V1)))
-    {
-        return DeviceConfigurationOption_X509CaRootBundle;
-    }
-    else if (!memcmp(
-                 c_MARKER_CONFIGURATION_X509DEVICECERTIFICATE_V1,
-                 config,
-                 sizeof(c_MARKER_CONFIGURATION_X509DEVICECERTIFICATE_V1)))
-    {
-        return DeviceConfigurationOption_X509DeviceCertificates;
-    }
-    else
-    {
-        // shouldn't EVER EVER get here
-        ASSERT(false);
-        return (DeviceConfigurationOption)0;
-    }
-}
-
-bool ConfigurationManager_StoreConfigurationBlockAll(void *configurationBlock, uint32_t blockSize, uint32_t offset)
-{
-    size_t chunkSize = 0;
-    uint32_t certificateIndex = 0;
-    bool result = false;
-    uint32_t configurationIndex = 0;
-
-    // All configuration blocks in one block
-    // Separate and update
-
-#ifdef DEBUG_CONFIG
-    ets_printf("Block size %d\n", blockSize);
-
-    ets_printf("sizeof HAL_Configuration_NetworkInterface %d\n", sizeof(HAL_Configuration_NetworkInterface));
-    ets_printf("sizeof HAL_Configuration_Wireless80211 %d\n", sizeof(HAL_Configuration_Wireless80211));
-    ets_printf("sizeof of X509Certificate varies\n");
-#endif
-
-    configurationIndex = 0;
-
-    char *config = (char *)configurationBlock;
-    char *pEndConfig = (config + blockSize);
-    DeviceConfigurationOption currentConfigType;
-
-    while (config < pEndConfig)
-    {
-        int remainingBlockSize = pEndConfig - config;
-
-#ifdef DEBUG_CONFIG
-        ets_printf("Parse block %d:%d\n", config, pEndConfig);
-        PrintBlock((char *)config, 16);
-#endif
-        currentConfigType = GetConfigOption(config);
-
-        // X509 certificate block ?
-        if (currentConfigType == DeviceConfigurationOption_X509CaRootBundle)
+        // if this is the 1st chunk of data for a certificate, delete the existing one, if that exists
+        if (ConfigStorage_DeleteFile(configuration, configurationIndex))
         {
-            if (offset == 0)
+            if (configuration == DeviceConfigurationOption_X509CaRootBundle)
             {
-                HAL_Configuration_X509CaRootBundle *pX509Certificate = (HAL_Configuration_X509CaRootBundle *)config;
-
-                // First block of certificate bundle
-                // set total bundle size including header
-                // because X509 certificate has a variable length need to compute the block size in two steps
-                savedBundleSize = offsetof(HAL_Configuration_X509CaRootBundle, Certificate);
-                savedBundleSize += pX509Certificate->CertificateSize;
-                remainingBundleSize = savedBundleSize;
-                savedBundleOffset = 0;
-
-                // Free if already allocated ( could be different size )
-                if (g_TargetConfiguration.CertificateStore->Certificates[certificateIndex] != 0)
+                // need to free memory before enumerating again
+                if (g_TargetConfiguration.CertificateStore->Count > 0)
                 {
-                    platform_free((void *)g_TargetConfiguration.CertificateStore->Certificates);
+                    platform_free(g_TargetConfiguration.CertificateStore->Certificates[0]);
                 }
+                platform_free(g_TargetConfiguration.CertificateStore);
 
-                g_TargetConfiguration.CertificateStore->Certificates[certificateIndex] =
-                    (HAL_Configuration_X509CaRootBundle *)platform_malloc(savedBundleSize);
-
-#ifdef DEBUG_CONFIG
-                ets_printf("X509 certificate block total size:%d\n", pX509Certificate->CertificateSize);
-#endif
+                g_TargetConfiguration.CertificateStore = ConfigStorage_FindX509CertificateConfigurationBlocks();
             }
-
-            // The current chunk size is what remains in current block
-            // we can't use offset as it relates to flash memory offset, not useful
-            chunkSize = remainingBlockSize;
-
-            // Copy into correct position in memory
-            memcpy(
-                (void *)(g_TargetConfiguration.CertificateStore->Certificates[0] + savedBundleOffset),
-                (const void *)config,
-                chunkSize);
-#ifdef DEBUG_CONFIG
-            ets_printf("X509 certificate chunksize:%d reminaing:%d\n", chunkSize, savedBundleSize);
-            PrintBlock((char *)config, 32);
-#endif
-            config += chunkSize;
-            remainingBundleSize -= chunkSize;
-            savedBundleOffset += chunkSize;
-            // Return true for partial blocks
-            result = true;
-
-            if (remainingBundleSize <= 0)
+            else if (configuration == DeviceConfigurationOption_X509DeviceCertificates)
             {
-                // Save Certificate Bundle to storage
-                result = StoreConfigBlock(
-                    DeviceConfigurationOption_X509CaRootBundle,
-                    certificateIndex,
-                    (void *)g_TargetConfiguration.CertificateStore->Certificates[certificateIndex],
-                    savedBundleSize);
-                certificateIndex++;
-#ifdef DEBUG_CONFIG
-                ets_printf("X509 certificate complete, saving\n");
-#endif
-            }
-
-#ifdef DEBUG_CONFIG
-            ets_printf("X509 certificate block ret:%d\n", result);
-#endif
-        }
-        // X509 device certificate block ?
-        else if (currentConfigType == DeviceConfigurationOption_X509DeviceCertificates)
-        {
-            if (offset == 0)
-            {
-                HAL_Configuration_X509DeviceCertificate *deviceCertificate =
-                    (HAL_Configuration_X509DeviceCertificate *)config;
-
-                // First block of certificate bundle
-                // set total bundle size including header
-                // because X509 certificate has a variable length need to compute the block size in two steps
-                savedBundleSize = offsetof(HAL_Configuration_X509DeviceCertificate, Certificate);
-                savedBundleSize += deviceCertificate->CertificateSize;
-                remainingBundleSize = savedBundleSize;
-                savedBundleOffset = 0;
-
-                // Free if already allocated ( could be different size )
-                if (g_TargetConfiguration.DeviceCertificates->Certificates[certificateIndex] != 0)
+                // need to free memory before enumerating again
+                if (g_TargetConfiguration.DeviceCertificates->Count > 0)
                 {
-                    platform_free((void *)g_TargetConfiguration.DeviceCertificates->Certificates);
+                    platform_free(g_TargetConfiguration.DeviceCertificates->Certificates[0]);
                 }
+                platform_free(g_TargetConfiguration.DeviceCertificates);
 
-                g_TargetConfiguration.DeviceCertificates->Certificates[certificateIndex] =
-                    (HAL_Configuration_X509DeviceCertificate *)platform_malloc(savedBundleSize);
-
-#ifdef DEBUG_CONFIG
-                ets_printf("Device certificate block total size:%d\n", deviceCertificate->CertificateSize);
-#endif
+                g_TargetConfiguration.DeviceCertificates =
+                    ConfigStorage_FindX509DeviceCertificatesConfigurationBlocks();
             }
-
-            // The current chunk size is what remains in current block
-            // we can't use offset as it relates to flash memory offset, not useful
-            chunkSize = remainingBlockSize;
-
-            // Copy into correct position in memory
-            memcpy(
-                (void *)(g_TargetConfiguration.DeviceCertificates->Certificates[0] + savedBundleOffset),
-                (const void *)config,
-                chunkSize);
-#ifdef DEBUG_CONFIG
-            ets_printf("Device certificate chunksize:%d reminaing:%d\n", chunkSize, savedBundleSize);
-            PrintBlock((char *)config, 32);
-#endif
-            config += chunkSize;
-            remainingBundleSize -= chunkSize;
-            savedBundleOffset += chunkSize;
-            // Return true for partial blocks
-            result = true;
-
-            if (remainingBundleSize <= 0)
-            {
-                // Save Certificate Bundle to storage
-                result = StoreConfigBlock(
-                    DeviceConfigurationOption_X509CaRootBundle,
-                    certificateIndex,
-                    (void *)g_TargetConfiguration.DeviceCertificates->Certificates[certificateIndex],
-                    savedBundleSize);
-                certificateIndex++;
-#ifdef DEBUG_CONFIG
-                ets_printf("Device certificate complete, saving\n");
-#endif
-            }
-
-#ifdef DEBUG_CONFIG
-            ets_printf("X509 certificate block ret:%d\n", result);
-#endif
         }
-        // Network interface block ?
-        else if (currentConfigType == DeviceConfigurationOption_Network)
-        {
-            HAL_Configuration_NetworkInterface *pNetConfig = (HAL_Configuration_NetworkInterface *)config;
-            config += sizeof(HAL_Configuration_NetworkInterface);
+    }
 
-            result = StoreConfigBlock(
-                currentConfigType,
-                configurationIndex,
-                (void *)pNetConfig,
-                sizeof(HAL_Configuration_NetworkInterface));
-            configurationIndex++;
-
-#ifdef DEBUG_CONFIG
-            ets_printf("Network block %X %X ret:%d\n", pNetConfig->InterfaceType, pNetConfig->SpecificConfigId, result);
-            PrintBlock((char *)pNetConfig, sizeof(HAL_Configuration_NetworkInterface));
-#endif
-        }
-        // Wireless block ?
-        else if (currentConfigType == DeviceConfigurationOption_Wireless80211Network)
-        {
-            HAL_Configuration_Wireless80211 *pWirelessConfig = (HAL_Configuration_Wireless80211 *)config;
-            config += sizeof(HAL_Configuration_Wireless80211);
-
-            result = StoreConfigBlock(
-                currentConfigType,
-                pWirelessConfig->Id,
-                (void *)pWirelessConfig,
-                sizeof(HAL_Configuration_Wireless80211));
-
-#ifdef DEBUG_CONFIG
-            ets_printf(
-                "Wireless block %d ssid:%s password:%s ret:%d\n",
-                pWirelessConfig->Id,
-                pWirelessConfig->Ssid,
-                pWirelessConfig->Password,
-                result);
-            PrintBlock((char *)pWirelessConfig, sizeof(HAL_Configuration_Wireless80211));
-#endif
-        }
-        else
-        {
-            break;
-        }
-
-    } // while
-
-#ifdef DEBUG_CONFIG
-    ets_printf("StoreConfig ALL exit %d\n", (int)result);
-#endif
-    return result;
+    return AppendConfigBlock(configuration, configurationIndex, configurationBlock, blockSize);
 }
 
 //
@@ -709,8 +519,8 @@ bool ConfigurationManager_StoreConfigurationBlockAll(void *configurationBlock, u
 //   configuration      : Type of configuration block to store or All for block with multiple types
 //   configurationIndex : Index of type to store ( not used for All )
 //   blockSize          : Size of data pointed to by configurationBlock
-//   offset             : Offset of data when multiple blocks ( currently Certificate Bundles only ), For single type
-//   this is offset withing the type
+//   offset             : Offset of data when multiple blocks (used for X502 CA Root and device certificate).
+//                        For remaining types this should be zero.
 //                        For ALL type blocks this is the offset in the total data of multiple types.
 // Return:-
 //    true - OK
@@ -738,10 +548,8 @@ bool ConfigurationManager_StoreConfigurationBlock(
 
     if (configuration == DeviceConfigurationOption_All)
     {
-        result = ConfigurationManager_StoreConfigurationBlockAll(configurationBlock, blockSize, offset);
-
-        // enumeration is required after we are DONE with SUCCESSFULLY storing all the config chunks
-        requiresEnumeration = (result && done);
+        // not supported
+        return false;
     }
     else
     {
@@ -765,10 +573,18 @@ bool ConfigurationManager_StoreConfigurationBlock(
             // check for 0 size on certificate
             if (((HAL_Configuration_X509CaRootBundle *)configurationBlock)->CertificateSize)
             {
-                // set blockSize size ( Total size of  X509 certificate )
-                // because X509 certificate has a variable length need to compute the block size in two steps
-                blockSize = offsetof(HAL_Configuration_X509CaRootBundle, Certificate);
-                blockSize += ((HAL_Configuration_X509CaRootBundle *)configurationBlock)->CertificateSize;
+                result = ConfigurationManager_StoreConfigurationBlockCertificate(
+                    configuration,
+                    configurationIndex,
+                    configurationBlock,
+                    blockSize,
+                    offset);
+
+                // reset blockSize because storing has been handled
+                blockSize = 0;
+
+                // enumeration is required after we are DONE with SUCCESSFULLY storing all the config chunks
+                requiresEnumeration = (result && done);
             }
             else
             {
@@ -780,11 +596,11 @@ bool ConfigurationManager_StoreConfigurationBlock(
                 {
                     // reset this
                     blockSize = 0;
+
+                    // enumeration is required
+                    requiresEnumeration = true;
                 }
             }
-
-            // removing or adding a config, enumeration is required
-            requiresEnumeration = true;
 
 #ifdef DEBUG_CONFIG
             ets_printf(
@@ -798,10 +614,18 @@ bool ConfigurationManager_StoreConfigurationBlock(
             // check for 0 size on certificate
             if (((HAL_Configuration_X509DeviceCertificate *)configurationBlock)->CertificateSize)
             {
-                // set blockSize size ( Total size of  X509 certificate )
-                // because X509 certificate has a variable length need to compute the block size in two steps
-                blockSize = offsetof(HAL_Configuration_X509DeviceCertificate, Certificate);
-                blockSize += ((HAL_Configuration_X509DeviceCertificate *)configurationBlock)->CertificateSize;
+                result = ConfigurationManager_StoreConfigurationBlockCertificate(
+                    configuration,
+                    configurationIndex,
+                    configurationBlock,
+                    blockSize,
+                    offset);
+
+                // reset blockSize because storing has been handled
+                blockSize = 0;
+
+                // enumeration is required after we are DONE with SUCCESSFULLY storing all the config chunks
+                requiresEnumeration = (result && done);
             }
             else
             {
@@ -813,11 +637,11 @@ bool ConfigurationManager_StoreConfigurationBlock(
                 {
                     // reset this
                     blockSize = 0;
+
+                    // enumeration is required
+                    requiresEnumeration = true;
                 }
             }
-
-            // removing or adding a config, enumeration is required
-            requiresEnumeration = true;
 
 #ifdef DEBUG_CONFIG
             ets_printf(
@@ -999,7 +823,7 @@ HAL_Configuration_X509CaRootBundle *ConfigurationManager_GetCertificateStore()
 
 HAL_Configuration_X509DeviceCertificate *ConfigurationManager_GetDeviceCertificate()
 {
-    if (g_TargetConfiguration.CertificateStore->Count)
+    if (g_TargetConfiguration.DeviceCertificates->Count)
     {
         // get cert store size
         int32_t certSize =


### PR DESCRIPTION
## Description
- Add missing case in Monitor_UpdateConfiguration to allow storing device certs.
- ESP32 SPIFFs storage now allow appending data to file.
- CA and device cert size are now available in ESP32 configuration storage structs.
- ESP32 configuration manager doesn't support store all anymore (doesn't make sense).
- Improve storage of CA and device certs.
- Add an extra 1k to ReceiverThread stack, otherwise file operation would fail.
- Improve comments.

## Motivation and Context
- Resolves nanoFramework/Home#830.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- VS extension storing and clearing CA and device certs. Tested with WROVER_KIT.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
