### PR TITLE
Improve ESP32 Wifi scan

### DIFF
--- a/src/PAL/Include/nanoPAL_Sockets.h
+++ b/src/PAL/Include/nanoPAL_Sockets.h
@@ -522,7 +522,7 @@ bool Network_Interface_Close(int index);
 int Network_Interface_Disconnect(int index);
 int Network_Interface_Start_Connect(int index, const char *ssid, const char *passphase, int options);
 int Network_Interface_Connect_Result(int configIndex);
-bool Network_Interface_Start_Scan(int index);
+int Network_Interface_Start_Scan(int index);
 
 // Wireless AP methods
 void Network_Interface_Add_Station(uint16_t index, uint8_t *macAddress);

--- a/targets/AzureRTOS/_common/target_network.cpp
+++ b/targets/AzureRTOS/_common/target_network.cpp
@@ -111,7 +111,7 @@ bool Network_Interface_Close(int index)
     return false;
 }
 
-bool Network_Interface_Start_Scan(int index)
+int Network_Interface_Start_Scan(int index)
 {
     HAL_Configuration_NetworkInterface networkConfiguration;
 
@@ -121,18 +121,21 @@ bool Network_Interface_Start_Scan(int index)
             DeviceConfigurationOption_Network,
             index))
     {
-        // failed to load configuration
-        // FIXME output error?
-        return SOCK_SOCKET_ERROR;
+        // failed to get configuration
+        // TODO include error code enum
+        return 7777; // StartScanOutcome_FailedToGetConfiguration;
     }
 
     // can only do this is this is STA
-    if (networkConfiguration.InterfaceType == NetworkInterfaceType_Wireless80211)
+    if (networkConfiguration.InterfaceType != NetworkInterfaceType_Wireless80211)
     {
-        // return (NF_ESP32_Wireless_Scan() == 0);
+        // TODO include error code enum
+        return 8888; // StartScanOutcome_WrongInterfaceType;
     }
 
-    return false;
+    // TODO return NF_ESP32_Wireless_Scan();
+    // TODO include error code enum
+    return 9999;
 }
 
 bool GetWirelessConfig(int index, HAL_Configuration_Wireless80211 **wirelessConfig)

--- a/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
+++ b/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
@@ -349,9 +349,7 @@ int NF_ESP32_Wireless_Scan()
 
     // Start a Wi-Fi scan
     // When complete a Scan Complete event will be fired
-    esp_err_t res = esp_wifi_scan_start(&config, false);
-
-    return (int)res;
+    return esp_wifi_scan_start(&config, false);
 }
 
 wifi_auth_mode_t MapAuthentication(AuthenticationType type)

--- a/targets/ESP32/_common/Target_Network.cpp
+++ b/targets/ESP32/_common/Target_Network.cpp
@@ -97,7 +97,7 @@ bool Network_Interface_Close(int index)
     return false;
 }
 
-bool Network_Interface_Start_Scan(int index)
+int Network_Interface_Start_Scan(int index)
 {
     HAL_Configuration_NetworkInterface networkConfiguration;
 
@@ -107,18 +107,17 @@ bool Network_Interface_Start_Scan(int index)
             DeviceConfigurationOption_Network,
             index))
     {
-        // failed to load configuration
-        // FIXME output error?
-        return SOCK_SOCKET_ERROR;
+        // failed to get configuration
+        return StartScanOutcome_FailedToGetConfiguration;
     }
 
     // can only do this is this is STA
-    if (networkConfiguration.InterfaceType == NetworkInterfaceType_Wireless80211)
+    if (networkConfiguration.InterfaceType != NetworkInterfaceType_Wireless80211)
     {
-        return (NF_ESP32_Wireless_Scan() == 0);
+        return StartScanOutcome_WrongInterfaceType;
     }
 
-    return false;
+    return NF_ESP32_Wireless_Scan();
 }
 
 bool GetWirelessConfig(int index, HAL_Configuration_Wireless80211 **wirelessConfig)

--- a/targets/ESP32/_include/NF_ESP32_Network.h
+++ b/targets/ESP32/_include/NF_ESP32_Network.h
@@ -7,7 +7,6 @@
 #define NF_ESP32_NETWORK_H
 
 #include <nanoHAL.h>
-#include <lwIP_Sockets.h>
 #include <esp32_idf.h>
 
 // ESP IDF 4.0 it's using an abstraction layer (esp_netif) that hides the netif index
@@ -16,6 +15,19 @@
 #define IDF_WIFI_STA_DEF    0
 #define IDF_WIFI_AP_DEF     1
 #define IDF_ETH_DEF         2
