### PR TITLE
Fix debug output for heap allocation

### DIFF
--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -153,9 +153,16 @@ HRESULT CLR_RT_ExecutionEngine::AllocateHeaps()
 #if NANOCLR_VALIDATE_HEAP >= NANOCLR_VALIDATE_HEAP_1_HeapBlocksAndUnlink
 
         CLR_Debug::Printf("Heap Cluster information\r\n");
+
+#if _WIN64
+        CLR_Debug::Printf("Start:       0x%I64X\r\n", (size_t)heapFirstFree);
+        CLR_Debug::Printf("Free:        0x%I64X\r\n", (size_t)heapFree);
+        CLR_Debug::Printf("Block size:  %d\r\n", sizeof(CLR_RT_HeapBlock));
+#else
         CLR_Debug::Printf("Start:       %08x\r\n", (size_t)heapFirstFree);
         CLR_Debug::Printf("Free:        %08x\r\n", (size_t)heapFree);
         CLR_Debug::Printf("Block size:  %d\r\n", sizeof(CLR_RT_HeapBlock));
+#endif
 
 #endif
         ///


### PR DESCRIPTION
## Description
- Add compiler define to handle different output for 64bits build.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
