### PR TITLE
Fix object not initialized

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -1277,7 +1277,7 @@ bool CLR_RT_HeapBlock::ObjectsEqual(
             if (rightObj->DataType() == DATATYPE_VALUETYPE)
             {
                 CLR_RT_TypeDef_Instance inst;
-                CLR_RT_HeapBlock *obj;
+                CLR_RT_HeapBlock *obj = NULL;
 
                 if (!inst.InitializeFromIndex(rightObj->ObjectCls()))
                 {


### PR DESCRIPTION
## Description

## Motivation and Context
When building against newer GCC versions, there is a `maybe-uninitialized` error. This is fixed by ensuring the object is initialized on creation.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Built locally using GCC `10.3-2021.10` against STM32F769I

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
