### PR TITLE
Add VS Code task to decode ESP32 backtrace

### DIFF
--- a/.vscode/tasks.TEMPLATE.json
+++ b/.vscode/tasks.TEMPLATE.json
@@ -36,6 +36,16 @@
       "problemMatcher": []
     },
     {
+      "label": "Decode ESP32 backtrace",
+      "type": "shell",
+      "command": "xtensa-${input:esp32series}-elf-addr2line -apsfCire \"${input:espBacktraceElfFile}\" \"${input:espBacktrace}\"",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "Flash MIMXRT1060",
       "type": "shell",
       "command": "C:/nxp/MCUXpressoIDE_10.2.1_795/ide/bin/crt_emu_cm_redlink.exe",
@@ -92,6 +102,29 @@
         "8mb",
         "16mb"
       ]
+    },
+    {
+      "id": "esp32series",
+      "type": "pickString",
+      "description": "ESP32 series",
+      "default": "esp32",
+      "options": [
+        "esp32",
+        "esp32s2",
+        "esp32s3"
+      ]
+    },
+    {
+      "id": "espBacktrace",
+      "type": "promptString",
+      "default": "",
+      "description": "Backtrace information from 'Guru Meditation Error' output. *** JUST THE BACKTRACE line, NOT the whole output! ***"
+    },
+    {
+      "id": "espBacktraceElfFile",
+      "type": "promptString",
+      "default": "${workspaceFolder}/build/nanoCLR.elf",
+      "description": "Path to ELF file. Default is the current build executable."
     }
   ]
 }


### PR DESCRIPTION
## Description
- Add VS Code task to decode ESP32 backtrace.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
