### PR TITLE
Added asynchronous transfer support to the SPI display interface

### DIFF
--- a/src/nanoFramework.Graphics/Graphics/Displays/DisplayInterface.h
+++ b/src/nanoFramework.Graphics/Graphics/Displays/DisplayInterface.h
@@ -45,6 +45,8 @@ struct DisplayInterface
     void DisplayBacklight(bool on); // true = on
     void SendCommand(CLR_UINT8 arg_count, ...);
     void SendBytes(CLR_UINT8 *data, CLR_UINT32 length);
+    void SendData16Windowed(CLR_UINT16 *data, CLR_UINT32 startX, CLR_UINT32 startY, CLR_UINT32 width, CLR_UINT32 height, CLR_UINT32 stride, bool doByteSwap);
+    void FillData16(CLR_UINT16 fillValue, CLR_UINT32 fillLength);
     void SetCommandMode(int mode);
 };
 

--- a/src/nanoFramework.Graphics/Graphics/Displays/ILI9341_240x320_SPI.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/ILI9341_240x320_SPI.cpp
@@ -243,24 +243,11 @@ void DisplayDriver::Clear()
     // Clear the ILI9341 controller frame
     SetWindow(0, 0, Attributes.Width - 1, Attributes.Height - 1);
 
-    // Clear buffer
-    memset(Attributes.TransferBuffer, 0, Attributes.TransferBufferSize);
+    g_DisplayInterface.SendCommand(1, Memory_Write);
 
-    int totalBytesToClear = Attributes.Width * Attributes.Height * 2;
-    int fullTransferBuffersCount = totalBytesToClear / Attributes.TransferBufferSize;
-    int remainderTransferBuffer = totalBytesToClear % Attributes.TransferBufferSize;
-
-    CLR_UINT8 command = Memory_Write;
-    for (int i = 0; i < fullTransferBuffersCount; i++)
-    {
-        g_DisplayInterface.WriteToFrameBuffer(command, Attributes.TransferBuffer, Attributes.TransferBufferSize);
-        command = Memory_Write_Continue;
-    }
-
-    if (remainderTransferBuffer > 0)
-    {
-        g_DisplayInterface.WriteToFrameBuffer(command, Attributes.TransferBuffer, remainderTransferBuffer);
-    }
+    g_DisplayInterface.FillData16(
+                    0,
+                    Attributes.Width * Attributes.Height);
 }
 
 void DisplayDriver::DisplayBrightness(CLR_INT16 brightness)
@@ -316,60 +303,16 @@ void DisplayDriver::BitBlt(
 
     SetWindow(screenX, screenY, (screenX + width - 1), (screenY + height - 1));
 
-    CLR_UINT16 *StartOfLine_src = (CLR_UINT16 *)&data[0];
-    CLR_UINT8 *transferBufferIndex = Attributes.TransferBuffer;
-    CLR_UINT32 transferBufferCount = Attributes.TransferBufferSize;
+    g_DisplayInterface.SendCommand(1, Memory_Write);
 
-    // Offset for window start
-    StartOfLine_src += (srcY * stride) + srcX;
-
-    CLR_UINT8 command = Memory_Write;
-    g_DisplayInterface.SendCommand(1, command);
-
-    while (height--)
-    {
-        CLR_UINT16 *src;
-        int xCount;
-
-        src = StartOfLine_src;
-        xCount = width;
-
-        while (xCount--)
-        {
-            CLR_UINT16 dt = *src++;
-            *transferBufferIndex++ = (dt >> 8);
-            *transferBufferIndex++ = dt & 0xff;
-            transferBufferCount -= 2;
-
-            // Send over SPI if no room for another 2 bytes
-            if (transferBufferCount < 1)
-            {
-                // Transfer buffer full, send it
-                g_DisplayInterface.WriteToFrameBuffer(
-                    command,
-                    Attributes.TransferBuffer,
-                    (Attributes.TransferBufferSize - transferBufferCount));
-
-                // Reset transfer ptrs/count
-                transferBufferIndex = Attributes.TransferBuffer;
-                transferBufferCount = Attributes.TransferBufferSize;
-                command = Memory_Write_Continue;
-            }
-        }
-
-        // Next row in data[]
-        StartOfLine_src += stride;
-    }
-
-    // Send remaining data in transfer buffer to SPI
-    if (transferBufferCount < Attributes.TransferBufferSize)
-    {
-        // Transfer buffer full, send it
-        g_DisplayInterface.WriteToFrameBuffer(
-            command,
-            Attributes.TransferBuffer,
-            (Attributes.TransferBufferSize - transferBufferCount));
-    }
+    g_DisplayInterface.SendData16Windowed(
+                    (CLR_UINT16 *)&data[0],
+                    srcX,
+                    srcY,
+                    width,
+                    height,
+                    stride,
+                    true);
 
     return;
 }

