### PR TITLE
Fix sending empty string over SerialPort

### DIFF
--- a/src/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort__.cpp
+++ b/src/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort__.cpp
@@ -49,8 +49,11 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::SetupWriteLine(
 
             newLineLength = hal_strlen_s(newLine);
 
+            // update buffer length
+            *length += newLineLength;
+
             // allocate memory for buffer
-            *buffer = (char *)platform_malloc(textLength + newLineLength);
+            *buffer = (char *)platform_malloc(*length);
 
             // sanity check for successful allocation
             if (*buffer)
@@ -60,9 +63,6 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::SetupWriteLine(
 
                 // flag allocation
                 *isNewAllocation = true;
-
-                // update buffer length
-                *length += newLineLength;
 
                 // concatenate both strings
                 strcat(*buffer, text);


### PR DESCRIPTION
## Description
- Code wasn't clearing allocated memory properly thus causing a failure in the string copy.

## Motivation and Context
- Fixes nanoFramework/Home#1099.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Code reproducing the issue description.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
