### PR TITLE
Fix tweaking sdkconfig for XTAL26 option

### DIFF
--- a/CMake/binutils.ESP32.cmake
+++ b/CMake/binutils.ESP32.cmake
@@ -464,7 +464,7 @@ macro(nf_add_idf_as_library)
         set(SDKCONFIG_DEFAULTS_FILE ${CMAKE_SOURCE_DIR}/targets/ESP32/_IDF/sdkconfig.default)
     endif()
 
-    message(STATUS "\n--SDK CONFIG is: '${SDKCONFIG_DEFAULTS_FILE}'.")
+    message(STATUS "\n-- SDK CONFIG is: '${SDKCONFIG_DEFAULTS_FILE}'.")
 
     # set list with the IDF components to add
     # need to match the list below with the respective libraries
@@ -573,12 +573,16 @@ macro(nf_add_idf_as_library)
     # option for automatic XTAL frequency detection
     # (default is OFF which means that fixed default frequency will be used)
     option(ESP32_XTAL_FREQ_26 "option to set XTAL frequency to 26MHz")
-    
+   
+    message(DEBUG "ESP32_XTAL_FREQ_26 option is ${ESP32_XTAL_FREQ_26}")
+
     if(ESP32_XTAL_FREQ_26)
 
         message(STATUS "Set XTAL frequency to 26MHz")
-                
-        # need to read the supplied SDK CONFIG file and replace the appropriate options            
+
+        # need to read the supplied SDK CONFIG file(s) and replace the appropriate options
+
+        message(DEBUG "Reading SDK config from '${SDKCONFIG_DEFAULTS_FILE}'")
         file(READ
             "${SDKCONFIG_DEFAULTS_FILE}"
             SDKCONFIG_DEFAULT_CONTENTS)
@@ -589,12 +593,31 @@ macro(nf_add_idf_as_library)
             SDKCONFIG_DEFAULT_FINAL_CONTENTS
             "${SDKCONFIG_DEFAULT_CONTENTS}")
 
+        # now do the same for the series config file, if it exists
+        file(READ
+            "${SDKCONFIG_DEFAULTS_FILE}.${TARGET_SERIES_SHORT}"
+            SDKCONFIG_DEFAULT_SERIES_CONTENTS)
+        
+        string(REPLACE
+            "CONFIG_ESP32_XTAL_FREQ_40"
+            "CONFIG_ESP32_XTAL_FREQ_26"
+            SDKCONFIG_DEFAULT_SERIES_FINAL_CONTENTS
+            "${SDKCONFIG_DEFAULT_SERIES_CONTENTS}")
+
         # need to temporarilly allow changes in source files
         set(CMAKE_DISABLE_SOURCE_CHANGES OFF)
 
         file(WRITE 
             ${SDKCONFIG_DEFAULTS_FILE} 
             ${SDKCONFIG_DEFAULT_FINAL_CONTENTS})
+
+        message(DEBUG "Wrote updated SDK config to '${SDKCONFIG_DEFAULTS_FILE}'")
+
+        file(WRITE 
+            "${SDKCONFIG_DEFAULTS_FILE}.${TARGET_SERIES_SHORT}" 
+            ${SDKCONFIG_DEFAULT_SERIES_FINAL_CONTENTS})
+
+        message(DEBUG "Wrote updated SDK config to '${SDKCONFIG_DEFAULTS_FILE}.${TARGET_SERIES_SHORT}'")
 
         set(CMAKE_DISABLE_SOURCE_CHANGES ON)
     else()


### PR DESCRIPTION
## Description
- Now adjusting series default file too.
- Add debug messages.

## Motivation and Context
- Fixes build issue for target ESP32_PSRAM_XTAL26_REV0 not adjusting XTAL frequency properly.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
