### PR TITLE
Debug and Console Write are now working on virtual device

### DIFF
--- a/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
+++ b/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
@@ -58,10 +58,6 @@ struct Settings
 #if !defined(BUILD_RTM)
         if (params.WaitForDebugger)
         {
-#if defined(VIRTUAL_DEVICE)
-            CLR_EE_DBG_SET(Enabled);
-            CLR_EE_DBG_SET(Quiet);
-#endif
             CLR_EE_DBG_SET(Stopped);
         }
 #endif

--- a/targets/win32/nanoCLR/CLRStartup.cpp
+++ b/targets/win32/nanoCLR/CLRStartup.cpp
@@ -53,9 +53,7 @@ struct Settings : CLR_RT_ParseOptions
 #if !defined(BUILD_RTM)
         if (params.WaitForDebugger)
         {
-#if defined(VIRTUAL_DEVICE)
             CLR_EE_DBG_SET(Enabled);
-#endif
             CLR_EE_DBG_SET(Stopped);
         }
 #endif


### PR DESCRIPTION
## Description
- Remove wrong setting of debug flags for .NET tool.
- Remove unnecessary config check for WIN32 startup.

## Motivation and Context
- These weren't being output on VS during a debug session.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
