### PR TITLE
Fix TickCount64

### DIFF
--- a/src/nanoFramework.Runtime.Native/nf_rt_native_System_Environment.cpp
+++ b/src/nanoFramework.Runtime.Native/nf_rt_native_System_Environment.cpp
@@ -10,7 +10,7 @@ HRESULT Library_nf_rt_native_System_Environment::get_TickCount64___STATIC__I8(CL
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    int64_t ticksValue = CLR_RT_ExecutionEngine::GetUptime();
+    int64_t ticksValue = CLR_RT_ExecutionEngine::GetUptime() / (int64_t)TIME_CONVERSION__TO_MILLISECONDS;
 
     stack.SetResult_I8(ticksValue);
 


### PR DESCRIPTION
## Description
- Dividing with conversion factor for msecs.

## Motivation and Context
- Now returns milliseconds.  Was returning .NET ticks.
- Related with nanoframework/Home#959.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes in the Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.
