### PR TITLE
Add option to boot to nanoBooter on CLR fault

### DIFF
--- a/src/CLR/Include/nanoCLR_Application.h
+++ b/src/CLR/Include/nanoCLR_Application.h
@@ -24,6 +24,11 @@ typedef struct CLR_SETTINGS
     // when building is set for RTM this configuration is ignored
     bool EnterDebuggerLoopAfterExit;
 
+    // Set this to TRUE if the device is to reboot to nanoBoother (or proprietary bootloader) in case the there is a
+    // fault in loading the application.
+    // This option is only available when building is set for RTM
+    bool RevertToBooterOnFault;
+
 #if defined(VIRTUAL_DEVICE)
     CLR_RT_StringVector StartArgs;
 #endif

--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -426,7 +426,21 @@ void ClrStartup(CLR_SETTINGS params)
             CLR_EE_DBG_EVENT_BROADCAST(CLR_DBG_Commands_c_Monitor_ProgramExit, 0, NULL, WP_Flags_c_NonCritical);
 #endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
-#if !defined(BUILD_RTM)
+#if defined(BUILD_RTM)
+            if (params.RevertToBooterOnFault)
+            {
+                // launch proprietary bootloader, if available
+                if (!RequestToLaunchProprietaryBootloader())
+                {
+                    // no proprietary bootloader available, launch nanoBooter
+
+#if (TARGET_HAS_NANOBOOTER == TRUE)
+                    RequestToLaunchNanoBooter();
+                    CPU_Reset();
+#endif // TARGET_HAS_NANOBOOTER
+                }
+            }
+#else
             if (params.EnterDebuggerLoopAfterExit)
             {
                 CLR_DBG_Debugger::Debugger_WaitForCommands();


### PR DESCRIPTION
## Description
- Add new member to CLR settings struct: `RevertToBooterOnFault`.
- Update code in ClrStartup to boot to proprietaty bootloader or nanoBooter on new CLR setting.

## Motivation and Context
- Makes possible for RTM build to actually upload/flash CLR and/or deployment. Without this an RTM build would be booting constantly making the device totally unresponsive.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- RTM build on several targets.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
