### PR TITLE
Fix loading the client certificate from the store

### DIFF
--- a/src/PAL/COM/sockets/ssl/mbedTLS/ssl_generic_init_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/mbedTLS/ssl_generic_init_internal.cpp
@@ -207,9 +207,9 @@ bool ssl_generic_init_internal(
             certificate = (const char *)deviceCert->Certificate;
             certLength = deviceCert->CertificateSize;
 
-            // clear private keys, just in case
-            privateKey = NULL;
-            privateKeyLength = 0;
+            // the private key is also part of the device certificate
+            privateKey = (const uint8_t *)deviceCert->Certificate;
+            privateKeyLength = deviceCert->CertificateSize;
         }
     }
 

--- a/targets/ESP32/_common/targetHAL_ConfigurationManager.cpp
+++ b/targets/ESP32/_common/targetHAL_ConfigurationManager.cpp
@@ -438,10 +438,10 @@ bool ConfigurationManager_GetConfigurationBlock(
         // set block size
         sizeOfBlock = ConfigurationManager_GetConfigurationBlockSize(DeviceConfigurationOption_X509CaRootBundle, 0);
     }
-    else if (configuration == DeviceConfigurationOption_X509CaRootBundle)
+    else if (configuration == DeviceConfigurationOption_X509DeviceCertificates)
     {
-        if (g_TargetConfiguration.CertificateStore->Count == 0 ||
-            (configurationIndex + 1) > g_TargetConfiguration.CertificateStore->Count)
+        if (g_TargetConfiguration.DeviceCertificates->Count == 0 ||
+            (configurationIndex + 1) > g_TargetConfiguration.DeviceCertificates->Count)
         {
 #ifdef DEBUG_CONFIG
             ets_printf("GetConfig XC exit false\n");


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
The client certificate was not loaded correctly from the certificate store. Also the private key was incorrectly discarded.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes connecting to SSL endpoint with device certificate.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a ESP32-WROOM-32 connecting to Azure with the nanoframework/nanoFramework.m2mqtt#188 and nanoframework/nanoFramework.Azure.Devices#49 patches applied.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
