### PR TITLE
Fix virtual device app exit

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1393,6 +1393,11 @@ bool CLR_DBG_Debugger::Debugging_Execution_ChangeConditions(WP_Message *msg)
     {
         // update conditions
         g_CLR_RT_ExecutionEngine.m_iDebugger_Conditions = newConditions;
+
+#ifdef VIRTTUAL_DEVICE
+        // fire event with update on debugger activity
+        ::Events_Set(SYSTEM_EVENT_FLAG_DEBUGGER_ACTIVITY);
+#endif // VIRTTUAL_DEVICE
     }
 
     return true;

--- a/targets/win32/nanoCLR/targetPAL_Events.cpp
+++ b/targets/win32/nanoCLR/targetPAL_Events.cpp
@@ -99,7 +99,14 @@ uint32_t Events_WaitForEvents(uint32_t powerLevel, uint32_t wakeupSystemEvents, 
 {
     std::unique_lock<std::mutex> scopeLock(EventsMutex);
 
+    if (CLR_EE_DBG_IS(RebootPending) || CLR_EE_DBG_IS(ExitPending))
+    {
+        // there is a reboot or program exit condition pending, no need to wait for anything
+        return 0;
+    }
+
     bool timeout = false;
+
     // check current condition before waiting as Condition var doesn't do that
     if ((wakeupSystemEvents & SystemEvents) == 0)
     {
@@ -107,6 +114,7 @@ uint32_t Events_WaitForEvents(uint32_t powerLevel, uint32_t wakeupSystemEvents, 
             return (wakeupSystemEvents & SystemEvents) != 0;
         });
     }
+
     return timeout ? 0 : SystemEvents & wakeupSystemEvents;
 }
 


### PR DESCRIPTION
## Description
- Debugger activity event is now set when condition changes.
- Wait for activity now checks for debugger conditions that should exit.

## Motivation and Context
- Virtual device wasn't exiting execution after program exit on debug session ending.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
