### PR TITLE
Fix check for TI-RTOS sys config file

### DIFF
--- a/CMake/binutils.TI_SimpleLink.cmake
+++ b/CMake/binutils.TI_SimpleLink.cmake
@@ -58,16 +58,8 @@ function(nf_check_radio_frequency)
         message(FATAL_ERROR "Radio frequncy NOT defined. Please set build option 'RADIO_FREQUENCY'. Valid values are 868 and 915.")
     endif()
 
-    find_file(
-        SYS-CONFIG-FILE 
-        *_${RADIO_FREQUENCY}.syscfg
-        
-        PATHS 
-            ${TARGET_BASE_LOCATION}
-        )
-
-    # check if file was found
-    if(SYS-CONFIG-FILE-NOTFOUND)
+    # check if file exists
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${TARGET_BOARD}_${RADIO_FREQUENCY}.syscfg")
         message(FATAL_ERROR "Couldn't find a sysconfig file for radio frequency ${RADIO_FREQUENCY}. Valid values are 868 and 915.")
     endif()
 
@@ -251,6 +243,8 @@ macro(nf_add_platform_sysconfig_steps ti_device ti_device_family)
         # compose sys config file name 
         set(SYS_CONFIG_FILENAME ${TARGET_BOARD}_${RADIO_FREQUENCY}.syscfg)
     endif()
+
+    message(STATUS "Using sysconfig file: ${CMAKE_CURRENT_SOURCE_DIR}/${SYS_CONFIG_FILENAME}.")
 
     # copy Sys Config file to build directory
     add_custom_command(


### PR DESCRIPTION
## Description
- Fix check for TI-RTOS sys config file.
- Add status message to have this exposed on the build log.

## Motivation and Context
- The existing check was dead wrong.
- Better make it clear and visible.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
