### PR TITLE
Improvements in USB Stream

### DIFF
--- a/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.UsbStream/sys_dev_usbstream_native_System_Device_Usb_UsbStream.cpp
+++ b/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.UsbStream/sys_dev_usbstream_native_System_Device_Usb_UsbStream.cpp
@@ -336,18 +336,14 @@ HRESULT Library_sys_dev_usbstream_native_System_Device_Usb_UsbStream::get_IsConn
 {
     NANOCLR_HEADER();
 
-    bool conn;
+    // default to false
+    bool conn = false;
 
-    if (sl_usbd_vendor_is_enabled(sl_usbd_vendor_winusb_number, &conn) == SL_STATUS_OK)
-    {
-        stack.SetResult_Boolean(conn);
-    }
-    else
-    {
-        NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
-    }
+    // don't care about return value as we'll just return false if the connection state can't be determined
+    sl_usbd_vendor_is_enabled(sl_usbd_vendor_winusb_number, &conn);
+    stack.SetResult_Boolean(conn);
 
-    NANOCLR_NOCLEANUP();
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 HRESULT Library_sys_dev_usbstream_native_System_Device_Usb_UsbStream::NativeClose___VOID(CLR_RT_StackFrame &stack)

--- a/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.UsbStream/sys_dev_usbstream_native_target.h
+++ b/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.UsbStream/sys_dev_usbstream_native_target.h
@@ -18,6 +18,9 @@ typedef struct
 
     uint16_t TxBytesSent;
 
+    bool WaitingForRxEvent;
+    bool WaitingForTxEvent;
+
 } NF_PAL_USB;
 
 extern NF_PAL_USB UsbStream_PAL;


### PR DESCRIPTION
## Description
- Improve execution of USB stream R/W operations with timeouts.
- USB async complete handlers now do not fire internal events if the operation was aborted.
- Add missing reset for TX count when starting a write operation.
- Improve handling of IsConnected property: doesn't throw anymore when USB system is not ready.
- Add tx and rx events to PAL struct.
- Rework USB event handlers to fire managed event processing only if the event was expected.
- Rx and Tx events are cleared in event handlers and set beforehand in preparation for execution.

## Motivation and Context
- Fixes nasty issues with buffer access overwriting memory and other heap allocation messup causing severe issues with GC.


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
