### PR TITLE
Add CPU_SPI_Initialize_Extended

### DIFF
--- a/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.Spi/sys_dev_spi_native_target.h
+++ b/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.Spi/sys_dev_spi_native_target.h
@@ -63,6 +63,12 @@
 #define GECKO_USE_SPI5 FALSE
 #endif
 
+// adjust number of buses
+#if defined(NUM_SPI_BUSES)
+#undef NUM_SPI_BUSES
+#endif
+#define NUM_SPI_BUSES 6
+
 // struct representing the SPI bus
 struct NF_PAL_SPI
 {
@@ -84,6 +90,7 @@ struct NF_PAL_SPI
     int32_t ChipSelect;
 
     NF_SpiDriver_Handle_t Handle;
+    NF_SpiDriver_Init_t *InitSpiData;
 };
 
 ////////////////////////////////////////////


### PR DESCRIPTION
## Description
- Add new call to CPU SPI to allow reconfiguration of SPI bus "on the fly".
- Add InitSpiData to NF_PAL_SPI struct.
- Rework CPU_SPI_Initialize to use the new function.

## Motivation and Context
- Allow reconfiguration of SPI bug on-the-fly (required by Skyworks SPI library).
- No conflicting with the official standard SPI as it is using the same code and call as it was.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
