### PR TITLE
Fixes incorrect files name casing in cmake

### DIFF
--- a/CMake/Modules/FindSystem.Device.Spi.cmake
+++ b/CMake/Modules/FindSystem.Device.Spi.cmake
@@ -18,7 +18,7 @@ list(APPEND System.Device.Spi_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/System.Device
 # source files
 set(System.Device.Spi_SRCS
     cpu_spi.cpp   
-    nanoHAL_spi.cpp
+    nanoHAL_Spi.cpp
     sys_dev_spi_native_System_Device_Spi_SpiBusInfo.cpp
     sys_dev_spi_native_System_Device_Spi_SpiDevice.cpp
     sys_dev_spi_native.cpp

--- a/CMake/Modules/FindSystem.Device.Wifi.cmake
+++ b/CMake/Modules/FindSystem.Device.Wifi.cmake
@@ -16,7 +16,7 @@ list(APPEND System.Device.Wifi_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/src/System.Dev
 set(System.Device.Wifi_SRCS
 
     sys_dev_wifi_native.cpp
-    sys_dev_wifi_native_System_Device_WiFi_WiFiAdapter.cpp
+    sys_dev_wifi_native_System_Device_Wifi_WifiAdapter.cpp
 )
 
 foreach(SRC_FILE ${System.Device.Wifi_SRCS})


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Corrected source files name casing in `FindSystem.Device.Spi.cmake` and `FindSystem.Device.Wifi.cmake`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixes nanoFramework/Home#1043

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
