### PR TITLE
Improve generation of deviceSelectorString for several drivers

### DIFF
--- a/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1277,32 +1277,33 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetDeviceSelector_
 
     // declare the device selector string whose max size is "COM1,COM2,COM3,COM4,COM5,COM6,COM7,COM8," + terminator
     // and init with the terminator
-    char deviceSelectorString[40 + 1] = {0};
+    static char deviceSelectorString[] =
 
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_USART1) && (NF_SERIAL_COMM_STM32_UART_USE_USART1 == TRUE)
-    strcat(deviceSelectorString, "COM1,");
+        "COM1,"
 #endif
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_USART2) && (NF_SERIAL_COMM_STM32_UART_USE_USART2 == TRUE)
-    strcat(deviceSelectorString, "COM2,");
+        "COM2,"
 #endif
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_USART3) && (NF_SERIAL_COMM_STM32_UART_USE_USART3 == TRUE)
-    strcat(deviceSelectorString, "COM3,");
+        "COM3,"
 #endif
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_UART4) && (NF_SERIAL_COMM_STM32_UART_USE_UART4 == TRUE)
-    strcat(deviceSelectorString, "COM4,");
+        "COM4,"
 #endif
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_UART5) && (NF_SERIAL_COMM_STM32_UART_USE_UART5 == TRUE)
-    strcat(deviceSelectorString, "COM5,");
+        "COM5,"
 #endif
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_USART6) && (NF_SERIAL_COMM_STM32_UART_USE_USART6 == TRUE)
-    strcat(deviceSelectorString, "COM6,");
+        "COM6,"
 #endif
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_UART7) && (NF_SERIAL_COMM_STM32_UART_USE_UART7 == TRUE)
-    strcat(deviceSelectorString, "COM7,");
+        "COM7,"
 #endif
 #if defined(NF_SERIAL_COMM_STM32_UART_USE_UART8) && (NF_SERIAL_COMM_STM32_UART_USE_UART8 == TRUE)
-    strcat(deviceSelectorString, "COM8,");
+        "COM8,"
 #endif
+        ;
 
     // replace the last comma with a terminator
     deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';

--- a/targets/ChibiOS/_nanoCLR/nanoFramework.Device.Can/nf_device_can_native_nanoFramework_Device_Can_CanController.cpp
+++ b/targets/ChibiOS/_nanoCLR/nanoFramework.Device.Can/nf_device_can_native_nanoFramework_Device_Can_CanController.cpp
@@ -456,17 +456,18 @@ HRESULT Library_nf_device_can_native_nanoFramework_Device_Can_CanController::Get
     {
         // declare the device selector string whose max size is "SPI1,SPI2,SPI3,SPI4,SPI5,SPI6," + terminator and init
         // with the terminator
-        char deviceSelectorString[30 + 1] = {0};
+        static char deviceSelectorString[] =
 
 #if defined(STM32_CAN_USE_CAN1) && (STM32_CAN_USE_CAN1 == TRUE)
-        strcat(deviceSelectorString, "CAN1,");
+            "CAN1,"
 #endif
 #if (STM32_CAN_USE_CAN2) && (STM32_CAN_USE_CAN2 == TRUE)
-        strcat(deviceSelectorString, "CAN2,");
+            "CAN2,"
 #endif
 #if (STM32_CAN_USE_CAN3) && (STM32_CAN_USE_CAN3 == TRUE)
-        strcat(deviceSelectorString, "CAN3,");
+            "CAN3,"
 #endif
+            ;
 
         // replace the last comma with a terminator
         deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1392,18 +1392,19 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetDeviceSelector_
 
     // declare the device selector string whose max size is "COM1,COM2,COM3" + terminator
     // and init with the terminator
-    char deviceSelectorString[14 + 1] = {0};
+    static char deviceSelectorString[] =
 
     // unless the build is configure to use USB CDC, COM1 is being used for VS debug, so it's not available
 #if defined(CONFIG_USB_CDC_ENABLED)
-    strcat(deviceSelectorString, "COM1,");
+        "COM1,"
 #endif
 #if defined(UART_NUM_1)
-    strcat(deviceSelectorString, "COM2,");
+        "COM2,"
 #endif
 #if defined(UART_NUM_2)
-    strcat(deviceSelectorString, "COM3,");
+        "COM3,"
 #endif
+        ;
 
     // replace the last comma with a terminator
     deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';

--- a/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1084,11 +1084,12 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetDeviceSelector_
 
     // declare the device selector string whose max size is "COM2," + terminator
     // and init with the terminator
-    char deviceSelectorString[4 + 1] = {0};
+    static char deviceSelectorString[] =
 
 #if defined(NF_SERIAL_COMM_TI_USE_UART1) && (NF_SERIAL_COMM_TI_USE_UART1 == TRUE)
-    strcat(deviceSelectorString, "COM2,");
+        "COM2,"
 #endif
+        ;
 
     // replace the last comma with a terminator
     deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';


### PR DESCRIPTION
## Description
- Improve generation of deviceSelectorString for several drivers.

## Motivation and Context
- Closes nanoFramework/Home#833.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
