### PR TITLE
Added SPI interface method to wait on any outstanding async transfers

### DIFF
--- a/src/HAL/Include/nanoHAL_Spi.h
+++ b/src/HAL/Include/nanoHAL_Spi.h
@@ -53,6 +53,8 @@ HRESULT nanoSPI_CloseDevice(uint32_t handle);
 // Return the time in ms for a byte transfer
 float nanoSPI_GetByteTime(uint32_t handle);
 
+void nanoSPI_Wait_Busy(uint32_t handle);
+
 // Execute a SPI write/read operation
 // if callback is null the operation will completed as part of the call
 // if callback is not null then the job will be queued and the callback called when completed

--- a/src/PAL/Include/CPU_SPI_decl.h
+++ b/src/PAL/Include/CPU_SPI_decl.h
@@ -130,6 +130,8 @@ HRESULT CPU_SPI_nWrite_nRead(
     uint8_t *readPtr,
     int32_t readSize);
 
+void CPU_SPI_Wait_Busy(uint32_t deviceHandle, SPI_DEVICE_CONFIGURATION &sdev);
+
 // Write / read 16 bit data to device specified by handle
 // return result 0=S_OK, CLR_E_BUSY async operation and operation still running or another error code
 HRESULT CPU_SPI_nWrite16_nRead16(

--- a/src/System.Device.Spi/nanoHAL_Spi.cpp
+++ b/src/System.Device.Spi/nanoHAL_Spi.cpp
@@ -53,6 +53,12 @@ __nfweak HRESULT CPU_SPI_Add_Device(const SPI_DEVICE_CONFIGURATION &spiDeviceCon
     return S_OK;
 }
 
+__nfweak void CPU_SPI_Wait_Busy(uint32_t deviceHandle, SPI_DEVICE_CONFIGURATION &spiDeviceConfig)
+{
+    (void)deviceHandle;
+    (void)spiDeviceConfig;
+}
+
 __nfweak bool CPU_SPI_Remove_Device(uint32_t deviceHandle)
 {
     (void)deviceHandle;
@@ -359,6 +365,9 @@ HRESULT nanoSPI_CloseDevice(uint32_t handle)
         return CLR_E_INVALID_PARAMETER;
     }
 
+    // Wait until device is not busy
+    CPU_SPI_Wait_Busy(spiconfig[spiBus].deviceHandles[deviceIndex], spiconfig[spiBus].deviceCongfig[deviceIndex]);
+
     // Remove device from bus (ignore any error )
     CPU_SPI_Remove_Device(spiconfig[spiBus].deviceHandles[deviceIndex]);
 
@@ -393,6 +402,16 @@ float nanoSPI_GetByteTime(uint32_t handle)
     getDevice(handle, spiBus, deviceIndex);
 
     return spiconfig[spiBus].byteTime[deviceIndex];
+}
+
+void nanoSPI_Wait_Busy(uint32_t handle)
+{
+    uint8_t spiBus;
+    int deviceIndex;
+
+    getDevice(handle, spiBus, deviceIndex);
+
+    CPU_SPI_Wait_Busy(spiconfig[spiBus].deviceHandles[deviceIndex], spiconfig[spiBus].deviceCongfig[deviceIndex]);
 }
 
 //


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
A method to wait on any outstanding async transfers ("**nanoSPI_Wait_Busy**") method was added to the SPI interface. This method is also now called on shtudown.

## Motivation and Context
There was previously no interface to allow waiting to ensure any outstanding SPI transfers had completed. This interface has now been added. 

The new wait method is also now called on SPI device shutdown to ensure a clean soft reboot. Previously, the device could get stuck in a busy state after a soft reboot.

The wait method has been implemented for ESP32. A weak method was added to allow compilation and unchanged operation of other platforms.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally on ESP32 (M5Stack Core2).

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
