### PR TITLE
Improvements in GPIO reservation for PSRAM

### DIFF
--- a/targets/ESP32/_nanoCLR/System.Device.Gpio/cpu_gpio.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.Gpio/cpu_gpio.cpp
@@ -23,6 +23,16 @@ static const char *TAG = "cpu_Gpio";
 #define ESP32_Gpio_MaxPins GPIO_PIN_COUNT // 0 -> 31,  32-39 (high)
 #define TOTAL_GPIO_PORTS   ((ESP32_Gpio_MaxPins + 15) / 16)
 
+// Maps reserved GPIOs used by SPI connecting to PSRAM
+// These have to be reserved in advanced so the user can't accidentally use them
+#if defined(CONFIG_IDF_TARGET_ESP32)
+static const int spiReservedInitialGpio = 6;
+static const int spiReservedFinalGpio = 11;
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+static const int spiReservedInitialGpio = 26;
+static const int spiReservedFinalGpio = 32;
+#endif
+
 TimerHandle_t oneshot;
 
 // Double linkedlist to hold the state of each Input pin
@@ -147,12 +157,11 @@ bool CPU_GPIO_Initialize()
     // Make sure all pins are not reserved
     memset(pinReserved, 0, sizeof(pinReserved));
 
-#ifdef CONFIG_IDF_TARGET_ESP32
-    // check if PSRAM it's available (querying largets free block available with SPIRAM capabilities)
+    // check if PSRAM it's available by querying largest free block available with SPIRAM capabilities
     if (heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_32BIT | MALLOC_CAP_SPIRAM))
     {
-        // Reserve Pins 6-11 as used by SPI flash
-        for (int pinNumber = 6; pinNumber <= 11; pinNumber++)
+        // reserve GPIO pins used by SPI flash
+        for (int pinNumber = spiReservedInitialGpio; pinNumber <= spiReservedFinalGpio; pinNumber++)
         {
             CPU_GPIO_ReservePin(pinNumber, true);
         }


### PR DESCRIPTION
## Description
- Now using a more structured (and clear) approach to this.
- Add configuration for ESP32-S2, S3 and C3.

## Motivation and Context
- Improves GPIO reservation for SPI bus used in PSRAM devices
- Addresses nanoFramework/Home#1033.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
