### PR TITLE
Rework inclusion of async completions and event files

### DIFF
--- a/CMake/Modules/FindNF_CoreCLR.cmake
+++ b/CMake/Modules/FindNF_CoreCLR.cmake
@@ -24,6 +24,7 @@ list(APPEND NF_CoreCLR_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/CLR/Debugger)
 list(APPEND NF_CoreCLR_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/CLR/Helpers/NanoRingBuffer)
 list(APPEND NF_CoreCLR_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/CLR/Helpers/nanoprintf)
 list(APPEND NF_CoreCLR_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/CLR/Helpers/Base64)
+list(APPEND NF_CoreCLR_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/nanoFramework.Runtime.Events)
 list(APPEND NF_CoreCLR_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/nanoFramework.Runtime.Native)
 list(APPEND NF_CoreCLR_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/nanoFramework.System.Collections)
 list(APPEND NF_CoreCLR_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/DeviceInterfaces/Networking.Sntp)
@@ -158,9 +159,14 @@ set(NF_CoreCLR_SRCS
     nanoPAL_PerformanceCounters_stubs.cpp
 
     # PAL stubs
-    Async_stubs.cpp
     COM_stubs.c
     GenericPort_stubs.c
+
+    # other features
+    AsyncCompletions.cpp
+    NativeEventDispatcher.cpp
+    InterruptHandler.cpp
+    Hardware.cpp
 )
 
 # append CRC32, if not already included with Wire Protocol

--- a/CMake/Modules/FindSystem.Device.Gpio.cmake
+++ b/CMake/Modules/FindSystem.Device.Gpio.cmake
@@ -23,13 +23,7 @@ set(System.Device.Gpio_SRCS
 
     sys_dev_gpio_native_System_Device_Gpio_GpioController.cpp
     sys_dev_gpio_native_System_Device_Gpio_GpioPin.cpp
-    
-    # core source files
-    AsyncCompletions.cpp
-    AsyncContinuations.cpp
-    NativeEventDispatcher.cpp
-    InterruptHandler.cpp
-    Hardware.cpp
+
 )
 
 foreach(SRC_FILE ${System.Device.Gpio_SRCS})
@@ -41,12 +35,6 @@ foreach(SRC_FILE ${System.Device.Gpio_SRCS})
 	        ${BASE_PATH_FOR_THIS_MODULE}
             ${TARGET_BASE_LOCATION}
             ${CMAKE_SOURCE_DIR}/src/System.Device.Gpio
-
-            # core source files
-            ${CMAKE_SOURCE_DIR}/src/PAL/AsyncProcCall
-            ${CMAKE_SOURCE_DIR}/src/CLR/Core/NativeEventDispatcher
-            ${CMAKE_SOURCE_DIR}/src/CLR/Core/InterruptHandler
-            ${CMAKE_SOURCE_DIR}/src/CLR/Core/Hardware
 
 	    CMAKE_FIND_ROOT_PATH_BOTH
     )

--- a/CMake/Modules/FindnanoFramework.Runtime.Events.cmake
+++ b/CMake/Modules/FindnanoFramework.Runtime.Events.cmake
@@ -25,7 +25,6 @@ set(nanoFramework.Runtime.Events_SRCS
     nf_rt_events_native.cpp
 
     # source files
-    AsyncCompletions.cpp
     AsyncContinuations.cpp
     nanoPAL_Events_functions.cpp
 

--- a/src/PAL/AsyncProcCall/AsyncCompletions.cpp
+++ b/src/PAL/AsyncProcCall/AsyncCompletions.cpp
@@ -122,6 +122,24 @@ void HAL_COMPLETION::EnqueueTicks(uint64_t eventTimeTicks)
     GLOBAL_UNLOCK();
 }
 
+void HAL_COMPLETION::EnqueueDelta64(uint64_t uSecFromNow)
+{
+    NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
+
+    // grab time first to be closest to now as possible from when this function was called
+    uint64_t now = HAL_Time_CurrentSysTicks();
+    uint64_t eventTimeTicks = CPU_MillisecondsToTicks(uSecFromNow * 1000);
+
+    EnqueueTicks(now + eventTimeTicks);
+}
+
+void HAL_COMPLETION::EnqueueDelta(uint32_t uSecFromNow)
+{
+    NATIVE_PROFILE_PAL_ASYNC_PROC_CALL();
+
+    EnqueueDelta64((uint64_t)uSecFromNow);
+}
+
 //--//
 
 void HAL_COMPLETION::Abort()


### PR DESCRIPTION
## Description
- Add missing implementations for HAL_COMPLETION.
- Adjust CMakes for Sys.Dev.Gpio, Runtime.Events and CoreCLR to allow disabling GPIO feature entirely.

## Motivation and Context
- Resolves nanoFramework/Home#1328.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
