### PR TITLE
Increase reservation for IDF allocation

### DIFF
--- a/targets/ESP32/CMakePresets.json
+++ b/targets/ESP32/CMakePresets.json
@@ -274,7 +274,8 @@
                 "NF_FEATURE_DEBUGGER": "ON",
                 "NF_FEATURE_RTC": "ON",
                 "NF_FEATURE_HAS_SDCARD": "ON",
-                "ESP32_USB_CDC": "ON"
+                "ESP32_USB_CDC": "ON",
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "150"
             }
         },
         {
@@ -294,7 +295,7 @@
                 "NF_FEATURE_HAS_SDCARD": "ON",
                 "ESP32_USB_CDC": "ON",
                 "API_nanoFramework.Device.Bluetooth": "ON",
-                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "100"
+                "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "180"
             }
         },
         {


### PR DESCRIPTION
## Description
- Increase reservation for IDF allocation.

## Motivation and Context
- S3 build seems to require a lot more memory in order to have WiFi working. Without this WiFi init was silently failing.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
