### PR TITLE
Fixes in power down for TI SimpleLink CC13x2

### DIFF
--- a/targets/TI_SimpleLink/_nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
@@ -10,7 +10,7 @@
 #include <ti/sysbios/knl/Clock.h>
 #include <xdc/runtime/Error.h>
 #include <ti/drivers/gpio/GPIOCC26XX.h>
-#include <ti/drivers/PIN.h>
+#include <ti/drivers/GPIO.h>
 #include <ti_drivers_config.h>
 
 // SimpleLink doesn't follow the port&pin design pattern, there are no ports, just GPIO pins
@@ -165,6 +165,9 @@ void UnlinkInputState(gpio_input_state *pState)
     // Remove interrupt associated with pin
     // it's OK to do always this, no matter if interrupts are enabled or not
     GPIO_disableInt(pState->pinConfigIndex);
+
+    // disable pin
+    GPIO_setConfig(pState->pinConfigIndex, GPIO_CFG_IN_NOPULL);
 
     // remove callback
     gpioCallbackFunctions[pState->pinConfigIndex] = NULL;
@@ -394,7 +397,8 @@ bool CPU_GPIO_EnableInputPin(
     pState->pinConfigIndex = FindPinConfig(pinNumber);
 
     // set default input config for GPIO pin
-    gpioPinConfigs[pState->pinConfigIndex] |= PIN_INPUT_EN | PIN_NOPULL | PIN_IRQ_DIS;
+    gpioPinConfigs[pState->pinConfigIndex] |=
+        GPIO_CFG_INPUT_INTERNAL | GPIO_CFG_IN_INT_NONE | GPIO_CFG_PULL_NONE_INTERNAL;
 
     if (!CPU_GPIO_SetDriveMode(pState->pinConfigIndex, driveMode))
     {

--- a/targets/TI_SimpleLink/_nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native_target.h
+++ b/targets/TI_SimpleLink/_nanoCLR/Windows.Devices.Gpio/win_dev_gpio_native_target.h
@@ -11,12 +11,10 @@
 #include <target_windows_devices_gpio.h>
 
 #include "rom.h"
-// #include "rom_map.h"
 #include <inc/hw_types.h>
 #include <inc/hw_memmap.h>
-// #include <inc/hw_common_reg.h>
 #include <gpio.h>
 #include <interrupt.h>
 #include <dpl/HwiP.h>
 
-#endif //WIN_DEV_GPIO_NATIVE_TARGET_H
+#endif // WIN_DEV_GPIO_NATIVE_TARGET_H

--- a/targets/TI_SimpleLink/_nanoCLR/targetHAL.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/targetHAL.cpp
@@ -10,7 +10,8 @@
 #include <nanoPAL_Events.h>
 #include <nanoPAL_BlockStorage.h>
 #include <nanoHAL_ConfigurationManager.h>
-// #include <FreeRTOS.h>
+
+#include <ti/drivers/pin/PINCC26XX.h>
 
 #if (HAL_USE_I2C_OPTION == TRUE)
 #include <ti/drivers/I2C.h>
@@ -148,6 +149,15 @@ void nanoHAL_Uninitialize()
 #if (HAL_USE_EASYLINK == ON)
     EasyLink_abort();
 #endif
+
+    // disable UART pins and ADC
+    PIN_Config BoardGpioInitTable[] = {
+        12 | PIN_INPUT_EN | PIN_NOPULL | PIN_IRQ_DIS,
+        13 | PIN_INPUT_EN | PIN_NOPULL | PIN_IRQ_DIS,
+        24 | PIN_INPUT_EN | PIN_NOPULL | PIN_IRQ_DIS,
+        PIN_TERMINATE};
+
+    PIN_init(BoardGpioInitTable);
 
     Events_Uninitialize();
 

--- a/targets/TI_SimpleLink/_nanoCLR/targetHAL_Power.c
+++ b/targets/TI_SimpleLink/_nanoCLR/targetHAL_Power.c
@@ -25,7 +25,11 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
     {
         case PowerLevel__Off:
             // gracefully shutdown everything
-            // FIXME TODO
+            nanoHAL_Uninitialize_C();
+
+            // now let's go with shutdown
+            Power_shutdown(0, 0);
+
             break;
 
         default:


### PR DESCRIPTION
## Description
- Rework power down sequence.
- Implement workaround for known issue with getting the device into deep sleep and waking from GPIO.
- Improve GPIO UnlinkInputState.
- Code cleanup.

## Motivation and Context
- Fixes issue with not being able to put board in sleep and wake-up from GPIO.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
