### PR TITLE
Default verbosity is now normal

### DIFF
--- a/targets/netcore/nanoFramework.nanoCLR.CLI/ClrInstanceOperationsOptions.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/ClrInstanceOperationsOptions.cs
@@ -50,7 +50,7 @@ namespace nanoFramework.nanoCLR.CLI
             'v',
             "verbosity",
             Required = false,
-            Default = "d",
+            Default = "n",
             HelpText = "Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. Not supported in every command; see specific command page to determine if this option is available.")]
         public string Verbosity { get; set; }
     }

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandLineOptions.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandLineOptions.cs
@@ -113,7 +113,7 @@ namespace nanoFramework.nanoCLR.CLI
             'v',
             "verbosity",
             Required = false,
-            Default = "d",
+            Default = "n",
             HelpText = "Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. Not supported in every command; see specific command page to determine if this option is available.")]
         public string Verbosity { get; set; }
     }


### PR DESCRIPTION

## Description
- Change default value for verbosity to normal.

## Motivation and Context
- Was at detail level, which is too much.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
