### PR TITLE
Rename struct element for clarity

### DIFF
--- a/src/PAL/Include/CPU_SPI_decl.h
+++ b/src/PAL/Include/CPU_SPI_decl.h
@@ -74,7 +74,7 @@ struct SPI_DEVICE_CONFIGURATION
     // SPI bus Configuration (full-duplex is default)
     SpiBusConfiguration BusConfiguration;
     // True = SPI data takes the form of 16-bit words otherwise 8-bit words.
-    bool MD16bits;
+    bool DataIs16bits;
     // Data order for 16 bit operation
     DataBitOrder DataOrder16;
     // Rough estimate on the time it takes to send/receive one byte (in milliseconds)

--- a/src/System.Device.Spi/sys_dev_spi_native_System_Device_Spi_SpiDevice.cpp
+++ b/src/System.Device.Spi/sys_dev_spi_native_System_Device_Spi_SpiDevice.cpp
@@ -289,6 +289,7 @@ HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeOpenDevice
     config = pThis[Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::FIELD___connectionSettings].Dereference();
 
     spiConfig.BusMode = SpiBusMode_master;
+    spiConfig.DataIs16bits = false;
 
     // internally SPI bus ID is zero based, so better take care of that here
     spiConfig.Spi_Bus = config[SpiConnectionSettings::FIELD___busId].NumericByRef().s4 - 1;


### PR DESCRIPTION
## Description
- Rename struct element for clarity.

## Motivation and Context
- The original name wasn't too clear about what was referring to.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
