### PR TITLE
Using wrong config for AP

### DIFF
--- a/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
+++ b/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
@@ -28,6 +28,7 @@ wifi_mode_t NF_ESP32_CheckExpectedWifiMode()
     wifi_mode_t mode = WIFI_MODE_NULL;
 
     HAL_Configuration_Wireless80211 *wirelessConfig = NULL;
+    HAL_Configuration_WirelessAP *wirelessAPConfig = NULL;
 
     HAL_Configuration_NetworkInterface *networkConfig =
         (HAL_Configuration_NetworkInterface *)platform_malloc(sizeof(HAL_Configuration_NetworkInterface));
@@ -69,11 +70,11 @@ wifi_mode_t NF_ESP32_CheckExpectedWifiMode()
             // Wireless Config with SSID setup
             if (networkConfig->InterfaceType == NetworkInterfaceType::NetworkInterfaceType_WirelessAP)
             {
-                wirelessConfig = ConfigurationManager_GetWirelessConfigurationFromId(networkConfig->SpecificConfigId);
+                wirelessAPConfig = ConfigurationManager_GetWirelessAPConfigurationFromId(networkConfig->SpecificConfigId);
 
-                if (wirelessConfig != NULL)
+                if (wirelessAPConfig != NULL)
                 {
-                    if (wirelessConfig->Options & WirelessAPConfiguration_ConfigurationOptions_Enable)
+                    if (wirelessAPConfig->Options & WirelessAPConfiguration_ConfigurationOptions_Enable)
                     {
                         // Use STATION + AP or just AP
                         mode = (mode == WIFI_MODE_STA) ? WIFI_MODE_APSTA : WIFI_MODE_AP;


### PR DESCRIPTION
## Description
When starting network used wrong config block for Wireless AP

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes nanoFramework/Home#917

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Supplied sample

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
