### PR TITLE
Improvements in power mode API

### DIFF
--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -444,7 +444,7 @@ void ClrStartup(CLR_SETTINGS params)
 
                 s_ClrSettings.Cleanup();
 
-                nanoHAL_Uninitialize();
+                nanoHAL_Uninitialize(false);
 
                 // re-init the hal for the reboot (initially it is called in bootentry)
                 nanoHAL_Initialize();

--- a/src/HAL/Include/nanoHAL.h
+++ b/src/HAL/Include/nanoHAL.h
@@ -800,7 +800,7 @@ template <typename T> class HAL_RingBuffer
 // hal cleanup for CLR reboot
 
 void nanoHAL_Initialize();
-void nanoHAL_Uninitialize();
+void nanoHAL_Uninitialize(bool isPoweringDown);
 
 typedef void (*ON_SOFT_REBOOT_HANDLER)(void);
 

--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -201,7 +201,7 @@ extern "C"
 #endif
 
     void nanoHAL_Initialize_C();
-    void nanoHAL_Uninitialize_C();
+    void nanoHAL_Uninitialize_C(bool isPoweringDown);
     void HeapLocation_C(unsigned char **baseAddress, unsigned int *sizeInBytes);
 
     // Call to the external memory configuration and initialization function
@@ -220,6 +220,10 @@ extern "C"
     void CPU_Reset();
     void CPU_Sleep(SLEEP_LEVEL_type level, uint64_t wakeEvents);
     void CPU_SetPowerMode(PowerLevel_type powerLevel);
+    // platform specific handler for power mode changes (may be empty)
+    void CPU_SetPowerModePlatform(PowerLevel_type powerLevel);
+    // target specific handler for power mode changes (may be empty)
+    void CPU_SetPowerModeTarget(PowerLevel_type powerLevel);
 
 #ifdef __cplusplus
 }

--- a/targets/AzureRTOS/Maxim/_nanoCLR/targetHAL.cpp
+++ b/targets/AzureRTOS/Maxim/_nanoCLR/targetHAL.cpp
@@ -40,9 +40,9 @@ extern "C"
         nanoHAL_Initialize();
     }
 
-    void nanoHAL_Uninitialize_C()
+    void nanoHAL_Uninitialize_C(bool isPoweringDown)
     {
-        nanoHAL_Uninitialize();
+        nanoHAL_Uninitialize(isPoweringDown);
     }
 }
 
@@ -161,8 +161,10 @@ void nanoHAL_Initialize()
     Network_Initialize();
 }
 
-void nanoHAL_Uninitialize()
+void nanoHAL_Uninitialize(bool isPoweringDown)
 {
+    (void)isPoweringDown;
+
     // release the global mutex, just in case it's locked somewhere
     // chMtxUnlock(&interpreterGlobalMutex);
 

--- a/targets/AzureRTOS/Maxim/_nanoCLR/targetHAL_Power.c
+++ b/targets/AzureRTOS/Maxim/_nanoCLR/targetHAL_Power.c
@@ -46,7 +46,7 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
             // wdgStop(&WDGD1);
 
             // gracefully shutdown everything
-            nanoHAL_Uninitialize_C();
+            nanoHAL_Uninitialize_C(true);
 
             // chSysDisable();
             // disable interrupts

--- a/targets/AzureRTOS/ST/_nanoCLR/targetHAL.cpp
+++ b/targets/AzureRTOS/ST/_nanoCLR/targetHAL.cpp
@@ -38,9 +38,9 @@ extern "C"
         nanoHAL_Initialize();
     }
 
-    void nanoHAL_Uninitialize_C()
+    void nanoHAL_Uninitialize_C(bool isPoweringDown)
     {
-        nanoHAL_Uninitialize();
+        nanoHAL_Uninitialize(isPoweringDown);
     }
 }
 
@@ -157,8 +157,10 @@ void nanoHAL_Initialize()
     Network_Initialize();
 }
 
-void nanoHAL_Uninitialize()
+void nanoHAL_Uninitialize(bool isPoweringDown)
 {
+    (void)isPoweringDown;
+
     // release the global mutex, just in case it's locked somewhere
     // chMtxUnlock(&interpreterGlobalMutex);
 

--- a/targets/AzureRTOS/ST/_nanoCLR/targetHAL_Power.c
+++ b/targets/AzureRTOS/ST/_nanoCLR/targetHAL_Power.c
@@ -70,7 +70,7 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
 #endif
 #endif
             // gracefully shutdown everything
-            nanoHAL_Uninitialize_C();
+            nanoHAL_Uninitialize_C(true);
 
             __disable_irq();
 

--- a/targets/AzureRTOS/SiliconLabs/_nanoCLR/targetHAL.cpp
+++ b/targets/AzureRTOS/SiliconLabs/_nanoCLR/targetHAL.cpp
@@ -37,7 +37,6 @@ extern void DeInitPwm();
 #include <sys_dev_usbstream_native_target.h>
 #endif
 
-
 // global mutex protecting the internal state of the interpreter, including event flags
 // mutex_t interpreterGlobalMutex;
 
@@ -51,9 +50,9 @@ extern "C"
         nanoHAL_Initialize();
     }
 
