### PR TITLE
Improve SNTP options

### DIFF
--- a/src/DeviceInterfaces/Networking.Sntp/lwip_sntp_default_options.h
+++ b/src/DeviceInterfaces/Networking.Sntp/lwip_sntp_default_options.h
@@ -13,10 +13,13 @@
 #define SNTP_UPDATE_DELAY 3600000
 #endif
 
-// better have a startup delay because we can have DHCP enabled (default 15 seconds)
-// value in milliseconds
-#define SNTP_STARTUP_DELAY 15 * 1000
+// startup delay (default 2 seconds)
+// (value in milliseconds)
+// Remarks: because we could have DHCP enabled
+//   we allow time for the IP to be established
+//   but also need to take into account that NetworkHelper is likely to timeout
+#define SNTP_STARTUP_DELAY 2000
 
 // retry timeout (15 minutes)
-// value in milliseconds
+// (value in milliseconds)
 #define SNTP_RETRY_TIMEOUT 900000

--- a/targets/TI_SimpleLink/TI_CC3220SF_LAUNCHXL/target_sntp_opts.h
+++ b/targets/TI_SimpleLink/TI_CC3220SF_LAUNCHXL/target_sntp_opts.h
@@ -14,12 +14,12 @@
 // Must wait at least 15 sec to retry NTP server (RFC 4330)
 #define SNTP_UPDATE_DELAY (60 * 60) // FIXME: possibily wrong?!
 
-// better have a startup delay because we can have DHCP enabled (default 30 seconds)
+// better have a startup delay because we can have DHCP enabled (default 2 seconds)
 // value in seconds
-#define SNTP_STARTUP_DELAY (0)  // FIXME: possibily wrong?!
+#define SNTP_STARTUP_DELAY (2)
 
 // retry timeout (15 minutes)
 // value in seconds
-#define SNTP_RETRY_TIMEOUT (15)
+#define SNTP_RETRY_TIMEOUT (15 * 60)
 
 #endif // TARGET_SNTP_OPTS_H

--- a/targets/TI_SimpleLink/TI_CC3220SF_LAUNCHXL/target_sntp_opts.h
+++ b/targets/TI_SimpleLink/TI_CC3220SF_LAUNCHXL/target_sntp_opts.h
@@ -12,7 +12,7 @@
 // update delay (default 1 hour)
 // (value in seconds)
 // Must wait at least 15 sec to retry NTP server (RFC 4330)
-#define SNTP_UPDATE_DELAY (60 * 60) // FIXME: possibily wrong?!
+#define SNTP_UPDATE_DELAY (60 * 60)
 
 // better have a startup delay because we can have DHCP enabled (default 2 seconds)
 // value in seconds

--- a/targets/TI_SimpleLink/TI_CC3220SF_LAUNCHXL/target_sntp_opts.h
+++ b/targets/TI_SimpleLink/TI_CC3220SF_LAUNCHXL/target_sntp_opts.h
@@ -12,14 +12,14 @@
 // update delay (default 1 hour)
 // (value in seconds)
 // Must wait at least 15 sec to retry NTP server (RFC 4330)
-#define SNTP_UPDATE_DELAY (60 * 60)
+#define SNTP_UPDATE_DELAY (60 * 60) // FIXME: possibily wrong?!
 
-// no startup delay for SNTP
+// better have a startup delay because we can have DHCP enabled (default 30 seconds)
 // value in seconds
-#define SNTP_STARTUP_DELAY (0)
+#define SNTP_STARTUP_DELAY (0)  // FIXME: possibily wrong?!
 
-// retry timeout
+// retry timeout (15 minutes)
 // value in seconds
-#define SNTP_RETRY_TIMEOUT (10)
+#define SNTP_RETRY_TIMEOUT (15)
 
 #endif // TARGET_SNTP_OPTS_H

--- a/targets/TI_SimpleLink/_include/targetSimpleLinkCC32xx_Sntp.h
+++ b/targets/TI_SimpleLink/_include/targetSimpleLinkCC32xx_Sntp.h
@@ -25,16 +25,16 @@
 #define SNTP_UPDATE_DELAY (15)
 #endif
 
-// better have a startup delay because we can have DHCP enabled (default 30 seconds)
+// better have a startup delay because we can have DHCP enabled (default 2 seconds)
 // value in seconds
 #ifndef SNTP_STARTUP_DELAY
-#define SNTP_STARTUP_DELAY (30)
+#define SNTP_STARTUP_DELAY (2)
 #endif
 
 // retry timeout (15 minutes)
 // value in seconds
 #ifndef SNTP_RETRY_TIMEOUT
-#define SNTP_RETRY_TIMEOUT (15 * 60) // FIXME: possibily wrong?!
+#define SNTP_RETRY_TIMEOUT (15 * 60)
 #endif
 
 #define NTP_SERVERS     2

--- a/targets/TI_SimpleLink/_include/targetSimpleLinkCC32xx_Sntp.h
+++ b/targets/TI_SimpleLink/_include/targetSimpleLinkCC32xx_Sntp.h
@@ -152,4 +152,4 @@ extern "C"
 }
 #endif
 
-#endif //TARGET_SNTP_H
+#endif // TARGET_SNTP_H

--- a/targets/TI_SimpleLink/_include/targetSimpleLinkCC32xx_Sntp.h
+++ b/targets/TI_SimpleLink/_include/targetSimpleLinkCC32xx_Sntp.h
@@ -34,7 +34,7 @@
 // retry timeout (15 minutes)
 // value in seconds
 #ifndef SNTP_RETRY_TIMEOUT
-#define SNTP_RETRY_TIMEOUT (15 * 60)
+#define SNTP_RETRY_TIMEOUT (15 * 60) // FIXME: possibily wrong?!
 #endif
 
 #define NTP_SERVERS     2


### PR DESCRIPTION
## Description
Improves default startup delay of SNTP for ChibiOS targets.

## Motivation and Context
By default the delay was 30 seconds.
Given that `return NetworkHelper.SetupAndConnectNetwork(requiresDateTime: true, token: token);`
Where all samples (and appropriate timeout) would be `CancellationTokenSource cs = new(10000); // ten seconds`
It generally fails as the SNTP helper was not yet started yet.
It passes on a restart of the target because enough time has generally elapsed by the time the user has noticed and re-plugged the USB.

Although there are a number of improvements could be made, this fixes the most specific issue and also makes aware and fixes similar related to TI targets.


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
