### PR TITLE
Re-enable async display writes

### DIFF
--- a/src/nanoFramework.Graphics/Graphics/Displays/Spi_To_Display.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/Spi_To_Display.cpp
@@ -30,10 +30,11 @@ CLR_UINT8 spiBuffer2[SPI_MAX_TRANSFER_SIZE];
 CLR_UINT8 spiCommandMode = 0; // 0 Command first byte, 1 = Command all bytes
 
 // State variables for writes
-CLR_UINT16 *currentBuffer = (CLR_UINT16 *)spiBuffer;
-CLR_UINT16 *bufferPtr = currentBuffer;
-CLR_UINT32 bufferWritten = 0;
+CLR_UINT16 *currentBuffer;
+CLR_UINT16 *bufferPtr;
+CLR_UINT32 bufferWritten;
 
+void SwapBuffers();
 void FlushData();
 void CopyData16ByteSwapped(CLR_UINT16 *dest, CLR_UINT16 *src, CLR_UINT32 length);
 void SendData16(CLR_UINT16 *data, CLR_UINT32 length, bool doByteSwap);
@@ -52,6 +53,10 @@ void DisplayInterface::Initialize(DisplayInterfaceConfig &config)
     spiConfig.DataOrder16 = DataBitOrder::DataBitOrder_MSB;
 
     spiConfig.Clock_RateHz = 40 * 1000 * 1000; // Spi clock speed.
+
+    currentBuffer = (CLR_UINT16 *)spiBuffer;
+    bufferPtr = currentBuffer;
+    bufferWritten = 0;
 
     HRESULT hr = nanoSPI_OpenDevice(spiConfig, spiDeviceHandle);
     ASSERT(hr == ESP_OK);
@@ -128,6 +133,9 @@ void DisplayInterface::SendCommand(CLR_UINT8 arg_count, ...)
         parameters[i] = va_arg(ap, int);
     }
 
+    // Make sure any outstanding async writes have finished before we set the pin low
+    nanoSPI_Wait_Busy(spiDeviceHandle);
+
     CPU_GPIO_SetPinState(lcdDC, GpioPinValue_Low); // Command mode
     if (spiCommandMode == 0)
     {
@@ -198,6 +206,14 @@ void InternalSendBytes(CLR_UINT8 *data, CLR_UINT32 length, bool sendAsync)
     return;
 }
 
+// Swap between our two data transfer buffers
+void SwapBuffers()
+{
+    currentBuffer = (currentBuffer == (CLR_UINT16 *)spiBuffer) ? (CLR_UINT16 *)spiBuffer2 : (CLR_UINT16 *)spiBuffer;
+    bufferPtr = currentBuffer;
+    bufferWritten = 0;
+}
+
 // Flush any remaining buffered data, and swap buffers
 void FlushData()
 {
@@ -205,9 +221,7 @@ void FlushData()
     {
         InternalSendBytes((CLR_UINT8 *)currentBuffer, bufferWritten * 2, true);
 
-        currentBuffer = (currentBuffer == (CLR_UINT16 *)spiBuffer) ? (CLR_UINT16 *)spiBuffer2 : (CLR_UINT16 *)spiBuffer;
-        bufferPtr = currentBuffer;
-        bufferWritten = 0;
+        SwapBuffers();
     }
 }
 
@@ -308,6 +322,9 @@ void DisplayInterface::FillData16(CLR_UINT16 fillValue, CLR_UINT32 fillLength)
 
         fillLength -= SPI_MAX_TRANSFER_16;
     }
+
+    // Swap buffers at the end so the next call doesn't overwrite our data
+    SwapBuffers();
 }
 
 #endif // SPI_TO_DISPLAY_

--- a/src/nanoFramework.Graphics/Graphics/Displays/Spi_To_Display.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/Spi_To_Display.cpp
@@ -193,11 +193,7 @@ void InternalSendBytes(CLR_UINT8 *data, CLR_UINT32 length, bool sendAsync)
     SPI_WRITE_READ_SETTINGS wrc;
 
     wrc.Bits16ReadWrite = false;
-
-    // setting this to 0 forces the transfer to be synchronous
-    // reverting to this for the time being until a definitive solution is found
-    wrc.callback = 0;
-
+    wrc.callback = sendAsync ? spi_callback : 0;
     wrc.fullDuplex = false;
     wrc.readOffset = 0;
 


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
This PR re-enables asynchronous display SPI writes. It also has a fix to ensure that async transfers complete before manipulating GPIO pins for the next command.

## Motivation and Context
The recent change enabling async display SPI writes was disabled temporarily to fix an issue with soft reboots. This fix has now been merged, so this PR re-enables the async writes.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally on M5Stack Core2.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
