### PR TITLE
Improvement in Wire Protocol

### DIFF
--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -307,6 +307,13 @@ void WP_Message_Process()
                     _receiveExpiryTicks = HAL_Time_CurrentSysTicks() + c_HeaderTimeout;
                 }
 
+                if (len == 0 && *_pos == 0)
+                {
+                    // this is probably just hanging and waiting for a connection, so we're better off and give
+                    // breading space to the RTOS
+                    return;
+                }
+
                 break;
 
             case ReceiveState_ReadingHeader:


### PR DESCRIPTION
## Description
- On no data received just bail out to give breading space to the RTOS.

## Motivation and Context
- The tight loop of WP processor it's prone to starve CPU on platforms whose Read layers have quick turnarounds because they are waiting for connections (like USB) or other situations were no WP occurs for too long. With this it bails out and gives breading space to the RTOS.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
