### PR TITLE
Replace implementation of nano printf

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -392,7 +392,7 @@ int Library_corlib_native_System_Number::Format_G(
             "%%%s%s%c",
             (isIntegerDataType) ? "" : nonIntegerPrecStr,
             (isIntegerDataType) ? GetPrintfLengthModifier(dataType) : "",
-            (!isIntegerDataType) ? 'f' : (IsSignedIntegerDataType(dataType)) ? 'd' : 'u');
+            (!isIntegerDataType) ? 'g' : (IsSignedIntegerDataType(dataType)) ? 'd' : 'u');
 
         ret = DoPrintfOnDataType(buffer, formatStr, value);
         if (ret > 0)

--- a/src/CLR/Helpers/nanoprintf/nanoprintf.h
+++ b/src/CLR/Helpers/nanoprintf/nanoprintf.h
@@ -1,15 +1,9 @@
 //
 // Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) 2001, 2002 Georges Menie. All rights reserved.
-// Portions Copyright (c) 2009-2013 Daniel D Miller. All rights reserved.
+// Portions Copyright (c) 2014-2019 Marco Paland (info@paland.com). All rights reserved.
+// Portions Copyright (c) 2021-2022 Eyal Rozenberg <eyalroz1@gmx.com>. All rights reserved.
 // See LICENSE file in the project root for full license information.
 //
-
-/*
-    The interface of nanoprintf begins here, to be compiled only if
-    NANOPRINTF_IMPLEMENTATION is not defined. In a multi-file library what
-    follows would be the public-facing nanoprintf.h.
-*/
 
 #ifndef NANOPRINTF_H
 #define NANOPRINTF_H
@@ -17,229 +11,186 @@
 #include <stdarg.h>
 #include <stddef.h>
 
-/* Define this to fully sandbox nanoprintf inside of a translation unit. */
-#ifdef NANOPRINTF_VISIBILITY_STATIC
-#define NPF_VISIBILITY static
-#else
-#define NPF_VISIBILITY extern
-#endif
-
-/* Compilers can warn when printf formatting strings are incorrect. */
-#if defined(__clang__)
-#define NPF_PRINTF_ATTR(FORMAT_INDEX, VARGS_INDEX) __attribute__((__format__(__printf__, FORMAT_INDEX, VARGS_INDEX)))
-#elif defined(__GNUC__) || defined(__GNUG__)
-#define NPF_PRINTF_ATTR(FORMAT_INDEX, VARGS_INDEX) __attribute__((format(printf, FORMAT_INDEX, VARGS_INDEX)))
-#else
-#define NPF_PRINTF_ATTR(FORMAT_INDEX, VARGS_INDEX)
-#endif
+#define PRINTF_SUPPORT_DECIMAL_SPECIFIERS            1
+#define PRINTF_SUPPORT_EXPONENTIAL_SPECIFIERS        1
+#define PRINTF_SUPPORT_WRITEBACK_SPECIFIER           1
+#define PRINTF_SUPPORT_MSVC_STYLE_INTEGER_SPECIFIERS 0
+#define PRINTF_SUPPORT_LONG_LONG                     1
+#define PRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL       15
+#define PRINTF_CHECK_FOR_NUL_IN_FORMAT_SPECIFIER     0
+#define PRINTF_ALIAS_STANDARD_FUNCTION_NAMES         1
+#define PRINTF_ALIAS_STANDARD_FUNCTION_NAMES_SOFT    1
+#define PRINTF_ALIAS_STANDARD_FUNCTION_NAMES_HARD    0
 
 #ifdef __cplusplus
+#include <cstdarg>
+#include <cstddef>
 extern "C"
 {
-#endif
-
-    /* Public API */
-
-    NPF_VISIBILITY int npf_snprintf(char *buffer, size_t bufsz, const char *format, ...) NPF_PRINTF_ATTR(3, 4);
-
-    NPF_VISIBILITY int npf_vsnprintf(char *buffer, size_t bufsz, char const *format, va_list vlist)
-        NPF_PRINTF_ATTR(3, 0);
-
-    typedef void (*npf_putc)(int c, void *ctx);
-    NPF_VISIBILITY int npf_pprintf(npf_putc pc, void *pc_ctx, char const *format, ...) NPF_PRINTF_ATTR(3, 4);
-
-    NPF_VISIBILITY int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list vlist) NPF_PRINTF_ATTR(3, 0);
-
-/* Public Configuration */
-
-/* Pick reasonable defaults if nothing's been configured. */
-#if !defined(NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS) && !defined(NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS) &&  \
-    !defined(NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS) && !defined(NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS) &&            \
-    !defined(NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS)
-#define NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS 1
-#define NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS   1
-#define NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS       1
-#define NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS       1
-#define NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS   0
-#endif
-
-/* If anything's been configured, everything must be configured. */
-#ifndef NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS
-#error NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS must be #defined to 0 or 1
-#endif
-
-#ifndef NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS
-#error NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS must be #defined to 0 or 1
-#endif
-
-#ifndef NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS
-#error NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS must be #defined to 0 or 1
-#endif
-
-#ifndef NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS
-#error NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS must be #defined to 0 or 1
-#endif
-
-#ifndef NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS
-#error NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS must be #defined to 0 or 1
-#endif
-
-/* Ensure flags are compatible. */
-#if (NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1) && (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 0)
-#error Precision format specifiers must be enabled if float support is enabled.
-#endif
-
-/* intmax_t / uintmax_t require stdint from c99 / c++11 */
-#ifndef _MSC_VER
-#ifdef __cplusplus
-#if __cplusplus < 201103L
-#error nanoprintf requires C++11 or later.
-#endif
 #else
