### PR TITLE
Fix memory check

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -678,6 +678,7 @@ void CLR_DBG_Debugger::AccessMemory(
 
     //--//
     unsigned int iRegion, iRange;
+    uint32_t crc32 = 0;
 
     if (BlockStorageDevice_FindRegionFromAddress(m_deploymentStorageDevice, location, &iRegion, &iRange))
     {
@@ -747,8 +748,8 @@ void CLR_DBG_Debugger::AccessMemory(
                             if (mode == AccessMemory_Check)
                             {
                                 // compute CRC32 of the memory segment
-                                *(CLR_DBG_Commands_Monitor_CheckMemory_Reply *)buf =
-                                    SUPPORT_ComputeCRC((const void *)accessAddress, NumOfBytes, 0);
+                                crc32 = SUPPORT_ComputeCRC((const void *)accessAddress, NumOfBytes, crc32);
+                                *(CLR_DBG_Commands_Monitor_CheckMemory_Reply *)buf = crc32;
                             }
                             else
                             {
@@ -815,8 +816,8 @@ void CLR_DBG_Debugger::AccessMemory(
                             }
 
                             // compute CRC32 of the memory segment
-                            *(CLR_DBG_Commands_Monitor_CheckMemory_Reply *)buf =
-                                SUPPORT_ComputeCRC(bufPtr, NumOfBytes, 0);
+                            crc32 = SUPPORT_ComputeCRC((const void *)bufPtr, NumOfBytes, crc32);
+                            *(CLR_DBG_Commands_Monitor_CheckMemory_Reply *)buf = crc32;
 
                             // free buffer if allocated
                             if (!isMemoryMapped)


### PR DESCRIPTION
## Description
- CRC32 computation now accumulates.

## Motivation and Context
- The current implementation was working only for single iterations, e.g. checking a memory segment inside a block storage. If there where multiple iterations to cover more storage blocks it would fail because the initial CRC32 value passed was always zero.
- Addresses Skyworks-Timing-Software/MCU#68.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Deploying an application with nanoff.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