--- a/src/nanoFramework.Graphics/Graphics/Displays/ILI9342_320x240_SPI.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/ILI9342_320x240_SPI.cpp
@@ -228,23 +228,11 @@ void DisplayDriver::Clear()
     // Clear the ILI9342 controller frame
     SetWindow(0, 0, Attributes.Width - 1, Attributes.Height - 1);
 
-    // Clear buffer
-    memset(Attributes.TransferBuffer, 0x00, Attributes.TransferBufferSize);
-    int totalBytesToClear = Attributes.Width * Attributes.Height * 2;
-    int fullTransferBuffersCount = totalBytesToClear / Attributes.TransferBufferSize;
-    int remainderTransferBuffer = totalBytesToClear % Attributes.TransferBufferSize;
+    g_DisplayInterface.SendCommand(1, Memory_Write);
 
-    CLR_UINT8 command = Memory_Write;
-    g_DisplayInterface.SendCommand(1, command);
-    for (int i = 0; i < fullTransferBuffersCount; i++)
-    {
-        g_DisplayInterface.SendBytes(Attributes.TransferBuffer, Attributes.TransferBufferSize);
-    }
-
-    if (remainderTransferBuffer > 0)
-    {
-        g_DisplayInterface.SendBytes(Attributes.TransferBuffer, remainderTransferBuffer);
-    }
+    g_DisplayInterface.FillData16(
+                    0,
+                    Attributes.Width * Attributes.Height);
 }
 
 void DisplayDriver::DisplayBrightness(CLR_INT16 brightness)
@@ -300,55 +288,16 @@ void DisplayDriver::BitBlt(
 
     SetWindow(screenX, screenY, (screenX + width - 1), (screenY + height - 1));
 
-    CLR_UINT16 *StartOfLine_src = (CLR_UINT16 *)&data[0];
-    CLR_UINT8 *transferBufferIndex = Attributes.TransferBuffer;
-    CLR_UINT32 transferBufferCount = Attributes.TransferBufferSize;
+    g_DisplayInterface.SendCommand(1, Memory_Write);
 
-    // Offset for window start
-    StartOfLine_src += (srcY * stride) + srcX;
-
-    CLR_UINT8 command = Memory_Write;
-    g_DisplayInterface.SendCommand(1, command);
-
-    while (height--)
-    {
-        CLR_UINT16 *src;
-        int xCount;
-
-        src = StartOfLine_src;
-        xCount = width;
-
-        while (xCount--)
-        {
-            CLR_UINT16 dt = *src++;
-            *transferBufferIndex++ = (dt >> 8);
-            *transferBufferIndex++ = dt & 0xff;
-            transferBufferCount -= 2;
-
-            // Send over SPI if no room for another 2 bytes
-            if (transferBufferCount < 1)
-            {
-                // Transfer buffer full, send it
-                g_DisplayInterface.SendBytes(
-                    Attributes.TransferBuffer,
-                    (Attributes.TransferBufferSize - transferBufferCount));
-
-                // Reset transfer ptrs/count
-                transferBufferIndex = Attributes.TransferBuffer;
-                transferBufferCount = Attributes.TransferBufferSize;
-            }
-        }
-
-        // Next row in data[]
-        StartOfLine_src += stride;
-    }
-
-    // Send remaining data in transfer buffer to SPI
-    if (transferBufferCount < Attributes.TransferBufferSize)
-    {
-        // Transfer buffer full, send it
-        g_DisplayInterface.SendBytes(Attributes.TransferBuffer, (Attributes.TransferBufferSize - transferBufferCount));
-    }
+    g_DisplayInterface.SendData16Windowed(
+                    (CLR_UINT16 *)&data[0],
+                    srcX,
+                    srcY,
+                    width,
+                    height,
+                    stride,
+                    true);
 
     return;
 }

