### PR TITLE
Add option to load local instance of nanoCLR

### DIFF
--- a/targets/netcore/nanoFramework.nanoCLR.CLI/ClrInstanceOperationsProcessor.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/ClrInstanceOperationsProcessor.cs
@@ -63,7 +63,7 @@ namespace nanoFramework.nanoCLR.CLI
 
                 Version version = Version.Parse(currentVersion);
 
-                string nanoClrDllLocation = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "nanoFramework.nanoCLR.dll");
+                string nanoClrDllLocation = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "NanoCLR", "nanoFramework.nanoCLR.dll");
 
                 _httpClient.BaseAddress = new Uri(_cloudSmithApiUrl);
                 _httpClient.DefaultRequestHeaders.Add("Accept", "*/*");
@@ -89,8 +89,12 @@ namespace nanoFramework.nanoCLR.CLI
                 {
                     Version latestFwVersion = Version.Parse(packageInfo.ElementAt(0).Version);
 
-                    if (latestFwVersion > version
-                        || (!string.IsNullOrEmpty(targetVersion)
+                    if (latestFwVersion < version)
+                    {
+                        Console.WriteLine($"Current version {version} lower than available version {packageInfo.ElementAt(0).Version}");
+                    }
+                    else if (latestFwVersion > version
+                            || (!string.IsNullOrEmpty(targetVersion)
                             && (Version.Parse(targetVersion) > Version.Parse(currentVersion))))
                     {
                         response = await _httpClient.GetAsync(packageInfo.ElementAt(0).DownloadUrl);

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandLineOptions.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandLineOptions.cs
@@ -3,8 +3,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System.Collections.Generic;
 using CommandLine;
+using System.Collections.Generic;
 
 namespace nanoFramework.nanoCLR.CLI
 {
@@ -92,6 +92,14 @@ namespace nanoFramework.nanoCLR.CLI
             Default = true,
             HelpText = "Option to remain in loop waiting for a debugger connection after the program exits.")]
         public bool EnterDebuggerLoopAfterExit { get; set; }
+
+        [Option(
+            "localinstance",
+            Required = false,
+            Default = null,
+            Hidden = true,
+            HelpText = "Path to a local instance of the nanoCLR.")]
+        public string LocalInstance { get; set; }
 
         /// <summary>
         /// Allowed values:

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandProcessor.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandProcessor.cs
@@ -7,6 +7,7 @@ using nanoFramework.nanoCLR.Host;
 using nanoFramework.nanoCLR.Host.Port.TcpIp;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 
@@ -21,6 +22,20 @@ namespace nanoFramework.nanoCLR.CLI
             VirtualSerialDeviceManager virtualBridgeManager)
         {
             Program.ProcessVerbosityOptions(options.Verbosity);
+
+            string pathForNanoClrDll = string.Empty;
+
+            // are we to use a local DLL?
+            if (options.LocalInstance != null)
+            {
+                // check if path exists
+                if (!File.Exists(options.LocalInstance))
+                {
+                    throw new CLIException(ExitCode.E9009);
+                }
+
+                pathForNanoClrDll = Path.GetDirectoryName(options.LocalInstance);
+            }
 
             // flag to signal that the intenal serial port has already been configured
             bool internalSerialPortConfig = false;
@@ -105,7 +120,6 @@ namespace nanoFramework.nanoCLR.CLI
             hostBuilder.WaitForDebugger = options.WaitForDebugger;
             hostBuilder.EnterDebuggerLoopAfterExit = options.EnterDebuggerLoopAfterExit;
 
-
             if (options.MonitorParentPid != null)
             {
                 try
@@ -120,7 +134,7 @@ namespace nanoFramework.nanoCLR.CLI
                 }
             }
 
-            var host = hostBuilder.Build();
+            var host = hostBuilder.Build(pathForNanoClrDll);
 
             Console.CancelKeyPress += (_, _) => host.Shutdown();
 

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/ExitCode.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/ExitCode.cs
@@ -100,5 +100,11 @@ namespace nanoFramework.nanoCLR.CLI
         /// </summary>
         [Display(Name = "Unknown error when starting the virtual device instance.")]
         E9008 = 9008,
+
+        /// <summary>
+        /// Specified nanoCLR DLL file does not exist.
+        /// </summary>
+        [Display(Name = " Specified nanoCLR DLL file does not exist.")]
+        E9009 = 9009,
     }
 }

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/Program.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/Program.cs
@@ -12,7 +12,10 @@ using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+
+[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.UserDirectories | DllImportSearchPath.UseDllDirectoryForDependencies)]
 
 namespace nanoFramework.nanoCLR.CLI
 {
@@ -92,6 +95,9 @@ namespace nanoFramework.nanoCLR.CLI
 
                 nanoCLRHostBuilder hostBuilder = nanoCLRHost.CreateBuilder();
                 hostBuilder.UseConsoleDebugPrint();
+
+                // need to set DLL directory to HHD interop DLL
+                SetDllDirectory(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Vendor"));
 
                 var parsedArguments = Parser.Default.ParseArguments<ExecuteCommandLineOptions, ClrInstanceOperationsOptions, VirtualSerialDeviceCommandLineOptions>(args);
 
@@ -210,5 +216,9 @@ namespace nanoFramework.nanoCLR.CLI
                 Console.WriteLine($"Error: {e.Message}");
             }
         }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern bool SetDllDirectory(string lpPathName);
