### PR TITLE
Update declaration for Serial.IO.Ports

### DIFF
--- a/src/System.IO.Ports/sys_io_ser_native.cpp
+++ b/src/System.IO.Ports/sys_io_ser_native.cpp
@@ -48,6 +48,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
     Library_sys_io_ser_native_System_IO_Ports_SerialPort::get_BytesToRead___I4,
     Library_sys_io_ser_native_System_IO_Ports_SerialPort::get_InvertSignalLevels___BOOLEAN,
     Library_sys_io_ser_native_System_IO_Ports_SerialPort::set_InvertSignalLevels___VOID__BOOLEAN,
@@ -104,7 +105,7 @@ const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_System_IO_Ports =
     "System.IO.Ports",
     0xB798CE30,
     method_lookup,
-    { 100, 1, 6, 0 }
+    { 100, 1, 6, 1 }
 };
 
 // clang-format on

--- a/src/System.IO.Ports/sys_io_ser_native.h
+++ b/src/System.IO.Ports/sys_io_ser_native.h
@@ -127,7 +127,7 @@ struct Library_sys_io_ser_native_System_IO_Ports_SerialDeviceEventListener
 
 struct Library_sys_io_ser_native_System_IO_Ports_SerialStream
 {
-    static const int FIELD___serial = 1;
+    static const int FIELD___serial = 2;
 
     //--//
 };


### PR DESCRIPTION
## Description

## Motivation and Context
- Was missing since nanoframework/System.IO.Ports#102.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [x] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
