### PR TITLE
Fix lookup assembly

### DIFF
--- a/src/CLR/Core/CLR_RT_SystemAssembliesTable.cpp
+++ b/src/CLR/Core/CLR_RT_SystemAssembliesTable.cpp
@@ -4,42 +4,34 @@
 // See LICENSE file in the project root for full license information.
 //
 #include <nanoCLR_Runtime.h>
-//#include <corlib_native.h>
-//#include <SPOT_native.h>
-//#include "nanoCLR_Interop.h"
 
-static const CLR_RT_NativeAssemblyData *LookUpAssemblyNativeDataByName
-(
+static const CLR_RT_NativeAssemblyData *LookUpAssemblyNativeDataByName(
     const CLR_RT_NativeAssemblyData **pAssembliesNativeData,
-    const char *lpszAssemblyName
-)
+    const char *lpszAssemblyName)
 {
     // Just sanity check to avoid crash in strcmp if name is NULL.
-    if ( lpszAssemblyName == NULL )
+    if (lpszAssemblyName == NULL)
     {
         return NULL;
     }
 
     // Loops in all entries and looks for the CLR_RT_NativeAssemblyData with name same as lpszAssemblyName
-    for ( int i = 0; pAssembliesNativeData[ i ]; i++ )
+    for (int i = 0; pAssembliesNativeData[i]; i++)
     {
-        if ( pAssembliesNativeData[ i ] != NULL  &&  0 == strcmp( lpszAssemblyName, pAssembliesNativeData[ i ]->m_szAssemblyName ) )
+        if (i < g_CLR_InteropAssembliesCount && pAssembliesNativeData[i] != NULL &&
+            0 == strcmp(lpszAssemblyName, pAssembliesNativeData[i]->m_szAssemblyName))
         {
-            return pAssembliesNativeData[ i ];
+            return pAssembliesNativeData[i];
         }
     }
+
     return NULL;
 }
 
-
-const CLR_RT_NativeAssemblyData *GetAssemblyNativeData( const char *lpszAssemblyName )
+const CLR_RT_NativeAssemblyData *GetAssemblyNativeData(const char *lpszAssemblyName)
 {
     extern const CLR_RT_NativeAssemblyData *g_CLR_InteropAssembliesNativeData[];
 
     // This will return NULL if there is no registered interop assembly of that name
-    return LookUpAssemblyNativeDataByName(
-            g_CLR_InteropAssembliesNativeData,
-            lpszAssemblyName
-            );
+    return LookUpAssemblyNativeDataByName(g_CLR_InteropAssembliesNativeData, lpszAssemblyName);
 }
-


### PR DESCRIPTION
## Description
- Add check to access only the available assemblies.

## Motivation and Context
- The check for pointer null wasn't enough on WIN builds. 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
