### PR TITLE
Fix GC recursive crawling of arrays with referenced objects

### DIFF
--- a/src/CLR/Core/GarbageCollector_ComputeReachabilityGraph.cpp
+++ b/src/CLR/Core/GarbageCollector_ComputeReachabilityGraph.cpp
@@ -239,15 +239,9 @@ bool CLR_RT_GarbageCollector::ComputeReachabilityGraphForMultipleBlocks(CLR_RT_H
 
                             if (array->m_fReference)
                             {
-                                for (uint32_t i = 0; i < array->m_numOfElements; i++)
-                                {
-                                    sub = (CLR_RT_HeapBlock *)array->GetElement(i);
-
-                                    if (sub)
-                                    {
-                                        sub->MarkAlive();
-                                    }
-                                }
+                                ComputeReachabilityGraphForMultipleBlocks(
+                                    (CLR_RT_HeapBlock *)array->GetFirstElement(),
+                                    array->m_numOfElements);
                             }
                         }
                         break;


### PR DESCRIPTION
## Description
- Replace wrong marking as alive with recursive crawling of array elements.

## Motivation and Context
- Fixes the fix introduced in #2705 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running test app with code snippet from https://github.com/nanoframework/nf-interpreter/pull/2705#issuecomment-1651674293

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
