### PR TITLE
Fixes in Profiler code

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -3108,6 +3108,8 @@ bool CLR_DBG_Debugger::Profiling_Command(WP_Message *msg)
         default:
             return false;
     }
+
+    return true;
 }
 
 bool CLR_DBG_Debugger::Profiling_ChangeConditions(WP_Message *msg)

--- a/src/CLR/Diagnostics/Profiler.cpp
+++ b/src/CLR/Diagnostics/Profiler.cpp
@@ -178,11 +178,19 @@ void CLR_PRF_Profiler::DumpRoot(
     CLR_RT_MethodDef_Index *source)
 {
     NATIVE_PROFILE_CLR_DIAGNOSTICS();
+
+#if defined(BUILD_RTM)
+    (void)flags;
+#endif
+
     m_stream->WriteBits(CLR_PRF_CMDS::c_Profiling_HeapDump_Root, CLR_PRF_CMDS::Bits::CommandHeader);
+    
     DumpPointer(root);
+    
     m_stream->WriteBits(type, CLR_PRF_CMDS::Bits::RootTypes);
 
     _ASSERTE(!flags);
+    
     if (type == CLR_PRF_CMDS::RootTypes::Root_Stack)
     {
         PackAndWriteBits(*source);

--- a/src/CLR/Diagnostics/Profiler.cpp
+++ b/src/CLR/Diagnostics/Profiler.cpp
@@ -448,26 +448,33 @@ void CLR_PRF_Profiler::DumpObject(CLR_RT_HeapBlock *ptr)
 CLR_RT_HeapBlock *CLR_PRF_Profiler::FindReferencedObject(CLR_RT_HeapBlock *ref)
 {
     NATIVE_PROFILE_CLR_DIAGNOSTICS();
+
     while (ref)
     {
         CLR_DataType dt = ref->DataType();
+
         switch (dt)
         {
             case DATATYPE_BYREF:
             case DATATYPE_OBJECT:
                 ref = ref->Dereference();
                 break;
+
 #if defined(NANOCLR_APPDOMAINS)
             case DATATYPE_TRANSPARENT_PROXY:
                 ref = ref->TransparentProxyDereference();
                 break;
 #endif
+
             case DATATYPE_ARRAY_BYREF:
                 ref = ref->Array();
+                return ref;
+
             default:
                 return ref;
         }
     }
+
     return NULL;
 }
 


### PR DESCRIPTION
## Description
- Fix missing return value in debugger profiling command.
- Fix switch case fall-through in profiler.
- Fix RTM build for Profiler::DumpRoot.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
