### PR TITLE
Fix declaration of enum

### DIFF
--- a/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native.h
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native.h
@@ -12,6 +12,12 @@
 #include <nanoCLR_Checks.h>
 #include <corlib_native.h>
 
+
+typedef enum __nfpack HighResTimerEventType
+{
+    HighResTimerEventType_TimerExpired = 101,
+} HighResTimerEventType;
+
 typedef enum __nfpack NativeMemory_MemoryType
 {
     NativeMemory_MemoryType_All = 0,

--- a/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_HighResTimer.cpp
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_HighResTimer.cpp
@@ -10,15 +10,6 @@
 
 esp_timer_handle_t hrtimers[MAX_HRTIMERS] = {};
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// !!! KEEP IN SYNC WITH nanoFramework.Hardware.Esp32.HighResTimerEventType (in managed code) !!! //
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-enum HighResTimerEventType
-{
-    TimerExpired = 101
-};
-
 static int FindNextTimerIndex()
 {
     for (int index = 0; index < MAX_HRTIMERS; index++)
@@ -33,7 +24,7 @@ static int FindNextTimerIndex()
 static void HRtimer_callback(void *arg)
 {
     esp_timer_handle_t timer_handle = hrtimers[(int)arg];
-    PostManagedEvent(EVENT_HIGH_RESOLUTION_TIMER, HighResTimerEventType::TimerExpired, 0, (uint32_t)timer_handle);
+    PostManagedEvent(EVENT_HIGH_RESOLUTION_TIMER, HighResTimerEventType_TimerExpired, 0, (uint32_t)timer_handle);
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_HighResTimer::


### PR DESCRIPTION
## Description
- Move enum to class declaration.
- Update code accordingly.

## Motivation and Context
- Fixes declaration to use generated enum.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
