### PR TITLE
Rework task creation for ESP32-S3

### DIFF
--- a/targets/ESP32/_IDF/esp32s3/app_main.c
+++ b/targets/ESP32/_IDF/esp32s3/app_main.c
@@ -62,8 +62,8 @@ void app_main()
     ESP_ERROR_CHECK(nvs_flash_init());
 
     // start receiver task
-    xTaskCreate(&receiver_task, "ReceiverThread", 3072, NULL, 5, &ReceiverTask);
+    xTaskCreatePinnedToCore(&receiver_task, "ReceiverThread", 3072, NULL, 5, &ReceiverTask, 0);
 
     // start the CLR main task
-    xTaskCreate(&main_task, "main_task", 15000, NULL, 5, NULL);
+    xTaskCreatePinnedToCore(&main_task, "main_task", 15000, NULL, 5, NULL, 0);
 }


### PR DESCRIPTION
## Description
- Replace task creation with `xTaskCreatePinnedToCore`.

## Motivation and Context
- Despite not having dual core, using `xTaskCreate` was causing the SPIFFs to take about 30 seconds to reformat SPIFFs on every boot. 
- Already reported at IDF, tracking progress here espressif/esp-idf#6792

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Checking boot confirms that SPIFFs init is back to expected (quick) execution.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
