### PR TITLE
Removed workaround for I2S in ESP32 S3

### DIFF
--- a/targets/ESP32/_nanoCLR/System.Device.I2s/sys_dev_i2s_native_System_Device_I2s_I2sDevice.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.I2s/sys_dev_i2s_native_System_Device_I2s_I2sDevice.cpp
@@ -319,16 +319,18 @@ HRESULT SetI2sConfig(i2s_port_t bus, CLR_RT_HeapBlock *config)
 #endif
     }
 
-// apply low-level workaround for bug in some ESP-IDF versions that swap
-// the left and right channels
-// https://github.com/espressif/esp-idf/issues/6625
-#if CONFIG_IDF_TARGET_ESP32S3
-    REG_SET_BIT(I2S_TX_CONF_REG(bus), I2S_TX_MSB_SHIFT);
-    REG_SET_BIT(I2S_TX_CONF_REG(bus), I2S_RX_MSB_SHIFT);
-#else
-    REG_SET_BIT(I2S_CONF_REG(bus), I2S_TX_MSB_RIGHT);
-    REG_SET_BIT(I2S_CONF_REG(bus), I2S_RX_MSB_RIGHT);
-#endif
+    // Removed workaround as bug has been fixed as per discussion:
+    //  https://github.com/nanoframework/Home/discussions/1198#discussioncomment-6429663
+    //// apply low-level workaround for bug in some ESP-IDF versions that swap
+    //// the left and right channels
+    //// https://github.com/espressif/esp-idf/issues/6625
+    // #if CONFIG_IDF_TARGET_ESP32S3
+    //     REG_SET_BIT(I2S_TX_CONF_REG(bus), I2S_TX_MSB_SHIFT);
+    //     REG_SET_BIT(I2S_TX_CONF_REG(bus), I2S_RX_MSB_SHIFT);
+    // #else
+    //     REG_SET_BIT(I2S_CONF_REG(bus), I2S_TX_MSB_RIGHT);
+    //     REG_SET_BIT(I2S_CONF_REG(bus), I2S_RX_MSB_RIGHT);
+    // #endif
 
 #if (ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 4)
     pin_config.mck_io_num = I2S_PIN_NO_CHANGE;

--- a/targets/ESP32/_nanoCLR/System.Device.I2s/sys_dev_i2s_native_System_Device_I2s_I2sDevice.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.I2s/sys_dev_i2s_native_System_Device_I2s_I2sDevice.cpp
@@ -319,19 +319,6 @@ HRESULT SetI2sConfig(i2s_port_t bus, CLR_RT_HeapBlock *config)
 #endif
     }
 
-    // Removed workaround as bug has been fixed as per discussion:
-    //  https://github.com/nanoframework/Home/discussions/1198#discussioncomment-6429663
-    //// apply low-level workaround for bug in some ESP-IDF versions that swap
-    //// the left and right channels
-    //// https://github.com/espressif/esp-idf/issues/6625
-    // #if CONFIG_IDF_TARGET_ESP32S3
-    //     REG_SET_BIT(I2S_TX_CONF_REG(bus), I2S_TX_MSB_SHIFT);
-    //     REG_SET_BIT(I2S_TX_CONF_REG(bus), I2S_RX_MSB_SHIFT);
-    // #else
-    //     REG_SET_BIT(I2S_CONF_REG(bus), I2S_TX_MSB_RIGHT);
-    //     REG_SET_BIT(I2S_CONF_REG(bus), I2S_RX_MSB_RIGHT);
-    // #endif
-
 #if (ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 4)
     pin_config.mck_io_num = I2S_PIN_NO_CHANGE;
 #endif


### PR DESCRIPTION
## Description
- Removed workaround to get ESP32 build working for C3.

## Motivation and Context
-   Bug has been fixed as per discussion: https://github.com/nanoframework/Home/discussions/1198#discussioncomment-6429663

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
