### PR TITLE
WIP: Fix ESP32 hardware debounce

### DIFF
--- a/targets/ESP32/_nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
+++ b/targets/ESP32/_nanoCLR/Windows.Devices.Gpio/cpu_gpio.cpp
@@ -562,11 +562,7 @@ bool CPU_GPIO_SetPinDebounce(GPIO_PIN pinNumber, uint32_t debounceTimeMillisecon
 
     if (state)
     {
-        if (state->debounceMs > 0 && debounceTimeMilliseconds)
-        {
-            // removing debounce, nothing to do here
-        }
-        else if (debounceTimeMilliseconds > 0)
+        if (debounceTimeMilliseconds > 0)
         {
             // compute ticks for debounce timer
             int ticks = debounceTimeMilliseconds / portTICK_PERIOD_MS;
@@ -590,6 +586,11 @@ bool CPU_GPIO_SetPinDebounce(GPIO_PIN pinNumber, uint32_t debounceTimeMillisecon
                 // no need to wait for the timer operation to execute
                 xTimerChangePeriod(state->debounceTimer, ticks, 0);
             }
+        }
+        else if (state->debounceTimer != NULL)
+        {
+            xTimerDelete(state->debounceTimer, 100);
+            state->debounceTimer = NULL;
         }
 
         // store new value for debounce time


### PR DESCRIPTION
## Description
Fix debounce timer reset condition, interfering with normal timer setup.

## Motivation and Context
Fixes erratic button behavior when using gpio hardware debounce on ESP32.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
WARNING: this has not yet been tested, using this PR to get image from build artifacts.

## Screenshots
NA

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
