### PR TITLE
Fixes and improvements in X.509 parsing

### DIFF
--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
@@ -6,6 +6,10 @@
 
 #include "sys_net_native.h"
 
+// remap types to ease code readability
+typedef Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate X509Certificate;
+typedef Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate2 X509Certificate2;
+
 //--//
 
 void Time_GetDateTime(DATE_TIME_INFO *dt)
@@ -419,7 +423,8 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
     CLR_RT_HeapBlock_Array *privateKey = NULL;
     CLR_UINT8 *sslCert = NULL;
     volatile int result;
-    const char *password = "";
+    const char *password = NULL;
+    CLR_UINT32 passwordLength = 0;
     uint8_t *pk = NULL;
 
     if (hbCert != NULL)
@@ -429,18 +434,14 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
             "System.Security.Cryptography.X509Certificates",
             x509Certificate2TypeDef);
 
-        arrCert = hbCert[Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate::
-                             FIELD___certificate]
-                      .DereferenceArray(); // FAULT_ON_NULL(arrCert);
+        arrCert = hbCert[X509Certificate::FIELD___certificate].DereferenceArray();
         arrCert->Pin();
 
         // there is a client certificate, find if it's a X509Certificate2
         if (hbCert->ObjectCls().Type() == x509Certificate2TypeDef.Type())
         {
             // get private key
-            privateKey = hbCert[Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate2::
-                                    FIELD___privateKey]
-                             .DereferenceArray();
+            privateKey = hbCert[X509Certificate2::FIELD___privateKey].DereferenceArray();
 
             // grab the first element, if there is a private key
             if (privateKey)
@@ -452,12 +453,15 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
         // get certificate
         sslCert = arrCert->GetFirstElement();
 
-        // get password
-        CLR_RT_HeapBlock *hbPwd =
-            hbCert
-                [Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate::FIELD___password]
-                    .Dereference(); // FAULT_ON_NULL(hbPwd);
-        password = hbPwd->StringText();
+        // get password field
+        CLR_RT_HeapBlock *passwordHb = hbCert[X509Certificate::FIELD___password].Dereference();
+
+        // get password length, if there is a password
+        if (passwordHb)
+        {
+            password = passwordHb->StringText();
+            passwordLength = hal_strlen_s(password);
+        }
     }
 
     if (isServer)
@@ -471,7 +475,7 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
                  pk,
                  pk == NULL ? 0 : privateKey->m_numOfElements,
                  password,
-                 hal_strlen_s(password),
+                 passwordLength,
                  sslContext,
                  useDeviceCertificate)
                  ? 0
@@ -488,7 +492,7 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
                  pk,
                  pk == NULL ? 0 : privateKey->m_numOfElements,
                  password,
-                 hal_strlen_s(password),
+                 passwordLength,
                  sslContext,
                  useDeviceCertificate)
                  ? 0
@@ -499,30 +503,24 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
 
     if (caCert != NULL)
     {
-        arrCert = caCert[Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate::
-                             FIELD___certificate]
-                      .DereferenceArray(); // FAULT_ON_NULL(arrCert);
+        arrCert = caCert[X509Certificate::FIELD___certificate].DereferenceArray();
 
         // If arrCert == NULL then the certificate is an X509Certificate2 which uses a certificate handle
         if (arrCert == NULL)
         {
             CLR_INT32 sessionCtx = 0;
 
-            arrCert = caCert[Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate::
-                                 FIELD___handle]
-                          .DereferenceArray();
+            arrCert = caCert[X509Certificate::FIELD___handle].DereferenceArray();
             FAULT_ON_NULL(arrCert);
 
             sslCert = arrCert->GetFirstElement();
 
-            arrCert = caCert[Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate::
-                                 FIELD___sessionHandle]
-                          .DereferenceArray();
+            arrCert = caCert[X509Certificate::FIELD___sessionHandle].DereferenceArray();
             FAULT_ON_NULL(arrCert);
 
             sessionCtx = *(int32_t *)arrCert->GetFirstElement();
 
-            // pass the session handle down as the password paramter and the certificate handle as the data parameter
+            // pass the session handle down as the password parameter and the certificate handle as the data parameter
             result =
                 (SSL_AddCertificateAuthority(
                      sslContext,
@@ -541,10 +539,7 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
 
             sslCert = arrCert->GetFirstElement();
 
-            CLR_RT_HeapBlock *hbPwd =
-                caCert[Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate::
-                           FIELD___password]
-                    .Dereference();
+            CLR_RT_HeapBlock *hbPwd = caCert[X509Certificate::FIELD___password].Dereference();
             FAULT_ON_NULL(hbPwd);
 
             LPCSTR szCAPwd = hbPwd->StringText();

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate2.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate2.cpp
@@ -15,20 +15,24 @@ HRESULT Library_sys_net_native_System_Security_Cryptography_X509Certificates_X50
     CLR_RT_HeapBlock_Array *keyData = stack.Arg0().DereferenceArray();
     CLR_UINT8 *keyBuffer;
     CLR_RT_HeapBlock *passwordHb = stack.Arg1().DereferenceString();
-    const char *password;
+    const char *password = NULL;
+    CLR_UINT32 passwordLength = 0;
 
     // get key buffer
     keyBuffer = keyData->GetFirstElement();
 
-    // manage password
-    FAULT_ON_NULL_ARG(passwordHb);
-    password = passwordHb->StringText();
+    // get password length, if there is a password
+    if (passwordHb)
+    {
+        password = passwordHb->StringText();
+        passwordLength = hal_strlen_s(password);
+    }
 
     if (SSL_DecodePrivateKey(
             (const unsigned char *)keyBuffer,
             keyData->m_numOfElements,
             (const unsigned char *)password,
-            hal_strlen_s(password)) < 0)
+            passwordLength) < 0)
     {
         NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
     }


### PR DESCRIPTION
## Description
- Now accepts password field as null.
- Code clean-up.

## Motivation and Context
- Need to accept `null` for password to allow usage of certificates and private keys not encrypted (which do not require a password).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Various TLS samples.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
