### PR TITLE
Add more program widths in block storage attributes

### DIFF
--- a/src/PAL/Include/nanoPAL_BlockStorage.h
+++ b/src/PAL/Include/nanoPAL_BlockStorage.h
@@ -179,6 +179,12 @@ typedef enum BlockRegionAttribute
     BlockRegionAttribute_ProgramWidthIs128bits = 0x0400,
     // Flash word size 256 bits
     BlockRegionAttribute_ProgramWidthIs256bits = 0x0800,
+   // Flash word size 512 bits
+   BlockRegionAttribute_ProgramWidthIs512bits = 0x1000,
+   // Flash word size 1024 bits
+   BlockRegionAttribute_ProgramWidthIs1024bits = 0x2000,
+   // Flash word size 2048 bits
+   BlockRegionAttribute_ProgramWidthIs2048bits = 0x4000
 
 } BlockRegionAttribute;
 


### PR DESCRIPTION
## Description
Add 2048 bits as a minimum size that can be programmed for the RP2040 (Raspberry Pi PICO)
Also add 512,1024 bits which at this stage are not identified for any particular MCU, but fit in
with the bit pattern

## Motivation and Context
New feature to support Raspberry PI PICO

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Successfully program RP2040 with an example containing 1.437MB


## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