+
     }
 }

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/nanoFramework.nanoCLR.CLI.csproj
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/nanoFramework.nanoCLR.CLI.csproj
@@ -34,7 +34,7 @@
 
   <!-- NuGet package files -->
   <ItemGroup>
-    <None Include="..\..\..\build\bin\$(Configuration)\nanoFramework.nanoCLR.dll">
+    <None Include="..\..\..\build\bin\$(Configuration)\nanoFramework.nanoCLR.dll" Link="NanoCLR\nanoFramework.nanoCLR.dll">
       <Pack>True</Pack>
       <PackagePath>tools\net6.0\any</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -85,5 +85,8 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
+  <ItemGroup>
+    <Folder Include="NanoCLR\" />
+  </ItemGroup>
+  
 </Project>

--- a/targets/netcore/nanoFramework.nanoCLR.Host/NanoClrHost.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.Host/NanoClrHost.cs
@@ -6,6 +6,8 @@
 using nanoFramework.nanoCLR.Host.Port;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 
 namespace nanoFramework.nanoCLR.Host
 {
@@ -19,8 +21,22 @@ namespace nanoFramework.nanoCLR.Host
         internal nanoCLRSettings nanoCLRSettings { get; set; } = nanoCLRSettings.Default;
         internal IPort WireProtocolPort { get; set; }
 
-        internal nanoCLRHost()
+        internal nanoCLRHost(string pathForNanoClrDll)
         {
+            // set app directory, if different from executing assembly
+            if (!string.IsNullOrEmpty(pathForNanoClrDll)
+               && pathForNanoClrDll != Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
+            {
+                Interop.nanoCLR.DllPath = pathForNanoClrDll;
+            }
+            else
+            {
+                // use default path
+                Interop.nanoCLR.DllPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "NanoCLR");
+            }
+
+            // set path to search nanoCLR DLL
+            Interop.nanoCLR.SetDllDirectory(Interop.nanoCLR.DllPath);
         }
 
         public void Run()

--- a/targets/netcore/nanoFramework.nanoCLR.Host/NanoClrHostBuilder.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.Host/NanoClrHostBuilder.cs
@@ -11,7 +11,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 
 namespace nanoFramework.nanoCLR.Host
 {
@@ -91,14 +90,14 @@ namespace nanoFramework.nanoCLR.Host
         public nanoCLRHostBuilder UsePortTrace() =>
             UseWireProtocolPort(new TraceDataPort(_wireProtocolPort));
 
-        public nanoCLRHost Build()
+        public nanoCLRHost Build(string pathForNanoClrDll)
         {
             if (s_nanoClrHost != null)
             {
                 throw new InvalidOperationException("Cannot build two nanoCLR runtime hosts");
             }
 
-            s_nanoClrHost = new nanoCLRHost();
+            s_nanoClrHost = new nanoCLRHost(pathForNanoClrDll);
 
             s_nanoClrHost.WireProtocolPort = _wireProtocolPort;
             s_nanoClrHost.ConfigureSteps.AddRange(_configureSteps);
@@ -116,9 +115,7 @@ namespace nanoFramework.nanoCLR.Host
 
         public void UnloadNanoClrDll()
         {
-            string nanoClrDllLocation = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "nanoFramework.nanoCLR.dll");
-
-            Interop.nanoCLR.UnloadNanoClrImageDll(nanoClrDllLocation);
+            Interop.nanoCLR.UnloadNanoClrImageDll();
         }
     }
 }


### PR DESCRIPTION
## Description
- Add option to execute option group.
- Major rework to load DLL and components from specific directory.
- Rework code dealing with instance version and update to accommodate this.
- Add new exit code for failure to find local instance.

## Motivation and Context
- Allow running local instances of nanoCLR. Useful for Unit Tests and development work.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
