### PR TITLE
Fix processing Wire Protocol header reception

### DIFF
--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -279,7 +279,7 @@ void WP_Message_Process()
                         break;
                     }
 
-                    size_t lenCmp = min(len, sizeof(_inboundMessage.m_header.m_signature));
+                    size_t lenCmp = min(len, sizeof(((WP_Packet *)0)->m_signature));
 
                     if (memcmp(&_inboundMessage.m_header, MARKER_DEBUGGER_V1, lenCmp) == 0)
                     {
@@ -290,11 +290,8 @@ void WP_Message_Process()
                         break;
                     }
 
-                    // move buffer 1 position down
-                    memmove(
-                        (uint8_t *)&(_inboundMessage.m_header),
-                        ((uint8_t *)&(_inboundMessage.m_header) + 1),
-                        len - 1);
+                    // move buffer one position to the left
+                    memmove((uint8_t *)&(_inboundMessage.m_header), ((uint8_t *)&(_inboundMessage.m_header) + 1), len);
 
                     _pos--;
                     _size++;


### PR DESCRIPTION
## Description
- Call to memmove and marker comparison where wrong and was causing issues.

## Motivation and Context
- Depending on length of data received this could access wrong memory location and cause an hard fault.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
