### PR TITLE
Device host name is not composed with last 3 bytes of MAC address

### DIFF
--- a/targets/ChibiOS/_common/targetHAL_Network.cpp
+++ b/targets/ChibiOS/_common/targetHAL_Network.cpp
@@ -8,35 +8,38 @@
 #include <nanoHAL.h>
 #include <lwipthread.h>
 
+// this is the declaration for the callback implement in nf_sys_arch.c
+extern "C" void set_signal_sock_function(void (*funcPtr)());
 
-// this is the declaration for the callback implement in nf_sys_arch.c 
-extern "C" void set_signal_sock_function( void (*funcPtr)() );
+// buffer with host name
+char hostName[18] = "nanodevice_";
 
 //
 // Callback from lwIP on event
 //
 void sys_signal_sock_event()
 {
-     Events_Set(SYSTEM_EVENT_FLAG_SOCKET);
+    Events_Set(SYSTEM_EVENT_FLAG_SOCKET);
 }
 
 void nanoHAL_Network_Initialize()
 {
     // Initialise the lwIP CLR signal callback
-    set_signal_sock_function( &sys_signal_sock_event );
+    set_signal_sock_function(&sys_signal_sock_event);
 
     // get network configuration, if available
-    if(g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0)
+    if (g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0)
     {
         // there is no networking configuration block, can't proceed
         return;
     }
 
     HAL_Configuration_NetworkInterface networkConfig;
-    
-    if(ConfigurationManager_GetConfigurationBlock((void *)&networkConfig, DeviceConfigurationOption_Network, 0) == true)
+
+    if (ConfigurationManager_GetConfigurationBlock((void *)&networkConfig, DeviceConfigurationOption_Network, 0) ==
+        true)
     {
-        // build lwIP configuration 
+        // build lwIP configuration
         lwipthread_opts lwipOptions;
 
         // init config
@@ -46,14 +49,14 @@ void nanoHAL_Network_Initialize()
         lwipOptions.macaddress = (uint8_t *)networkConfig.MacAddress;
 
         // static or dinamic address
-        if(networkConfig.StartupAddressMode == AddressMode_Static)
+        if (networkConfig.StartupAddressMode == AddressMode_Static)
         {
             // IPv4 configs
             lwipOptions.address = networkConfig.IPv4Address;
             lwipOptions.netmask = networkConfig.IPv4NetMask;
             lwipOptions.gateway = networkConfig.IPv4GatewayAddress;
         }
-        else if(networkConfig.StartupAddressMode == AddressMode_DHCP)
+        else if (networkConfig.StartupAddressMode == AddressMode_DHCP)
         {
             // clear  IPv4 configs
             lwipOptions.address = 0;
@@ -65,8 +68,19 @@ void nanoHAL_Network_Initialize()
         // our enum follows lwIP defines for address mode
         lwipOptions.addrMode = (net_addr_mode_t)networkConfig.StartupAddressMode;
 
-        // we could consider making the device name configurable (or maybe not)
-        lwipOptions.ourHostName = "nanodevice";
+        // compose host name with nanodevice and last 3 bytes of MAC address
+        // nanodevice_XXXXXX
+        char *macPosition = hostName + 11;
+
+        // copy over last 3 bytes of MAC address
+        for (int index = 3; index < 6; index++)
+        {
+            sprintf(macPosition, "%02X", (int)networkConfig.MacAddress[index]);
+            macPosition += 2;
+        }
+
+        // set host name
+        lwipOptions.ourHostName = hostName;
 
         // Start lwIP thread in ChibiOS bindings using the above options
         lwipInit(&lwipOptions);

--- a/targets/ESP32/_common/targetHAL_Network.cpp
+++ b/targets/ESP32/_common/targetHAL_Network.cpp
@@ -16,6 +16,9 @@ extern "C" void set_signal_sock_function(void (*funcPtr)());
 
 //#define 	PRINT_NET_EVENT 	1
 
+// buffer with host name
+char hostName[18] = "nanodevice_";
+
 //
 // Call-back from LWIP on event
 //
@@ -77,6 +80,24 @@ static void initialize_sntp()
     sntp_init();
 }
 
+static void compose_esp32_hostname()
+{
+    // compose host name with nanodevice and last 3 bytes of MAC address
+    // nanodevice_XXXXXX
+    uint8_t mac[6];
+    char *macPosition = hostName + 11;
+
+    // get MAC address
+    esp_efuse_mac_get_default(mac);
+
+    // copy over last 3 bytes of MAC address
+    for (int index = 3; index < 6; index++)
+    {
+        sprintf(macPosition, "%02X", (int)mac[index]);
+        macPosition += 2;
+    }
+}
+
 //
 // Network event loop handler
 //
@@ -84,6 +105,7 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
 {
     esp_err_t result;
     int stationIndex;
+    esp_netif_t *espNetif;
     wifi_event_ap_staconnected_t *apConnectedEvent;
     wifi_event_ap_stadisconnected_t *apDisconnectedEvent;
     wifi_event_sta_disconnected_t *staDisconnectedEvent;
@@ -101,6 +123,12 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
 #ifdef PRINT_NET_EVENT
                 ets_printf("WIFI_EVENT_STA_START\n");
 #endif
+
+                // get Netif for STA
+                espNetif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+
+                // set host name for STA
+                esp_netif_set_hostname(espNetif, hostName);
 
                 if (NF_ESP32_IsToConnect)
                 {
@@ -271,6 +299,12 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
 #ifdef PRINT_NET_EVENT
                 ets_printf("ETHERNET_EVENT_START\n");
 #endif
+                // get Netif for ETH
+                espNetif = esp_netif_get_handle_from_ifkey("ETH_DEF");
+
+                // set host name for ETH
+                esp_netif_set_hostname(espNetif, hostName);
+
                 break;
 
             case ETHERNET_EVENT_STOP:
@@ -306,6 +340,9 @@ void nanoHAL_Network_Initialize()
 
     // initialize network interface
     ESP_ERROR_CHECK(esp_netif_init());
+
+    // set hostname
+    compose_esp32_hostname();
 
     // create the default event loop
     ESP_ERROR_CHECK(esp_event_loop_create_default());

--- a/targets/FreeRTOS/NXP/_nanoCLR/targetHAL_Network.cpp
+++ b/targets/FreeRTOS/NXP/_nanoCLR/targetHAL_Network.cpp
@@ -8,36 +8,40 @@
 #include <nanoHAL.h>
 #include "nf_lwipthread.h"
 
-// this is the declaration for the callback implement in nf_sys_arch.c 
-extern "C" void set_signal_sock_function( void (*funcPtr)() );
+// this is the declaration for the callback implement in nf_sys_arch.c
+extern "C" void set_signal_sock_function(void (*funcPtr)());
+
+// buffer with host name
+char hostName[18] = "nanodevice_";
 
 //
 // Callback from lwIP on event
 //
 void sys_signal_sock_event()
 {
-     Events_Set(SYSTEM_EVENT_FLAG_SOCKET);
+    Events_Set(SYSTEM_EVENT_FLAG_SOCKET);
 }
 
 void nanoHAL_Network_Initialize()
 {
     // Initialise the lwIP CLR signal callback
-    set_signal_sock_function( &sys_signal_sock_event );
+    set_signal_sock_function(&sys_signal_sock_event);
 
     // get network configuration, if available
-    if(g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0)
+    if (g_TargetConfiguration.NetworkInterfaceConfigs->Count == 0)
     {
         // there is no networking configuration block, can't proceed
         return;
     }
 
     HAL_Configuration_NetworkInterface networkConfig;
-    
-    if(ConfigurationManager_GetConfigurationBlock((void *)&networkConfig, DeviceConfigurationOption_Network, 0) == true)
+
+    if (ConfigurationManager_GetConfigurationBlock((void *)&networkConfig, DeviceConfigurationOption_Network, 0) ==
+        true)
     {
-        // build lwIP configuration 
+        // build lwIP configuration
         struct lwipthread_opts lwipOptions;
-        
+
         // init config
         memset(&lwipOptions, 0, sizeof(lwipOptions));
 
@@ -45,14 +49,14 @@ void nanoHAL_Network_Initialize()
         lwipOptions.macaddress = (uint8_t *)networkConfig.MacAddress;
 
         // static or dinamic address
-        if(networkConfig.StartupAddressMode == AddressMode_Static)
+        if (networkConfig.StartupAddressMode == AddressMode_Static)
         {
             // IPv4 configs
             lwipOptions.address = networkConfig.IPv4Address;
             lwipOptions.netmask = networkConfig.IPv4NetMask;
             lwipOptions.gateway = networkConfig.IPv4GatewayAddress;
         }
-        else if(networkConfig.StartupAddressMode == AddressMode_DHCP)
+        else if (networkConfig.StartupAddressMode == AddressMode_DHCP)
         {
             // clear  IPv4 configs
             lwipOptions.address = 0;
@@ -64,8 +68,19 @@ void nanoHAL_Network_Initialize()
         // our enum follows lwIP defines for address mode
         lwipOptions.addrMode = (net_addr_mode_t)networkConfig.StartupAddressMode;
 
-        // we could consider making the device name configurable (or maybe not)
-        lwipOptions.ourHostName = "nanodevice";
+        // compose host name with nanodevice and last 3 bytes of MAC address
+        // nanodevice_XXXXXX
+        char *macPosition = hostName + 11;
+
+        // copy over last 3 bytes of MAC address
+        for (int index = 3; index < 6; index++)
+        {
+            sprintf(macPosition, "%02X", (int)networkConfig.MacAddress[index]);
+            macPosition += 2;
+        }
+
+        // set host name
+        lwipOptions.ourHostName = hostName;
 
         // Start lwIP thread in ChibiOS bindings using the above options
         lwipInit(&lwipOptions);


### PR DESCRIPTION
## Description
- Hostname is now composed of "nanodevice_" plus the 3 last bytes of the MAC address in hexadecimal. e.g. `nanodevice_9ABE00`.

## Motivation and Context
- Closes nanoFramework/Home#940.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
