### PR TITLE
Fix name for Azure RTOS folder

### DIFF
--- a/targets/AzureRTOS/CMakeLists.txt
+++ b/targets/AzureRTOS/CMakeLists.txt
@@ -38,11 +38,11 @@ endif()
 # Define PLATFORM base path
 set(BASE_PATH_FOR_PLATFORM ${CMAKE_CURRENT_SOURCE_DIR} PARENT_SCOPE)
 
-# check if RTOS_SOURCE_FOLDER was specified or if it's empty (default is empty)
-set(NO_RTOS_SOURCE_FOLDER TRUE)
-if(RTOS_SOURCE_FOLDER)
-    if(NOT "${RTOS_SOURCE_FOLDER}" STREQUAL "")
-        set(NO_RTOS_SOURCE_FOLDER FALSE)
+# check if AZURERTOS_SOURCE_FOLDER was specified or if it's empty (default is empty)
+set(NO_AZURERTOS_SOURCE_FOLDER TRUE)
+if(AZURERTOS_SOURCE_FOLDER)
+    if(NOT "${AZURERTOS_SOURCE_FOLDER}" STREQUAL "")
+        set(NO_AZURERTOS_SOURCE_FOLDER FALSE)
     endif()
 endif()
 
@@ -63,7 +63,7 @@ if(RTOS_VERSION_EMPTY)
     set(RTOS_VERSION "v6.1.11_rel")
 endif()
 
-if(NO_RTOS_SOURCE_FOLDER)
+if(NO_AZURERTOS_SOURCE_FOLDER)
     # no AzureRTOS source specified, download it from it's repo
 
     message(STATUS "RTOS is: AzureRTOS ${RTOS_VERSION} from GitHub repo")
@@ -78,16 +78,16 @@ else()
     # AzureRTOS source was specified
 
     # sanity check is source path exists
-    if(EXISTS "${RTOS_SOURCE_FOLDER}/")
-        message(STATUS "RTOS is: AzureRTOS ${RTOS_VERSION} (source from: ${RTOS_SOURCE_FOLDER})")
+    if(EXISTS "${AZURERTOS_SOURCE_FOLDER}/")
+        message(STATUS "RTOS is: AzureRTOS ${RTOS_VERSION} (source from: ${AZURERTOS_SOURCE_FOLDER})")
 
         FetchContent_Declare(
             azure_rtos
-            SOURCE_DIR $(RTOS_SOURCE_FOLDER)
+            SOURCE_DIR $(AZURERTOS_SOURCE_FOLDER)
         )
 
     else()
-        message(FATAL_ERROR "Couldn't find AzureRTOS source at ${RTOS_SOURCE_FOLDER}/")
+        message(FATAL_ERROR "Couldn't find AzureRTOS source at ${AZURERTOS_SOURCE_FOLDER}/")
     endif()
 
 endif()


### PR DESCRIPTION
## Description
- Rename to correct name, was using a generic name.

## Motivation and Context
- Uses meaningful name for build option.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
