### PR TITLE
Remove unnecessary compile flags for Gecko SDK

### DIFF
--- a/CMake/Modules/FindGecko_SDK.cmake
+++ b/CMake/Modules/FindGecko_SDK.cmake
@@ -256,15 +256,7 @@ if("${TARGET_SERIES}" STREQUAL "EFM32GG11")
     endforeach()
 
     # unset this warning as error required for this source file
-    SET_SOURCE_FILES_PROPERTIES(${gecko_sdk_SOURCE_DIR}/protocol/usb/src/sl_usbd_core_ep.c PROPERTIES COMPILE_FLAGS -Wno-undef)
-    SET_SOURCE_FILES_PROPERTIES(${gecko_sdk_SOURCE_DIR}/protocol/usb/src/sl_usbd_class_cdc.c PROPERTIES COMPILE_FLAGS -Wno-undef)
-    SET_SOURCE_FILES_PROPERTIES(${gecko_sdk_SOURCE_DIR}/protocol/usb/src/sl_usbd_class_cdc_acm.c PROPERTIES COMPILE_FLAGS -Wno-undef)
-    SET_SOURCE_FILES_PROPERTIES(${gecko_sdk_SOURCE_DIR}/protocol/usb/src/sl_usbd_class_hid.c PROPERTIES COMPILE_FLAGS -Wno-undef)
-    SET_SOURCE_FILES_PROPERTIES(${gecko_sdk_SOURCE_DIR}/protocol/usb/src/sl_usbd_class_hid_report.c PROPERTIES COMPILE_FLAGS -Wno-undef)
-    SET_SOURCE_FILES_PROPERTIES(${CMAKE_SOURCE_DIR}/targets/AzureRTOS/SiliconLabs/_common/nano_sl_usbd_class_vendor.c PROPERTIES COMPILE_FLAGS -Wno-undef)
-    SET_SOURCE_FILES_PROPERTIES(${gecko_sdk_SOURCE_DIR}/protocol/usb/src/sl_usbd_driver_dwc_otg_fs.c PROPERTIES COMPILE_FLAGS -Wno-undef)
-    SET_SOURCE_FILES_PROPERTIES(${CMAKE_SOURCE_DIR}/targets/AzureRTOS/SiliconLabs/_common/sl_usbd_init.c PROPERTIES COMPILE_FLAGS -Wno-undef)
-    set_source_files_properties(${gecko_sdk_SOURCE_DIR}/platform/service/iostream/src/sl_iostream_uart.c PROPERTIES COMPILE_OPTIONS "-Wno-maybe-uninitialized")
+    set_source_files_properties(${gecko_sdk_SOURCE_DIR}/protocol/usb/src/sl_usbd_driver_dwc_otg_fs.c PROPERTIES COMPILE_FLAGS -Wno-undef)
 
     list(REMOVE_DUPLICATES Gecko_SDK_INCLUDE_DIRS)
 

--- a/targets/AzureRTOS/SiliconLabs/_common/nano_sl_usbd_class_vendor.c
+++ b/targets/AzureRTOS/SiliconLabs/_common/nano_sl_usbd_class_vendor.c
@@ -524,7 +524,7 @@ sl_status_t sl_usbd_vendor_add_microsoft_ext_property(uint8_t        class_nbr,
   CORE_ENTER_ATOMIC();
   ext_property_nbr = p_ctrl->microsoft_ext_property_next;
 
-#if (RTOS_ARG_CHK_EXT_EN == 1)
+#if defined(RTOS_ARG_CHK_EXT_EN) && RTOS_ARG_CHK_EXT_EN == 1
   if (ext_property_nbr >= SL_USBD_VENDOR_MS_EXTENDED_PROPERTIES_QUANTITY) {
     CORE_EXIT_ATOMIC();
 


### PR DESCRIPTION
## Description
- Most code has been fixed in Gecko SDK.
- Fix code in nano implementation for sl_usbd_class_vendor.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
