### PR TITLE
Fix memory leak with Directory.GetFiles() and GetDirectories()

### DIFF
--- a/src/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_Directory.cpp
+++ b/src/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_Directory.cpp
@@ -231,15 +231,17 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_Directory::GetFilesNative___STATI
                 }
             }
         }
+
+        f_closedir(&currentDirectory);
     }
 
     NANOCLR_CLEANUP();
 
-    if (stringBuffer == NULL)
+    if (stringBuffer != NULL)
     {
         platform_free(stringBuffer);
     }
-    if (workingBuffer == NULL)
+    if (workingBuffer != NULL)
     {
         platform_free(workingBuffer);
     }

--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_Directory.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_Directory.cpp
@@ -204,6 +204,8 @@ int CountEntries(const char *folderPath, int type)
         }
     }
 
+    closedir(currentDirectory);
+
     return count;
 }
 
@@ -211,11 +213,11 @@ HRESULT BuildPathsArray(const char *vfsFolderPath, const char *folderPath, CLR_R
 {
     char *stringBuffer = NULL;
     char *workingBuffer = NULL;
+    DIR *currentDirectory = NULL;
 
     NANOCLR_HEADER();
     {
         CLR_RT_HeapBlock *pathEntry;
-        DIR *currentDirectory;
         struct dirent *fileInfo;
 
         // get a pointer to the first object in the array (which is of type <String>)
@@ -271,11 +273,17 @@ HRESULT BuildPathsArray(const char *vfsFolderPath, const char *folderPath, CLR_R
     }
     NANOCLR_CLEANUP();
 
-    if (stringBuffer == NULL)
+    if (currentDirectory != NULL)
+    {
+        closedir(currentDirectory);
+    }
+
+    if (stringBuffer != NULL)
     {
         platform_free(stringBuffer);
     }
-    if (workingBuffer == NULL)
+
+    if (workingBuffer != NULL)
     {
         platform_free(workingBuffer);
     }


### PR DESCRIPTION
## Description

Fixes a memory leak in Directory.GetFiles() and Directory.GetDirectories() for all platforms

## Motivation and Context
Testing SD card changes and found this problem

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

Checked native memory before and after calls on ESP32. After fix no memory lost.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