--- a/src/nanoFramework.Graphics/Graphics/Displays/SSD1331_94x64_SPI.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/SSD1331_94x64_SPI.cpp
@@ -256,55 +256,16 @@ void DisplayDriver::BitBlt(
 
     SetWindow(screenX, screenY, (screenX + width - 1), (screenY + height - 1));
 
-    CLR_UINT16 *StartOfLine_src = (CLR_UINT16 *)&data[0];
-    CLR_UINT8 *transferBufferIndex = Attributes.TransferBuffer;
-    CLR_UINT32 transferBufferCount = Attributes.TransferBufferSize;
+    g_DisplayInterface.SendCommand(1, Memory_Write);
 
-    // Offset for window start
-    StartOfLine_src += (srcY * stride) + srcX;
-
-    CLR_UINT8 command = Memory_Write;
-    g_DisplayInterface.SendCommand(1, command);
-
-    while (height--)
-    {
-        CLR_UINT16 *src;
-        int xCount;
-
-        src = StartOfLine_src;
-        xCount = width;
-
-        while (xCount--)
-        {
-            CLR_UINT16 dt = *src++;
-            *transferBufferIndex++ = (dt >> 8);
-            *transferBufferIndex++ = dt & 0xff;
-            transferBufferCount -= 2;
-
-            // Send over SPI if no room for another 2 bytes
-            if (transferBufferCount < 1)
-            {
-                // Transfer buffer full, send it
-                g_DisplayInterface.SendBytes(
-                    Attributes.TransferBuffer,
-                    (Attributes.TransferBufferSize - transferBufferCount));
-
-                // Reset transfer ptrs/count
-                transferBufferIndex = Attributes.TransferBuffer;
-                transferBufferCount = Attributes.TransferBufferSize;
-            }
-        }
-
-        // Next row in data[]
-        StartOfLine_src += Attributes.Width;
-    }
-
-    // Send remaining data in transfer buffer to SPI
-    if (transferBufferCount < Attributes.TransferBufferSize)
-    {
-        // Transfer buffer full, send it
-        g_DisplayInterface.SendBytes(Attributes.TransferBuffer, (Attributes.TransferBufferSize - transferBufferCount));
-    }
+    g_DisplayInterface.SendData16Windowed(
+                    (CLR_UINT16 *)&data[0],
+                    srcX,
+                    srcY,
+                    width,
+                    height,
+                    stride,
+                    true);
 
     return;
 }

--- a/src/nanoFramework.Graphics/Graphics/Displays/ST7735S_SPI.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/ST7735S_SPI.cpp
@@ -232,23 +232,11 @@ void DisplayDriver::Clear()
     // Clear the ILI9342 controller frame
     SetWindow(0, 0, Attributes.Width - 1, Attributes.Height - 1);
 
-    // Clear buffer
-    memset(Attributes.TransferBuffer, 0x00, Attributes.TransferBufferSize);
-    int totalBytesToClear = Attributes.Width * Attributes.Height * 2;
-    int fullTransferBuffersCount = totalBytesToClear / Attributes.TransferBufferSize;
-    int remainderTransferBuffer = totalBytesToClear % Attributes.TransferBufferSize;
+    g_DisplayInterface.SendCommand(1, Memory_Write);
 
-    CLR_UINT8 command = Memory_Write;
-    g_DisplayInterface.SendCommand(1, command);
-    for (int i = 0; i < fullTransferBuffersCount; i++)
-    {
-        g_DisplayInterface.SendBytes(Attributes.TransferBuffer, Attributes.TransferBufferSize);
-    }
-
-    if (remainderTransferBuffer > 0)
-    {
-        g_DisplayInterface.SendBytes(Attributes.TransferBuffer, remainderTransferBuffer);
-    }
+    g_DisplayInterface.FillData16(
+                    0,
+                    Attributes.Width * Attributes.Height);
 }
 
 void DisplayDriver::DisplayBrightness(CLR_INT16 brightness)
