### PR TITLE
Fix Environment.TickCount64

### DIFF
--- a/src/nanoFramework.Runtime.Native/nf_rt_native_System_Environment.cpp
+++ b/src/nanoFramework.Runtime.Native/nf_rt_native_System_Environment.cpp
@@ -10,11 +10,9 @@ HRESULT Library_nf_rt_native_System_Environment::get_TickCount64___STATIC__I8(CL
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock &ref = stack.PushValue();
+    int64_t ticksValue = CLR_RT_ExecutionEngine::GetUptime();
 
-    // get pointer to object pushed to the stack
-    // and set with value from EE
-    ref.Dereference()->NumericByRef().s8 = CLR_RT_ExecutionEngine::GetUptime();
+    stack.SetResult_I8(ticksValue);
 
     NANOCLR_NOCLEANUP_NOLABEL();
 }


### PR DESCRIPTION
## Description
- Code was wrongly creating a new HB instead of just setting the return value on the stack.

## Motivation and Context
- Fixes nanoFramework/Home#959.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
