### PR TITLE
Fixed typo in variable name

### DIFF
--- a/targets/ESP32/_nanoCLR/System.Device.Spi/cpu_spi.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.Spi/cpu_spi.cpp
@@ -76,7 +76,7 @@ struct NF_PAL_SPI
 };
 
 NF_PAL_SPI nf_pal_spi[2];
-bool haveAsycTrans[2];
+bool haveAsyncTrans[2];
 
 // Remove device from bus
 // return true of OK, false = error
@@ -391,12 +391,12 @@ HRESULT CPU_SPI_nWrite_nRead(
         pnf_pal_spi->readOffset = wrc.readOffset; // dummy bytes between write & read on half duplex
         pnf_pal_spi->callback = wrc.callback;
 
-        if (haveAsycTrans[sdev.Spi_Bus])
+        if (haveAsyncTrans[sdev.Spi_Bus])
         {
             spi_transaction_t *rtrans;
             ret = spi_device_get_trans_result((spi_device_handle_t)deviceHandle, &rtrans, portMAX_DELAY);
 
-            haveAsycTrans[sdev.Spi_Bus] = false;
+            haveAsyncTrans[sdev.Spi_Bus] = false;
         }
 
         // Set up SPI Transaction
@@ -446,7 +446,7 @@ HRESULT CPU_SPI_nWrite_nRead(
             }
             else
             {
-                haveAsycTrans[sdev.Spi_Bus] = true;
+                haveAsyncTrans[sdev.Spi_Bus] = true;
             }
 
             pnf_pal_spi->status = SPI_OP_STATUS::SPI_OP_RUNNING;


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Fixed variable typo in ESP32 async fix

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally on M5Stack Core2

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
