### PR TITLE
Improve GPIO assigment validation

### DIFF
--- a/targets/ESP32/_common/ESP32_DeviceMapping.cpp
+++ b/targets/ESP32/_common/ESP32_DeviceMapping.cpp
@@ -37,7 +37,7 @@ int8_t Esp32_SERIAL_DevicePinMap[UART_NUM_MAX][Esp32SerialPin_Max] = {
 //  I2C
 //  2 devices I2C1 & I2C2
 //  Map pins Data & Clock
-int8_t Esp32_I2C_DevicePinMap[2][2] = {
+int8_t Esp32_I2C_DevicePinMap[I2C_NUM_MAX][2] = {
     // I2C1 - pins 18, 19,
     {I2C1_DATA, I2C1_CLOCK},
     // I2C2 - pins 25, 26

--- a/targets/ESP32/_common/ESP32_S2_DeviceMapping.cpp
+++ b/targets/ESP32/_common/ESP32_S2_DeviceMapping.cpp
@@ -38,7 +38,7 @@ int8_t Esp32_SERIAL_DevicePinMap[UART_NUM_MAX][Esp32SerialPin_Max] = {
 //  I2C
 //  2 devices I2C1 & I2C2
 //  Map pins Data & Clock
-int8_t Esp32_I2C_DevicePinMap[2][2] = {
+int8_t Esp32_I2C_DevicePinMap[I2C_NUM_MAX][2] = {
     // I2C1 - pins 18, 19,
     {I2C1_DATA, I2C1_CLOCK},
     // I2C2 - pins 25, 26

--- a/targets/ESP32/_common/FEATHER_S2_DeviceMapping.cpp
+++ b/targets/ESP32/_common/FEATHER_S2_DeviceMapping.cpp
@@ -34,7 +34,7 @@ int8_t Esp32_SERIAL_DevicePinMap[UART_NUM_MAX][Esp32SerialPin_Max] = {
 //  I2C
 //  2 devices I2C1 & I2C2
 //  Map pins Data & Clock
-int8_t Esp32_I2C_DevicePinMap[2][2] = {
+int8_t Esp32_I2C_DevicePinMap[I2C_NUM_MAX][2] = {
     // I2C1 - pins 8, 9
     {GPIO_NUM_8, GPIO_NUM_9},
     // I2C2 - pins 25, 26

--- a/targets/ESP32/_include/Esp32_DeviceMapping.h
+++ b/targets/ESP32/_include/Esp32_DeviceMapping.h
@@ -51,7 +51,7 @@ enum Esp32_MapDeviceType
 };
 
 extern int8_t Esp32_SPI_DevicePinMap[MAX_SPI_DEVICES][Esp32SpiPin_Max];
-extern int8_t Esp32_I2C_DevicePinMap[2][2];
+extern int8_t Esp32_I2C_DevicePinMap[I2C_NUM_MAX][2];
 extern int8_t Esp32_SERIAL_DevicePinMap[UART_NUM_MAX][Esp32SerialPin_Max];
 extern int8_t Esp32_LED_DevicePinMap[16];
 extern int8_t Esp32_ADC_DevicePinMap[20];


### PR DESCRIPTION
## Description
- I2C array now uses IDF constant to get max I2C buses available.
- Add GPIO output validation to I2C and UART.
- Remove output validation for MOSI pin.

## Motivation and Context
- Improves validation on assigning GPIO functions.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