@@ -304,55 +292,16 @@ void DisplayDriver::BitBlt(
 
     SetWindow(screenX, screenY, (screenX + width - 1), (screenY + height - 1));
 
-    CLR_UINT16 *StartOfLine_src = (CLR_UINT16 *)&data[0];
-    CLR_UINT8 *transferBufferIndex = Attributes.TransferBuffer;
-    CLR_UINT32 transferBufferCount = Attributes.TransferBufferSize;
+    g_DisplayInterface.SendCommand(1, Memory_Write);
 
-    // Offset for window start
-    StartOfLine_src += (srcY * stride) + srcX;
-
-    CLR_UINT8 command = Memory_Write;
-    g_DisplayInterface.SendCommand(1, command);
-
-    while (height--)
-    {
-        CLR_UINT16 *src;
-        int xCount;
-
-        src = StartOfLine_src;
-        xCount = width;
-
-        while (xCount--)
-        {
-            CLR_UINT16 dt = *src++;
-            *transferBufferIndex++ = (dt >> 8);
-            *transferBufferIndex++ = dt & 0xff;
-            transferBufferCount -= 2;
-
-            // Send over SPI if no room for another 2 bytes
-            if (transferBufferCount < 1)
-            {
-                // Transfer buffer full, send it
-                g_DisplayInterface.SendBytes(
-                    Attributes.TransferBuffer,
-                    (Attributes.TransferBufferSize - transferBufferCount));
-
-                // Reset transfer ptrs/count
-                transferBufferIndex = Attributes.TransferBuffer;
-                transferBufferCount = Attributes.TransferBufferSize;
-            }
-        }
-
-        // Next row in data[]
-        StartOfLine_src += Attributes.Width;
-    }
-
-    // Send remaining data in transfer buffer to SPI
-    if (transferBufferCount < Attributes.TransferBufferSize)
-    {
-        // Transfer buffer full, send it
-        g_DisplayInterface.SendBytes(Attributes.TransferBuffer, (Attributes.TransferBufferSize - transferBufferCount));
-    }
+    g_DisplayInterface.SendData16Windowed(
+                    (CLR_UINT16 *)&data[0],
+                    srcX,
+                    srcY,
+                    width,
+                    height,
+                    stride,
+                    true);
 
     return;
 }

--- a/src/nanoFramework.Graphics/Graphics/Displays/ST7789V_240x320_SPI.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/ST7789V_240x320_SPI.cpp
@@ -209,23 +209,11 @@ void DisplayDriver::Clear()
     // Clear the ST7789V2 controller frame
     SetWindow(0, 0, Attributes.Width - 1, Attributes.Height - 1);
 
-    // Clear buffer
-    memset(Attributes.TransferBuffer, 0x00, Attributes.TransferBufferSize);
-    int totalBytesToClear = Attributes.Width * Attributes.Height * 2;
-    int fullTransferBuffersCount = totalBytesToClear / Attributes.TransferBufferSize;
-    int remainderTransferBuffer = totalBytesToClear % Attributes.TransferBufferSize;
+    g_DisplayInterface.SendCommand(1, Memory_Write);
 
-    CLR_UINT8 command = Memory_Write;
-    g_DisplayInterface.SendCommand(1, command);
-    for (int i = 0; i < fullTransferBuffersCount; i++)
-    {
-        g_DisplayInterface.SendBytes(Attributes.TransferBuffer, Attributes.TransferBufferSize);
-    }
-
-    if (remainderTransferBuffer > 0)
-    {
-        g_DisplayInterface.SendBytes(Attributes.TransferBuffer, remainderTransferBuffer);
-    }
+    g_DisplayInterface.FillData16(
+                    0,
+                    Attributes.Width * Attributes.Height);
 }
 
 void DisplayDriver::DisplayBrightness(CLR_INT16 brightness)
