### PR TITLE
Add missing defines for ReceiverThread

### DIFF
--- a/targets/AzureRTOS/SiliconLabs/_common/WireProtocol_ReceiverThread_Platform.c
+++ b/targets/AzureRTOS/SiliconLabs/_common/WireProtocol_ReceiverThread_Platform.c
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include <target_platform.h>
 #include <targetHAL.h>
 #include <WireProtocol_Message.h>
 
@@ -30,10 +31,13 @@
 __attribute__((noreturn)) void ReceiverThread_entry(uint32_t parameter)
 {
     (void)parameter;
+
+#if HAL_WP_USE_USB_CDC == TRUE
     sl_status_t status = SL_STATUS_OK;
     bool conn = false;
 
     const uint32_t xDelay = TX_TICKS_PER_MILLISEC(TASK_DELAY_MS);
+#endif
 
     tx_thread_sleep(50);
 
@@ -42,6 +46,8 @@ __attribute__((noreturn)) void ReceiverThread_entry(uint32_t parameter)
     // loop until thread receives a request to terminate
     while (1)
     {
+
+#if HAL_WP_USE_USB_CDC == TRUE
         // Wait until device is in configured state
         status = sl_usbd_cdc_acm_is_enabled(sl_usbd_cdc_acm_acm0_number, &conn);
         _ASSERTE(status == SL_STATUS_OK);
@@ -55,6 +61,7 @@ __attribute__((noreturn)) void ReceiverThread_entry(uint32_t parameter)
             status = sl_usbd_cdc_acm_is_enabled(sl_usbd_cdc_acm_acm0_number, &conn);
             _ASSERTE(status == SL_STATUS_OK);
         }
+#endif
 
         WP_Message_Process();
 


### PR DESCRIPTION
## Description
- Add missing defines for ReceiverThread.

## Motivation and Context
- The code wasn't handling properly the differences between CDC and serial for WP.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