-#if __STDC_VERSION__ < 199409L
-#error nanoprintf requires C99 or later.
-#endif
-#endif
+#include <stdarg.h>
+#include <stddef.h>
 #endif
 
-    /* Implementation Details (prototype / config helper functions) */
-
-#include <inttypes.h>
-#include <stdint.h>
-
-#if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
-    typedef enum
-    {
-        NPF_FMT_SPEC_FIELD_WIDTH_NONE,
-        NPF_FMT_SPEC_FIELD_WIDTH_STAR,
-        NPF_FMT_SPEC_FIELD_WIDTH_LITERAL
-    } npf__format_spec_field_width_t;
-#endif
-
-#if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
-    typedef enum
-    {
-        NPF_FMT_SPEC_PRECISION_NONE,
-        NPF_FMT_SPEC_PRECISION_STAR,
-        NPF_FMT_SPEC_PRECISION_LITERAL
-    } npf__format_spec_precision_t;
-#endif
-
-    typedef enum
-    {
-        NPF_FMT_SPEC_LEN_MOD_NONE,
-        NPF_FMT_SPEC_LEN_MOD_SHORT,       /* 'h' */
-        NPF_FMT_SPEC_LEN_MOD_LONG,        /* 'l' */
-        NPF_FMT_SPEC_LEN_MOD_LONG_DOUBLE, /* 'L' */
-        NPF_FMT_SPEC_LEN_MOD_CHAR         /* 'hh' */
-#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
-        ,
-        NPF_FMT_SPEC_LEN_MOD_LARGE_LONG_LONG, /* 'll' */
-        NPF_FMT_SPEC_LEN_MOD_LARGE_INTMAX,    /* 'j' */
-        NPF_FMT_SPEC_LEN_MOD_LARGE_SIZET,     /* 'z' */
-        NPF_FMT_SPEC_LEN_MOD_LARGE_PTRDIFFT   /* 't' */
-#endif
-    } npf__format_spec_length_modifier_t;
-
-    typedef enum
-    {
-        NPF_FMT_SPEC_CONV_PERCENT,      /* '%' */
-        NPF_FMT_SPEC_CONV_CHAR,         /* 'c' */
-        NPF_FMT_SPEC_CONV_STRING,       /* 's' */
-        NPF_FMT_SPEC_CONV_SIGNED_INT,   /* 'i', 'd' */
-        NPF_FMT_SPEC_CONV_OCTAL,        /* 'o' */
-        NPF_FMT_SPEC_CONV_HEX_INT,      /* 'x', 'X' */
-        NPF_FMT_SPEC_CONV_UNSIGNED_INT, /* 'u' */
-        NPF_FMT_SPEC_CONV_POINTER       /* 'p' */
-#if NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS == 1
-        ,
-        NPF_FMT_SPEC_CONV_WRITEBACK /* 'n' */
-#endif
-#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
-        ,
-        NPF_FMT_SPEC_CONV_FLOAT_DECIMAL /* 'f', 'F' */
-#endif
-    } npf__format_spec_conversion_t;
-
-    typedef enum
-    {
-        NPF_FMT_SPEC_CONV_CASE_LOWER,
-        NPF_FMT_SPEC_CONV_CASE_UPPER
-    } npf__format_spec_conversion_case_t;
-
-    typedef struct
-    {
-        /* optional flags */
-        char prepend_sign;     /* '+' */
-        char prepend_space;    /* ' ' */
-        char alternative_form; /* '#' */
-
-#if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
-        /* field width */
-        npf__format_spec_field_width_t field_width_type;
-        int field_width;
-        char left_justified;   /* '-' */
-        char leading_zero_pad; /* '0' */
-#endif
-
-#if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
-        /* precision */
-        npf__format_spec_precision_t precision_type;
-        int precision;
-#endif
-
-        /* length modifier for specifying argument size */
-        npf__format_spec_length_modifier_t length_modifier;
-
-        /* conversion specifiers */
-        npf__format_spec_conversion_t conv_spec;
-        npf__format_spec_conversion_case_t conv_spec_case;
-    } npf__format_spec_t;
-
-#if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 0
-    typedef long npf__int_t;
-    typedef unsigned long npf__uint_t;
+#ifdef __GNUC__
+#if ((__GNUC__ == 4 && __GNUC_MINOR__ >= 4) || __GNUC__ > 4)
+#define ATTR_PRINTF(one_based_format_index, first_arg)                                                                 \
+    __attribute__((format(gnu_printf, (one_based_format_index), (first_arg))))
 #else
