### PR TITLE
Fix parsing private key when empty

### DIFF
--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
@@ -441,7 +441,12 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
             privateKey = hbCert[Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate2::
                                     FIELD___privateKey]
                              .DereferenceArray();
-            pk = privateKey->GetFirstElement();
+
+            // grab the first element, if there is a private key
+            if (privateKey)
+            {
+                pk = privateKey->GetFirstElement();
+            }
         }
 
         // get certificate


### PR DESCRIPTION
## Description
- Add check for empty byte array in private key.

## Motivation and Context
- Fixes issue with parsing private when that one is empty. 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Test code with connection with X.509 certificate without PK.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
