### PR TITLE
Fix output of build messages

### DIFF
--- a/CMake/Modules/FindChibiOS.cmake
+++ b/CMake/Modules/FindChibiOS.cmake
@@ -31,7 +31,9 @@ include(CHIBIOS_${TARGET_SERIES}_sources)
 # and here the GCC options tuned for the target series 
 include(CHIBIOS_${TARGET_SERIES}_GCC_options)
 
-# message("ChibiOS board series is ${TARGET_SERIES}") # debug helper
+if (BUILD_VERBOSE)
+    message("ChibiOS board series is ${TARGET_SERIES}")
+endif()
 
 # set include directories for ChibiOS
 list(APPEND CHIBIOS_INCLUDE_DIRS ${chibios_SOURCE_DIR}/os) 

--- a/CMake/Modules/FindFreeRTOS.cmake
+++ b/CMake/Modules/FindFreeRTOS.cmake
@@ -27,7 +27,9 @@ include(FreeRTOS_${TARGET_SERIES}_sources)
 # and here the GCC options tuned for the target series 
 include(FreeRTOS_${TARGET_SERIES}_GCC_options)
 
-# message("FreeRTOS board series is ${TARGET_SERIES}") # debug helper
+if (BUILD_VERBOSE)
+    message("FreeRTOS board series is ${TARGET_SERIES}")
+endif()
 
 # set include directories for FreeRTOS
 list(APPEND FreeRTOS_INCLUDE_DIRS ${freertos_SOURCE_DIR}/include)
@@ -60,7 +62,7 @@ foreach(SRC_FILE ${FreeRTOS_SRCS})
     )
 
     if (BUILD_VERBOSE)
-        message("${SRC_FILE} >> ${FreeRTOS_SRC_FILE}") # debug helper
+        message("${SRC_FILE} >> ${FreeRTOS_SRC_FILE}")
     endif()
      
     list(APPEND FreeRTOS_SOURCES ${FreeRTOS_SRC_FILE})

--- a/CMake/Modules/FindNF_HALCore.cmake
+++ b/CMake/Modules/FindNF_HALCore.cmake
@@ -30,7 +30,10 @@ set(NF_HALCore_SRCS
 
 )
 
-# message("BASE_PATH_FOR_PLATFORM >> ${BASE_PATH_FOR_PLATFORM}") # debug helper
+if (BUILD_VERBOSE)
+    message("BASE_PATH_FOR_PLATFORM >> ${BASE_PATH_FOR_PLATFORM}")
+endif()
+
 foreach(SRC_FILE ${NF_HALCore_SRCS})
 
     set(NF_HALCore_SRC_FILE SRC_FILE-NOTFOUND)

--- a/CMake/Modules/FindRPIPicoSdk.cmake
+++ b/CMake/Modules/FindRPIPicoSdk.cmake
@@ -20,7 +20,11 @@ foreach(SRC_FILE ${RPI_PICO_SKD_SRCS})
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )
-    # message("${SRC_FILE} >> ${RPI_PICO_SKD_SRC_FILE}") # debug helper
+
+    if (BUILD_VERBOSE)
+        message("${SRC_FILE} >> ${RPI_PICO_SKD_SRC_FILE}")
+    endif()
+
     list(APPEND RPI_PICO_SKD_SOURCES ${RPI_PICO_SKD_SRC_FILE})
 endforeach()
 

--- a/CMake/Modules/FindSystem.Device.Pwm.cmake
+++ b/CMake/Modules/FindSystem.Device.Pwm.cmake
@@ -35,7 +35,11 @@ foreach(SRC_FILE ${System.Device.Pwm_SRCS})
 
 	    CMAKE_FIND_ROOT_PATH_BOTH
     )
-    # message("${SRC_FILE} >> ${System.Device.Pwm_SRC_FILE}") # debug helper
+
+    if (BUILD_VERBOSE)
+        message("${SRC_FILE} >> ${System.Device.Pwm_SRC_FILE}")
+    endif()
+
     list(APPEND System.Device.Pwm_SOURCES ${System.Device.Pwm_SRC_FILE})
 endforeach()
 

--- a/CMake/Modules/FindSystem.Device.Spi.cmake
+++ b/CMake/Modules/FindSystem.Device.Spi.cmake
@@ -35,7 +35,11 @@ foreach(SRC_FILE ${System.Device.Spi_SRCS})
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )
-    # message("${SRC_FILE} >> ${System.Device.Spi_SRC_FILE}") # debug helper
+
+    if (BUILD_VERBOSE)
+        message("${SRC_FILE} >> ${System.Device.Spi_SRC_FILE}")
+    endif()
+
     list(APPEND System.Device.Spi_SOURCES ${System.Device.Spi_SRC_FILE})
 endforeach()
 

--- a/CMake/Modules/FindSystem.IO.Ports.cmake
+++ b/CMake/Modules/FindSystem.IO.Ports.cmake
@@ -35,7 +35,11 @@ foreach(SRC_FILE ${System.IO.Ports_SRCS})
 
         CMAKE_FIND_ROOT_PATH_BOTH
     )
-    # message("${SRC_FILE} >> ${System.IO.Ports_SRC_FILE}") # debug helper
+
+    if (BUILD_VERBOSE)
+        message("${SRC_FILE} >> ${System.IO.Ports_SRC_FILE}")
+    endif()
+
     list(APPEND System.IO.Ports_SOURCES ${System.IO.Ports_SRC_FILE})
 endforeach()
 

--- a/CMake/Modules/FindWireProtocol.cmake
+++ b/CMake/Modules/FindWireProtocol.cmake
@@ -31,7 +31,9 @@ if(NF_WP_TRACE_ALL)
     math(EXPR WP_TRACE_MASK "16 + 8 + 4 + 2 + 1")
 endif()
 
-message(STATUS "Wire Protocol TRACE_MASK is '${WP_TRACE_MASK}'") # debug helper
+if (BUILD_VERBOSE)
+    message(STATUS "Wire Protocol TRACE_MASK is '${WP_TRACE_MASK}'")
+endif()
 
 # set include directories for Wire Protocol
 list(APPEND WireProtocol_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/CLR/Include)

--- a/CMake/Modules/FindnanoFramework.Device.Bluetooth.cmake
+++ b/CMake/Modules/FindnanoFramework.Device.Bluetooth.cmake
@@ -56,7 +56,11 @@ foreach(SRC_FILE ${nanoFramework.Device.Bluetooth_SRCS})
 
 	    CMAKE_FIND_ROOT_PATH_BOTH
     )
-    # message("${SRC_FILE} >> ${nanoFramework.Device.Bluetooth_SRC_FILE}") # debug helper
+
+    if (BUILD_VERBOSE)
+        message("${SRC_FILE} >> ${nanoFramework.Device.Bluetooth_SRC_FILE}")
+    endif()
+
     list(APPEND nanoFramework.Device.Bluetooth_SOURCES ${nanoFramework.Device.Bluetooth_SRC_FILE})
 endforeach()
 


### PR DESCRIPTION
## Description
- Replace/enable/fix several messages related with the BUILD_VERBOSE option.

## Motivation and Context
- Need to have all the build helper messages to behave on a coherent manner. 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
