### PR TITLE
Add cache control to Flash driver v4

### DIFF
--- a/targets/ChibiOS/_nf-overlay/os/hal/ports/STM32/LLD/FLASHv4/flash_lld.c
+++ b/targets/ChibiOS/_nf-overlay/os/hal/ports/STM32/LLD/FLASHv4/flash_lld.c
@@ -167,6 +167,12 @@ int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t *buffe
     uint32_t remainingBytes = length;
     uint32_t error = FLASH_NO_ERROR;
 
+    // Disable data cache
+    __HAL_FLASH_DATA_CACHE_DISABLE();
+
+    // read (and clear) error flags
+    FLASH_CheckErrors();
+
     // Unlock the Flash to enable the flash control register access
     HAL_FLASH_Unlock();
 
@@ -177,7 +183,7 @@ int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t *buffe
     {
         volatile uint32_t *address;
 
-        // unwritten bytes are initialized to flahs erase value
+        // unwritten bytes are initialized to flash erase value
         line.w[0] = 0xFFFFFFFFU;
         line.w[1] = 0xFFFFFFFFU;
 
@@ -216,6 +222,9 @@ int flash_lld_write(uint32_t startAddress, uint32_t length, const uint8_t *buffe
 
     // Lock the Flash to disable the flash control register access
     HAL_FLASH_Lock();
+
+    // enable back data cache
+    __HAL_FLASH_DATA_CACHE_ENABLE();
 
     // done here
     return (error == FLASH_NO_ERROR);


### PR DESCRIPTION
## Description
- Now cache is disable before flash write and enabled back afterwards.
- Also clear flash errors before operation.

## Motivation and Context
- Flash write was showing random failures on programming.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