+
+typedef enum __nfpack StartScanOutcome
+{
+    StartScanOutcome_Success = 0,
+    StartScanOutcome_FailedToGetConfiguration  = 10,
+    StartScanOutcome_WrongInterfaceType = 20,
+    // these are the same as the IDF error codes
+    StartScanOutcome_Esp32WifiNotInit = ESP_ERR_WIFI_NOT_INIT,
+    StartScanOutcome_Esp32WifiNotStarted = ESP_ERR_WIFI_NOT_STARTED,
+    StartScanOutcome_Esp32WifiTimeout = ESP_ERR_WIFI_TIMEOUT,
+    StartScanOutcome_Esp32WifiState = ESP_ERR_WIFI_STATE,
+
+} StartScanOutcome;
 
 extern bool NF_ESP32_ConnectInProgress;
 extern int NF_ESP32_ConnectResult;

--- a/targets/ESP32/_nanoCLR/System.Device.Wifi/sys_dev_wifi_native_System_Device_Wifi_WifiAdapter.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.Wifi/sys_dev_wifi_native_System_Device_Wifi_WifiAdapter.cpp
@@ -7,8 +7,9 @@
 #include <sys_dev_wifi_native.h>
 #include <nf_rt_events_native.h>
 #include <esp_wifi_types.h>
+#include <NF_ESP32_Network.h>
 
-///////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
 // !!! KEEP IN SYNC WITH System.Device.Wifi (in managed code) !!! //
 ///////////////////////////////////////////////////////////////////////////////////////
 struct ScanRecord
@@ -180,17 +181,38 @@ HRESULT Library_sys_dev_wifi_native_System_Device_Wifi_WifiAdapter::NativeDiscon
 HRESULT Library_sys_dev_wifi_native_System_Device_Wifi_WifiAdapter::NativeScanAsync___VOID(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
+
+    int netIndex;
+    int startScanResult;
+
+    NANOCLR_CHECK_HRESULT(GetNetInterfaceIndex(stack, &netIndex));
+
+    // Start scan
+    startScanResult = Network_Interface_Start_Scan(netIndex);
+
+    switch (startScanResult)
     {
-        int netIndex;
+        case StartScanOutcome_FailedToGetConfiguration:
+            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
+            break;
 
-        NANOCLR_CHECK_HRESULT(GetNetInterfaceIndex(stack, &netIndex));
-
-        // Start scan
-        if (Network_Interface_Start_Scan(netIndex) == false)
-        {
+        case StartScanOutcome_WrongInterfaceType:
+        case StartScanOutcome_Esp32WifiNotInit:
+        case StartScanOutcome_Esp32WifiNotStarted:
+        case StartScanOutcome_Esp32WifiState:
             NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_OPERATION);
-        }
+            break;
+
+        case StartScanOutcome_Esp32WifiTimeout:
+            NANOCLR_SET_AND_LEAVE(CLR_E_TIMEOUT);
+            break;
+
+        default:
+        debug_printf("START SCAN  error %d", startScanResult);
+            NANOCLR_SET_AND_LEAVE(CLR_E_UNKNOWN_TYPE);
+            break;
     }
+
     NANOCLR_NOCLEANUP();
 }
 

--- a/targets/ESP32/_nanoCLR/System.Device.Wifi/sys_dev_wifi_native_System_Device_Wifi_WifiAdapter.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.Wifi/sys_dev_wifi_native_System_Device_Wifi_WifiAdapter.cpp
@@ -192,24 +192,24 @@ HRESULT Library_sys_dev_wifi_native_System_Device_Wifi_WifiAdapter::NativeScanAs
 
     switch (startScanResult)
     {
-        case StartScanOutcome_FailedToGetConfiguration:
-            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
-            break;
 
         case StartScanOutcome_WrongInterfaceType:
         case StartScanOutcome_Esp32WifiNotInit:
         case StartScanOutcome_Esp32WifiNotStarted:
-        case StartScanOutcome_Esp32WifiState:
             NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_OPERATION);
+            break;
+
+        case StartScanOutcome_Esp32WifiState:
+            NANOCLR_SET_AND_LEAVE(CLR_E_BUSY);
             break;
 
         case StartScanOutcome_Esp32WifiTimeout:
             NANOCLR_SET_AND_LEAVE(CLR_E_TIMEOUT);
             break;
 
+        case StartScanOutcome_FailedToGetConfiguration:
         default:
-        debug_printf("START SCAN  error %d", startScanResult);
-            NANOCLR_SET_AND_LEAVE(CLR_E_UNKNOWN_TYPE);
+            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
             break;
     }
 


### PR DESCRIPTION
## Description
- Rework Network_Interface_Start_Scan to return detailed success/error code.
- Update caller accordingly.
- Processing the return codes on the call stack was being oversimplified. This is now improved with different exceptions being thrown depending on the cause of failure to execute the scan.
- If needed this can be further improved by adding a `WifiScanException` or equivalent which could transmit an error code reporting exactly what was the failure.

## Motivation and Context
- Improve feedback on failure to help pinpoint the cause.
- Somewhat addresses nanoFramework/Home#1166.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running the scan wifi sample.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
