### PR TITLE
Fix PWM for ESP32-C3

### DIFF
--- a/targets/ESP32/_nanoCLR/System.Device.Pwm/sys_dev_pwm_native_System_Device_Pwm_PwmChannel.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.Pwm/sys_dev_pwm_native_System_Device_Pwm_PwmChannel.cpp
@@ -233,7 +233,7 @@ HRESULT Library_sys_dev_pwm_native_System_Device_Pwm_PwmChannel::NativeSetDesire
     // Working from 15 bit duty resolution down until we have a valid divisor
     optimumDutyResolution = 1;
 
-    for (int dutyResolution = 15; dutyResolution > 0; dutyResolution--)
+    for (int dutyResolution = SOC_LEDC_TIMER_BIT_WIDE_NUM - 1; dutyResolution > 0; dutyResolution--)
     {
         precision = (0x1 << dutyResolution); // 2**depth
 


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Fix duty resolution for the C3 series.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Resolves nanoFramework/Home#1298

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested:

* 50Hz on XIAO_ESP32C3
* 40KHz on XIAO_ESP32C3
* 50Hz on ESP32_REV3
* 40KHz on ESP32_REV3

But I **don't** test for ESP32S2 and ESP32S3.

**Code:**

```csharp
using nanoFramework.Hardware.Esp32;
using System.Device.Pwm;
using System.Threading;

Configuration.SetPinFunction(5, DeviceFunction.PWM1); // GPIO5

var pwm = PwmChannel.CreateFromPin(5, 50, 0);
pwm.Start();

while (true)
{
    for (double duty = 0; duty <= 1.0; duty += 0.01)
    {
        pwm.DutyCycle = duty;
        Thread.Sleep(10);
    }
}
```

## Screenshots<!-- (IF APPLICABLE): -->

**50Hz on XIAO_ESP32C3:**
![image](https://github.com/nanoframework/nf-interpreter/assets/8079404/acfaa4d5-690b-4782-85b0-2631e94bda2f)
![image](https://github.com/nanoframework/nf-interpreter/assets/8079404/02f05b7c-4e09-4419-b22c-dd04d1a468ad)

**40KHz on XIAO_ESP32C3:**
![image](https://github.com/nanoframework/nf-interpreter/assets/8079404/ae0a16a0-d6fe-4685-83d2-966121542ade)
![image](https://github.com/nanoframework/nf-interpreter/assets/8079404/0408fd81-1b20-46c4-9c0d-fbf81eec47b1)

**50Hz on ESP32_REV3:**
![image](https://github.com/nanoframework/nf-interpreter/assets/8079404/10f239c5-0451-4583-9ace-7f7852c0d2af)
![image](https://github.com/nanoframework/nf-interpreter/assets/8079404/b81c8bfd-4ebb-4a6f-a686-1ec66e77c42e)

**40KHz on ESP32_REV3:**
![image](https://github.com/nanoframework/nf-interpreter/assets/8079404/b5812120-3a3b-4b0e-9457-2ee20e63eb6f)
![image](https://github.com/nanoframework/nf-interpreter/assets/8079404/37edc228-d7b8-4840-a298-077c39c368e7)

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
