### PR TITLE
Move ByteTime field to SPI_DEVICE_CONFIGURATION

### DIFF
--- a/src/HAL/Include/nanoHAL_Spi.h
+++ b/src/HAL/Include/nanoHAL_Spi.h
@@ -20,7 +20,6 @@ struct nanoSPI_BusConfig
     int8_t devicesInUse;
     SPI_DEVICE_CONFIGURATION deviceConfig[MAX_SPI_DEVICES];
     uint32_t deviceHandles[MAX_SPI_DEVICES];
-    float byteTime[MAX_SPI_DEVICES];
     SPI_OP_STATUS spiStatus;
 };
 

--- a/src/PAL/Include/CPU_SPI_decl.h
+++ b/src/PAL/Include/CPU_SPI_decl.h
@@ -77,6 +77,9 @@ struct SPI_DEVICE_CONFIGURATION
     bool MD16bits;
     // Data order for 16 bit operation
     DataBitOrder DataOrder16;
+    // Rough estimate on the time it takes to send/receive one byte (in milliseconds)
+    // Used to compute length of time for each IO to see if this is a long running operation
+    float ByteTime;
 
     // Master Only
     uint32_t Clock_RateHz;   // Master - SPI bus clock frequency, in hertz (Hz).

--- a/src/System.Device.Spi/nanoHAL_Spi.cpp
+++ b/src/System.Device.Spi/nanoHAL_Spi.cpp
@@ -347,15 +347,15 @@ HRESULT nanoSPI_OpenDeviceEx(
         }
     }
 
+    // Compute rough estimate on the time to tx/rx a byte (in milliseconds)
+    // Used to compute length of time for each IO to see if this is a long running operation
+    // Store for each device as each device could use a different bit rate
+    spiDeviceConfig.ByteTime = (1.0 / spiDeviceConfig.Clock_RateHz) * 1000.0 * 8;
+
     // Add next Device - Copy device config, save handle, increment number devices on bus
     nanoSPI_BusConfig *pBusConfig = &spiconfig[spiDeviceConfig.Spi_Bus];
     pBusConfig->deviceConfig[spiDeviceConfig.Spi_Bus] = spiDeviceConfig;
     pBusConfig->deviceHandles[spiDeviceConfig.Spi_Bus] = deviceHandle;
-
-    // Compute rough estimate on the time to tx/rx a byte (in milliseconds)
-    // Used to compute length of time for each IO to see if this is a long running operation
-    // Store for each device as each device could use a different bit rate
-    pBusConfig->byteTime[spiDeviceConfig.Spi_Bus] = (float)(1.0 / spiDeviceConfig.Clock_RateHz) * 1000 * 8;
 
     pBusConfig->devicesInUse++;
 
@@ -419,7 +419,7 @@ float nanoSPI_GetByteTime(uint32_t handle)
 
     getDevice(handle, spiBus, deviceIndex);
 
-    return spiconfig[spiBus].byteTime[deviceIndex];
+    return spiconfig[spiBus].deviceConfig->ByteTime;
 }
 
 void nanoSPI_Wait_Busy(uint32_t handle)

--- a/src/System.Device.Spi/sys_dev_spi_native_System_Device_Spi_SpiDevice.cpp
+++ b/src/System.Device.Spi/sys_dev_spi_native_System_Device_Spi_SpiDevice.cpp
@@ -26,7 +26,7 @@ bool System_Device_IsLongRunningOperation(
     uint32_t readSize,
     bool fullDuplex,
     bool bufferIs16bits,
-    float byteTime,
+    int32_t byteTime,
     uint32_t &estimatedDurationMiliseconds)
 {
     if (bufferIs16bits)


### PR DESCRIPTION
## Description
- Move ByteTime field to SPI_DEVICE_CONFIGURATION.
- Update code accordingly.

## Motivation and Context
- No need to keep this field outside of device configuration. More useful, accessible and reasonable to have it there.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
