### PR TITLE
Improve progress messages of GC and heap compaction

### DIFF
--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -1626,7 +1626,7 @@ CLR_RT_HeapBlock *CLR_RT_ExecutionEngine::ExtractHeapBlocks(
                         {
                             if (phase != 0)
                             {
-                                CLR_Debug::Printf("ExtractHeapBlocks succeeded at phase %d\r\n", phase);
+                                CLR_Debug::Printf("\r\n\r\nExtractHeapBlocks succeeded at phase %d\r\n", phase);
                             }
                         }
 #endif
@@ -1652,7 +1652,7 @@ CLR_RT_HeapBlock *CLR_RT_ExecutionEngine::ExtractHeapBlocks(
                 if (s_CLR_RT_fTrace_Memory >= c_CLR_RT_Trace_Info)
                 {
                     CLR_Debug::Printf(
-                        "    Memory: ExtractHeapBlocks: %d bytes needed.\r\n",
+                        "\r\n\r\n    Memory: ExtractHeapBlocks: %d bytes needed.\r\n",
                         length * sizeof(CLR_RT_HeapBlock));
                 }
 #endif
@@ -1664,7 +1664,7 @@ CLR_RT_HeapBlock *CLR_RT_ExecutionEngine::ExtractHeapBlocks(
             default: // Total failure...
 #if !defined(BUILD_RTM)
                 CLR_Debug::Printf(
-                    "Failed allocation for %d blocks, %d bytes\r\n\r\n",
+                    "\r\n\r\nFailed allocation for %d blocks, %d bytes\r\n\r\n",
                     length,
                     length * sizeof(CLR_RT_HeapBlock));
 #endif

--- a/src/CLR/Core/GarbageCollector.cpp
+++ b/src/CLR/Core/GarbageCollector.cpp
@@ -144,7 +144,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteGarbageCollection()
 #if defined(NANOCLR_GC_VERBOSE)
     if (s_CLR_RT_fTrace_GC >= c_CLR_RT_Trace_Info)
     {
-        CLR_Debug::Printf("    Memory: Start %s\r\n", HAL_Time_CurrentDateTimeToString());
+        CLR_Debug::Printf("\r\n\r\n    Memory: Start %s\r\n", HAL_Time_CurrentDateTimeToString());
     }
 #endif
 
@@ -176,7 +176,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteGarbageCollection()
                        TIME_CONVERSION__TICKUNITS;
 
         CLR_Debug::Printf(
-            "GC: %dmsec %d bytes used, %d bytes available\r\n",
+            "\r\nGC: %dmsec %d bytes used, %d bytes available\r\n\r\n",
             milliSec,
             m_totalBytes - m_freeBytes,
             m_freeBytes);
@@ -232,7 +232,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteGarbageCollection()
             if (countBlocks[dt])
             {
                 CLR_Debug::Printf(
-                    "Type %02X (%-20s): %6d bytes\r\n",
+                    "Type %02X (%-20s): %8d bytes\r\n",
                     dt,
                     c_CLR_RT_DataTypeLookup[dt].m_name,
                     countBlocks[dt] * sizeof(CLR_RT_HeapBlock));
@@ -244,7 +244,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteGarbageCollection()
                         if (countArryBlocks[dt2])
                         {
                             CLR_Debug::Printf(
-                                "   Type %02X (%-17s): %6d bytes\r\n",
+                                "   Type %02X (%-17s): %8d bytes\r\n",
                                 dt2,
                                 c_CLR_RT_DataTypeLookup[dt2].m_name,
                                 countArryBlocks[dt2] * sizeof(CLR_RT_HeapBlock));
@@ -265,7 +265,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteGarbageCollection()
 #if defined(NANOCLR_GC_VERBOSE)
     if (s_CLR_RT_fTrace_GC >= c_CLR_RT_Trace_Info)
     {
-        CLR_Debug::Printf("    Memory: End %s\r\n", HAL_Time_CurrentDateTimeToString());
+        CLR_Debug::Printf("\r\n\r\n    Memory: End %s\r\n", HAL_Time_CurrentDateTimeToString());
     }
 #endif
 

--- a/src/CLR/Core/GarbageCollector_Compaction.cpp
+++ b/src/CLR/Core/GarbageCollector_Compaction.cpp
@@ -17,7 +17,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteCompaction()
 #if defined(NANOCLR_TRACE_MEMORY_STATS)
     if (s_CLR_RT_fTrace_MemoryStats >= c_CLR_RT_Trace_Info)
     {
-        CLR_Debug::Printf("GC: performing heap compaction\r\n");
+        CLR_Debug::Printf("\r\nGC: performing heap compaction\r\n");
     }
 #endif
 
@@ -39,7 +39,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteCompaction()
 #if defined(NANOCLR_TRACE_MEMORY_STATS)
     if (s_CLR_RT_fTrace_MemoryStats >= c_CLR_RT_Trace_Info)
     {
-        CLR_Debug::Printf("GC: heap compaction completed\r\n");
+        CLR_Debug::Printf("\r\n\r\nGC: heap compaction completed\r\n");
     }
 #endif
 

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -32,11 +32,11 @@ int s_CLR_RT_fTrace_Exceptions = NANOCLR_TRACE_DEFAULT(c_CLR_RT_Trace_Info, c_CL
 #endif
 
 #if defined(NANOCLR_TRACE_INSTRUCTIONS)
-int s_CLR_RT_fTrace_Instructions = NANOCLR_TRACE_DEFAULT(c_CLR_RT_Trace_None, c_CLR_RT_Trace_None);
+int s_CLR_RT_fTrace_Instructions = NANOCLR_TRACE_DEFAULT(c_CLR_RT_Trace_Info, c_CLR_RT_Trace_None);
 #endif
 
 #if defined(NANOCLR_GC_VERBOSE)
-int s_CLR_RT_fTrace_Memory = NANOCLR_TRACE_DEFAULT(c_CLR_RT_Trace_None, c_CLR_RT_Trace_None);
+int s_CLR_RT_fTrace_Memory = NANOCLR_TRACE_DEFAULT(c_CLR_RT_Trace_Info, c_CLR_RT_Trace_None);
 #endif
 
 #if defined(NANOCLR_TRACE_MEMORY_STATS)
@@ -44,7 +44,7 @@ int s_CLR_RT_fTrace_MemoryStats = NANOCLR_TRACE_DEFAULT(c_CLR_RT_Trace_Info, c_C
 #endif
 
 #if defined(NANOCLR_GC_VERBOSE)
-int s_CLR_RT_fTrace_GC = NANOCLR_TRACE_DEFAULT(c_CLR_RT_Trace_None, c_CLR_RT_Trace_None);
+int s_CLR_RT_fTrace_GC = NANOCLR_TRACE_DEFAULT(c_CLR_RT_Trace_Info, c_CLR_RT_Trace_None);
 #endif
 
 #if defined(VIRTUAL_DEVICE)


### PR DESCRIPTION
## Description
- Improve progress messages of GC and heap compaction.

## Motivation and Context
- Need for a more clear output during GC and heap compaction runs.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
