### PR TITLE
Improvements in virtual device

### DIFF
--- a/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandLineOptions.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandLineOptions.cs
@@ -79,6 +79,20 @@ namespace nanoFramework.nanoCLR.CLI
             HelpText = "Parent process id to monitor - exit if the parent exits.")]
         public int? MonitorParentPid { get; set; }
 
+        [Option(
+            "waitfordebugger",
+            Required = false,
+            Default = false,
+            HelpText = "Option to wait for a debugger connection after nanoCLR is started.")]
+        public bool WaitForDebugger { get; set; }
+
+        [Option(
+            "loopafterexit",
+            Required = false,
+            Default = true,
+            HelpText = "Option to remain in loop waiting for a debugger connection after the program exits.")]
+        public bool EnterDebuggerLoopAfterExit { get; set; }
+
         /// <summary>
         /// Allowed values:
         /// q[uiet]

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandProcessor.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandProcessor.cs
@@ -60,8 +60,6 @@ namespace nanoFramework.nanoCLR.CLI
                     // need to set debugger serial port to the _other_ port so it shows at the expected end
                     var internalSerialPort = $"COM{bridge.GetOtherPort(options.ExposedSerialPort)}";
 
-                    hostBuilder.WaitForDebugger = true;
-                    hostBuilder.EnterDebuggerLoopAfterExit = true;
                     hostBuilder.UseSerialPortWireProtocol(internalSerialPort);
 
                     // set flag
@@ -81,12 +79,6 @@ namespace nanoFramework.nanoCLR.CLI
             if (options.TryResolve)
             {
                 hostBuilder.TryResolve();
-            }
-
-            if (options.ExposedSerialPort != null || options.ExposedTcpIpPort != null || options.ExposedNamedPipe != null)
-            {
-                hostBuilder.WaitForDebugger = true;
-                hostBuilder.EnterDebuggerLoopAfterExit = true;
             }
 
             if (!internalSerialPortConfig
@@ -109,6 +101,10 @@ namespace nanoFramework.nanoCLR.CLI
             {
                 hostBuilder.UsePortTrace();
             }
+
+            hostBuilder.WaitForDebugger = options.WaitForDebugger;
+            hostBuilder.EnterDebuggerLoopAfterExit = options.EnterDebuggerLoopAfterExit;
+
 
             if (options.MonitorParentPid != null)
             {

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/README.md
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/README.md
@@ -116,6 +116,11 @@ This option tries to resolve cross-assembly references between the loaded assemb
 nanoclr run --resolve (--assemblies ...)
 ```
 
+### Options to control debugger connection
+
+There are two options that control how the nanoCLR execution interacts with a debugger. If it's intended that after a program terminates and exits the execution a debugger will be connecting, the option `--loopafterexit` should be included.
+In case it's expected that imediatly after nanoCLR is started,a debugger is to connect to it, the option `--waitfordebugger` should be included.
+
 ## Maintenance operations with the nanoCLR
 
 The nanoCLR it's, in fact, a wrapper to the nanoCLR instance that is distributed as DLL so it can be easily updated.

--- a/targets/netcore/nanoFramework.nanoCLR.Host/Port/Serial/SerialPort.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.Host/Port/Serial/SerialPort.cs
@@ -18,7 +18,7 @@ namespace nanoFramework.nanoCLR.Host.Port.Serial
             _serialPort = new System.IO.Ports.SerialPort(name, baudRate);
         }
 
-        public int BytesAvailable => _serialPort.BytesToRead;
+        public int BytesAvailable => (_serialPort != null && _serialPort.IsOpen ? _serialPort.BytesToRead : 0);
 
         public byte[] ReceiveData() => _serialPort.ReadAllBytes();
 


### PR DESCRIPTION
## Description
- Add new options to wait for debugger and loop after program exit.
- Update readme accordingly.
- Update processor to pass these to host class.
- Improve sync lock handling in NativeWireProtocolPort.
- Add check for port open before returning available bytes.

## Motivation and Context
- Adds options required to config nanoCLR running in different usage scenarios.
- Improves start and stop of host process and communications reliability.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
