### PR TITLE
Add back LTO

### DIFF
--- a/CMake/Modules/AzureRTOS_MAX78000_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_MAX78000_GCC_options.cmake
@@ -47,13 +47,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs --specs=nosys.specs")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs --specs=nosys.specs")
       
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/AzureRTOS_MAX78000_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_MAX78000_GCC_options.cmake
@@ -52,7 +52,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os")
     endif()
       
     # include libraries in build

--- a/CMake/Modules/AzureRTOS_MICROBIT_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_MICROBIT_GCC_options.cmake
@@ -48,13 +48,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs --specs=nosys.specs")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs --specs=nosys.specs")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/AzureRTOS_MICROBIT_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_MICROBIT_GCC_options.cmake
@@ -53,7 +53,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os")
     endif()
 
     # include libraries in build

--- a/CMake/Modules/AzureRTOS_RP2040_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_RP2040_GCC_options.cmake
@@ -46,13 +46,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/AzureRTOS_RP2040_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_RP2040_GCC_options.cmake
@@ -51,7 +51,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
 
     # include libraries in build

--- a/CMake/Modules/AzureRTOS_STM32F7xx_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_STM32F7xx_GCC_options.cmake
@@ -52,13 +52,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs --specs=nosys.specs")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs --specs=nosys.specs")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/AzureRTOS_STM32L4xx_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_STM32L4xx_GCC_options.cmake
@@ -52,13 +52,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs --specs=nosys.specs")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs --specs=nosys.specs")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/AzureRTOS_STM32L4xx_GCC_options.cmake
+++ b/CMake/Modules/AzureRTOS_STM32L4xx_GCC_options.cmake
@@ -57,7 +57,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -fuse-linker-plugin -Os")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os")
     endif()
 
     # include libraries in build

--- a/CMake/Modules/CHIBIOS_STM32F0xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F0xx_GCC_options.cmake
@@ -50,7 +50,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
 
     # include libraries in build

--- a/CMake/Modules/CHIBIOS_STM32F0xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F0xx_GCC_options.cmake
@@ -45,13 +45,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/CHIBIOS_STM32F4xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F4xx_GCC_options.cmake
@@ -46,13 +46,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/CHIBIOS_STM32F4xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F4xx_GCC_options.cmake
@@ -51,7 +51,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
 
     # include libraries in build

--- a/CMake/Modules/CHIBIOS_STM32F7xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F7xx_GCC_options.cmake
@@ -50,7 +50,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
 
     # include libraries in build

--- a/CMake/Modules/CHIBIOS_STM32F7xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32F7xx_GCC_options.cmake
@@ -45,13 +45,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/CHIBIOS_STM32H7xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32H7xx_GCC_options.cmake
@@ -52,7 +52,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
 
     # include libraries in build

--- a/CMake/Modules/CHIBIOS_STM32H7xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32H7xx_GCC_options.cmake
@@ -47,13 +47,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/CHIBIOS_STM32L0xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32L0xx_GCC_options.cmake
@@ -50,13 +50,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/CHIBIOS_STM32L0xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32L0xx_GCC_options.cmake
@@ -55,7 +55,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -Os -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -frounding-math -fsignaling-nans -ffloat-store -fno-math-errno -ftree-vectorize -fno-default-inline -finline-functions-called-once -fno-defer-pop ")
     endif()
 
     # include libraries in build

--- a/CMake/Modules/CHIBIOS_STM32L4xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32L4xx_GCC_options.cmake
@@ -51,7 +51,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -fuse-linker-plugin -Os ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os ")
     endif()
 
     # include libraries in build

--- a/CMake/Modules/CHIBIOS_STM32L4xx_GCC_options.cmake
+++ b/CMake/Modules/CHIBIOS_STM32L4xx_GCC_options.cmake
@@ -46,13 +46,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/FreeRTOS_IMXRT10xx_GCC_options.cmake
+++ b/CMake/Modules/FreeRTOS_IMXRT10xx_GCC_options.cmake
@@ -52,7 +52,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -fuse-linker-plugin -Os ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os ")
     endif()
       
     # include libraries in build

