### PR TITLE
Add flags to support 128 and 256 bit word flash architectures

### DIFF
--- a/src/PAL/Include/nanoPAL_BlockStorage.h
+++ b/src/PAL/Include/nanoPAL_BlockStorage.h
@@ -172,8 +172,13 @@ typedef enum BlockRegionAttribute
 {
     // block region is memory mapped
     BlockRegionAttribute_MemoryMapped = 0x0100,
-    // programming width is 64bits
+
+    // Flash word size 64 bits
     BlockRegionAttribute_ProgramWidthIs64bits = 0x0200,
+    // Flash word size 128 bits
+    BlockRegionAttribute_ProgramWidthIs128bits = 0x0400,
+    // Flash word size 256 bits
+    BlockRegionAttribute_ProgramWidthIs256bits = 0x0800, 
 
 } BlockRegionAttribute;
 


### PR DESCRIPTION
## Description
For STM32H72x/3x/4x/5x lines, the flash memory word (smallest programmable amount of memory) is 256 bits,
while on STM32H7Ax/Bx lines it is 128 bits

## Motivation and Context
New bit flags are required to send to the nf-debugger to program the onboard Flash of the STM32 series mentioned above

## How Has This Been Tested
Additional bit flags have been added without changing existing functionality


## Screenshots
None

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
