### PR TITLE
Fix Events_SetBoolTimer for Azure RTOS

### DIFF
--- a/targets/AzureRTOS/_common/nanoCLR/targetPAL_Events.cpp
+++ b/targets/AzureRTOS/_common/nanoCLR/targetPAL_Events.cpp
@@ -51,7 +51,7 @@ void Events_SetBoolTimer(bool *timerCompleteFlag, uint32_t millisecondsFromNow)
 
         // need to stop the timer first
         tx_timer_deactivate(&boolEventsTimer);
-        tx_timer_change(&boolEventsTimer, 0, TX_TICKS_PER_MILLISEC(millisecondsFromNow));
+        tx_timer_change(&boolEventsTimer, TX_TICKS_PER_MILLISEC(millisecondsFromNow), 0);
         tx_timer_activate(&boolEventsTimer);
     }
 }


### PR DESCRIPTION
## Description
- Timer change was being called with the wrong parameters.

## Motivation and Context
- Fixes issue with HAL events in Azure RTOS what where preventing thread scheduler to relinquish exection after thread quantum expired.
- Addresses Skyworks-Timing-Software/MCU#83.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