-typedef intmax_t npf__int_t;
-typedef uintmax_t npf__uint_t;
+#define ATTR_PRINTF(one_based_format_index, first_arg)                                                                 \
+    __attribute__((format(printf, (one_based_format_index), (first_arg))))
+#endif
+#define ATTR_VPRINTF(one_based_format_index) ATTR_PRINTF((one_based_format_index), 0)
+#else
+#define ATTR_PRINTF(one_based_format_index, first_arg)
+#define ATTR_VPRINTF(one_based_format_index)
 #endif
 
-    NPF_VISIBILITY int npf__parse_format_spec(char const *format, npf__format_spec_t *out_spec);
-
-    typedef struct
-    {
-        char *dst;
-        size_t len;
-        size_t cur;
-    } npf__bufputc_ctx_t;
-
-    NPF_VISIBILITY void npf__bufputc(int c, void *ctx);
-    NPF_VISIBILITY void npf__bufputc_nop(int c, void *ctx);
-    NPF_VISIBILITY int npf__itoa_rev(char *buf, npf__int_t i);
-    NPF_VISIBILITY int npf__utoa_rev(char *buf, npf__uint_t i, unsigned base, npf__format_spec_conversion_case_t cc);
-#if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
-    NPF_VISIBILITY int npf__dsplit_abs(
-        double d,
-        uint64_t *out_int_part,
-        uint64_t *out_frac_part,
-        int *out_frac_base10_neg_e);
-    NPF_VISIBILITY int npf__dtoa_rev(
-        char *buf,
-        double d,
-        unsigned base,
-        npf__format_spec_conversion_case_t cc,
-        int *out_frac_chars);
+#ifndef PRINTF_ALIAS_STANDARD_FUNCTION_NAMES
+#define PRINTF_ALIAS_STANDARD_FUNCTION_NAMES 0
 #endif
