### PR TITLE
WatchChar is not set on SerialPort init

### DIFF
--- a/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -856,6 +856,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
 
     NF_PAL_UART *palUart;
     int32_t bufferSize;
+    uint8_t watchChar;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock *pThis = stack.This();
@@ -943,6 +944,15 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     palUart->Uart_cfg.txend1_cb = TxEnd1;
     palUart->Uart_cfg.rxchar_cb = RxChar;
     // palUart->Uart_cfg.rxend_cb = RxEnd;
+
+    // get watch character
+    watchChar = pThis[FIELD___watchChar].NumericByRef().u1;
+
+    // set watch char, if set
+    if (watchChar != 0)
+    {
+        palUart->WatchChar = watchChar;
+    }
 
     // call the configure
     return NativeConfig___VOID(stack);

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -840,6 +840,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     uart_port_t uart_num;
     esp_err_t esp_err;
     int32_t bufferSize;
+    uint8_t watchChar;
 
     NF_PAL_UART *palUart;
 
@@ -910,6 +911,21 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     }
 
     NANOCLR_CHECK_HRESULT(NativeConfig___VOID(stack));
+
+    // Get the watch char
+    watchChar = (uint8_t)pThis[FIELD___watchChar].NumericByRef().u1;
+
+    // get watch character
+    watchChar = pThis[FIELD___watchChar].NumericByRef().u1;
+
+    // set watch char, if set
+    if (watchChar != 0)
+    {
+        // Enable pattern detection for the serial device
+        uart_enable_pattern_det_baud_intr(uart_num, watchChar, 1, 9, 0, 00);
+        // Reset the pattern queue length to record at most 10 pattern positions.
+        uart_pattern_queue_reset(uart_num, 10);
+    }
 
     // Create a task to handle UART event from ISR
     snprintf(task_name, ARRAYSIZE(task_name), "uart%d_events", uart_num);

--- a/targets/FreeRTOS/NXP/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/FreeRTOS/NXP/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -690,6 +690,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     NF_PAL_UART *palUart = NULL;
     BaseType_t xReturned;
     int32_t bufferSize;
+    uint8_t watchChar;
 
     CLR_RT_HeapBlock *pThis = stack.This();
     FAULT_ON_NULL(pThis);
@@ -720,9 +721,17 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     palUart->RxRingBuffer.Initialize(palUart->RxBuffer, bufferSize);
     palUart->RxBytesToRead = 0;
 
+    // get watch character
+    watchChar = pThis[FIELD___watchChar].NumericByRef().u1;
+
+    // set watch char, if set
+    if (watchChar != 0)
+    {
+        palUart->WatchChar = watchChar;
+    }
+
     // now all the rest
     palUart->TxOngoingCount = 0;
-    palUart->WatchChar = 0;
     palUart->NewLineChar = 0;
 
     // Get default config structure for initializing given UART peripheral and enable TX, RX

--- a/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -714,6 +714,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
         NF_PAL_UART *palUart;
         uint8_t uartNum;
         int32_t bufferSize;
+        uint8_t watchChar;
 
         // get a pointer to the managed object instance and check that it's not NULL
         CLR_RT_HeapBlock *pThis = stack.This();
@@ -758,8 +759,15 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
 
 #endif
 
+        // get watch character
+        watchChar = pThis[FIELD___watchChar].NumericByRef().u1;
+
+        // set watch char, if set
+        if (watchChar != 0)
+        {
+            palUart->WatchChar = watchChar;
+        }
         // all the rest
-        palUart->WatchChar = 0;
         palUart->NewLineChar = 0;
         palUart->RxBytesToRead = 0;
         palUart->TxOngoingCount = 0;


### PR DESCRIPTION
## Description
- Add code to NativeInit on serial port to set wach char according to platform.

## Motivation and Context
- Fixes nanoFramework/Home#1035.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