@@ -282,55 +270,16 @@ void DisplayDriver::BitBlt(
 
     SetWindow(screenX, screenY, (screenX + width - 1), (screenY + height - 1));
 
-    CLR_UINT16 *StartOfLine_src = (CLR_UINT16 *)&data[0];
-    CLR_UINT8 *transferBufferIndex = Attributes.TransferBuffer;
-    CLR_UINT32 transferBufferCount = Attributes.TransferBufferSize;
+    g_DisplayInterface.SendCommand(1, Memory_Write);
 
-    // Offset for window start
-    StartOfLine_src += (srcY * stride) + srcX;
-
-    CLR_UINT8 command = Memory_Write;
-    g_DisplayInterface.SendCommand(1, command);
-
-    while (height--)
-    {
-        CLR_UINT16 *src;
-        int xCount;
-
-        src = StartOfLine_src;
-        xCount = width;
-
-        while (xCount--)
-        {
-            CLR_UINT16 dt = *src++;
-            *transferBufferIndex++ = (dt >> 8);
-            *transferBufferIndex++ = dt & 0xff;
-            transferBufferCount -= 2;
-
-            // Send over SPI if no room for another 2 bytes
-            if (transferBufferCount < 1)
-            {
-                // Transfer buffer full, send it
-                g_DisplayInterface.SendBytes(
-                    Attributes.TransferBuffer,
-                    (Attributes.TransferBufferSize - transferBufferCount));
-
-                // Reset transfer ptrs/count
-                transferBufferIndex = Attributes.TransferBuffer;
-                transferBufferCount = Attributes.TransferBufferSize;
-            }
-        }
-
-        // Next row in data[]
-        StartOfLine_src += stride;
-    }
-
-    // Send remaining data in transfer buffer to SPI
-    if (transferBufferCount < Attributes.TransferBufferSize)
-    {
-        // Transfer buffer full, send it
-        g_DisplayInterface.SendBytes(Attributes.TransferBuffer, (Attributes.TransferBufferSize - transferBufferCount));
-    }
+    g_DisplayInterface.SendData16Windowed(
+                    (CLR_UINT16 *)&data[0],
+                    srcX,
+                    srcY,
+                    width,
+                    height,
+                    stride,
+                    true);
 
     return;
 }

--- a/src/nanoFramework.Graphics/Graphics/Displays/Spi_To_Display.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/Spi_To_Display.cpp
@@ -228,13 +228,19 @@ void SendData16(CLR_UINT16 *data, CLR_UINT32 length, bool doByteSwap)
         CLR_UINT32 toWrite = length;
 
         if (toWrite > (SPI_MAX_TRANSFER_16 - bufferWritten))
+        {
             toWrite = (SPI_MAX_TRANSFER_16 - bufferWritten);
+        }
 
         // If we need to byteswap the data, do that - otherwise we can just memcpy it
         if (doByteSwap)
+        {
             CopyData16ByteSwapped(bufferPtr, data, toWrite);
+        }
         else
+        {
             memcpy(bufferPtr, data, toWrite * 2);
+        }
 
         bufferPtr += toWrite;
         data += toWrite;

--- a/src/nanoFramework.Graphics/Graphics/Displays/Spi_To_Display.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/Spi_To_Display.cpp
@@ -11,8 +11,9 @@
 #include <nanoPAL.h>
 #include <target_platform.h>
 
-#define NUMBER_OF_LINES       16
+#define NUMBER_OF_LINES 8
 #define SPI_MAX_TRANSFER_SIZE (320 * 2 * NUMBER_OF_LINES) // 320 pixels 2 words wide ( 16 bit colour)
+#define SPI_MAX_TRANSFER_16 (SPI_MAX_TRANSFER_SIZE / 2)
 
 struct DisplayInterface g_DisplayInterface;
 DisplayInterfaceConfig g_DisplayInterfaceConfig;
@@ -25,7 +26,18 @@ CLR_INT16 lcdBacklight;
 CLR_UINT32 spiDeviceHandle = 0;
 CLR_INT16 outputBufferSize;
 CLR_UINT8 spiBuffer[SPI_MAX_TRANSFER_SIZE];
+CLR_UINT8 spiBuffer2[SPI_MAX_TRANSFER_SIZE];
 CLR_UINT8 spiCommandMode = 0; // 0 Command first byte, 1 = Command all bytes
+
+// State variables for writes
+CLR_UINT16 *currentBuffer = (CLR_UINT16 *)spiBuffer;
+CLR_UINT16 *bufferPtr = currentBuffer;
+CLR_UINT32 bufferWritten = 0;
+
+void FlushData();
+void CopyData16ByteSwapped(CLR_UINT16 *dest, CLR_UINT16 *src, CLR_UINT32 length);
+void SendData16(CLR_UINT16 *data, CLR_UINT32 length, bool doByteSwap);
+void InternalSendBytes(CLR_UINT8 *data, CLR_UINT32 length, bool sendAsync);
 
 // Display Interface
 void DisplayInterface::Initialize(DisplayInterfaceConfig &config)
