### PR TITLE
Fix for Bitmap resources

### DIFF
--- a/src/nanoFramework.Graphics/Graphics/Core/Graphics.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/Graphics.cpp
@@ -374,7 +374,7 @@ void CLR_GFX_Bitmap::Decompress(const CLR_UINT8 *data, CLR_UINT32 size)
     }
 }
 
-CLR_UINT32 CLR_GFX_Bitmap::ConvertToNative1BppHelper(CLR_UINT32 flags, CLR_UINT16 &opacity, void *param)
+CLR_UINT32 CLR_GFX_Bitmap::ConvertToNative1BppHelper(int x, int y, CLR_UINT32 flags, CLR_UINT16 &opacity, void *param)
 {
     ConvertToNativeHelperParam *myParam = (ConvertToNativeHelperParam *)param;
     if (flags & PAL_GFX_Bitmap::c_SetPixels_NewRow)
@@ -394,7 +394,7 @@ CLR_UINT32 CLR_GFX_Bitmap::ConvertToNative1BppHelper(CLR_UINT32 flags, CLR_UINT1
     return color;
 }
 
-CLR_UINT32 CLR_GFX_Bitmap::ConvertToNative16BppHelper(CLR_UINT32 flags, CLR_UINT16 &opacity, void *param)
+CLR_UINT32 CLR_GFX_Bitmap::ConvertToNative16BppHelper(int x, int y,CLR_UINT32 flags, CLR_UINT16 &opacity, void *param)
 {
     ConvertToNativeHelperParam *myParam = (ConvertToNativeHelperParam *)param;
     if (flags & PAL_GFX_Bitmap::c_SetPixels_NewRow)

--- a/src/nanoFramework.Graphics/Graphics/Core/Graphics.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/Graphics.cpp
@@ -376,6 +376,9 @@ void CLR_GFX_Bitmap::Decompress(const CLR_UINT8 *data, CLR_UINT32 size)
 
 CLR_UINT32 CLR_GFX_Bitmap::ConvertToNative1BppHelper(int x, int y, CLR_UINT32 flags, CLR_UINT16 &opacity, void *param)
 {
+    (void)x;
+    (void)y;
+
     ConvertToNativeHelperParam *myParam = (ConvertToNativeHelperParam *)param;
     if (flags & PAL_GFX_Bitmap::c_SetPixels_NewRow)
     {
@@ -396,6 +399,9 @@ CLR_UINT32 CLR_GFX_Bitmap::ConvertToNative1BppHelper(int x, int y, CLR_UINT32 fl
 
 CLR_UINT32 CLR_GFX_Bitmap::ConvertToNative16BppHelper(int x, int y, CLR_UINT32 flags, CLR_UINT16 &opacity, void *param)
 {
+    (void)x;
+    (void)y;
+
     ConvertToNativeHelperParam *myParam = (ConvertToNativeHelperParam *)param;
     if (flags & PAL_GFX_Bitmap::c_SetPixels_NewRow)
     {

--- a/src/nanoFramework.Graphics/Graphics/Core/Graphics.h
+++ b/src/nanoFramework.Graphics/Graphics/Core/Graphics.h
@@ -485,8 +485,8 @@ struct CLR_GFX_Bitmap
     static HRESULT DeleteInstance(CLR_RT_HeapBlock &ref);
 
     static CLR_UINT32 CreateInstanceJpegHelper(int x, int y, CLR_UINT32 flags, CLR_UINT16 &opacity, void *param);
-    static CLR_UINT32 ConvertToNative1BppHelper(CLR_UINT32 flags, CLR_UINT16 &opacity, void *param);
-    static CLR_UINT32 ConvertToNative16BppHelper(CLR_UINT32 flags, CLR_UINT16 &opacity, void *param);
+    static CLR_UINT32 ConvertToNative1BppHelper(int x, int y,CLR_UINT32 flags, CLR_UINT16 &opacity, void *param);
+    static CLR_UINT32 ConvertToNative16BppHelper(int x, int y,CLR_UINT32 flags, CLR_UINT16 &opacity, void *param);
 
     void Bitmap_Initialize();
     void Clear();
@@ -890,7 +890,7 @@ struct BmpDecoder
     BmpEncodingType encodingType;
     HRESULT BmpInitOutput(const CLR_UINT8 *src, CLR_UINT32 srcSize);
     HRESULT BmpStartOutput(CLR_GFX_Bitmap *bitmap);
-    static CLR_UINT32 BmpOutputHelper(CLR_UINT32 flags, CLR_UINT16 &opacity, void *param);
+    static CLR_UINT32 BmpOutputHelper(int x, int y,CLR_UINT32 flags, CLR_UINT16 &opacity, void *param);
 
   private:
     CLR_RT_ByteArrayReader source;

--- a/src/nanoFramework.Graphics/Graphics/Core/Support/Bmp/Bitmap_Decoder.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/Support/Bmp/Bitmap_Decoder.cpp
@@ -220,7 +220,7 @@ HRESULT BmpDecoder::BmpStartOutput(CLR_GFX_Bitmap *bitmap)
     NANOCLR_NOCLEANUP();
 }
 
-CLR_UINT32 BmpDecoder::BmpOutputHelper(CLR_UINT32 flags, CLR_UINT16 &opacity, void *param)
+CLR_UINT32 BmpDecoder::BmpOutputHelper(int x, int y, CLR_UINT32 flags, CLR_UINT16 &opacity, void *param)
 {
     BmpOutputHelperParam *myParam = (BmpOutputHelperParam *)param;
 

--- a/src/nanoFramework.Graphics/Graphics/Core/Support/Bmp/Bitmap_Decoder.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/Support/Bmp/Bitmap_Decoder.cpp
@@ -221,6 +221,8 @@ HRESULT BmpDecoder::BmpStartOutput(CLR_GFX_Bitmap *bitmap)
 
 CLR_UINT32 BmpDecoder::BmpOutputHelper(int x, int y, CLR_UINT32 flags, CLR_UINT16 &opacity, void *param)
 {
+    (void)x;
+    (void)y;
     BmpOutputHelperParam *myParam = (BmpOutputHelperParam *)param;
 
     if (flags & PAL_GFX_Bitmap::c_SetPixels_NewRow)

--- a/src/nanoFramework.Graphics/Graphics/Core/Support/Bmp/Bitmap_Decoder.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/Support/Bmp/Bitmap_Decoder.cpp
@@ -223,6 +223,7 @@ CLR_UINT32 BmpDecoder::BmpOutputHelper(int x, int y, CLR_UINT32 flags, CLR_UINT1
 {
     (void)x;
     (void)y;
+
     BmpOutputHelperParam *myParam = (BmpOutputHelperParam *)param;
 
     if (flags & PAL_GFX_Bitmap::c_SetPixels_NewRow)


### PR DESCRIPTION
## Description
Native Bitmap methods have incorrect signature.
These methods were never called until the change to visual studio extension and meta-data to process bitmap resources waws implemented

## Motivation and Context
Complete fix to #729 and #156

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Working example

## Screenshots

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
