### PR TITLE
Fix IDF detection for dirty repo

### DIFF
--- a/CMake/binutils.ESP32.cmake
+++ b/CMake/binutils.ESP32.cmake
@@ -420,28 +420,16 @@ endmacro()
 # macro to add IDF as a library to the build and add the IDF components according to variant and options
 macro(nf_add_idf_as_library)
 
+    FetchContent_GetProperties(esp32_idf)
+
+    # discard any changes in the IDF git repo
+    # this is required to prevent IDF detecting dirty git repo and messing up the IDF version for bootloader
+    execute_process(COMMAND
+        ${GIT_EXECUTABLE}
+        checkout .
+        WORKING_DIRECTORY ${esp32_idf_SOURCE_DIR})
+
     include(${IDF_PATH_CMAKED}/tools/cmake/idf.cmake)
-
-    # if running on Azure Pipeline, tweak the reported version so it doesn't show '-dirty'
-    if(DEFINED ENV{Agent_HomeDirectory} AND DEFINED ENV{Build_BuildNumber})
-
-        get_property(MY_IDF_VER TARGET __idf_build_target PROPERTY IDF_VER )
-
-        string(REPLACE "-dirty" "" MY_IDF_VER_FIXED "${MY_IDF_VER}")
- 
-        set_property(TARGET __idf_build_target PROPERTY IDF_VER ${MY_IDF_VER_FIXED})
-
-        # for COMPILE DEFINITIONS it's a bit more work
-        get_property(IDF_COMPILE_DEFINITIONS TARGET __idf_build_target PROPERTY COMPILE_DEFINITIONS )
-
-        string(REPLACE "-dirty" "" IDF_COMPILE_DEFINITIONS_FIXED "${IDF_COMPILE_DEFINITIONS}")
-
-        set_property(TARGET __idf_build_target PROPERTY COMPILE_DEFINITIONS ${IDF_COMPILE_DEFINITIONS_FIXED})
-
-        message(STATUS "Fixing IDF version. It is now: ${MY_IDF_VER_FIXED}")
-    else()
-        message(STATUS "SKIP Fixing IDF version.")
-    endif()
 
     target_sources(${NANOCLR_PROJECT_NAME}.elf PUBLIC
         ${CMAKE_SOURCE_DIR}/targets/ESP32/_IDF/${TARGET_SERIES_SHORT}/app_main.c)

--- a/targets/ESP32/CMakeLists.txt
+++ b/targets/ESP32/CMakeLists.txt
@@ -76,9 +76,10 @@ endif()
 
 # if using FatFS need to remove IDF ffconfig.h so it can pick ours
 if(NF_FEATURE_HAS_SDCARD)
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -E remove ${esp32_idf_SOURCE_DIR}/components/fatfs/src/ffconf.h
-    )
+    add_custom_command(
+        OUTPUT ${esp32_idf_SOURCE_DIR}/components/fatfs/src/ffconf.h
+        PRE_BUILD 
+        COMMAND ${CMAKE_COMMAND} -E remove ${esp32_idf_SOURCE_DIR}/components/fatfs/src/ffconf.h)
 endif()
 
 # target folder was added in main CMakeList


### PR DESCRIPTION
## Description
- Move deletion of ffconf.h to add_custom_command running before build.
- Remove all tweaks and hacks messing with IDF version in project properties and compile definitions.

## Motivation and Context
- Resolves wrong version being output on bootloader.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
