### PR TITLE
2nd write to open file clears file

### DIFF
--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
@@ -334,7 +334,7 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::WriteNative___VOID__S
     // Convert to ESP32 VFS path
     vfsPath = ConvertToVfsPath(filePath);
 
-    // open file for write / read 
+    // open file for write / read
     file = fopen(vfsPath, "a+");
     if (file != NULL)
     {

--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
@@ -334,8 +334,8 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::WriteNative___VOID__S
     // Convert to ESP32 VFS path
     vfsPath = ConvertToVfsPath(filePath);
 
-    // open file for write
-    file = fopen(vfsPath, "w");
+    // open file for write / read 
+    file = fopen(vfsPath, "a+");
     if (file != NULL)
     {
         // Change to actual position in file to start write


### PR DESCRIPTION
## Description

Because of the way the FileStream is implemented. It opens the file for every write.
This fixes a problem where it always clears/creates file when you write to a filestream on ESP32.

You end up with the last writen information in file instead of all writes to file.
  
## Motivation and Context


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Yes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