--- a/CMake/Modules/FreeRTOS_IMXRT10xx_GCC_options.cmake
+++ b/CMake/Modules/FreeRTOS_IMXRT10xx_GCC_options.cmake
@@ -47,13 +47,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs --specs=nosys.specs -Wl,--start-group -Xlinker --gc-sections -Xlinker --sort-section=alignment -Xlinker -print-memory-usage")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs --specs=nosys.specs -Wl,--start-group -Xlinker --gc-sections -Xlinker --sort-section=alignment -Xlinker -print-memory-usage")
       
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/TI_SimpleLink_CC13X2_GCC_options.cmake
+++ b/CMake/Modules/TI_SimpleLink_CC13X2_GCC_options.cmake
@@ -54,7 +54,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -fuse-linker-plugin -Os ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os ")
     endif()
 
     # include libraries in build

--- a/CMake/Modules/TI_SimpleLink_CC13X2_GCC_options.cmake
+++ b/CMake/Modules/TI_SimpleLink_CC13X2_GCC_options.cmake
@@ -49,13 +49,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_link_options()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/TI_SimpleLink_CC32xx_GCC_options.cmake
+++ b/CMake/Modules/TI_SimpleLink_CC32xx_GCC_options.cmake
@@ -47,13 +47,13 @@ macro(nf_set_link_options)
         message(FATAL_ERROR "Need to set TARGET argument when calling nf_set_compile_definitions()")
     endif()
 
-    # request specs from newlib nano
-    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
-
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Os -flto ")
     endif()
+
+    # request specs from newlib nano
+    set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " --specs=nano.specs ")
 
     # include libraries in build
     nf_include_libraries_in_build(${NFSLO_TARGET})

--- a/CMake/Modules/TI_SimpleLink_CC32xx_GCC_options.cmake
+++ b/CMake/Modules/TI_SimpleLink_CC32xx_GCC_options.cmake
@@ -52,7 +52,7 @@ macro(nf_set_link_options)
 
     # set optimization linker flags for RELEASE and MinSizeRel
     if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -fuse-linker-plugin -Os ")
