### PR TITLE
Fix ObjectsEqual

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -1362,12 +1362,24 @@ bool CLR_RT_HeapBlock::ObjectsEqual(
                     // boxed primitive or enum type
                     obj = &rightObj[1];
                 }
+                else
+                {
+                    // boxed value type
+                    obj = rightObj;
+                }
 
                 return ObjectsEqual(*leftObj, *obj, false);
             }
             else
             {
-                return ObjectsEqual(*leftObj, *rightObj, false);
+                if (rightObj == NULL)
+                {
+                    return false;
+                }
+                else
+                {
+                    return ObjectsEqual(*leftObj, *rightObj, false);
+                }
             }
         }
         else


### PR DESCRIPTION
## Description
- Improve checks and add conditions to deal with NULL comparisons and structs.

## Motivation and Context
- Fixes nanoFramework/Home#1143.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