+
+#if PRINTF_ALIAS_STANDARD_FUNCTION_NAMES_HARD
+#define printf_    printf
+#define sprintf_   sprintf
+#define vsprintf_  vsprintf
+#define snprintf_  snprintf
+#define vsnprintf_ vsnprintf
+#define vprintf_   vprintf
+#endif
+
+// If you want to include this implementation file directly rather than
+// link against, this will let you control the functions' visibility,
+// e.g. make them static so as not to clash with other objects also
+// using them.
+#ifndef PRINTF_VISIBILITY
+#define PRINTF_VISIBILITY
+#endif
+
+    /**
+     * Prints/send a single character to some opaque output entity
+     *
+     * @note This function is not implemented by the library, only declared; you must provide an
+     * implementation if you wish to use the @ref printf / @ref vprintf function (and possibly
+     * for linking against the library, if your toolchain does not support discarding unused functions)
+     *
+     * @note The output could be as simple as a wrapper for the `write()` system call on a Unix-like
+     * system, or even libc's @ref putchar , for replicating actual functionality of libc's @ref printf
+     * function; but on an embedded system it may involve interaction with a special output device,
+     * like a UART, etc.
+     *
+     * @note in libc's @ref putchar, the parameter type is an int; this was intended to support the
+     * representation of either a proper character or EOF in a variable - but this is really not
+     * meaningful to pass into @ref putchar and is discouraged today. See further discussion in:
+     * @link https://stackoverflow.com/q/17452847/1593077
+     *
+     * @param c the single character to print
+     */
+    PRINTF_VISIBILITY
+    void putchar_(char c);
+
+    /**
+     * An implementation of the C standard's printf/vprintf
+     *
+     * @note you must implement a @ref putchar_ function for using this function - it invokes @ref putchar_
+     * rather than directly performing any I/O (which insulates it from any dependence on the operating system
+     * and external libraries).
+     *
+     * @param format A string specifying the format of the output, with %-marked specifiers of how to interpret
+     * additional arguments.
+     * @param arg Additional arguments to the function, one for each %-specifier in @p format string
+     * @return The number of characters written into @p s, not counting the terminating null character
+     */
+    ///@{
+    PRINTF_VISIBILITY
+    int printf_(const char *format, ...) ATTR_PRINTF(1, 2);
+    PRINTF_VISIBILITY
+    int vprintf_(const char *format, va_list arg) ATTR_VPRINTF(1);
+    ///@}
+
+    /**
+     * An implementation of the C standard's sprintf/vsprintf
+     *
+     * @note For security considerations (the potential for exceeding the buffer bounds), please consider using
+     * the size-constrained variant, @ref snprintf / @ref vsnprintf , instead.
+     *
+     * @param s An array in which to store the formatted string. It must be large enough to fit the formatted
+     * output!
+     * @param format A string specifying the format of the output, with %-marked specifiers of how to interpret
+     * additional arguments.
+     * @param arg Additional arguments to the function, one for each specifier in @p format
+     * @return The number of characters written into @p s, not counting the terminating null character
+     */
+    ///@{
+    PRINTF_VISIBILITY
+    int sprintf_(char *s, const char *format, ...) ATTR_PRINTF(2, 3);
+    PRINTF_VISIBILITY
+    int vsprintf_(char *s, const char *format, va_list arg) ATTR_VPRINTF(2);
+    ///@}
+
+    /**
+     * An implementation of the C standard's snprintf/vsnprintf
+     *
+     * @param s An array in which to store the formatted string. It must be large enough to fit either the
+     * entire formatted output, or at least @p n characters. Alternatively, it can be NULL, in which case
+     * nothing will be printed, and only the number of characters which _could_ have been printed is
+     * tallied and returned.
+     * @param n The maximum number of characters to write to the array, including a terminating null character
+     * @param format A string specifying the format of the output, with %-marked specifiers of how to interpret
+     * additional arguments.
+     * @param arg Additional arguments to the function, one for each specifier in @p format
+     * @return The number of characters that COULD have been written into @p s, not counting the terminating
+     *         null character. A value equal or larger than @p n indicates truncation. Only when the returned value
+     *         is non-negative and less than @p n, the null-terminated string has been fully and successfully printed.
+     */
+    ///@{
+    PRINTF_VISIBILITY
+    int snprintf_(char *s, size_t count, const char *format, ...) ATTR_PRINTF(3, 4);
+    PRINTF_VISIBILITY
+    int vsnprintf_(char *s, size_t count, const char *format, va_list arg) ATTR_VPRINTF(3);
+    ///@}
+
+    /**
+     * printf/vprintf with user-specified output function
+     *
+     * An alternative to @ref printf_, in which the output function is specified dynamically
+     * (rather than @ref putchar_ being used)
+     *
+     * @param out An output function which takes one character and a type-erased additional parameters
+     * @param extra_arg The type-erased argument to pass to the output function @p out with each call
+     * @param format A string specifying the format of the output, with %-marked specifiers of how to interpret
+     * additional arguments.
+     * @param arg Additional arguments to the function, one for each specifier in @p format
+     * @return The number of characters for which the output f unction was invoked, not counting the terminating null
+     * character
+     *
+     */
+    PRINTF_VISIBILITY
+    int fctprintf(void (*out)(char c, void *extra_arg), void *extra_arg, const char *format, ...) ATTR_PRINTF(3, 4);
+    PRINTF_VISIBILITY
+    int vfctprintf(void (*out)(char c, void *extra_arg), void *extra_arg, const char *format, va_list arg)
+        ATTR_VPRINTF(3);
 
 #ifdef __cplusplus
-}
+} // extern "C"
 #endif
 
-// do not define sprintf, it is not safe
-//#define sprintf snprintf(buff, ARRAYSIZE(buff), fmt, ##__VA_ARGS__)
-
-// the defines below allow using the regular calls to *snprintf
-#define snprintf  npf_snprintf
-#define vsnprintf npf_vsnprintf
+#if PRINTF_ALIAS_STANDARD_FUNCTION_NAMES_HARD
+#undef printf_
+#undef sprintf_
+#undef vsprintf_
+#undef snprintf_
+#undef vsnprintf_
+#undef vprintf_
+#else
+#if PRINTF_ALIAS_STANDARD_FUNCTION_NAMES_SOFT
+#define printf    printf_
+#define sprintf   sprintf_
+#define vsprintf  vsprintf_
+#define snprintf  snprintf_
+#define vsnprintf vsnprintf_
+#define vprintf   vprintf_
+#endif
+#endif
 
 #endif // NANOPRINTF_H


### PR DESCRIPTION
## Description
- Replace implementation of nano printf with [eyalroz/printf](https://github.com/eyalroz/printf).
- Default format specifier for general is now "g" to allow scientific or decimal floating point formats.

## Motivation and Context
- The current implemention is buggy in several aspects and doesn't support other format specifiers that are in demand like engineering (E).
- Addresses nanoframework/Home#1282.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running mscorlib unit tests.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
