### PR TITLE
Fix comparison for IDF path

### DIFF
--- a/targets/ESP32/CMakeLists.txt
+++ b/targets/ESP32/CMakeLists.txt
@@ -85,9 +85,12 @@ list(APPEND CMAKE_MODULE_PATH ${esp32_idf_SOURCE_DIR}/CMake)
 # parse IDF path to allow proper comparison with environment variable
 string(REPLACE "\\" "/" IDF_SOURCE_DIR_PATH "$ENV{IDF_PATH}")
 
+# need to lowercase both paths to compare them
+string(TOLOWER "${IDF_SOURCE_DIR_PATH}" IDF_SOURCE_DIR_PATH_LOWER )
+string(TOLOWER "${esp32_idf_SOURCE_DIR}" esp32_idf_SOURCE_DIR_LOWER )
+
 # check IDF_PATH environment variable
-if(NOT "${IDF_SOURCE_DIR_PATH}" STREQUAL "${esp32_idf_SOURCE_DIR}")
-    
+if(NOT "${IDF_SOURCE_DIR_PATH_LOWER}" STREQUAL "${esp32_idf_SOURCE_DIR_LOWER}")
     # variable is set and it's different from the current location
     # can't continue
 
@@ -96,7 +99,15 @@ if(NOT "${IDF_SOURCE_DIR_PATH}" STREQUAL "${esp32_idf_SOURCE_DIR}")
 else()
     message(STATUS "\n-- IDF_PATH is '${IDF_SOURCE_DIR_PATH}'\r")
 
+    # on Windows need to make sure the path has the same case as the actual path
+    if(CMAKE_HOST_WIN32)
+        if(NOT "${IDF_SOURCE_DIR_PATH}" STREQUAL "${esp32_idf_SOURCE_DIR}")
+            message(FATAL_ERROR "ESP32_IDF_PATH var is '${esp32_idf_SOURCE_DIR}'. It's using a different case than the actual path. Please fix this.")
+        endif()
+    endif()
+
     set(IDF_PATH_CMAKED ${IDF_SOURCE_DIR_PATH} CACHE INTERNAL "CMake formated IDF path")
+
 endif()
 
 # if using FatFS need to remove IDF ffconfig.h so it can pick ours


### PR DESCRIPTION
## Description
- Lowers case both vars in order to make a proper comparison.
- Add check for correct IDF path case (and fatal message if that happens).

## Motivation and Context
- CMake can't make case insensitive comparisons and this comparison could potentially fail because of it.
- Usage of IDF path with wrong case will cause parts of the CMake build system to fail.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