-    void nanoHAL_Uninitialize_C()
+    void nanoHAL_Uninitialize_C(bool isPoweringDown)
     {
-        nanoHAL_Uninitialize();
+        nanoHAL_Uninitialize(isPoweringDown);
     }
 }
 
@@ -138,10 +137,10 @@ void nanoHAL_Initialize()
 #endif
 
 #if (GECKO_USE_ADC0 == TRUE) && defined(NANO_GG_ADC_NATIVE_TARGET_H)
-adc0Initialized = false;
+    adc0Initialized = false;
 #endif
 #if (GECKO_USE_ADC1 == TRUE) && defined(NANO_GG_ADC_NATIVE_TARGET_H)
-adc1Initialized = false;
+    adc1Initialized = false;
 #endif
 
 #if GECKO_FEATURE_USBD_WINUSB == TRUE
@@ -205,8 +204,10 @@ adc1Initialized = false;
     Network_Initialize();
 }
 
-void nanoHAL_Uninitialize()
+void nanoHAL_Uninitialize(bool isPoweringDown)
 {
+    (void)isPoweringDown;
+
     // release the global mutex, just in case it's locked somewhere
     // chMtxUnlock(&interpreterGlobalMutex);
 
@@ -283,16 +284,16 @@ void nanoHAL_Uninitialize()
 #endif
 
 #if (GECKO_USE_ADC0 == TRUE) && defined(NANO_GG_ADC_NATIVE_TARGET_H)
-ADC_Reset(ADC0);
-adc0Initialized = false;
+    ADC_Reset(ADC0);
+    adc0Initialized = false;
 #endif
 #if (GECKO_USE_ADC1 == TRUE) && defined(NANO_GG_ADC_NATIVE_TARGET_H)
-ADC_Reset(ADC1);
-adc1Initialized = false;
+    ADC_Reset(ADC1);
+    adc1Initialized = false;
 #endif
 
 #if GECKO_FEATURE_USBD_WINUSB == TRUE
-    
+
     // abort any transfer in progress, just in case
     sl_usbd_vendor_abort_write_bulk(sl_usbd_vendor_winusb_number);
     sl_usbd_vendor_abort_read_bulk(sl_usbd_vendor_winusb_number);

--- a/targets/AzureRTOS/SiliconLabs/_nanoCLR/targetHAL_Power.c
+++ b/targets/AzureRTOS/SiliconLabs/_nanoCLR/targetHAL_Power.c
@@ -44,7 +44,7 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
             // wdgStop(&WDGD1);
 
             // gracefully shutdown everything
-            nanoHAL_Uninitialize_C();
+            nanoHAL_Uninitialize_C(true);
 
             __disable_irq();
 

--- a/targets/ChibiOS/_nanoCLR/targetHAL.cpp
+++ b/targets/ChibiOS/_nanoCLR/targetHAL.cpp
@@ -40,9 +40,9 @@ extern "C"
         nanoHAL_Initialize();
     }
 
-    void nanoHAL_Uninitialize_C()
+    void nanoHAL_Uninitialize_C(bool isPoweringDown)
     {
-        nanoHAL_Uninitialize();
+        nanoHAL_Uninitialize(isPoweringDown);
     }
 }
 
@@ -155,8 +155,10 @@ void nanoHAL_Initialize()
     Network_Initialize();
 }
 
-void nanoHAL_Uninitialize()
+void nanoHAL_Uninitialize(bool isPoweringDown)
 {
+    (void)isPoweringDown;
+
     // release the global mutex, just in case it's locked somewhere
     // chMtxUnlock(&interpreterGlobalMutex);
 

--- a/targets/ChibiOS/_nanoCLR/targetHAL_Power.c
+++ b/targets/ChibiOS/_nanoCLR/targetHAL_Power.c
@@ -69,7 +69,7 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
 #endif
 
             // gracefully shutdown everything
-            nanoHAL_Uninitialize_C();
+            nanoHAL_Uninitialize_C(true);
 
             chSysDisable();
 

--- a/targets/ESP32/_nanoCLR/targetHAL.cpp
+++ b/targets/ESP32/_nanoCLR/targetHAL.cpp
@@ -55,9 +55,9 @@ extern "C"
         nanoHAL_Initialize();
     }
 
-    void nanoHAL_Uninitialize_C()
+    void nanoHAL_Uninitialize_C(bool isPoweringDown)
     {
-        nanoHAL_Uninitialize();
+        nanoHAL_Uninitialize(isPoweringDown);
     }
 }
 
@@ -112,8 +112,10 @@ void nanoHAL_Initialize()
 #endif
 }
 
