### PR TITLE
Fix Monitor UpdateConfiguration

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1263,8 +1263,6 @@ bool CLR_DBG_Debugger::Monitor_UpdateConfiguration(WP_Message *message)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    bool success = false;
-
     // include handling of configuration block only if feature is available
 #if (HAS_CONFIG_BLOCK == TRUE)
 
@@ -1287,7 +1285,6 @@ bool CLR_DBG_Debugger::Monitor_UpdateConfiguration(WP_Message *message)
                     cmd->Done) == true)
             {
                 cmdReply.ErrorCode = 0;
-                success = true;
             }
             else
             {
@@ -1299,15 +1296,16 @@ bool CLR_DBG_Debugger::Monitor_UpdateConfiguration(WP_Message *message)
             cmdReply.ErrorCode = 10;
     }
 
-    WP_ReplyToCommand(message, success, false, &cmdReply, sizeof(cmdReply));
+    WP_ReplyToCommand(message, true, false, (uint8_t *)&cmdReply, sizeof(Monitor_UpdateConfiguration_Reply));
+
+    return true;
 
 #else
 
     (void)message;
+    return false;
 
-#endif // (HAS_CONFIG_BLOCK == TRUE)
-
-    return success;
+#endif
 }
 
 //--//


### PR DESCRIPTION
## Description
- Operation is meant to return success or failure in error code, not it the operation execution.

## Motivation and Context
- The operation result wasn't being properly reported back to caller on failure.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Improved code in debugger library.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