@@ -84,6 +96,7 @@ void DisplayInterface::GetTransferBuffer(CLR_UINT8 *&TransferBuffer, CLR_UINT32 
     TransferBuffer = spiBuffer;
     TransferBufferSize = sizeof(spiBuffer);
 }
+
 void DisplayInterface::ClearFrameBuffer()
 {
     // Not Used
@@ -97,13 +110,9 @@ void DisplayInterface::WriteToFrameBuffer(
 {
     (void)frameOffset;
 
-    CPU_GPIO_SetPinState(lcdDC, GpioPinValue_Low); // Command mode
-
-    SendBytes(&command, 1);
-
-    CPU_GPIO_SetPinState(lcdDC, GpioPinValue_High); // Data mode
-
+    SendCommand(1, command);
     SendBytes(data, dataCount);
+
     return;
 }
 
@@ -158,7 +167,17 @@ void DisplayInterface::DisplayBacklight(bool on) // true = on
     return;
 }
 
+// Dummy callback to enable async spi writes
+void spi_callback(int busIndex)
+{
+}
+
 void DisplayInterface::SendBytes(CLR_UINT8 *data, CLR_UINT32 length)
+{
+    InternalSendBytes(data, length, false);
+}
+
+void InternalSendBytes(CLR_UINT8 *data, CLR_UINT32 length, bool sendAsync)
 {
     if (length == 0)
         return; // no need to send anything
@@ -166,16 +185,112 @@ void DisplayInterface::SendBytes(CLR_UINT8 *data, CLR_UINT32 length)
     SPI_WRITE_READ_SETTINGS wrc;
 
     wrc.Bits16ReadWrite = false;
-    wrc.callback = 0; // No callback, synchronous
+    wrc.callback = sendAsync ? spi_callback : 0;
     wrc.fullDuplex = false;
     wrc.readOffset = 0;
 
-    // Theoretically, we could do work this asynchronously and continue to work, but this would require
-    // double buffering.
-
-    // Start a synchronous read / write spi job
     nanoSPI_Write_Read(spiDeviceHandle, wrc, data, length, NULL, 0);
+
     return;
+}
+
+// Flush any remaining buffered data, and swap buffers
+void FlushData()
+{
+    if (bufferWritten > 0)
+    {
+        InternalSendBytes((CLR_UINT8 *)currentBuffer, bufferWritten * 2, true);
+
+        currentBuffer = (currentBuffer == (CLR_UINT16 *)spiBuffer) ? (CLR_UINT16 *)spiBuffer2 : (CLR_UINT16 *)spiBuffer;
+        bufferPtr = currentBuffer;
+        bufferWritten = 0;
+    }
+}
+
+// Copy 16bit data src to dest, swapping the high and low bytes
+void CopyData16ByteSwapped(CLR_UINT16 *dest, CLR_UINT16 *src, CLR_UINT32 length)
+{
+    while (length > 0)
+    {
+        *dest = (*src << 8) | (*src >> 8 );
+
+        dest++;
+        src++;
+
+        length--;
+    }
+}
+
+void SendData16(CLR_UINT16 *data, CLR_UINT32 length, bool doByteSwap)
+{
+    while (length > 0)
+    {
+        CLR_UINT32 toWrite = length;
+
+        if (toWrite > (SPI_MAX_TRANSFER_16 - bufferWritten))
+            toWrite = (SPI_MAX_TRANSFER_16 - bufferWritten);
+
+        // If we need to byteswap the data, do that - otherwise we can just memcpy it
+        if (doByteSwap)
+            CopyData16ByteSwapped(bufferPtr, data, toWrite);
+        else
+            memcpy(bufferPtr, data, toWrite * 2);
+
+        bufferPtr += toWrite;
+        data += toWrite;
+        bufferWritten += toWrite;
+        length -= toWrite;
+
+        if (bufferWritten == SPI_MAX_TRANSFER_16)
+        {
+            FlushData();
+        }
+    }
+}
+
+void DisplayInterface::SendData16Windowed(CLR_UINT16 *data, CLR_UINT32 startX, CLR_UINT32 startY, CLR_UINT32 width, CLR_UINT32 height, CLR_UINT32 stride, bool doByteSwap)
+{
+    // Offset for window start
+    CLR_UINT16 *startOfLine = data + (startY * stride) + startX;
+
+    if (width == stride)    // Optimize full-stride writes
+    {
+        SendData16(startOfLine, width * height, doByteSwap);
+    }
+    else
+    {
+        while (height--)
+        {
+            SendData16(startOfLine, width, doByteSwap);
+
+            startOfLine += stride;
+        }
+    }
+
+    FlushData();
+
+    return;    
+}
+
+void DisplayInterface::FillData16(CLR_UINT16 fillValue, CLR_UINT32 fillLength)
+{
+    // Fill the current buffer full of fillValue, or as much as we need
+    memset(currentBuffer, fillValue, ((fillLength < SPI_MAX_TRANSFER_16) ? fillLength : SPI_MAX_TRANSFER_16) * 2);
+
+    // If our length doesn't evenly divide our buffer size, send out the small buffer first
+    // This gives us the maximum freed up time at the end
+    CLR_UINT32 firstSize = fillLength % SPI_MAX_TRANSFER_16;
+
+    InternalSendBytes((CLR_UINT8 *)currentBuffer, firstSize * 2, true);
+
+    fillLength -= firstSize;
+
+    while (fillLength > 0)
+    {
+        InternalSendBytes((CLR_UINT8 *)currentBuffer, SPI_MAX_TRANSFER_SIZE, true);
+
+        fillLength -= SPI_MAX_TRANSFER_16;
+    }
 }
 
 #endif // SPI_TO_DISPLAY_

--- a/targets/ESP32/_nanoCLR/System.Device.Spi/cpu_spi.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.Spi/cpu_spi.cpp
@@ -76,6 +76,7 @@ struct NF_PAL_SPI
 };
 
 NF_PAL_SPI nf_pal_spi[2];
