### PR TITLE
Fix SerialPort.GetPortNames() on all platforms

### DIFF
--- a/targets/AzureRTOS/ST/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/AzureRTOS/ST/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1289,7 +1289,10 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetDeviceSelector_
 #endif
 
     // replace the last comma with a terminator
-    deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+    if (deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] == ',')
+    {
+        deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+    }
 
     // because the caller is expecting a result to be returned
     // we need set a return result in the stack argument using the appropriate SetResult according to the variable

--- a/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1306,7 +1306,10 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetDeviceSelector_
         ;
 
     // replace the last comma with a terminator
-    deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+    if (deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] == ',')
+    {
+        deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+    }
 
     // because the caller is expecting a result to be returned
     // we need set a return result in the stack argument using the appropriate SetResult according to the variable

--- a/targets/ChibiOS/_nanoCLR/nanoFramework.Device.Can/nf_device_can_native_nanoFramework_Device_Can_CanController.cpp
+++ b/targets/ChibiOS/_nanoCLR/nanoFramework.Device.Can/nf_device_can_native_nanoFramework_Device_Can_CanController.cpp
@@ -470,7 +470,10 @@ HRESULT Library_nf_device_can_native_nanoFramework_Device_Can_CanController::Get
             ;
 
         // replace the last comma with a terminator
-        deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+        if (deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] == ',')
+        {
+            deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+        }
 
         // because the caller is expecting a result to be returned
         // we need set a return result in the stack argument using the appropriate SetResult according to the variable

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1407,7 +1407,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetDeviceSelector_
         ;
 
     // replace the last comma with a terminator
-    if (deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = ',')
+    if (deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] == ',')
     {
         deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
     }

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1407,7 +1407,10 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetDeviceSelector_
         ;
 
     // replace the last comma with a terminator
-    deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+    if (deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = ',')
+    {
+        deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+    }
 
     // because the caller is expecting a result to be returned
     // we need set a return result in the stack argument using the appropriate SetResult according to the variable

--- a/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1092,7 +1092,10 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetDeviceSelector_
         ;
 
     // replace the last comma with a terminator
-    deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+    if (deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] == ',')
+    {
+        deviceSelectorString[hal_strlen_s(deviceSelectorString) - 1] = '\0';
+    }
 
     // because the caller is expecting a result to be returned
     // we need set a return result in the stack argument using the appropriate SetResult according to the variable


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
SerialPort.GetPortNames() port name text gets shorter on devices

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixes nanoFramework/Home#1066.
- Fixes as well similar bugs for other similar cases

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
