### PR TITLE
Fix ChibiOS HAL path for dev containers

### DIFF
--- a/CMakeUserPresets.TEMPLATE.json
+++ b/CMakeUserPresets.TEMPLATE.json
@@ -33,7 +33,7 @@
                 "CHIBIOS_SOURCE_FOLDER": "/sources/ChibiOs",
                 "FREERTOS_SOURCE_FOLDER": "/sources/FreeRTOS",
                 "CHIBIOS_CONTRIB_SOURCE": "/sources/ChibiOs-Contrib",
-                "CHIBIOS_HAL_SOURCE": null,
+                "CHIBIOS_HAL_SOURCE": "/sources/ChibiOs",
                 "STM32_CUBE_PACKAGE_SOURCE": "/sources/STM32CubeL4",
                 "MBEDTLS_SOURCE": "/sources/mbedtls",
                 "FATFS_SOURCE": "/sources/fatfs",


### PR DESCRIPTION
## Description

## Motivation and Context
If downloading the ChibiOS HAL via docker, it can tineout.
Given it is the same as the RTOS src, it should be set to the same dir,

## How Has This Been Tested?
Local PC with latest src image.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [x] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
