### PR TITLE
Fix Messaging creation and destruction

### DIFF
--- a/src/CLR/Messaging/Messaging.cpp
+++ b/src/CLR/Messaging/Messaging.cpp
@@ -9,8 +9,6 @@
 #include <WireProtocol.h>
 #include <WireProtocol_Message.h>
 
-extern CLR_Messaging *g_CLR_Messaging;
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //--//
@@ -30,8 +28,6 @@ static const CLR_Messaging_CommandHandlerLookup c_Messaging_Lookup_Reply[] = {
 //--//
 
 CLR_Messaging *g_CLR_Messaging;
-
-CLR_UINT32 g_scratchMessaging[sizeof(CLR_Messaging)];
 
 bool CLR_Messaging::AllocateAndQueueMessage(
     CLR_UINT32 cmd,
@@ -258,11 +254,18 @@ HRESULT CLR_Messaging::CreateInstance()
     NATIVE_PROFILE_CLR_MESSAGING();
     NANOCLR_HEADER();
 
-    NANOCLR_CLEAR(g_CLR_Messaging);
+    // alloc memory for Messaging
+    g_CLR_Messaging = (CLR_Messaging *)platform_malloc(sizeof(CLR_Messaging));
+
+    // sanity check...
+    FAULT_ON_NULL(g_CLR_Messaging);
+
+    //... and clear memory
+    memset(g_CLR_Messaging, 0, sizeof(CLR_Messaging));
 
     g_CLR_Messaging->Initialize(NULL, 0, NULL, 0);
 
-    NANOCLR_NOCLEANUP_NOLABEL();
+    NANOCLR_NOCLEANUP();
 }
 
 //--//
@@ -301,6 +304,11 @@ HRESULT CLR_Messaging::DeleteInstance()
     NANOCLR_HEADER();
 
     g_CLR_Messaging->Cleanup();
+
+    // free messaging
+    platform_free(g_CLR_Messaging);
+
+    g_CLR_Messaging = NULL;
 
     NANOCLR_NOCLEANUP_NOLABEL();
 }


### PR DESCRIPTION
## Description
- Replace static allocation with one from heap.
- Rework init and destroy accordingly.

## Motivation and Context
- Fixes nanoFramework/Home#1307.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
