### PR TITLE
Fix boxing in custom attributes

### DIFF
--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -4837,9 +4837,16 @@ HRESULT CLR_RT_AttributeParser::ReadString(CLR_RT_HeapBlock *&value)
     NANOCLR_HEADER();
 
     CLR_UINT32 tk;
+
+    CLR_RT_TypeDescriptor desc;
+    NANOCLR_CHECK_HRESULT(desc.InitializeFromType(g_CLR_RT_WellKnownTypes.m_String));
+
     NANOCLR_READ_UNALIGNED_UINT16(tk, m_blob);
 
     NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_String::CreateInstance(*value, CLR_TkFromType(TBL_Strings, tk), m_assm));
+
+    // need to box this
+    value->PerformBoxing(desc.m_handlerCls);
 
     NANOCLR_NOCLEANUP();
 }
@@ -4851,6 +4858,9 @@ HRESULT CLR_RT_AttributeParser::ReadNumericValue(
     const CLR_UINT32 size)
 {
     NANOCLR_HEADER();
+
+    CLR_RT_TypeDescriptor desc;
+    NANOCLR_CHECK_HRESULT(desc.InitializeFromType(*m_cls));
 
     NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(*value, g_CLR_RT_WellKnownTypes.m_TypeStatic));
 
@@ -4865,8 +4875,6 @@ HRESULT CLR_RT_AttributeParser::ReadNumericValue(
         NANOCLR_READ_UNALIGNED_UINT8(boolValue, m_blob);
 
         value->SetBoolean((bool)boolValue);
-        // this is a bool so need to box it
-        value->PerformBoxingIfNeeded();
     }
     else
     {
@@ -4876,6 +4884,9 @@ HRESULT CLR_RT_AttributeParser::ReadNumericValue(
 
         m_blob += size;
     }
+
+    // need to box this
+    value->PerformBoxing(desc.m_handlerCls);
 
     NANOCLR_NOCLEANUP();
 }


### PR DESCRIPTION
## Description
- Attribute objects are not properly boxed when created. Object type is now correctly set.

## Motivation and Context
- Resolves nanoFramework/Home#989.
- Resolves nanoFramework/Home#990.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Reflection sample.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
