### PR TITLE
Fix inclusion of Azure RTOS user config file

### DIFF
--- a/CMake/Modules/AzureRTOS_MAX78000_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_MAX78000_GCC_options.cmake
@@ -27,8 +27,11 @@ macro(nf_set_compile_options)
     # can't include -Wundef because of MAXIM SDK
     target_compile_options(${NFSCO_TARGET} PUBLIC ${NFSCO__EXTRA_COMPILE_OPTIONS} -mthumb -mcpu=cortex-m4 -mfloat-abi=soft -mfpu=fpv4-sp-d16 -mfloat-abi=soft -Wa,-mimplicit-it=thumb -Wall -Wextra -Werror -Wshadow -Wimplicit-fallthrough -ffunction-sections -fshort-wchar -falign-functions=16 -fdata-sections -fno-builtin -fno-common -fomit-frame-pointer -mlong-calls -fdollars-in-identifiers -fno-exceptions -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fcheck-new )
 
-    # this series has FPU 
-    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DPLATFORM_ARM -DCORTEX_USE_FPU=TRUE -DTARGET=MAX78000 -DTARGET_REV=0x4131 -DFTHR_RevA ) 
+    # enable:
+    # - FPU 
+    # - user TX file
+    # - MAXIM target and revision
+    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DPLATFORM_ARM -DCORTEX_USE_FPU=TRUE -DTARGET=MAX78000 -DTARGET_REV=0x4131 -DFTHR_RevA -DTX_INCLUDE_USER_DEFINE_FILE) 
 
 endmacro()
 

--- a/CMake/Modules/AzureRTOS_MICROBIT_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_MICROBIT_GCC_options.cmake
@@ -29,8 +29,10 @@ macro(nf_set_compile_options)
     # include any extra options coming from any extra args?
     target_compile_options(${NFSCO_TARGET} PUBLIC ${NFSCO__EXTRA_COMPILE_OPTIONS} -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -mabi=aapcs -Wall -Wextra -Werror -Wundef -Wshadow -Wimplicit-fallthrough -ffunction-sections -fshort-wchar -falign-functions=16 -fdata-sections -fno-builtin -fno-common -fomit-frame-pointer -mlong-calls -fdollars-in-identifiers -fno-exceptions -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fcheck-new )
 
-    # this series has FPU 
-    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DPLATFORM_ARM -DCORTEX_USE_FPU=TRUE) 
+    # enable:
+    # - FPU 
+    # - user TX file
+    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DPLATFORM_ARM -DCORTEX_USE_FPU=TRUE -DTX_INCLUDE_USER_DEFINE_FILE ) 
 
 endmacro()
 

--- a/CMake/Modules/AzureRTOS_RP2040_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_RP2040_GCC_options.cmake
@@ -28,7 +28,9 @@ macro(nf_set_compile_options)
     target_compile_options(${NFSCO_TARGET} PUBLIC  ${NFSCO__EXTRA_COMPILE_OPTIONS} -mthumb -mcpu=cortex-m0plus -mtune=cortex-m0plus -nostdlib -Wall -Wextra -Werror -Wundef -Wshadow -Wimplicit-fallthrough -fshort-wchar -fno-builtin -fno-common -mno-long-calls -fno-exceptions -fcheck-new )
 
     # this series doesn't have FPU 
-    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DPLATFORM_ARM -DUSE_FPU=FALSE)
+    # enable:
+    # - user TX file
+    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DPLATFORM_ARM -DUSE_FPU=FALSE -DTX_INCLUDE_USER_DEFINE_FILE )
 
 endmacro()
 

--- a/CMake/Modules/AzureRTOS_STM32F7xx_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_STM32F7xx_GCC_options.cmake
@@ -34,7 +34,9 @@ macro(nf_set_compile_options)
 
     # enable:
     # - FPU 
-    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DPLATFORM_ARM -DCORTEX_USE_FPU=TRUE -DUSE_FPU=TRUE -DSTM32F7XX)
+    # - user TX file
+    # - STM series
+    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DPLATFORM_ARM -DCORTEX_USE_FPU=TRUE -DUSE_FPU=TRUE -DSTM32F7XX -DTX_INCLUDE_USER_DEFINE_FILE )
 
 endmacro()
 

--- a/CMake/Modules/AzureRTOS_STM32L4xx_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_STM32L4xx_GCC_options.cmake
@@ -33,7 +33,9 @@ macro(nf_set_compile_options)
 
     # enable:
     # - FPU 
-    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DPLATFORM_ARM -DCORTEX_USE_FPU=TRUE -DUSE_FPU=TRUE -DSTM32L4XX)
+    # - user TX file
+    # - STM series
+    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DPLATFORM_ARM -DCORTEX_USE_FPU=TRUE -DUSE_FPU=TRUE -DSTM32L4XX -DTX_INCLUDE_USER_DEFINE_FILE )
 
 endmacro()
 

--- a/CMake/binutils.AzureRTOS.cmake
+++ b/CMake/binutils.AzureRTOS.cmake
@@ -252,7 +252,6 @@ macro(nf_add_platform_dependencies target)
                 ${AZRTOS_INCLUDES}
                 
             EXTRA_COMPILE_DEFINITIONS 
-                -DTX_INCLUDE_USER_DEFINE_FILE
                 -DNX_INCLUDE_USER_DEFINE_FILE            
         )
         
@@ -272,7 +271,6 @@ macro(nf_add_platform_dependencies target)
                     ${${TARGET_STM32_CUBE_PACKAGE}_CubePackage_INCLUDE_DIRS}
 
                 EXTRA_COMPILE_DEFINITIONS 
