### PR TITLE
Fix out of memory when no characteristics in service

### DIFF
--- a/targets/ESP32/_nanoCLR/nanoFramework.Device.Bluetooth/sys_dev_ble_native_nanoFramework_Device_Bluetooth_GenericAttributeProfile_GattServiceProvider.cpp
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Device.Bluetooth/sys_dev_ble_native_nanoFramework_Device_Bluetooth_GenericAttributeProfile_GattServiceProvider.cpp
@@ -374,13 +374,13 @@ bool ParseAndBuildNimbleDefinition(ble_context &context, CLR_RT_HeapBlock *pGatt
 
     // Allocate tables
     context.descriptorDefs = (ble_gatt_dsc_def *)platform_malloc(sizeof(ble_gatt_dsc_def) * descriptorCount);
-    if (context.descriptorDefs == NULL)
+    if (context.descriptorDefs == NULL && descriptorCount != 0)
     {
         // Out of memory
         return false;
     }
     context.descriptorUuids = (ble_uuid_any_t *)platform_malloc(sizeof(ble_uuid_any_t) * descriptorCount);
-    if (context.descriptorUuids == NULL)
+    if (context.descriptorUuids == NULL && descriptorCount != 0)
     {
         // Out of memory
         return false;


### PR DESCRIPTION
## Description
This stops the native code from reporting an out of memory error if no characteristics in a service.

## Motivation and Context
- Fixes nanoFramework/Home#1250

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Test code without characteristics, start advertising, stop advertising.
Test code bluetooth sample 3

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
