### PR TITLE
More fixes in Number.Format

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -939,7 +939,7 @@ HRESULT Library_corlib_native_System_Number::
 
     if (!GetFormatSpec(format, isInteger, &formatChar, &precision))
     {
-        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        ret = format;
     }
     else
     {

--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -106,10 +106,10 @@ int Library_corlib_native_System_Number::DoPrintfOnDataType(char *buffer, char *
             ret = snprintf(buffer, FORMAT_RESULT_BUFFER_SIZE, formatStr, value->NumericByRef().u4);
             break;
         case DATATYPE_I8:
-            ret = snprintf(buffer, FORMAT_RESULT_BUFFER_SIZE, formatStr, (CLR_INT64_TEMP_CAST)value->NumericByRef().s8);
+            ret = snprintf(buffer, FORMAT_RESULT_BUFFER_SIZE, formatStr, value->NumericByRef().s8);
             break;
         case DATATYPE_U8:
-            ret = snprintf(buffer, FORMAT_RESULT_BUFFER_SIZE, formatStr, (CLR_INT64_TEMP_CAST)value->NumericByRef().s8);
+            ret = snprintf(buffer, FORMAT_RESULT_BUFFER_SIZE, formatStr, value->NumericByRef().u8);
             break;
         case DATATYPE_R4:
             ret = snprintf(buffer, FORMAT_RESULT_BUFFER_SIZE, formatStr, value->NumericByRef().r4);

--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -612,8 +612,37 @@ int Library_corlib_native_System_Number::Format_X(char *buffer, CLR_RT_HeapBlock
 {
     int ret = -1;
 
+    CLR_DataType dataType = value->DataType();
+    
+    // set max width for the conversion
+    int maxWidth = 0;
+    switch (dataType)
+    {
+        case DATATYPE_I1:
+        case DATATYPE_U1:
+            maxWidth = 2;
+            break;
+        case DATATYPE_I2:
+        case DATATYPE_U2:
+            maxWidth = 4;
+            break;
+        case DATATYPE_I4:
+        case DATATYPE_U4:
+            maxWidth = 8;
+            break;
+        case DATATYPE_I8:
+        case DATATYPE_U8:
+            maxWidth = 16;
+            break;
+        default:
+            break;
+    }
+
+    int requestedPrecision = precision;
+
     if (precision == -1)
     {
+        // no precision specified
         precision = 0;
     }
 

--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -472,12 +472,15 @@ int Library_corlib_native_System_Number::Format_G(
                                     buffer[ret] = 0;
                                 }
 
-                                if (!isIntegerDataType && buffer[ret - 1] == '0')
+                                // drop last digit in case it's a rounding digit
+                                // conditions are:
+                                // - not an integer type
+                                // - number of digits is at least 2
+                                // - number of digits is greater than the default precision (otherwise we could be mistaking a valid last fraction digit for a rounding digit)
+                                if (!isIntegerDataType && numDigits >= 2 && numDigits >= defaultPrecision &&
+                                    buffer[strlen(buffer) - 2] == '0')
                                 {
-                                    // drop last digit in case it's a rounding digit
-                                    memmove(&buffer[ret], &buffer[ret + 1], savedResultLength - ret);
-
-                                    buffer[ret] = 0;
+                                    buffer[ret - 1] = 0;
                                     ret--;
 
                                     break;
@@ -521,7 +524,7 @@ int Library_corlib_native_System_Number::Format_G(
                     }
                 }
 
-                if ((dotIndex == -1) || (dotIndex > (requestedPrecision + offsetBecauseOfNegativeSign)))
+                if ((dotIndex == -1) || exponent != 0 || (dotIndex > (precision + offsetBecauseOfNegativeSign)))
                 {
                     // insert '.', only if request precision requires it
                     // this is: requestedPrecision is specified and is more than 1 (taking into account the sign)

--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -642,8 +642,6 @@ int Library_corlib_native_System_Number::Format_X(char *buffer, CLR_RT_HeapBlock
             break;
     }
 
-    int requestedPrecision = precision;
-
     if (precision == -1)
     {
         // no precision specified

--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -479,7 +479,7 @@ int Library_corlib_native_System_Number::Format_G(
                                 // - number of digits is greater than the default precision (otherwise we could be
                                 // mistaking a valid last fraction digit for a rounding digit)
                                 if (!isIntegerDataType && numDigits >= 2 && numDigits >= defaultPrecision &&
-                                    buffer[strlen(buffer) - 2] == '0')
+                                    buffer[ret - 2] == '0')
                                 {
                                     buffer[ret - 1] = 0;
                                     ret--;

--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -628,6 +628,15 @@ int Library_corlib_native_System_Number::Format_X(char *buffer, CLR_RT_HeapBlock
 
     ret = DoPrintfOnDataType(buffer, formatStr, value);
 
+    if (ret > maxWidth)
+    {
+		// we have more digits than the max width, so we need to strip the leading ones
+		memmove(&buffer[0], &buffer[ret - maxWidth], maxWidth);
+
+		buffer[maxWidth] = 0;
+		ret = maxWidth;
+	}
+
     return ret;
 }
 


### PR DESCRIPTION
## Description
- Add processing for correct length in format specifier X.
- Miscelaneous fixes in format specifier X.
- Several fixes in format specifier G: exponent, double rounding processing.
- Fix output for invalid format specifier: it's meant to return the format string on error, not throwing an exception.
- Fix wrong cast on DoPrintfOnDataType.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- mscrolib unit tests.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
