### PR TITLE
Restarts firmware when ethernet driver fails to install

### DIFF
--- a/targets/ESP32/_Network/NF_ESP32_Ethernet.cpp
+++ b/targets/ESP32/_Network/NF_ESP32_Ethernet.cpp
@@ -8,6 +8,8 @@
 #include <NF_ESP32_Network.h>
 #include <esp32_ethernet_options.h>
 
+static const char *TAG = "ETH";
+
 esp_eth_handle_t eth_handle = NULL;
 
 // OLIMEX ESP32-EVB Rev B, OLIMEX ESP32-Gateway, Generic Lan8270
@@ -55,9 +57,6 @@ esp_err_t NF_ESP32_InitialiseEthernet(uint8_t *pMacAdr)
 
     esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
     esp_netif_t *eth_netif = esp_netif_new(&cfg);
-
-    // Set default handlers to process TCP/IP stuffs
-    ESP_ERROR_CHECK(esp_eth_set_default_handlers(eth_netif));
 
     // now MAC and PHY configs
     eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
@@ -139,7 +138,12 @@ esp_err_t NF_ESP32_InitialiseEthernet(uint8_t *pMacAdr)
 
     // now the do the Ethernet config
     esp_eth_config_t config = ETH_DEFAULT_CONFIG(mac, phy);
-    ESP_ERROR_CHECK(esp_eth_driver_install(&config, &eth_handle));
+    esp_err_t err = esp_eth_driver_install(&config, &eth_handle);
+    if (err != ESP_OK)
+    {
+        ESP_LOGI(TAG, "Unable to install ethernet driver");
+        return err;
+    }
 
 #ifndef ESP32_ETHERNET_INTERNAL
     // The SPI Ethernet module might doesn't have a burned factory MAC address, we have to set it manually.


### PR DESCRIPTION
## Description
When an Ethernet  firmware with an invalid config starts it ends up restarting if the Ethernet driver fails to load.
This changes behavior to continue with an error so Ethernet interface isn't active in system.

Also removed a deprecated method which is no longer needed in latest IDF version. 

## Motivation and Context
Noticed other day when testing Olimex build,  In that case CMAKEPRESETS was also wrong. (typos)  Already fixed.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested with Olimex Ethernet ESP32 
## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
