### PR TITLE
Fix output of x64 addresses in nanoCLR WIN64 build

### DIFF
--- a/src/CLR/Core/GarbageCollector_Info.cpp
+++ b/src/CLR/Core/GarbageCollector_Info.cpp
@@ -128,7 +128,11 @@ void CLR_RT_GarbageCollector::ValidateBlockNotInFreeList(CLR_RT_DblLinkedList &l
 
             if (ptr <= dst && dst < ptrEnd)
             {
+#if _WIN64
+                CLR_Debug::Printf("Pointer into free list!! %I64X %I64X %I64X\r\n", dst, ptr, ptrEnd);
+#else
                 CLR_Debug::Printf("Pointer into free list!! %08x %08x %08x\r\n", dst, ptr, ptrEnd);
+#endif
 
                 NANOCLR_DEBUG_STOP();
             }
@@ -211,20 +215,30 @@ bool CLR_RT_GarbageCollector::TestPointers_PopulateOld_Worker(void **ref)
 
         if (s_mapOldToRecord.find(ref) != s_mapOldToRecord.end())
         {
+#if _WIN64
+            CLR_Debug::Printf("Duplicate base OLD: %I64X\r\n", ref);
+#else
             CLR_Debug::Printf("Duplicate base OLD: %08x\r\n", ref);
+#endif
+
+            NANOCLR_DEBUG_STOP();
         }
 
         s_mapOldToRecord[ref] = ptr;
 
         if (IsBlockInFreeList(g_CLR_RT_ExecutionEngine.m_heap, (CLR_RT_HeapBlock_Node *)dst, false))
         {
+#if _WIN64
+            CLR_Debug::Printf("Some data points into a free list: %I64X\r\n", dst);
+#else
             CLR_Debug::Printf("Some data points into a free list: %08x\r\n", dst);
+#endif
 
             NANOCLR_DEBUG_STOP();
         }
     }
 
-    return false;
+    return true;
 }
 
 void CLR_RT_GarbageCollector::TestPointers_PopulateOld()
@@ -272,7 +286,12 @@ void CLR_RT_GarbageCollector::TestPointers_Remap()
 
         if (s_mapNewToRecord.find(ref) != s_mapNewToRecord.end())
         {
+#if _WIN64
+            CLR_Debug::Printf("Duplicate base NEW: %I64X\r\n", ref);
+#else
             CLR_Debug::Printf("Duplicate base NEW: %08x\r\n", ref);
+#endif
+            NANOCLR_DEBUG_STOP();
         }
 
         s_mapNewToRecord[ref] = ptr;
@@ -299,23 +318,46 @@ bool CLR_RT_GarbageCollector::TestPointers_PopulateNew_Worker(void **ref)
 
             if (ptr->newPtr != dst)
             {
+#if _WIN64
+                CLR_Debug::Printf("Bad pointer: %I64X %I64X\r\n", ptr->newPtr, dst);
+#else
                 CLR_Debug::Printf("Bad pointer: %08x %08x\r\n", ptr->newPtr, dst);
+#endif
+                NANOCLR_DEBUG_STOP();
             }
             else if (ptr->data != *dst)
             {
+#if _WIN64
+                CLR_Debug::Printf("Bad data: %I64X %I64X\r\n", ptr->data, *dst);
+#else
                 CLR_Debug::Printf("Bad data: %08x %08x\r\n", ptr->data, *dst);
+#endif
+
+                NANOCLR_DEBUG_STOP();
             }
 
             if (IsBlockInFreeList(g_CLR_RT_ExecutionEngine.m_heap, (CLR_RT_HeapBlock_Node *)dst, false))
             {
+#if _WIN64
+                CLR_Debug::Printf("Some data points into a free list: %I64X\r\n", dst);
+#else
                 CLR_Debug::Printf("Some data points into a free list: %08x\r\n", dst);
+#endif
 
                 NANOCLR_DEBUG_STOP();
             }
+
+            return true;
         }
         else
         {
-            CLR_Debug::Printf("Bad base: %08x\r\n", ref);
+#if _WIN64
+            CLR_Debug::Printf("Bad base: 0x%0I64X\r\n", ref);
+#else
+            CLR_Debug::Printf("Bad base: 0x%08x\r\n", ref);
+#endif
+
+            NANOCLR_DEBUG_STOP();
         }
     }
 


### PR DESCRIPTION
## Description
- Fix output of x64 addresses in nanoCLR WIN64 build.

## Motivation and Context
- The current format string wasn't working for x64 builds.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
