### PR TITLE
Fix dealing with array types when getting method parameters

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Reflection_MethodBase.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Reflection_MethodBase.cpp
@@ -256,6 +256,12 @@ HRESULT Library_corlib_native_System_Reflection_MethodBase::GetParametersNative_
         hbObj = paraTypeHB.Dereference();
         hbObj->SetReflection(paramElement.m_cls);
 
+        // deal with array types
+        if (paramElement.m_levels > 0)
+        {
+            hbObj->ReflectionData().m_levels = (CLR_UINT16)paramElement.m_levels;
+        }
+
         // move pointer to the next element
         paramInfoElement++;
     }


### PR DESCRIPTION
## Description
- Setting the parameter type was not dealing with array types. Now it sets the relevant property.

## Motivation and Context
- Fixes nanoFramework/Home#1086.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Code in the issue is now producing expected output.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