-void nanoHAL_Uninitialize()
+void nanoHAL_Uninitialize(bool isPoweringDown)
 {
+    (void)isPoweringDown;
+
     // check for s_rebootHandlers
     for (unsigned int i = 0; i < ARRAYSIZE(s_rebootHandlers); i++)
     {

--- a/targets/ESP32/_nanoCLR/targetHAL_Power.c
+++ b/targets/ESP32/_nanoCLR/targetHAL_Power.c
@@ -29,7 +29,7 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
     {
         case PowerLevel__Off:
             // gracefully shutdown everything
-            nanoHAL_Uninitialize_C();
+            nanoHAL_Uninitialize_C(true);
 
             esp_deep_sleep_start();
 

--- a/targets/FreeRTOS/NXP/_nanoCLR/targetHAL.cpp
+++ b/targets/FreeRTOS/NXP/_nanoCLR/targetHAL.cpp
@@ -42,9 +42,9 @@ extern "C"
         nanoHAL_Initialize();
     }
 
-    void nanoHAL_Uninitialize_C()
+    void nanoHAL_Uninitialize_C(bool isPoweringDown)
     {
-        nanoHAL_Uninitialize();
+        nanoHAL_Uninitialize(isPoweringDown);
     }
 }
 
@@ -83,8 +83,10 @@ void nanoHAL_Initialize()
     // SOCKETS_DbgInitialize( 0 );
 }
 
-void nanoHAL_Uninitialize()
+void nanoHAL_Uninitialize(bool isPoweringDown)
 {
+    (void)isPoweringDown;
+
     // check for s_rebootHandlers
     for (unsigned int i = 0; i < ARRAYSIZE(s_rebootHandlers); i++)
     {

--- a/targets/TI_SimpleLink/_nanoCLR/targetHAL.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/targetHAL.cpp
@@ -57,9 +57,9 @@ extern "C"
         nanoHAL_Initialize();
     }
 
-    void nanoHAL_Uninitialize_C()
+    void nanoHAL_Uninitialize_C(bool isPoweringDown)
     {
-        nanoHAL_Uninitialize();
+        nanoHAL_Uninitialize(isPoweringDown);
     }
 }
 
@@ -110,8 +110,10 @@ void nanoHAL_Initialize()
     // SOCKETS_DbgInitialize( 0 );
 }
 
-void nanoHAL_Uninitialize()
+void nanoHAL_Uninitialize(bool isPoweringDown)
 {
+    (void)isPoweringDown;
+
     // check for s_rebootHandlers
     for (unsigned int i = 0; i < ARRAYSIZE(s_rebootHandlers); i++)
     {

--- a/targets/TI_SimpleLink/_nanoCLR/targetHAL_Power.c
+++ b/targets/TI_SimpleLink/_nanoCLR/targetHAL_Power.c
@@ -25,7 +25,10 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
     {
         case PowerLevel__Off:
             // gracefully shutdown everything
-            nanoHAL_Uninitialize_C();
+            nanoHAL_Uninitialize_C(true);
+
+            // take care of platform and target specific taks for powering down
+            CPU_SetPowerModePlatform(powerLevel);
 
             // now let's go with shutdown
             Power_shutdown(0, 0);
@@ -36,4 +39,16 @@ void CPU_SetPowerMode(PowerLevel_type powerLevel)
             // all the other power modes are unsupported here
             break;
     }
+}
+
+void CPU_SetPowerModePlatform(PowerLevel_type powerLevel)
+{
+    // call target specific implementation
+    CPU_SetPowerModeTarget(powerLevel);
+}
+
+// implemented as weak symbol to be overridden by target implementation
+__nfweak void CPU_SetPowerModeTarget(PowerLevel_type powerLevel)
+{
+    (void)powerLevel;
 }

--- a/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
+++ b/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
@@ -630,7 +630,7 @@ void ClrStartup(CLR_SETTINGS params)
 
                 s_ClrSettings.Cleanup();
 
-                nanoHAL_Uninitialize();
+                nanoHAL_Uninitialize(false);
 
                 // re-init the hal for the reboot (initially it is called in bootentry)
                 nanoHAL_Initialize();

--- a/targets/win32/nanoCLR/Various.cpp
+++ b/targets/win32/nanoCLR/Various.cpp
@@ -154,8 +154,10 @@ void __cdecl nanoHAL_Initialize(void)
     Events_Initialize();
 }
 
-void __cdecl nanoHAL_Uninitialize(void)
+void __cdecl nanoHAL_Uninitialize(bool isPoweringDown)
 {
+    (void)isPoweringDown;
+
     int i;
 
     // UNDONE: FIXME: CPU_GPIO_Uninitialize();


### PR DESCRIPTION
## Description
- Add parameter `isPoweringDown` to `nanoHAL_Uninitialize`.
- Add declaration for `CPU_SetPowerModePlatform` and `CPU_SetPowerModeTarget`.
- Add implementation of this to TI SimpleLink.

## Motivation and Context
- Adds parameters that allow finer control over power mode changes propagating down to the target level.
- For example: some platforms have specific ways of dealing with GPIO configurations when entering sleep mode in order to allow waking from sleep. These changes allow those platform and target specific implementations to be seamlessly integrated in the HAP/PAL.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
