### PR TITLE
Port changes from ChibiOS v21.11.3

### DIFF
--- a/targets/ChibiOS/_Lwip/nf_lwipthread.c
+++ b/targets/ChibiOS/_Lwip/nf_lwipthread.c
@@ -56,7 +56,7 @@ static void low_level_init(struct netif *netif)
 
     /* device capabilities */
     /* don't set NETIF_FLAG_ETHARP if this device is not an Ethernet one */
-    netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_LINK_UP;
+    netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP;
 
     /* Do whatever else is needed to initialize interface. */
 }
@@ -92,7 +92,7 @@ static err_t low_level_output(struct netif *netif, struct pbuf *p)
     /* Iterates through the pbuf chain. */
     for (q = p; q != NULL; q = q->next)
         macWriteTransmitDescriptor(&td, (uint8_t *)q->payload, (size_t)q->len);
-    macReleaseTransmitDescriptor(&td);
+    macReleaseTransmitDescriptorX(&td);
 
     MIB2_STATS_NETIF_ADD(netif, ifoutoctets, p->tot_len);
     if (((u8_t *)p->payload)[0] & 1)
@@ -156,7 +156,7 @@ static bool low_level_input(struct netif *netif, struct pbuf **pbuf)
         /* Iterates through the pbuf chain. */
         for (q = *pbuf; q != NULL; q = q->next)
             macReadReceiveDescriptor(&rd, (uint8_t *)q->payload, (size_t)q->len);
-        macReleaseReceiveDescriptor(&rd);
+        macReleaseReceiveDescriptorX(&rd);
 
         MIB2_STATS_NETIF_ADD(netif, ifinoctets, (*pbuf)->tot_len);
 
@@ -179,7 +179,7 @@ static bool low_level_input(struct netif *netif, struct pbuf **pbuf)
     }
     else
     {
-        macReleaseReceiveDescriptor(&rd); // Drop packet
+        macReleaseReceiveDescriptorX(&rd); // Drop packet
         LINK_STATS_INC(link.memerr);
         LINK_STATS_INC(link.drop);
         MIB2_STATS_NETIF_INC(netif, ifindiscards);
@@ -389,7 +389,7 @@ static THD_FUNCTION(lwip_thread, p)
     evtObjectInit(&evt, LWIP_LINK_POLL_INTERVAL);
     evtStart(&evt);
     chEvtRegisterMask(&evt.et_es, &el0, PERIODIC_TIMER_ID);
-    chEvtRegisterMask(macGetReceiveEventSource(&ETHD1), &el1, FRAME_RECEIVED_ID);
+    chEvtRegisterMaskWithFlags(macGetEventSource(&ETHD1), &el1, FRAME_RECEIVED_ID, MAC_FLAGS_RX);
     chEvtAddEvents(PERIODIC_TIMER_ID | FRAME_RECEIVED_ID);
 
     /* Resumes the caller and goes to the final priority.*/


### PR DESCRIPTION
## Description
- Fix ChibiOS bug #1227 fixing wrong handling of NETIF_FLAG_LINK_UP.
- Replace several calls to MAC API.
- Replace call to event register.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
