### PR TITLE
Fix open file in read update mode while writing

### DIFF
--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_FileStream.cpp
@@ -334,8 +334,8 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_FileStream::WriteNative___VOID__S
     // Convert to ESP32 VFS path
     vfsPath = ConvertToVfsPath(filePath);
 
-    // open file for write / read
-    file = fopen(vfsPath, "a+");
+    // open file for read / update
+    file = fopen(vfsPath, "r+");
     if (file != NULL)
     {
         // Change to actual position in file to start write


### PR DESCRIPTION
## Description
- While file is open in append mode position is always set at end of file.

## Motivation and Context
- Resolves nanoFramework/Home#1287

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Tested at ESP32

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
