### PR TITLE
Fix Debugging_Value struct

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1772,7 +1772,7 @@ static bool FillValues(
 
     memset(dst, 0, sizeof(*dst));
 
-    dst->m_referenceID = (reference != NULL) ? reference : ptr;
+    dst->m_referenceID = (CLR_UINT32)((reference != NULL) ? reference : ptr);
     dst->m_dt = ptr->DataType();
     dst->m_flags = ptr->DataFlags();
     dst->m_size = ptr->DataSize();
@@ -1818,7 +1818,7 @@ static bool FillValues(
 
             if (text != NULL)
             {
-                dst->m_charsInString = text;
+                dst->m_charsInString = (CLR_UINT32)text;
                 dst->m_bytesInString = (CLR_UINT32)hal_strlen_s(text);
 
                 hal_strncpy_s(
@@ -1829,7 +1829,8 @@ static bool FillValues(
             }
             else
             {
-                dst->m_charsInString = NULL;
+                // equivalent to a null string
+                dst->m_charsInString = 0;
                 dst->m_bytesInString = 0;
                 dst->m_builtinValue[0] = 0;
             }
@@ -1861,7 +1862,7 @@ static bool FillValues(
             break;
 
         case DATATYPE_ARRAY_BYREF:
-            dst->m_arrayref_referenceID = ptr->Array();
+            dst->m_arrayref_referenceID = (CLR_UINT32)ptr->Array();
             dst->m_arrayref_index = ptr->ArrayIndex();
 
             break;

--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -550,7 +550,9 @@ struct CLR_DBG_Commands
 
     struct Debugging_Value
     {
-        CLR_RT_HeapBlock *      m_referenceID;
+        // this is a CLR_RT_HeapBlock *
+        // has to be stored as CLR_UINT32 because CLR_RT_HeapBlock has different size on 32 and 64 bit platforms
+        CLR_UINT32              m_referenceID;
         CLR_UINT32              m_dt;                // CLR_RT_HeapBlock::DataType ()
         CLR_UINT32              m_flags;             // CLR_RT_HeapBlock::DataFlags()
         CLR_UINT32              m_size;              // CLR_RT_HeapBlock::DataSize ()
@@ -564,7 +566,9 @@ struct CLR_DBG_Commands
         // For DATATYPE_STRING
         //
         CLR_UINT32              m_bytesInString;
-        const char *                 m_charsInString;
+        // this is a const char *
+        // has to be stored as CLR_UINT32 because const char * has different size on 32 and 64 bit platforms
+        CLR_UINT32 		        m_charsInString;
 
         //
         // For DATATYPE_VALUETYPE or DATATYPE_CLASSTYPE
@@ -581,7 +585,10 @@ struct CLR_DBG_Commands
         //
         // For values from an array.
         //
-        CLR_RT_HeapBlock_Array *m_arrayref_referenceID;
+        
+        // this is a CLR_RT_HeapBlock_Array *
+        // has to be stored as CLR_UINT32 because CLR_RT_HeapBlock_Array has different size on 32 and 64 bit platforms
+        CLR_UINT32              m_arrayref_referenceID;
         CLR_UINT32              m_arrayref_index;
     };
 


### PR DESCRIPTION
## Description
- Replace pointers with CLR_UINT32 types.
- Update code accordingly.

## Motivation and Context
- VS extension wasn't able to properly process this because of the different type sizes in 32 and 64 builds. Reverting to pointer storage solves the issue and allows reusing the struct among all platforms.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
