### PR TITLE
Correct directory variables for Azure RTOS build

### DIFF
--- a/targets/AzureRTOS/CMakeLists.txt
+++ b/targets/AzureRTOS/CMakeLists.txt
@@ -100,7 +100,7 @@ else()
 
         FetchContent_Declare(
             azure_rtos
-            SOURCE_DIR $(AZURERTOS_SOURCE_FOLDER)
+            SOURCE_DIR ${AZURERTOS_SOURCE_FOLDER}
         )
 
     else()
@@ -159,7 +159,7 @@ if(AZURERTOS_USBX_REQUIRED)
 
             FetchContent_Declare(
                 azure_rtos_usbx
-                SOURCE_DIR $(USBX_SOURCE_FOLDER)
+                SOURCE_DIR ${USBX_SOURCE_FOLDER}
             )
 
         else()
@@ -220,7 +220,7 @@ if(AZURERTOS_FILEX_REQUIRED)
 
             FetchContent_Declare(
                 azure_rtos_filex
-                SOURCE_DIR $(FILEX_SOURCE_FOLDER)
+                SOURCE_DIR ${FILEX_SOURCE_FOLDER}
             )
 
         else()
@@ -281,7 +281,7 @@ if(AZURERTOS_NETXDUO_REQUIRED)
 
             FetchContent_Declare(
                 azure_rtos_netxduo
-                SOURCE_DIR $(NETXDUO_SOURCE_FOLDER)
+                SOURCE_DIR ${NETXDUO_SOURCE_FOLDER}
             )
 
         else()


### PR DESCRIPTION

## Description
For azureRTOS CMaleLists.txt
Change directory variables from $(variable) to ${variable}
This is only required when building locally and repositories are already downloaded and available


## Motivation and Context


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Builds successfully if fix applied and uses local repositories.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
