### PR TITLE
Improvements in build artifacts generation

### DIFF
--- a/CMake/binutils.arm-none-eabi.cmake
+++ b/CMake/binutils.arm-none-eabi.cmake
@@ -5,24 +5,6 @@
 
 include(binutils.common)
 
-function(nf_add_hex_bin_dump_targets target)
-    if(EXECUTABLE_OUTPUT_PATH)
-        set(FILENAME "${EXECUTABLE_OUTPUT_PATH}/${target}")
-    else()
-        set(FILENAME "${target}")
-    endif()
-
-	#get_filename_component(FNSHORT ${FILENAME} NAME_WE)
-	string(REGEX REPLACE "\\.[^.]*$" "" FNSHORT ${FILENAME})
-
-    # add targets for HEX, BIN and S19 formats with no output so they will always be built
-    add_custom_target(${target}.hex DEPENDS ${target} COMMAND ${CMAKE_OBJCOPY} -Oihex ${FILENAME} ${FNSHORT}.hex)
-    add_custom_target(${target}.s19 DEPENDS ${target} COMMAND ${CMAKE_OBJCOPY} -Osrec ${FILENAME} ${FNSHORT}.s19)
-    add_custom_target(${target}.bin DEPENDS ${target} COMMAND ${CMAKE_OBJCOPY} -Obinary ${FILENAME} ${FNSHORT}.bin)
-    add_custom_target(${target}.dump DEPENDS ${target} COMMAND ${CMAKE_OBJDUMP} -d -EL -S ${FILENAME} ${FNSHORT}.dump)
-endfunction()
-
-
 function(nf_print_target_size target)
     if(EXECUTABLE_OUTPUT_PATH)
       set(FILENAME "${EXECUTABLE_OUTPUT_PATH}/${target}")
@@ -31,7 +13,6 @@ function(nf_print_target_size target)
     endif()
     add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_SIZE_UTIL} -A -x ${FILENAME})
 endfunction()
-
 
 function(nf_set_linker_file target linker_file_name)
 

--- a/CMake/binutils.common.cmake
+++ b/CMake/binutils.common.cmake
@@ -317,33 +317,32 @@ function(nf_generate_build_output_files target)
     string(SUBSTRING ${target} 0 ${TARGET_EXTENSION_DOT_INDEX} TARGET_SHORT)
 
     set(TARGET_HEX_FILE ${CMAKE_BINARY_DIR}/${TARGET_SHORT}.hex)
-    set(TARGET_S19_FILE ${CMAKE_BINARY_DIR}/${TARGET_SHORT}.s19)
     set(TARGET_BIN_FILE ${CMAKE_BINARY_DIR}/${TARGET_SHORT}.bin)
     set(TARGET_DUMP_FILE ${CMAKE_BINARY_DIR}/${TARGET_SHORT}.lst)
 
-    if(CMAKE_BUILD_TYPE EQUAL "Release" OR CMAKE_BUILD_TYPE EQUAL "MinSizeRel")
+    if(CMAKE_BUILD_TYPE MATCHES "Release" OR CMAKE_BUILD_TYPE MATCHES "MinSizeRel")
 
         add_custom_command(TARGET ${TARGET_SHORT}.elf POST_BUILD
-                # copy target image to other formats
-                COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${TARGET_SHORT}.elf> ${TARGET_HEX_FILE}
-                COMMAND ${CMAKE_OBJCOPY} -Osrec $<TARGET_FILE:${TARGET_SHORT}.elf> ${TARGET_S19_FILE}
-                COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${TARGET_SHORT}.elf> ${TARGET_BIN_FILE}
+            # copy target image to other formats
+            COMMAND ${CMAKE_OBJCOPY} $<TARGET_FILE:${TARGET_SHORT}.elf> ${CMAKE_BINARY_DIR}/${TARGET_SHORT}.elf
+            COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${TARGET_SHORT}.elf> ${TARGET_HEX_FILE}
+            COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${TARGET_SHORT}.elf> ${TARGET_BIN_FILE}
 
-                # copy target file to build folder (this is only useful for debugging in VS Code because of path in launch.json)
-                COMMAND ${CMAKE_OBJCOPY} $<TARGET_FILE:${TARGET_SHORT}.elf> ${CMAKE_SOURCE_DIR}/build/${TARGET_SHORT}.elf
+            BYPRODUCTS 
+                ${TARGET_HEX_FILE} 
+                ${TARGET_BIN_FILE}
 
-                COMMENT "Generate nanoBooter HEX and BIN files for deployment")
+            COMMENT "Generate nanoBooter HEX and BIN files for deployment")
 
     else()
 
         add_custom_command(TARGET ${TARGET_SHORT}.elf POST_BUILD
                 # copy target image to other formats
                 COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${TARGET_SHORT}.elf> ${TARGET_HEX_FILE}
-                COMMAND ${CMAKE_OBJCOPY} -Osrec $<TARGET_FILE:${TARGET_SHORT}.elf> ${TARGET_S19_FILE}
                 COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${TARGET_SHORT}.elf> ${TARGET_BIN_FILE}
 
                 # copy target file to build folder (this is only useful for debugging in VS Code because of path in launch.json)
-                COMMAND ${CMAKE_OBJCOPY} $<TARGET_FILE:${TARGET_SHORT}.elf> ${CMAKE_SOURCE_DIR}/build/${TARGET_SHORT}.elf
+                COMMAND ${CMAKE_OBJCOPY} $<TARGET_FILE:${TARGET_SHORT}.elf> ${CMAKE_BINARY_DIR}/${TARGET_SHORT}.elf
 
                 # dump target image as source code listing 
                 # ONLY when DEBUG info is available, this is on 'Debug' and 'RelWithDebInfo'
@@ -352,8 +351,6 @@ function(nf_generate_build_output_files target)
                 COMMENT "Generate nanoBooter HEX and BIN files for deployment, LST file for debug")
 
     endif()
-
-    nf_add_hex_bin_dump_targets(${target})
         
     # add this to print the size of the output targets
     nf_print_target_size(${target})

--- a/azure-pipelines-templates/pack-publish-artifacts.yml
+++ b/azure-pipelines-templates/pack-publish-artifacts.yml
@@ -15,7 +15,6 @@ steps:
       Contents: |
         *.bin
         *.hex
-        *.s19
         *.dfu
       TargetFolder: '$(Build.ArtifactStagingDirectory)\$(TargetPublishName)'
       flattenFolders: true


### PR DESCRIPTION
## Description
- Move generation of HEX, BIN and dump files to bin utils common. Replacing nf_add_hex_bin_dump_targets.
- Remove generation of s19 format. Not used anywhere.

## Motivation and Context
- Simplification of the build system.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
