### PR TITLE
Add build option to reserve internal RAM for IDF allocation

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -655,7 +655,6 @@
             "hidden": true,
             "cacheVariables": {
                 "SDK_CONFIG_FILE": "sdkconfig.default_nopsram.esp32",
-                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "NF_FEATURE_RTC": "ON",
@@ -726,7 +725,6 @@
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "TARGET_SERIAL_BAUDRATE": "115200",
-                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
                 "NF_FEATURE_RTC": "ON",
                 "API_System.IO.FileSystem": "ON",
                 "API_nanoFramework.Device.OneWire": "ON",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -632,7 +632,6 @@
             "hidden": true,
             "cacheVariables": {
                 "SDK_CONFIG_FILE": "sdkconfig.default_ble_rev3.esp32",
-                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "NF_FEATURE_RTC": "ON",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -576,7 +576,7 @@
                 "API_System.IO.FileSystem": "ON",
                 "API_nanoFramework.Device.OneWire": "ON"
             }
-        },       
+        },
         {
             "name": "LilygoTWatch2020_preset",
             "inherits": [
@@ -639,13 +639,13 @@
                 "ESP32_ETHERNET_SUPPORT": "ON",
                 "ESP32_ETHERNET_INTERFACE": "IP101",
                 "ETH_PHY_RST_GPIO": "5",
-                "ETH_RMII_CLK_IN_GPIO" : "0",
+                "ETH_RMII_CLK_IN_GPIO": "0",
                 "ETH_PHY_ADDR": "1",
                 "API_System.IO.FileSystem": "ON",
                 "API_nanoFramework.Device.OneWire": "ON",
                 "API_nanoFramework.Device.Bluetooth": "ON"
             }
-        },        
+        },
         {
             "name": "ESP32_WT32_ETH01_preset",
             "inherits": [
@@ -661,13 +661,13 @@
                 "NF_FEATURE_RTC": "ON",
                 "NF_FEATURE_HAS_SDCARD": "ON",
                 "ESP32_ETHERNET_SUPPORT": "ON",
-                "ETH_RMII_CLK_IN_GPIO" : "0",
-                "ETH_PHY_ADDR":"1",
+                "ETH_RMII_CLK_IN_GPIO": "0",
+                "ETH_PHY_ADDR": "1",
                 "ETH_PHY_RST_GPIO": "16",
                 "API_System.IO.FileSystem": "ON",
                 "API_nanoFramework.Device.OneWire": "ON"
             }
-        },        
+        },
         {
             "name": "ESP32_WESP32_preset",
             "inherits": [
@@ -684,13 +684,13 @@
                 "NF_FEATURE_HAS_SDCARD": "ON",
                 "ESP32_ETHERNET_SUPPORT": "ON",
                 "ESP32_ETHERNET_INTERFACE": "RTL8201",
-                "ETH_RMII_CLK_IN_GPIO" : "0",
-                "ETH_MDIO_GPIO":"17",
+                "ETH_RMII_CLK_IN_GPIO": "0",
+                "ETH_MDIO_GPIO": "17",
                 "ETH_MDC_GPIO": "16",
                 "API_System.IO.FileSystem": "ON",
                 "API_nanoFramework.Device.OneWire": "ON"
             }
-        },        
+        },
         {
             "name": "M5StickC_preset",
             "inherits": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -431,6 +431,7 @@
             "cacheVariables": {
                 "SDK_CONFIG_FILE": "sdkconfig.default_pico",
                 "TARGET_SERIAL_BAUDRATE": "115200",
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "NF_FEATURE_RTC": "ON",
@@ -564,6 +565,7 @@
             "hidden": true,
             "cacheVariables": {
                 "SDK_CONFIG_FILE": "",
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "NF_FEATURE_RTC": "ON",
@@ -630,6 +632,7 @@
             "hidden": true,
             "cacheVariables": {
                 "SDK_CONFIG_FILE": "sdkconfig.default_ble_rev3.esp32",
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "NF_FEATURE_RTC": "ON",
@@ -653,6 +656,7 @@
             "hidden": true,
             "cacheVariables": {
                 "SDK_CONFIG_FILE": "sdkconfig.default_nopsram.esp32",
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "NF_FEATURE_RTC": "ON",
@@ -674,6 +678,7 @@
             "hidden": true,
             "cacheVariables": {
                 "SDK_CONFIG_FILE": "",
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "NF_FEATURE_RTC": "ON",
@@ -696,6 +701,7 @@
             "hidden": true,
             "cacheVariables": {
                 "SDK_CONFIG_FILE": "sdkconfig.default_pico",
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "TARGET_SERIAL_BAUDRATE": "115200",
@@ -721,6 +727,7 @@
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "TARGET_SERIAL_BAUDRATE": "115200",
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
                 "NF_FEATURE_RTC": "ON",
                 "API_System.IO.FileSystem": "ON",
                 "API_nanoFramework.Device.OneWire": "ON",

--- a/targets/ESP32/CMakeLists.txt
+++ b/targets/ESP32/CMakeLists.txt
@@ -6,6 +6,8 @@
 include(FetchContent)
 include(binutils.ESP32)
 
+option(ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION "Reserved RAM for IDF allocation (in kBytes)" 0)
+
 # Set target series in lower case
 nf_set_esp32_target_series()
 

--- a/targets/ESP32/CMakeLists.txt
+++ b/targets/ESP32/CMakeLists.txt
@@ -6,10 +6,15 @@
 include(FetchContent)
 include(binutils.ESP32)
 
-option(ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION "Reserved RAM for IDF allocation (in kBytes)" 0)
-
 # Set target series in lower case
 nf_set_esp32_target_series()
+
+# option to reserve RAM for IDF allocator
+option(ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION "Reserved RAM for IDF allocation (in kBytes)")
+if(NOT (ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION EQUAL OFF))
+    unset(ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION CACHE)
+    set(ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION "0" CACHE STRING "Setting default value for ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION")
+endif()
 
 # Define PLATFORM base path
 set(BASE_PATH_FOR_PLATFORM ${CMAKE_CURRENT_SOURCE_DIR} PARENT_SCOPE)

--- a/targets/ESP32/_nanoCLR/Memory.cpp
+++ b/targets/ESP32/_nanoCLR/Memory.cpp
@@ -25,8 +25,7 @@ static const char *TAG = "Memory";
 #define INTERNAL_RAM_LEAVE_FREE_FOR_ALLOCATION (30 * 1024)
 #else
 // Space to leave free in internal RAM for allocation by IDF malloc
-// We leave 10K free to allow room for Wifi initialisation
-#define INTERNAL_RAM_LEAVE_FREE_FOR_ALLOCATION (10 * 1024)
+#define INTERNAL_RAM_LEAVE_FREE_FOR_ALLOCATION (ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION * 1024)
 #endif
 
 // Saved memory allocation for when heap is reset so we can return same value.

--- a/targets/ESP32/_nanoCLR/target_platform.h.in
+++ b/targets/ESP32/_nanoCLR/target_platform.h.in
@@ -8,11 +8,12 @@
 
 #include "esp32_ethernet_options.h"
 
-#define NANOCLR_GRAPHICS                @NANOCLR_GRAPHICS@
-#define ESP32_SPIRAM_FOR_IDF_ALLOCATION @ESP32_SPIRAM_FOR_IDF_ALLOCATION@
-#define HAL_USE_SPI                     @HAL_USE_SPI_OPTION@
-#define HAL_USE_SDC                     @HAL_USE_SDC_OPTION@
-#define HAL_USE_BLE                     @HAL_USE_BLE_OPTION@
+#define NANOCLR_GRAPHICS                      @NANOCLR_GRAPHICS@
+#define ESP32_SPIRAM_FOR_IDF_ALLOCATION       @ESP32_SPIRAM_FOR_IDF_ALLOCATION@
+#define ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION @ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION@
+#define HAL_USE_SPI                           @HAL_USE_SPI_OPTION@
+#define HAL_USE_SDC                           @HAL_USE_SDC_OPTION@
+#define HAL_USE_BLE                           @HAL_USE_BLE_OPTION@
 
 #if (HAL_USE_SDC == TRUE)
 #define SDC_MAX_OPEN_FILES 5


### PR DESCRIPTION
## Description
- Add CMake build option `ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION`.
- Update CMake and ESP32 target platform accordingly.
- Update memory allocation define.
- Update CmakePresets for all PICO and Ethernet targets to reserve 10k of internal RAM.

## Motivation and Context
- Exposes option to reserve RAM for IDF allocation.
- This has come up in the review of PR #2456 which was fixing nanoframework/Home#1166.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
