### PR TITLE
Fix check for STM32_CUBE_PACKAGE_SOURCE

### DIFF
--- a/CMake/Modules/STM32_CubePackage.cmake
+++ b/CMake/Modules/STM32_CubePackage.cmake
@@ -38,7 +38,7 @@ macro(ProcessSTM32CubePackage)
         # STM32 Cube package source was specified
 
         # sanity check is source path exists
-        if(EXISTS ${STM32_CUBE_PACKAGE_SOURCE})
+        if(IS_DIRECTORY ${STM32_CUBE_PACKAGE_SOURCE})
             message(STATUS "STM32 Cube package (source from: ${STM32_CUBE_PACKAGE_SOURCE})")
 
             FetchContent_Declare(

--- a/CMake/Modules/STM32_CubePackage.cmake
+++ b/CMake/Modules/STM32_CubePackage.cmake
@@ -38,13 +38,12 @@ macro(ProcessSTM32CubePackage)
         # STM32 Cube package source was specified
 
         # sanity check is source path exists
-        if(EXISTS "${STM32_CUBE_PACKAGE_SOURCE}/")
-            message(STATUS "STM32 Cube package source from: ${STM32_CUBE_PACKAGE_SOURCE}")
+        if(EXISTS ${STM32_CUBE_PACKAGE_SOURCE})
+            message(STATUS "STM32 Cube package (source from: ${STM32_CUBE_PACKAGE_SOURCE})")
 
             FetchContent_Declare(
                 stm32${TARGET_SERIES_SHORT}_cubepackage
-                GIT_REPOSITORY ${STM32_CUBE_PACKAGE_SOURCE}
-                GIT_TAG nf-build
+                SOURCE_DIR ${STM32_CUBE_PACKAGE_SOURCE}
             )
     
         else()


### PR DESCRIPTION
## Description
The STM32Cube package is very large and is more likely to be cached on a local machine. Currently it relies on it being a git repo.

## Motivation and Context
Other third party libs dont require it. This one should be the same.

## How Has This Been Tested?
Checked build locally, using a direct URL download

## Screenshots<!-- (if appropriate): -->
![image](https://user-images.githubusercontent.com/11439699/148117642-c5b038e3-3782-4d1f-8d89-d186206eee91.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
