### PR TITLE
Fix ChibiOS F7 mcuconfig

### DIFF
--- a/targets/ChibiOS/ORGPAL_PALTHREE/nanoBooter/mcuconf.h
+++ b/targets/ChibiOS/ORGPAL_PALTHREE/nanoBooter/mcuconf.h
@@ -7,6 +7,8 @@
 #ifndef MCUCONF_H
 #define MCUCONF_H
 
+// clang-format off
+
 /*
  * STM32F7xx drivers configuration.
  * The following settings override the default settings present in
@@ -23,6 +25,14 @@
 
 #define STM32F7xx_MCUCONF
 #define STM32F769_MCUCONF
+
+/*
+ * Memory attributes settings.
+ */
+#define STM32_NOCACHE_ENABLE                FALSE
+// #define STM32_NOCACHE_MPU_REGION            MPU_REGION_6
+// #define STM32_NOCACHE_RBAR                  0x2004C000U
+// #define STM32_NOCACHE_RASR                  MPU_RASR_SIZE_16K
 
 /*
  * HAL driver system settings.
@@ -428,3 +438,5 @@
 #include "mcuconf_nf.h"
 
 #endif /* MCUCONF_H */
+
+// clang-format on

--- a/targets/ChibiOS/ORGPAL_PALTHREE/nanoCLR/mcuconf.h
+++ b/targets/ChibiOS/ORGPAL_PALTHREE/nanoCLR/mcuconf.h
@@ -7,6 +7,8 @@
 #ifndef MCUCONF_H
 #define MCUCONF_H
 
+// clang-format off
+
 /*
  * STM32F7xx drivers configuration.
  * The following settings override the default settings present in
@@ -23,6 +25,14 @@
 
 #define STM32F7xx_MCUCONF
 #define STM32F769_MCUCONF
+
+/*
+ * Memory attributes settings.
+ */
+#define STM32_NOCACHE_ENABLE                FALSE
+// #define STM32_NOCACHE_MPU_REGION            MPU_REGION_6
+// #define STM32_NOCACHE_RBAR                  0x2004C000U
+// #define STM32_NOCACHE_RASR                  MPU_RASR_SIZE_16K
 
 /*
  * HAL driver system settings.
@@ -429,3 +439,5 @@
 #include "mcuconf_community.h"
 
 #endif /* MCUCONF_H */
+
+// clang-format on

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/mcuconf.h
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/mcuconf.h
@@ -7,6 +7,8 @@
 #ifndef MCUCONF_H
 #define MCUCONF_H
 
+// clang-format off
+
 /*
  * STM32F7xx drivers configuration.
  * The following settings override the default settings present in
@@ -22,11 +24,15 @@
  */
 
 #define STM32F7xx_MCUCONF
-//#define STM32F765_MCUCONF
-//#define STM32F767_MCUCONF
-//#define STM32F777_MCUCONF
 #define STM32F769_MCUCONF
-//#define STM32F779_MCUCONF
+
+/*
+ * Memory attributes settings.
+ */
+#define STM32_NOCACHE_ENABLE                FALSE
+// #define STM32_NOCACHE_MPU_REGION            MPU_REGION_6
+// #define STM32_NOCACHE_RBAR                  0x2004C000U
+// #define STM32_NOCACHE_RASR                  MPU_RASR_SIZE_16K
 
 /*
  * HAL driver system settings.
@@ -46,7 +52,6 @@
 #define STM32_PLLN_VALUE                    432
 #define STM32_PLLP_VALUE                    2
 #define STM32_PLLQ_VALUE                    9
-#define STM32_PLLR_VALUE                    4 //NOT IN LATEST VERSION, KEEPING JUST INCASE
 #define STM32_HPRE                          STM32_HPRE_DIV1
 #define STM32_PPRE1                         STM32_PPRE1_DIV4
 #define STM32_PPRE2                         STM32_PPRE2_DIV2
@@ -255,7 +260,6 @@
 /*
  * PWM driver system settings.
  */
-#define STM32_PWM_USE_ADVANCED              FALSE
 #define STM32_PWM_USE_TIM1                  FALSE
 #define STM32_PWM_USE_TIM2                  FALSE
 #define STM32_PWM_USE_TIM3                  FALSE