+        set_property(TARGET ${NFSLO_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -flto -fuse-linker-plugin -Os ")
     endif()
 
     # include libraries in build

--- a/CMake/binutils.ChibiOS.cmake
+++ b/CMake/binutils.ChibiOS.cmake
@@ -10,8 +10,8 @@ function(nf_set_optimization_options target)
     # debug compile options: -Og (optimize for debugging) and -ggdb (produce debug symbols specifically for gdb)
     target_compile_options(${target} PRIVATE
         $<$<CONFIG:Debug>:-Og -ggdb>
-        $<$<CONFIG:Release>:-O3 -flto -fuse-linker-plugin -fno-fat-lto-objects>
-        $<$<CONFIG:MinSizeRel>:-Os -flto>
+        $<$<CONFIG:Release>:-O3 -flto -ffat-lto-objects>
+        $<$<CONFIG:MinSizeRel>:-Os -flto -ffat-lto-objects>
         $<$<CONFIG:RelWithDebInfo>:-Os -ggdb>
     )
 

--- a/CMake/binutils.ChibiOS.cmake
+++ b/CMake/binutils.ChibiOS.cmake
@@ -10,8 +10,8 @@ function(nf_set_optimization_options target)
     # debug compile options: -Og (optimize for debugging) and -ggdb (produce debug symbols specifically for gdb)
     target_compile_options(${target} PRIVATE
         $<$<CONFIG:Debug>:-Og -ggdb>
-        $<$<CONFIG:Release>:-O3>
-        $<$<CONFIG:MinSizeRel>:-Os>
+        $<$<CONFIG:Release>:-O3 -flto -fuse-linker-plugin -fno-fat-lto-objects>
+        $<$<CONFIG:MinSizeRel>:-Os -flto>
         $<$<CONFIG:RelWithDebInfo>:-Os -ggdb>
     )
 

--- a/CMake/binutils.FreeRTOS.cmake
+++ b/CMake/binutils.FreeRTOS.cmake
@@ -8,8 +8,8 @@ function(nf_set_optimization_options target)
     # debug compile options: -Og (optimize for debugging) and -ggdb (produce debug symbols specifically for gdb)
     target_compile_options(${target} PRIVATE
         $<$<CONFIG:Debug>:-Og -ggdb>
-        $<$<CONFIG:Release>:-O3>
-        $<$<CONFIG:MinSizeRel>:-Os>
+        $<$<CONFIG:Release>:-O3 -flto -fuse-linker-plugin -fno-fat-lto-objects>
+        $<$<CONFIG:MinSizeRel>:-Os -flto -fuse-linker-plugin -fno-fat-lto-objects>
         $<$<CONFIG:RelWithDebInfo>:-Os -ggdb>
     )
 

--- a/CMake/binutils.FreeRTOS.cmake
+++ b/CMake/binutils.FreeRTOS.cmake
@@ -8,8 +8,8 @@ function(nf_set_optimization_options target)
     # debug compile options: -Og (optimize for debugging) and -ggdb (produce debug symbols specifically for gdb)
     target_compile_options(${target} PRIVATE
         $<$<CONFIG:Debug>:-Og -ggdb>
-        $<$<CONFIG:Release>:-O3 -flto -fuse-linker-plugin -fno-fat-lto-objects>
-        $<$<CONFIG:MinSizeRel>:-Os -flto -fuse-linker-plugin -fno-fat-lto-objects>
+        $<$<CONFIG:Release>:-O3 -flto -ffat-lto-objects>
+        $<$<CONFIG:MinSizeRel>:-Os -flto -ffat-lto-objects>
         $<$<CONFIG:RelWithDebInfo>:-Os -ggdb>
     )
 

--- a/CMake/binutils.TI_SimpleLink.cmake
+++ b/CMake/binutils.TI_SimpleLink.cmake
@@ -13,8 +13,8 @@ function(nf_set_optimization_options target)
     # debug compile options: -Og (optimize for debugging) and -ggdb (produce debug symbols specifically for gdb)
     target_compile_options(${target} PRIVATE
         $<$<CONFIG:Debug>:-Og -ggdb>
-        $<$<CONFIG:Release>:-O3>
-        $<$<CONFIG:MinSizeRel>:-Os>
+        $<$<CONFIG:Release>:-O3 -flto -fuse-linker-plugin -fno-fat-lto-objects>
+        $<$<CONFIG:MinSizeRel>:-Os -flto -fuse-linker-plugin -fno-fat-lto-objects>
         $<$<CONFIG:RelWithDebInfo>:-Os -ggdb>
     )
 

--- a/CMake/binutils.TI_SimpleLink.cmake
+++ b/CMake/binutils.TI_SimpleLink.cmake
@@ -13,8 +13,8 @@ function(nf_set_optimization_options target)
     # debug compile options: -Og (optimize for debugging) and -ggdb (produce debug symbols specifically for gdb)
     target_compile_options(${target} PRIVATE
         $<$<CONFIG:Debug>:-Og -ggdb>
-        $<$<CONFIG:Release>:-O3 -flto -fuse-linker-plugin -fno-fat-lto-objects>
-        $<$<CONFIG:MinSizeRel>:-Os -flto -fuse-linker-plugin -fno-fat-lto-objects>
+        $<$<CONFIG:Release>:-O3 -flto -ffat-lto-objects>
+        $<$<CONFIG:MinSizeRel>:-Os -flto -ffat-lto-objects>
         $<$<CONFIG:RelWithDebInfo>:-Os -ggdb>
     )
 

--- a/src/CLR/Core/CLR_RT_HeapBlock_Lock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Lock.cpp
@@ -5,6 +5,11 @@
 //
 #include "Core.h"
 
+#ifdef __GNUC__
+#pragma GCC push_options
+#pragma GCC optimize("O1")
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 HRESULT CLR_RT_HeapBlock_Lock::CreateInstance(
@@ -237,3 +242,7 @@ void CLR_RT_HeapBlock_Lock::Relocate_Owner()
 {
     NATIVE_PROFILE_CLR_CORE();
 }
+
+#ifdef __GNUC__
+#pragma GCC push_options
+#endif

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/CMakeLists.txt
@@ -43,7 +43,7 @@ if(SRECORD_TOOL_AVAILABLE)
         nf_generate_bin_package(
             ${CMAKE_SOURCE_DIR}/build/${NANOBOOTER_PROJECT_NAME}.bin
             ${CMAKE_SOURCE_DIR}/build/${NANOCLR_PROJECT_NAME}.bin
-            5000
+            2800
             ${CMAKE_SOURCE_DIR}/build/nanobooter-nanoclr.bin)
     endif()
 

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/common/Device_BlockStorage.c
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/common/Device_BlockStorage.c
@@ -9,13 +9,13 @@
 // 2kB block
 const BlockRange BlockRange1[] = {
     // 0x08000000 nanoBooter
-    {BlockRange_BLOCKTYPE_BOOTSTRAP, 0, 9},
+    {BlockRange_BLOCKTYPE_BOOTSTRAP, 0, 4},
 
-    // 0x08005000 nanoCLR
-    {BlockRange_BLOCKTYPE_CODE, 10, 95},
+    // 0x08002800 nanoCLR
+    {BlockRange_BLOCKTYPE_CODE, 5, 86},
 
-    // 0x08030000 deployment
-    {BlockRange_BLOCKTYPE_DEPLOYMENT, 96, 127}};
+    // 0x0802B800 deployment
+    {BlockRange_BLOCKTYPE_DEPLOYMENT, 87, 127}};
 
 const BlockRegionInfo BlockRegions[] = {
     {

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/STM32F091xC_booter.ld
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoBooter/STM32F091xC_booter.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash0     (rx) : org = 0x08000000, len = 20k     /* space reserved for nanoBooter */
+    flash0     (rx) : org = 0x08000000, len = 10k     /* space reserved for nanoBooter */
     flash1     (rx) : org = 0x00000000, len = 0
     flash2     (rx) : org = 0x00000000, len = 0
     flash3     (rx) : org = 0x00000000, len = 0

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/STM32F091xC_CLR.ld
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/STM32F091xC_CLR.ld
@@ -17,7 +17,7 @@
 
 MEMORY
 {
-    flash0     (rx) : org = 0x08005000, len = 256k - 20k - 46k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    flash0     (rx) : org = 0x08002800, len = 256k - 10k - 82k   /* flash size less the space reserved for nanoBooter and application deployment*/
     flash1     (rx) : org = 0x00000000, len = 0
     flash2     (rx) : org = 0x00000000, len = 0
     flash3     (rx) : org = 0x00000000, len = 0
@@ -26,7 +26,7 @@ MEMORY
     flash6     (rx) : org = 0x00000000, len = 0
     flash7     (rx) : org = 0x00000000, len = 0
     config     (rw) : org = 0x00000000, len = 0                  /* space reserved for configuration block */
-    deployment (rx) : org = 0x08030000, len = 46k                /* space reserved for application deployment */
+    deployment (rx) : org = 0x0802B800, len = 82k                /* space reserved for application deployment */
     ramvt      (wx) : org = 0x20000000, len = 0xC0               /* initial RAM address is reserved for a copy of the vector table */
     ram0       (wx) : org = 0x200000C0, len = 32k - 0xC0 - 48    /* remaining RAM is free for use */
     ram1       (wx) : org = 0x00000000, len = 0

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/common/Device_BlockStorage.c
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/common/Device_BlockStorage.c
@@ -7,129 +7,136 @@
 #include <nanoPAL_BlockStorage.h>
 
 // 16kB blocks
-const BlockRange BlockRange1[] = {
-    {BlockRange_BLOCKTYPE_BOOTSTRAP, 0, 1}, // 0x08000000 nanoBooter
-    {BlockRange_BLOCKTYPE_CODE, 2, 3}       // 0x08008000 nanoCLR
+const BlockRange BlockRange1[] = 
+{
+    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 0 },            // 0x08000000 nanoBooter
+    { BlockRange_BLOCKTYPE_CODE      ,   1, 3 }             // 0x08004000 nanoCLR
 };
 
 // 64kB blocks
-const BlockRange BlockRange2[] = {
-    {BlockRange_BLOCKTYPE_CODE, 0, 0} // 0x08010000 nanoCLR
+const BlockRange BlockRange2[] = 
+{
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 0x08010000 nanoCLR
 };
 
 // 128kB blocks
-const BlockRange BlockRange3[] = {
-    {BlockRange_BLOCKTYPE_CODE, 0, 1},       // 0x08020000 nanoCLR
-    {BlockRange_BLOCKTYPE_DEPLOYMENT, 2, 6}, // 0x08060000 deployment
+const BlockRange BlockRange3[] =
+{
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 },            // 0x08020000 nanoCLR
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   1, 6 },            // 0x08040000 deployment
 };
 
 // 16kB blocks
-const BlockRange BlockRange4[] = {
-    {BlockRange_BLOCKTYPE_DEPLOYMENT, 0, 3} // 0x08100000 deployment
+const BlockRange BlockRange4[] = 
+{
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 3 }             // 0x08100000 deployment
 };
 
 // 64kB blocks
-const BlockRange BlockRange5[] = {
-    {BlockRange_BLOCKTYPE_DEPLOYMENT, 0, 0} // 0x08110000 deployment
+const BlockRange BlockRange5[] = 
+{
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 0 }             // 0x08110000 deployment
 };
 
 // 128kB blocks
-const BlockRange BlockRange6[] = {
-    {BlockRange_BLOCKTYPE_DEPLOYMENT, 0, 6} // 0x08120000 deployment
+const BlockRange BlockRange6[] =
+{
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 6 }             // 0x08120000 deployment
 };
 
-const BlockRegionInfo BlockRegions[] = {
+const BlockRegionInfo BlockRegions[] = 
+{
     {
-        (0),        // no attributes for this region
-        0x08000000, // start address for block region
-        4,          // total number of blocks in this region
-        0x4000,     // total number of bytes per block
+        (0),                                // no attributes for this region
+        0x08000000,                         // start address for block region
+        4,                                  // total number of blocks in this region
+        0x4000,                             // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange1),
         BlockRange1,
     },
 
     {
-        (0),        // no attributes for this region
-        0x08010000, // start address for block region
-        1,          // total number of blocks in this region
-        0x10000,    // total number of bytes per block
+        (0),                                // no attributes for this region
+        0x08010000,                         // start address for block region
+        1,                                  // total number of blocks in this region
+        0x10000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange2),
         BlockRange2,
     },
 
     {
-        (0),        // no attributes for this region
-        0x08020000, // start address for block region
-        7,          // total number of blocks in this region
-        0x20000,    // total number of bytes per block
+        (0),                                // no attributes for this region
+        0x08020000,                         // start address for block region
+        7,                                  // total number of blocks in this region
+        0x20000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange3),
         BlockRange3,
     },
 
     {
-        (0),        // no attributes for this region
-        0x08100000, // start address for block region
-        4,          // total number of blocks in this region
-        0x4000,     // total number of bytes per block
+        (0),                                // no attributes for this region
+        0x08100000,                         // start address for block region
+        4,                                  // total number of blocks in this region
+        0x4000,                             // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange4),
         BlockRange4,
     },
 
     {
-        (0),        // no attributes for this region
-        0x08110000, // start address for block region
-        1,          // total number of blocks in this region
-        0x10000,    // total number of bytes per block
+        (0),                                // no attributes for this region
+        0x08110000,                         // start address for block region
+        1,                                  // total number of blocks in this region
+        0x10000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange5),
         BlockRange5,
     },
 
     {
-        (0),        // no attributes for this region
-        0x08120000, // start address for block region
-        7,          // total number of blocks in this region
-        0x20000,    // total number of bytes per block
+        (0),                                // no attributes for this region
+        0x08120000,                         // start address for block region
+        7,                                  // total number of blocks in this region
+        0x20000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange6),
         BlockRange6,
     },
 
 };
 
-const DeviceBlockInfo Device_BlockInfo = {
-    (MediaAttribute_SupportsXIP),       // STM32 flash memory is XIP
-    2,                                  // UINT32 BytesPerSector
-    ARRAYSIZE_CONST_EXPR(BlockRegions), // UINT32 NumRegions;
-    (BlockRegionInfo *)BlockRegions,    // const BlockRegionInfo* pRegions;
+const DeviceBlockInfo Device_BlockInfo =
+{
+    (MediaAttribute_SupportsXIP),           // STM32 flash memory is XIP
+    2,                                      // UINT32 BytesPerSector
+    ARRAYSIZE_CONST_EXPR(BlockRegions),     // UINT32 NumRegions;
+    (BlockRegionInfo*)BlockRegions,         // const BlockRegionInfo* pRegions;
 };
 
-MEMORY_MAPPED_NOR_BLOCK_CONFIG Device_BlockStorageConfig = {
-    {
-        // BLOCK_CONFIG
+MEMORY_MAPPED_NOR_BLOCK_CONFIG Device_BlockStorageConfig =
+{
+    { // BLOCK_CONFIG
         {
-            0,     // GPIO_PIN             Pin;
-            false, // BOOL                 ActiveState;
+            0,          // GPIO_PIN             Pin;
+            false,      // BOOL                 ActiveState;
         },
 
-        (DeviceBlockInfo *)&Device_BlockInfo, // BlockDeviceinfo
+        (DeviceBlockInfo*)&Device_BlockInfo,    // BlockDeviceinfo
     },
 
-    {
-        // CPU_MEMORY_CONFIG
-        0,          // UINT8  CPU_MEMORY_CONFIG::ChipSelect;
-        true,       // UINT8  CPU_MEMORY_CONFIG::ReadOnly;
-        0,          // UINT32 CPU_MEMORY_CONFIG::WaitStates;
-        0,          // UINT32 CPU_MEMORY_CONFIG::ReleaseCounts;
-        16,         // UINT32 CPU_MEMORY_CONFIG::BitWidth;
-        0x08000000, // UINT32 CPU_MEMORY_CONFIG::BaseAddress;
-        0x00200000, // UINT32 CPU_MEMORY_CONFIG::SizeInBytes;
-        0,          // UINT8  CPU_MEMORY_CONFIG::XREADYEnable
-        0,          // UINT8  CPU_MEMORY_CONFIG::ByteSignalsForRead
-        0,          // UINT8  CPU_MEMORY_CONFIG::ExternalBufferEnable
+    { // CPU_MEMORY_CONFIG
+        0,                          // UINT8  CPU_MEMORY_CONFIG::ChipSelect;
+        true,                       // UINT8  CPU_MEMORY_CONFIG::ReadOnly;
+        0,                          // UINT32 CPU_MEMORY_CONFIG::WaitStates;
+        0,                          // UINT32 CPU_MEMORY_CONFIG::ReleaseCounts;
+        16,                         // UINT32 CPU_MEMORY_CONFIG::BitWidth;
+        0x08000000,                 // UINT32 CPU_MEMORY_CONFIG::BaseAddress;
+        0x00200000,                 // UINT32 CPU_MEMORY_CONFIG::SizeInBytes;
+        0,                          // UINT8  CPU_MEMORY_CONFIG::XREADYEnable 
+        0,                          // UINT8  CPU_MEMORY_CONFIG::ByteSignalsForRead 
+        0,                          // UINT8  CPU_MEMORY_CONFIG::ExternalBufferEnable
     },
 
-    0, // UINT32 ChipProtection;
-    0, // UINT32 ManufacturerCode;
-    0, // UINT32 DeviceCode;
+    0,                              // UINT32 ChipProtection;
+    0,                              // UINT32 ManufacturerCode;
+    0,                              // UINT32 DeviceCode;
 };
 
-BlockStorageDevice Device_BlockStorage;
+BlockStorageDevice    Device_BlockStorage;

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/STM32F429xI_booter.ld
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoBooter/STM32F429xI_booter.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash0     (rx) : org = 0x08000000, len = 32k     /* space reserved for nanoBooter (1st sector 0x08000000 to 0x08004000)*/
+    flash0     (rx) : org = 0x08000000, len = 16k     /* space reserved for nanoBooter (1st sector 0x08000000 to 0x08004000)*/
     flash1     (rx) : org = 0x00000000, len = 0
     flash2     (rx) : org = 0x00000000, len = 0
     flash3     (rx) : org = 0x00000000, len = 0

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash0     (rx) : org = 0x08008000, len = 2M - 32k - 1536k      /* flash size less the space reserved for nanoBooter and application deployment*/
+    flash0     (rx) : org = 0x08004000, len = 2M - 16k - 1664k      /* flash size less the space reserved for nanoBooter and application deployment*/
     flash1     (rx) : org = 0x00000000, len = 0
     flash2     (rx) : org = 0x00000000, len = 0
     flash3     (rx) : org = 0x00000000, len = 0
@@ -21,7 +21,7 @@ MEMORY
     flash6     (rx) : org = 0x00000000, len = 0
     flash7     (rx) : org = 0x00000000, len = 0
     config     (rw) : org = 0x00000000, len = 0                     /* space reserved for configuration block */
-    deployment (rx) : org = 0x08060000, len = 1536k                 /* space reserved for application deployment */
+    deployment (rx) : org = 0x08040000, len = 1664k                 /* space reserved for application deployment */
     ramvt      (wx) : org = 0x00000000, len = 0                     /* initial RAM address is reserved for a copy of the vector table */
     ram0       (wx) : org = 0x20000030, len = 192k-48               /* SRAM1 + SRAM2 + SRAM3 */
     ram1       (wx) : org = 0x20000000, len = 112k                  /* SRAM1 */


### PR DESCRIPTION
## Description
- Revert #2431.
- Rework LTO options:
  + Sync LTO options for all platforms.
  + Remove use pf link plug-in.
  + Reorder LTO options for compiler and linker. Also removed some unused/unnecessary ones.
  + Move inclusion of specs options to the end of linker options (required for optimal LTO).
  + Add pragma to downgrade compiler optimizations in HeapBlock_Lock as it was causing issues executing C# `lock` blocks when using an optimization level higher than O1.

## Motivation and Context
- Adds back LTO which builds considerably smaller images.
- Resolves critical issue with execution of C# `lock` statements.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
