### PR TITLE
Add Security to Characteristics & Descriptors

### DIFF
--- a/targets/ESP32/_nanoCLR/nanoFramework.Device.Bluetooth/sys_ble.h
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Device.Bluetooth/sys_ble.h
@@ -30,20 +30,32 @@ typedef struct
 
 struct ble_context
 {
+    // The service definition is discoverable
     bool isDiscoverable;
+    // The service can be connected to
     bool isConnectable;
+    // The device name
     char *pDeviceName;
 
+    // Number of services in service definition
     int serviceCount;
+    // Ptr to service definition
     ble_gatt_svc_def *gatt_service_def;
 
+    // Number of items in characteristics definitions/Uuid array & Attribute handles
     int characteristicsCount;
+    // Ptr to characteristics definitions array
     ble_gatt_chr_def *characteristicsDefs;
+    // Ptr to characteristics Uuid array
     ble_uuid_any_t *characteristicsUuids;
+    // Ptr to array of attribute handles
     uint16_t *attrHandles;
 
+    // Number of items in array of descriptor definitions & descriptor UUID
     int descriptorCount;
+    // Ptr to descriptor definitions array
     ble_gatt_dsc_def *descriptorDefs;
+    // Ptr to descriptor Uuid array
     ble_uuid_any_t *descriptorUuids;
 };
 


### PR DESCRIPTION
## Description

Adds the security to Characteristic and Descriptor access.

Now when Read or Write protection levels are set accessing the Characteristic the device will be forced to Pair and be Bonded so as to generate keys for connection.

Also encryption will be enabled depending on protection levels

## Motivation and Context
- Resolves nanoFramework/Home#977
- 
## How Has This Been Tested?<!-- (IF APPLICABLE) -->
With simple app that sets ReadProtectionLevel & WriteProtectionLevel on Characteritic & descriptor.


## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