@@ -412,9 +416,6 @@
 #define STM32_USB_OTG2_IRQ_PRIORITY         14
 #define STM32_USB_OTG1_RX_FIFO_SIZE         512
 #define STM32_USB_OTG2_RX_FIFO_SIZE         1024
-#define STM32_USB_OTG_THREAD_PRIO           LOWPRIO //NOT IN LATEST VERSION, KEEPING JUST INCASE
-#define STM32_USB_OTG_THREAD_STACK_SIZE     128 //NOT IN LATEST VERSION, KEEPING JUST INCASE
-#define STM32_USB_OTGFIFO_FILL_BASEPRI      0 //NOT IN LATEST VERSION, KEEPING JUST INCASE
 
 /*
  * WDG driver system settings.
@@ -429,3 +430,5 @@
 #define STM32_WSPI_QUADSPI1_PRESCALER_VALUE 2
 
 #endif /* MCUCONF_H */
+
+// clang-format on

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/mcuconf.h
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoBooter/mcuconf.h
@@ -52,6 +52,7 @@
 #define STM32_PLLN_VALUE                    432
 #define STM32_PLLP_VALUE                    2
 #define STM32_PLLQ_VALUE                    9
+#define STM32_PLLR_VALUE                    4 //NOT IN LATEST VERSION, KEEPING JUST INCASE
 #define STM32_HPRE                          STM32_HPRE_DIV1
 #define STM32_PPRE1                         STM32_PPRE1_DIV4
 #define STM32_PPRE2                         STM32_PPRE2_DIV2
@@ -260,6 +261,7 @@
 /*
  * PWM driver system settings.
  */
+#define STM32_PWM_USE_ADVANCED              FALSE //NOT IN LATEST VERSION, KEEPING JUST INCASE
 #define STM32_PWM_USE_TIM1                  FALSE
 #define STM32_PWM_USE_TIM2                  FALSE
 #define STM32_PWM_USE_TIM3                  FALSE
@@ -416,6 +418,9 @@
 #define STM32_USB_OTG2_IRQ_PRIORITY         14
 #define STM32_USB_OTG1_RX_FIFO_SIZE         512
 #define STM32_USB_OTG2_RX_FIFO_SIZE         1024
+#define STM32_USB_OTG_THREAD_PRIO           LOWPRIO //NOT IN LATEST VERSION, KEEPING JUST INCASE
+#define STM32_USB_OTG_THREAD_STACK_SIZE     128 //NOT IN LATEST VERSION, KEEPING JUST INCASE
+#define STM32_USB_OTGFIFO_FILL_BASEPRI      0 //NOT IN LATEST VERSION, KEEPING JUST INCASE
 
 /*
  * WDG driver system settings.

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/mcuconf.h
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/mcuconf.h
@@ -7,6 +7,8 @@
 #ifndef MCUCONF_H
 #define MCUCONF_H
 
+// clang-format off
+
 /*
  * STM32F7xx drivers configuration.
  * The following settings override the default settings present in
@@ -22,11 +24,15 @@
  */
 
 #define STM32F7xx_MCUCONF
-//#define STM32F765_MCUCONF
-//#define STM32F767_MCUCONF
-//#define STM32F777_MCUCONF
 #define STM32F769_MCUCONF
-//#define STM32F779_MCUCONF
+
+/*
+ * Memory attributes settings.
+ */
+#define STM32_NOCACHE_ENABLE                FALSE
+// #define STM32_NOCACHE_MPU_REGION            MPU_REGION_6
+// #define STM32_NOCACHE_RBAR                  0x2004C000U
+// #define STM32_NOCACHE_RASR                  MPU_RASR_SIZE_16K
 
 /*
  * HAL driver system settings.
@@ -433,3 +439,5 @@
 #include "mcuconf_nf.h"
 
 #endif /* MCUCONF_H */
+
+// clang-format on


### PR DESCRIPTION
## Description
* Updates F7 series mcuconfig files
* pre-emptive flags (commented out) for incoming changes.
* Removes clang format from files for easier updating.

## Motivation and Context
ChibiOS have changed the mcuconfig to require `STM32_NOCACHE_ENABLE`

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