+bool haveAsycTrans[2];
 
 // Remove device from bus
 // return true of OK, false = error
@@ -390,6 +391,14 @@ HRESULT CPU_SPI_nWrite_nRead(
         pnf_pal_spi->readOffset = wrc.readOffset; // dummy bytes between write & read on half duplex
         pnf_pal_spi->callback = wrc.callback;
 
+        if (haveAsycTrans[sdev.Spi_Bus])
+        {
+            spi_transaction_t *rtrans;
+            ret = spi_device_get_trans_result((spi_device_handle_t)deviceHandle, &rtrans, portMAX_DELAY);
+
+            haveAsycTrans[sdev.Spi_Bus] = false;
+        }
+
         // Set up SPI Transaction
         spi_transaction_t *pTrans = &pnf_pal_spi->trans;
 
@@ -434,6 +443,10 @@ HRESULT CPU_SPI_nWrite_nRead(
                     default:
                         NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
                 }
+            }
+            else
+            {
+                haveAsycTrans[sdev.Spi_Bus] = true;
             }
 
             pnf_pal_spi->status = SPI_OP_STATUS::SPI_OP_RUNNING;


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
This PR adds asynchronous transfer support to the SPI display interface. This increases the throughput of SPI-based display updates by almost 50%.

## Motivation and Context
Previously, SPI display data transfers were synchronous. The meant that any other work done by the display transfer code happened in between transfers. The display code does a copy operation and byte-switches the 16bit data as required by the SPI displays. This copy/swap operation takes a significant amount of time. With asynchronous operation, the copy/swap can be done while the previous transfer is occurring.

Two methods have been added to DisplayInterface: SendData16Windowed and FillData16. These functions remove significant duplicate code among the SPI display drivers and put in one place. They also allow for the asynchronous transfer to be implemented.

The display drivers updated are: **ILI9341_240x320_SPI**, **ILI9342_320x240_SPI**, **SSD1331_94x64_SPI**, **ST7735S_SPI**, and **ST7789V_240x320_SPI**.

There are two other display drivers that were not modified. **SSD1306_128x64** is a 1-bit display which requires custom data handling and **Otm8009a_DSI_Video_Mode** uses a different display transfer implementation (**DSI_To_Display_Video_Mode.cpp**).


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally on M5Stack Core2.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
