### PR TITLE
Increase IDF reserved memory for ESP32 PICO

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -464,7 +464,8 @@
             "cacheVariables": {
                 "SDK_CONFIG_FILE": "sdkconfig.default_pico",
                 "TARGET_SERIAL_BAUDRATE": "115200",
-                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
+                "ESP32_SPIRAM_FOR_IDF_ALLOCATION": "0",
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "15",
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "NF_FEATURE_RTC": "ON",
@@ -751,7 +752,8 @@
             "hidden": true,
             "cacheVariables": {
                 "SDK_CONFIG_FILE": "sdkconfig.default_pico",
-                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "10",
+                "ESP32_SPIRAM_FOR_IDF_ALLOCATION": "0",
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "15",
                 "NF_BUILD_RTM": "OFF",
                 "NF_FEATURE_DEBUGGER": "ON",
                 "TARGET_SERIAL_BAUDRATE": "115200",


### PR DESCRIPTION
## Description
- Adjust CMake presets to reserve more RAM for IDF.

## Motivation and Context
- Fixes nanoFramework/Home#1194.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
