### PR TITLE
Add GC and compaction options for CLR_SETTINGS

### DIFF
--- a/src/CLR/Core/Cache.cpp
+++ b/src/CLR/Core/Cache.cpp
@@ -571,13 +571,25 @@ CLR_RT_HeapBlock *CLR_RT_EventCache::Extract_Node_Bytes(CLR_UINT32 dataType, CLR
 CLR_RT_HeapBlock *CLR_RT_EventCache::Extract_Node(CLR_UINT32 dataType, CLR_UINT32 flags, CLR_UINT32 blocks)
 {
     NATIVE_PROFILE_CLR_CORE();
+
 #if defined(NANOCLR_FORCE_GC_BEFORE_EVERY_ALLOCATION)
     return g_CLR_RT_ExecutionEngine.ExtractHeapBlocksForEvents(dataType, flags, blocks);
 #else
-    if (blocks > 0 && blocks < c_maxFastLists)
-        return Extract_Node_Fast(dataType, flags, blocks);
+    if (g_CLR_RT_ExecutionEngine.m_fPerformGarbageCollection)
+    {
+        return g_CLR_RT_ExecutionEngine.ExtractHeapBlocksForEvents(dataType, flags, blocks);
+    }
     else
-        return Extract_Node_Slow(dataType, flags, blocks);
+    {
+        if (blocks > 0 && blocks < c_maxFastLists)
+        {
+            return Extract_Node_Fast(dataType, flags, blocks);
+        }
+        else
+        {
+            return Extract_Node_Slow(dataType, flags, blocks);
+        }
+    }
 #endif
 }
 

--- a/src/CLR/Include/nanoCLR_Application.h
+++ b/src/CLR/Include/nanoCLR_Application.h
@@ -30,6 +30,8 @@ typedef struct CLR_SETTINGS
     bool RevertToBooterOnFault;
 
 #if defined(VIRTUAL_DEVICE)
+    bool PerformGarbageCollection;
+    bool PerformHeapCompaction;
     CLR_RT_StringVector StartArgs;
 #endif
 

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -3388,6 +3388,7 @@ CT_ASSERT(sizeof(CLR_RT_EventCache::Payload) == 12)
 
 #include <nanoCLR_Debugging.h>
 #include <nanoCLR_Profiling.h>
+#include <nanoCLR_Application.h>
 // #include <nanoCLR_Messaging.h>
 
 //--//
@@ -3666,7 +3667,11 @@ struct CLR_RT_ExecutionEngine
 
     //--//
 
+#if defined(VIRTUAL_DEVICE)
+    static HRESULT CreateInstance(CLR_SETTINGS params);
+#else
     static HRESULT CreateInstance();
+#endif
 
     HRESULT ExecutionEngine_Initialize();
 

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandLineOptions.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandLineOptions.cs
@@ -94,6 +94,20 @@ namespace nanoFramework.nanoCLR.CLI
         public bool EnterDebuggerLoopAfterExit { get; set; }
 
         [Option(
+            "forcegc",
+            Required = false,
+            Default = false,
+            HelpText = "Option to force GC before each allocation.")]
+        public bool PerformGarbageCollection { get; set; }
+
+        [Option(
+            "compactionaftergc",
+            Required = false,
+            Default = false,
+            HelpText = "Option to force heap compaction after each GC run.")]
+        public bool PerformHeapCompaction { get; set; }
+
+        [Option(
             "localinstance",
             Required = false,
             Default = null,

--- a/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandProcessor.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.CLI/ExecuteCommandProcessor.cs
@@ -129,6 +129,8 @@ namespace nanoFramework.nanoCLR.CLI
 
             hostBuilder.WaitForDebugger = options.WaitForDebugger;
             hostBuilder.EnterDebuggerLoopAfterExit = options.EnterDebuggerLoopAfterExit;
+            hostBuilder.PerformGarbageCollection = options.PerformGarbageCollection;
+            hostBuilder.PerformHeapCompaction = options.PerformHeapCompaction;
 
             if (options.MonitorParentPid != null)
             {

--- a/targets/netcore/nanoFramework.nanoCLR.Host/NanoClrHostBuilder.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.Host/NanoClrHostBuilder.cs
@@ -26,6 +26,10 @@ namespace nanoFramework.nanoCLR.Host
         public bool WaitForDebugger { get; set; } = false;
         public bool EnterDebuggerLoopAfterExit { get; set; } = false;
 
+        public bool PerformGarbageCollection { get; set; } = false;
+
+        public bool PerformHeapCompaction { get; set; } = false;
+
         public nanoCLRHostBuilder()
         {
             Interop.nanoCLR.DllPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "NanoCLR");
@@ -118,7 +122,9 @@ namespace nanoFramework.nanoCLR.Host
             {
                 MaxContextSwitches = (ushort)MaxContextSwitches,
                 WaitForDebugger = WaitForDebugger,
-                EnterDebuggerLoopAfterExit = EnterDebuggerLoopAfterExit
+                EnterDebuggerLoopAfterExit = EnterDebuggerLoopAfterExit,
+                PerformGarbageCollection = PerformGarbageCollection,
+                PerformHeapCompaction = PerformHeapCompaction
             };
 
             return s_nanoClrHost;

--- a/targets/netcore/nanoFramework.nanoCLR.Host/NanoClrSettings.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.Host/NanoClrSettings.cs
@@ -16,11 +16,17 @@ namespace nanoFramework.nanoCLR.Host
 
         public bool EnterDebuggerLoopAfterExit { get; set; }
 
+        public bool PerformGarbageCollection { get; set; }
+
+        public bool PerformHeapCompaction { get; set; }
+
         public static nanoCLRSettings Default = new()
         {
             MaxContextSwitches = 50,
             WaitForDebugger = false,
             EnterDebuggerLoopAfterExit = false,
+            PerformGarbageCollection = false,
+            PerformHeapCompaction = false,
         };
     }
 }

--- a/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
+++ b/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
@@ -30,9 +30,10 @@ struct Settings
 
         m_clrOptions = params;
 
-#if defined(PLATFORM_WINDOWS_EMULATOR)
         g_CLR_RT_ExecutionEngine.m_fPerformGarbageCollection = params.PerformGarbageCollection;
         g_CLR_RT_ExecutionEngine.m_fPerformHeapCompaction = params.PerformHeapCompaction;
+
+#if defined(PLATFORM_WINDOWS_EMULATOR)
 
         CLR_UINT32 clockFrequencyBaseline = 27000000;
         CLR_UINT32 clockFrequency = CPU_SystemClock();

--- a/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
+++ b/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
@@ -30,8 +30,6 @@ struct Settings
 
         m_clrOptions = params;
 
-
-
 #if defined(PLATFORM_WINDOWS_EMULATOR)
 
         CLR_UINT32 clockFrequencyBaseline = 27000000;

--- a/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
+++ b/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
@@ -30,8 +30,7 @@ struct Settings
 
         m_clrOptions = params;
 
-        g_CLR_RT_ExecutionEngine.m_fPerformGarbageCollection = params.PerformGarbageCollection;
-        g_CLR_RT_ExecutionEngine.m_fPerformHeapCompaction = params.PerformHeapCompaction;
+
 
 #if defined(PLATFORM_WINDOWS_EMULATOR)
 
@@ -51,7 +50,7 @@ struct Settings
         g_HAL_Configuration_Windows.GraphHeapEnabled = false;
 #endif
 
-        NANOCLR_CHECK_HRESULT(CLR_RT_ExecutionEngine::CreateInstance());
+        NANOCLR_CHECK_HRESULT(CLR_RT_ExecutionEngine::CreateInstance(params));
 #if !defined(BUILD_RTM)
         CLR_Debug::Printf("Created EE.\r\n");
 #endif
@@ -438,7 +437,8 @@ struct Settings
 
         if (!m_fInitialized)
         {
-            CLR_RT_ExecutionEngine::CreateInstance();
+            // TODO: all this LoadAssembliesSet is to be removed in another PR
+            // CLR_RT_ExecutionEngine::CreateInstance();
         }
 
         {

--- a/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
+++ b/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
@@ -435,8 +435,7 @@ struct Settings
 
         if (!m_fInitialized)
         {
-            // TODO: all this LoadAssembliesSet is to be removed in another PR
-            // CLR_RT_ExecutionEngine::CreateInstance();
+            CLR_RT_ExecutionEngine::CreateInstance(m_clrOptions);
         }
 
         {

--- a/targets/netcore/nanoFramework.nanoCLR/nanoCLR_native.cpp
+++ b/targets/netcore/nanoFramework.nanoCLR/nanoCLR_native.cpp
@@ -112,6 +112,8 @@ void nanoCLR_Run(NANO_CLR_SETTINGS nanoClrSettings)
     clrSettings.MaxContextSwitches = nanoClrSettings.MaxContextSwitches;
     clrSettings.WaitForDebugger = nanoClrSettings.WaitForDebugger;
     clrSettings.EnterDebuggerLoopAfterExit = nanoClrSettings.EnterDebuggerLoopAfterExit;
+    clrSettings.PerformGarbageCollection = nanoClrSettings.PerformGarbageCollection;
+    clrSettings.PerformHeapCompaction = nanoClrSettings.PerformHeapCompaction;
 
     ClrStartup(clrSettings);
 

--- a/targets/netcore/nanoFramework.nanoCLR/nanoCLR_native.h
+++ b/targets/netcore/nanoFramework.nanoCLR/nanoCLR_native.h
@@ -25,6 +25,13 @@ typedef struct NANO_CLR_SETTINGS
     // this is required for launching a debug session in Visual Studio
     // when building is set for RTM this configuration is ignored
     BOOL EnterDebuggerLoopAfterExit;
+    
+    // set this to TRUE if execution engine is to performa GC before each allocation
+    BOOL PerformGarbageCollection;
+    
+    // set this to TRUE if execution engine is to performa heap compaction after each GC run
+    BOOL PerformHeapCompaction;
+
 } NANO_CLR_SETTINGS;
 
 typedef HRESULT(__stdcall *ConfigureRuntimeCallback)();

--- a/targets/netcore/nanoFramework.nanoCLR/nanoCLR_native.h
+++ b/targets/netcore/nanoFramework.nanoCLR/nanoCLR_native.h
@@ -25,10 +25,10 @@ typedef struct NANO_CLR_SETTINGS
     // this is required for launching a debug session in Visual Studio
     // when building is set for RTM this configuration is ignored
     BOOL EnterDebuggerLoopAfterExit;
-    
+
     // set this to TRUE if execution engine is to performa GC before each allocation
     BOOL PerformGarbageCollection;
-    
+
     // set this to TRUE if execution engine is to performa heap compaction after each GC run
     BOOL PerformHeapCompaction;
 

--- a/targets/netcore/nanoFramework.nanoCLR/nanoCLR_native.h
+++ b/targets/netcore/nanoFramework.nanoCLR/nanoCLR_native.h
@@ -25,10 +25,10 @@ typedef struct NANO_CLR_SETTINGS
     // this is required for launching a debug session in Visual Studio
     // when building is set for RTM this configuration is ignored
     BOOL EnterDebuggerLoopAfterExit;
-
+    
     // set this to TRUE if execution engine is to performa GC before each allocation
     BOOL PerformGarbageCollection;
-
+    
     // set this to TRUE if execution engine is to performa heap compaction after each GC run
     BOOL PerformHeapCompaction;
 

--- a/targets/win32/nanoCLR/CLRStartup.cpp
+++ b/targets/win32/nanoCLR/CLRStartup.cpp
@@ -45,7 +45,7 @@ struct Settings : CLR_RT_ParseOptions
         g_HAL_Configuration_Windows.GraphHeapEnabled = false;
 #endif
 
-        NANOCLR_CHECK_HRESULT(CLR_RT_ExecutionEngine::CreateInstance());
+        NANOCLR_CHECK_HRESULT(CLR_RT_ExecutionEngine::CreateInstance(params));
 #if !defined(BUILD_RTM)
         CLR_Debug::Printf("Created EE.\r\n");
 #endif
@@ -465,7 +465,7 @@ struct Settings : CLR_RT_ParseOptions
 
         if (!m_fInitialized)
         {
-            CLR_RT_ExecutionEngine::CreateInstance();
+            CLR_RT_ExecutionEngine::CreateInstance(m_clrOptions);
         }
 
         {
@@ -562,7 +562,7 @@ struct Settings : CLR_RT_ParseOptions
 
         NANOCLR_NOCLEANUP();
     }
-#endif //#if defined(VIRTUAL_DEVICE)
+#endif // #if defined(VIRTUAL_DEVICE)
 };
 
 static Settings s_ClrSettings;
@@ -641,7 +641,7 @@ void ClrStartup(CLR_SETTINGS params)
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
             CLR_EE_DBG_SET_MASK(StateProgramExited, StateMask);
             CLR_EE_DBG_EVENT_BROADCAST(CLR_DBG_Commands::c_Monitor_ProgramExit, 0, NULL, WP_Flags_c_NonCritical);
-#endif //#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
             if (params.EnterDebuggerLoopAfterExit)
             {


### PR DESCRIPTION
## Description
- Add GC and compaction options for CLR_SETTINGS.
- Expose this in nanoCLR options.
- Add code to adjust settings on CLR host run.
- Add new call to ExecutionEngine.CreateInstance taking CLR settings as parameter.
- Adjust code to actually set execution engine config from start parameters.

## Motivation and Context
- These are required in virtual device to allow running it with these options.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