-                    -DTX_INCLUDE_USER_DEFINE_FILE
                     -DNX_INCLUDE_USER_DEFINE_FILE
                     -DUSE_HAL_DRIVER
                     -D${STM32_DRIVER_TARGET_DEVICE}

--- a/targets/AzureRTOS/CMakeLists.txt
+++ b/targets/AzureRTOS/CMakeLists.txt
@@ -409,6 +409,9 @@ else()
 
 endif()
 
+set(TARGET_BASE_LOCATION_BINARY ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_VENDOR}/${TARGET_BOARD})
+set(TX_USER_FILE ${TARGET_BASE_LOCATION}/target_tx_user.h CACHE STRING "Enable TX user configuration")
+
 ##############################
 # AzureRTOS common directories
 add_subdirectory(_common)

--- a/targets/AzureRTOS/Maxim/MAX78000_FTHR/CMakeLists.txt
+++ b/targets/AzureRTOS/Maxim/MAX78000_FTHR/CMakeLists.txt
@@ -14,7 +14,6 @@ set(THREADX_TOOLCHAIN "gnu")
 set(MCPU_FLAGS "-mthumb -mcpu=cortex-m4")
 set(VFP_FLAGS "")
 set(SPEC_FLAGS "--specs=nosys.specs")
-set(TX_USER_FILE ${TARGET_BASE_LOCATION}/tx_user.h)
 
 add_subdirectory(${azure_rtos_SOURCE_DIR} AzureSource)
 

--- a/targets/AzureRTOS/MicroBit/MICRO_BIT_2/CMakeLists.txt
+++ b/targets/AzureRTOS/MicroBit/MICRO_BIT_2/CMakeLists.txt
@@ -12,7 +12,6 @@ ENABLE_LANGUAGE(ASM)
 # Azure RTOS settings and inclusion of build system
 set(THREADX_ARCH "cortex_m4")
 set(THREADX_TOOLCHAIN "gnu")
-set(TX_USER_FILE ${TARGET_BASE_LOCATION}/tx_user.h)
 add_subdirectory(${CMAKE_BINARY_DIR}/AzureRTOS_Source AzureSource)
 
 # add packages

--- a/targets/AzureRTOS/RaspberryPi/RPI_PICO/CMakeLists.txt
+++ b/targets/AzureRTOS/RaspberryPi/RPI_PICO/CMakeLists.txt
@@ -18,7 +18,6 @@ set(THREADX_TOOLCHAIN "gnu")
 set(MCPU_FLAGS "-mthumb -mcpu=cortex-m0")
 set(VFP_FLAGS "")
 set(SPEC_FLAGS "--specs=nosys.specs")
-set(TX_USER_FILE ${TARGET_BASE_LOCATION}/tx_user.h)
 add_subdirectory(${azure_rtos_SOURCE_DIR} AzureSource)
 
 # add packages

--- a/targets/AzureRTOS/ST/ORGPAL_PALTHREE/CMakeLists.txt
+++ b/targets/AzureRTOS/ST/ORGPAL_PALTHREE/CMakeLists.txt
@@ -14,9 +14,8 @@ include(AzureRTOS_${TARGET_SERIES}_GCC_options)
 # endif()
 
 # Azure RTOS settings and inclusion of build system
-set(THREADX_ARCH "cortex_m7" )
-set(THREADX_TOOLCHAIN "gnu" )
-set(TX_USER_FILE ${TARGET_BASE_LOCATION}/target_tx_user.h CACHE STRING "Enable TX user configuration")
+set(THREADX_ARCH "cortex_m7")
+set(THREADX_TOOLCHAIN "gnu")
 # set(UX_USER_FILE ${TARGET_BASE_LOCATION}/target_ux_user.h CACHE STRING "Enable UX user configuration")
 set(NX_USER_FILE ${TARGET_BASE_LOCATION}/target_nx_user.h CACHE STRING "Enable NX user configuration")
 set(NXD_ENABLE_FILE_SERVERS OFF CACHE BOOL "Disable fileX dependency by netxduo")

--- a/targets/AzureRTOS/ST/ST_B_L475E_IOT01A/CMakeLists.txt
+++ b/targets/AzureRTOS/ST/ST_B_L475E_IOT01A/CMakeLists.txt
@@ -9,9 +9,8 @@ include(binutils.AzureRTOS)
 include(AzureRTOS_${TARGET_SERIES}_GCC_options)
 
 # Azure RTOS settings and inclusion of build system
-set(THREADX_ARCH "cortex_m4" )
-set(THREADX_TOOLCHAIN "gnu" )
-set(TX_USER_FILE ${TARGET_BASE_LOCATION}/target_tx_user.h CACHE STRING "Enable TX user configuration")
+set(THREADX_ARCH "cortex_m4")
+set(THREADX_TOOLCHAIN "gnu")
 set(NX_USER_FILE ${TARGET_BASE_LOCATION}/target_nx_user.h CACHE STRING "Enable NX user configuration")
 set(NXD_ENABLE_FILE_SERVERS OFF CACHE BOOL "Disable fileX dependency by netxduo")
 

--- a/targets/AzureRTOS/_common/include/targetHAL.h
+++ b/targets/AzureRTOS/_common/include/targetHAL.h
@@ -6,8 +6,6 @@
 #ifndef _TARGET_HAL_H_
 #define _TARGET_HAL_H_
 
-#include <tx_api.h>
-
 #include <target_board.h>
 #include <nanoHAL_v2.h>
 


### PR DESCRIPTION
## Description
- Now define is set at GCC series define.
- Remove setting CMake var from all targets, move it up at general CMake file.

## Motivation and Context
- Fixes inclusion of user tx config file which wasn't being properly handled on some situations.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
