### PR TITLE
Using wrong length on serial write

### DIFF
--- a/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -721,23 +721,23 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
         data = dataBuffer->GetElement(offset);
 
         // push onto the eval stack how many bytes are being pushed to the UART
-        stack.PushValueI4(length - offset);
+        stack.PushValueI4(count);
 
         // flush DMA buffer to ensure cache coherency
         // (only required for Cortex-M7)
-        cacheBufferFlush(data, length - offset);
+        cacheBufferFlush(data, count);
 
         // store pointer
         palUart->TxBuffer = data;
 
         // set TX ongoing count
-        palUart->TxOngoingCount = length - offset;
+        palUart->TxOngoingCount = count;
 
         // because the UART can be accessed from several threads need to get exclusive access to it
         uartAcquireBus(palUart->UartDriver);
 
         // start sending data (DMA will read from the ring buffer)
-        uartStartSend(palUart->UartDriver, length - offset, (uint8_t *)data);
+        uartStartSend(palUart->UartDriver, count, (uint8_t *)data);
 
         // bump custom state
         stack.m_customState = 2;
@@ -756,7 +756,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
         {
             // event occurred
             // get from the eval stack how many bytes were buffered to Tx
-            length = stack.m_evalStack[1].NumericByRef().s4;
+            count = stack.m_evalStack[1].NumericByRef().s4;
 
             // done here
             break;
@@ -767,13 +767,13 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
         }
     }
 
-    // pop "length" heap block from stack
+    // pop "count" heap block from stack
     stack.PopValue();
 
     // pop "hbTimeout" heap block from stack
     stack.PopValue();
 
-    stack.SetResult_U4(length);
+    stack.SetResult_U4(count);
 
     // null pointers and vars
     pThis = NULL;

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -741,7 +741,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
 
         // check if this is a long running operation
         palUart->IsLongRunning = IsLongRunningOperation_sys(
-            length,
+            count,
             (uint32_t)pThis[FIELD___baudRate].NumericByRef().s4,
             (uint32_t &)estimatedDurationMiliseconds);
 
@@ -755,13 +755,13 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
             // this is a long running operation and
 
             // push to the stack how many bytes bytes where buffered for Tx
-            stack.PushValueI4(length);
+            stack.PushValueI4(count);
 
             // store pointer
             palUart->TxBuffer = data;
 
             // set TX count
-            palUart->TxOngoingCount = length;
+            palUart->TxOngoingCount = count;
 
             // Create a task to handle UART event from ISR
             char task_name[16];
@@ -783,7 +783,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
 
             // Write data to ring buffer to start sending
             // by design: don't bother checking the return value
-            uart_write_bytes(uart_num, (const char *)data, length);
+            uart_write_bytes(uart_num, (const char *)data, count);
         }
     }
 

--- a/targets/FreeRTOS/NXP/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/FreeRTOS/NXP/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -583,17 +583,17 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
         data = dataBuffer->GetElement(offset);
 
         // push onto the eval stack how many bytes are being pushed to the UART
-        stack.PushValueI4(length - offset);
+        stack.PushValueI4(count);
 
         // store pointer
         palUart->TxBuffer = data;
 
         // set TX ongoing count
-        palUart->TxOngoingCount = length - offset;
+        palUart->TxOngoingCount = count;
 
         // Set transfer structure to nano ring buffer
         palUart->xfer.data = (uint8_t *)palUart->TxBuffer;
-        palUart->xfer.dataSize = length;
+        palUart->xfer.dataSize = count;
 
         // Notify task that we want to transmit data.
         xTaskNotify(palUart->xWTaskToNotify, 0x01, eSetBits);
@@ -612,7 +612,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
         {
             // event occurred
             // get from the eval stack how many bytes were buffered to TX
-            length = stack.m_evalStack[1].NumericByRef().s4;
+            count = stack.m_evalStack[1].NumericByRef().s4;
 
             // reset TX ongoing count
             palUart->TxOngoingCount = 0;
@@ -627,13 +627,13 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
         }
     }
 
-    // pop "length" heap block from stack
+    // pop "count" heap block from stack
     stack.PopValue();
 
     // pop "hbTimeout" heap block from stack
     stack.PopValue();
 
-    stack.SetResult_U4(length);
+    stack.SetResult_U4(count);
 
     // null pointers and vars
     pThis = NULL;

--- a/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -605,7 +605,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
 
         // check if this is a long running operation
         palUart->IsLongRunning = IsLongRunningOperation(
-            length,
+            count,
             (uint32_t)pThis[FIELD___baudRate].NumericByRef().s4,
             (uint32_t &)estimatedDurationMiliseconds);
 
@@ -621,14 +621,14 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
             if (stack.m_customState == 1)
             {
                 // push to the stack how many bytes bytes where buffered for TX
-                stack.PushValueI4(length);
+                stack.PushValueI4(count);
 
                 // set TX count
-                palUart->TxOngoingCount = length;
+                palUart->TxOngoingCount = count;
 
                 // Write data to start sending
                 // by design: don't bother checking the return value
-                UART2_write(palUart->UartDriver, (const void *)data, length, NULL);
+                UART2_write(palUart->UartDriver, (const void *)data, count, NULL);
 
                 // bump custom state so the read value above is pushed only once
                 stack.m_customState = 2;
@@ -641,7 +641,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
 
             // Write data to ring buffer to start sending
             // by design: don't bother checking the return value
-            UART2_write(palUart->UartDriver, (const void *)data, length, NULL);
+            UART2_write(palUart->UartDriver, (const void *)data, count, NULL);
         }
     }
 
@@ -661,7 +661,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
         {
             // event occurred
             // get from the eval stack how many bytes were buffered to Tx
-            length = stack.m_evalStack[1].NumericByRef().s4;
+            count = stack.m_evalStack[1].NumericByRef().s4;
 
             // reset Tx ongoing count
             palUart->TxOngoingCount = 0;
@@ -677,14 +677,14 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::Write___VOID__SZAR
 
     if (palUart->IsLongRunning)
     {
-        // pop "length" heap block from stack
+        // pop "count" heap block from stack
         stack.PopValue();
 
         // pop "hbTimeout" heap block from stack
         stack.PopValue();
     }
 
-    stack.SetResult_U4(length);
+    stack.SetResult_U4(count);
 
     NANOCLR_NOCLEANUP();
 }


### PR DESCRIPTION
## Description

When you write a byte buffer to a SerialPort it always writes the whole buffer length instead of the supplied count.

Note this is just for ESP32. Looks like all other platforms have same problem.


## Motivation and Context
Caused issue in own project

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

```
bye[ ] bytes = new bytes[256];
bytes[0] = 'a';
_serial.Write(bytes, 0, 1);
```
Used to write all 256 byes, where it should write 'count' bytes = 1

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
