### PR TITLE
Fixed incorrect x/y rectangle offsets in DisplayControl calls.

### DIFF
--- a/src/nanoFramework.Graphics/Graphics/Native/nanoFramework_Graphics_nanoFramework_UI_DisplayControl.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Native/nanoFramework_Graphics_nanoFramework_UI_DisplayControl.cpp
@@ -90,8 +90,8 @@ HRESULT Library_nanoFramework_Graphics_nanoFramework_UI_DisplayControl::
 
         writeData = (CLR_UINT32 *)colors->GetFirstElement();
         g_DisplayDriver.BitBlt(
-            stack.Arg0().NumericByRef().u2, // srcX
-            stack.Arg1().NumericByRef().u2, // srcY
+            0, // srcX
+            0, // srcY
             stack.Arg2().NumericByRef().u2, // width
             stack.Arg3().NumericByRef().u2, // height
             stack.Arg2().NumericByRef().u2, // stride
@@ -319,7 +319,7 @@ HRESULT Library_nanoFramework_Graphics_nanoFramework_UI_DisplayControl::
                     // to fit into the rectangle.
                     if (posY <= height)
                     {
-                        g_GraphicsDriver.Screen_Flush(*bitmap, posX, posY, bm.m_width, bm.m_height, posX, posY);
+                        g_GraphicsDriver.Screen_Flush(*bitmap, 0, 0, bm.m_width, bm.m_height, posX, posY);
                     }
 
                     prevCharWidth = widthChar;


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Corrected the x/y rectangle offsets in DisplayControl Write() methods.

## Motivation and Context
The recent changes to made to the graphics system incorrectly set the x/y coordinates of the sub-rectangle to be drawn. They were set to the screen coordinates when they should have been zero. This has been fixed.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally on M5Stack Core2.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
