### PR TITLE
Fix access check code for memory mapped devices

### DIFF
--- a/targets/win32/nanoCLR/Target_BlockStorage.cpp
+++ b/targets/win32/nanoCLR/Target_BlockStorage.cpp
@@ -359,6 +359,15 @@ __nfweak bool BlockStorageDevice_Memset(
     return false;
 }
 
+__nfweak bool BlockStorageDevice_GetMemoryMappedAddress(
+    BlockStorageDevice *device,
+    unsigned int blockRegionIndex,
+    unsigned int blockRangeIndex,
+    unsigned int *address)
+{
+    return false;
+}
+
 //__nfweak bool BlockStorageDevice_GetSectorMetadata(BlockStorageDevice* device, unsigned int sectorStart,
 //SectorMetadata* pSectorMetadata);
 //__nfweak bool BlockStorageDevice_SetSectorMetadata(BlockStorageDevice* device, unsigned int sectorStart,


### PR DESCRIPTION
## Description
- Rework implementation for memory mapped devices.
- Buffer allocation was failing for large deployments. Now it's using platform malloc and only for non memory mapped devices.

## Motivation and Context
- Fixes nanoFramework/Home#1060.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Deployment of small and large applications in ESP32 devices.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
