### PR TITLE
Fix LL FlashErase for v2 of ChibiOS nano overlay

### DIFF
--- a/targets/ChibiOS/_nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
+++ b/targets/ChibiOS/_nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.c
@@ -372,8 +372,8 @@ int flash_lld_erase(uint32_t address)
         __DSB();
 #endif
 
-        // wait 500ms for any flash operation to be completed
-        success = FLASH_WaitForLastOperation(2000);
+        // wait 2000ms for any flash operation to be completed
+        success = FLASH_WaitForLastOperation(2000) == HAL_OK;
 
         // after erase operation completed disable the SER and SNB Bits
         CLEAR_BIT(FLASH->CR, (FLASH_CR_SER | FLASH_CR_SNB));

--- a/targets/ChibiOS/_nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.h
+++ b/targets/ChibiOS/_nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.h
@@ -53,6 +53,10 @@ typedef struct STM32FlashDriver
 #define FLASH_OPT_KEY2 ((uint32_t)0x4C5D6E7FU)
 #define SECTOR_MASK    ((uint32_t)0xFFFFFF07)
 
+#ifndef HAL_OK
+#define HAL_OK 0x00U
+#endif
+
 // FLASH_Error_Code FLASH Error Code
 #define HAL_FLASH_ERROR_NONE      ((uint32_t)0x00000000U) /*!< No error                      */
 #define HAL_FLASH_ERROR_ERS       ((uint32_t)0x00000002U) /*!< Programming Sequence error    */
@@ -98,17 +102,6 @@ typedef struct STM32FlashDriver
     (FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR)
 
 #endif // FLASH_SR_RDERR
-
-/**
- * @brief  HAL Status structures definition
- */
-typedef enum
-{
-    HAL_OK = 0x00U,
-    HAL_ERROR = 0x01U,
-    HAL_BUSY = 0x02U,
-    HAL_TIMEOUT = 0x03U
-} HAL_StatusTypeDef;
 
 //---------------------------------- STM32F7xx ------------------------------//
 #elif defined(STM32F756xx) || defined(STM32F746xx) || defined(STM32F745xx) || defined(STM32F765xx) ||                  \

--- a/targets/ChibiOS/_nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.h
+++ b/targets/ChibiOS/_nf-overlay/os/hal/ports/STM32/LLD/FLASHv2/flash_lld.h
@@ -99,6 +99,17 @@ typedef struct STM32FlashDriver
 
 #endif // FLASH_SR_RDERR
 
+/**
+ * @brief  HAL Status structures definition
+ */
+typedef enum
+{
+    HAL_OK = 0x00U,
+    HAL_ERROR = 0x01U,
+    HAL_BUSY = 0x02U,
+    HAL_TIMEOUT = 0x03U
+} HAL_StatusTypeDef;
+
 //---------------------------------- STM32F7xx ------------------------------//
 #elif defined(STM32F756xx) || defined(STM32F746xx) || defined(STM32F745xx) || defined(STM32F765xx) ||                  \
     defined(STM32F767xx) || defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) ||                    \


### PR DESCRIPTION
## Description
- Fix comparison which wasn't doing a correct translation from HAL_OK and boolean value.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
