### PR TITLE
GC pressure thresholds now have defaults dependent on heap size

### DIFF
--- a/src/CLR/Core/CLR_RT_Memory.cpp
+++ b/src/CLR/Core/CLR_RT_Memory.cpp
@@ -24,6 +24,10 @@ void CLR_RT_Memory::Reset()
     NATIVE_PROFILE_CLR_CORE();
     ::HeapLocation(s_CLR_RT_Heap.m_location, s_CLR_RT_Heap.m_size);
 
+    // adjust GC thresholds
+    g_CLR_RT_GarbageCollector.c_memoryThreshold = s_CLR_RT_Heap.m_size * HEAP_SIZE_THRESHOLD_RATIO;
+    g_CLR_RT_GarbageCollector.c_memoryThreshold2 = s_CLR_RT_Heap.m_size * HEAP_SIZE_THRESHOLD_UPPER_RATIO;
+
 #if defined(NANOCLR_TRACE_MALLOC)
     s_TotalAllocated = 0;
 #endif

--- a/src/CLR/Include/nanoCLR_PlatformDef.h
+++ b/src/CLR/Include/nanoCLR_PlatformDef.h
@@ -6,7 +6,8 @@
 #ifndef NANOCLR_PLATFORMDEF_H
 #define NANOCLR_PLATFORMDEF_H
 
-//#include <CLR_Defines.h>
+#include <target_platform.h>
+#include <target_common.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // DEFINITIONS
@@ -41,20 +42,20 @@
 //-o-//-o-//-o-//-o-//-o-//-o-//
 
 //--//
-// Setting the threshold value to start Garbagge collector
-// PLATFORM_DEPENDENT_HEAP_SIZE_THRESHOLD should set in the file platform.settings file, eg sam7x_ek.settings.
-// defaults are 32Kb and 48 kb for lower and upper threshold respectively
+// Setting the threshold value to start garbage collection
+// PLATFORM_DEPENDENT_HEAP_SIZE_THRESHOLD should be set in target_platform or target_common to override the defaults.
+// defaults are 50% and 75% for lower and upper threshold respectively
 
 #ifdef PLATFORM_DEPENDENT_HEAP_SIZE_THRESHOLD
-#define HEAP_SIZE_THRESHOLD PLATFORM_DEPENDENT_HEAP_SIZE_THRESHOLD
+#define HEAP_SIZE_THRESHOLD_RATIO PLATFORM_DEPENDENT_HEAP_SIZE_THRESHOLD
 #else
-#define HEAP_SIZE_THRESHOLD 48 * 1024
+#define HEAP_SIZE_THRESHOLD_RATIO 0.5
 #endif
 
 #ifdef PLATFORM_DEPENDENT_HEAP_SIZE_THRESHOLD_UPPER
-#define HEAP_SIZE_THRESHOLD_UPPER PLATFORM_DEPENDENT_HEAP_SIZE_THRESHOLD_UPPER
+#define HEAP_SIZE_THRESHOLD_UPPER_RATIO PLATFORM_DEPENDENT_HEAP_SIZE_THRESHOLD_UPPER
 #else
-#define HEAP_SIZE_THRESHOLD_UPPER HEAP_SIZE_THRESHOLD + 16 * 1024
+#define HEAP_SIZE_THRESHOLD_UPPER_RATIO 0.75
 #endif
 
 //--//

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -2579,18 +2579,20 @@ struct CLR_RT_GarbageCollector
     static const int c_minimumSpaceForGC = 128;
     static const int c_minimumSpaceForCompact = 128;
     static const CLR_UINT32 c_pressureThreshold = 10;
-    static const CLR_UINT32 c_memoryThreshold = HEAP_SIZE_THRESHOLD;
-    static const CLR_UINT32 c_memoryThreshold2 = HEAP_SIZE_THRESHOLD_UPPER;
 
     static const CLR_UINT32 c_StartGraphEvent = 0x00000001;
     static const CLR_UINT32 c_StopGraphEvent = 0x00000002;
     static const CLR_UINT32 c_DumpGraphHeapEvent = 0x00000004;
     static const CLR_UINT32 c_DumpPerfCountersEvent = 0x00000008;
 
+    CLR_UINT32 c_memoryThreshold;
+    CLR_UINT32 c_memoryThreshold2;
+
     CLR_UINT32 m_numberOfGarbageCollections;
     CLR_UINT32 m_numberOfCompactions;
 
-    CLR_RT_DblLinkedList m_weakDelegates_Reachable; // list of CLR_RT_HeapBlock_Delegate_List
+    // list of CLR_RT_HeapBlock_Delegate_List
+    CLR_RT_DblLinkedList m_weakDelegates_Reachable;
 
     CLR_UINT32 m_totalBytes;
     CLR_UINT32 m_freeBytes;


### PR DESCRIPTION
## Description
- Defaults are now 75% and 50% of heap size.
- Can be overridden by compiler defines at platform or target levels.

(cherry picked from commit a641d5382ed7b3bfd95771400bd600292d2af3e9)

## Motivation and Context
- Compiler defs controlling these (being the default values) were totally off as they were inherited from .NETMF.
- These should have proper settings. Being adjusted according to the heap size offer reasonable default values.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
