### PR TITLE
Add trace for profiler messages

### DIFF
--- a/src/CLR/Diagnostics/Profiler.cpp
+++ b/src/CLR/Diagnostics/Profiler.cpp
@@ -694,6 +694,17 @@ void CLR_PRF_Profiler::TrackObjectCreation(CLR_RT_HeapBlock *ptr)
                 PackAndWriteBits(array->ReflectionDataConst().m_levels);
             }
             Stream_Send();
+
+#ifdef NANOCLR_TRACE_PROFILER_MESSAGES
+
+#if _WIN64
+            CLR_Debug::Printf("\r\n    Profiler msg: ! %d 0x%I64X\r\n", m_currentThreadPID, (size_t)(CLR_UINT8 *)ptr);
+
+#else
+            CLR_Debug::Printf("\r\n    Profiler msg: ! %d 0x%08x\r\n", m_currentThreadPID, (size_t)(CLR_UINT8 *)ptr);
+#endif
+
+#endif //  NANOCLR_TRACE_PROFILER_MESSAGES
         }
     }
 }
@@ -746,6 +757,25 @@ void CLR_PRF_Profiler::TrackObjectRelocation()
             DumpPointer(relocBlocks[i].m_start);
             DumpPointer(relocBlocks[i].m_end);
             PackAndWriteBits(relocBlocks[i].m_offset);
+
+#ifdef NANOCLR_TRACE_PROFILER_MESSAGES
+
+#if _WIN64
+            CLR_Debug::Printf(
+                "\r\n    Profiler msg: u 0x%I64X 0x%I64X %d\r\n",
+                relocBlocks[i].m_start,
+                relocBlocks[i].m_start + relocBlocks[i].m_offset,
+                relocBlocks[i].m_end - relocBlocks[i].m_offset);
+
+#else
+            CLR_Debug::Printf(
+                "\r\n    Profiler msg: u 0x%08x 0x%08x %d\r\n",
+                relocBlocks[i].m_start,
+                relocBlocks[i].m_start + relocBlocks[i].m_offset,
+                relocBlocks[i].m_end - relocBlocks[i].m_offset);
+#endif
+
+#endif //  NANOCLR_TRACE_PROFILER_MESSAGES
         }
     }
 }
@@ -766,6 +796,25 @@ void CLR_PRF_Profiler::RecordGarbageCollectionBegin()
         m_stream->WriteBits(CLR_PRF_CMDS::c_Profiling_GarbageCollect_Begin, CLR_PRF_CMDS::Bits::CommandHeader);
         PackAndWriteBits(g_CLR_RT_GarbageCollector.m_freeBytes);
         Stream_Send();
+
+#ifdef NANOCLR_TRACE_PROFILER_MESSAGES
+
+#if _WIN64
+        CLR_Debug::Printf(
+            "\r\n    Profiler msg: b 1 0 0 0x%I64X 0x%I64X %d 0\r\n",
+            (CLR_UINT32)s_CLR_RT_Heap.m_location,
+            s_CLR_RT_Heap.m_size,
+            g_CLR_RT_GarbageCollector.m_totalBytes);
+
+#else
+        CLR_Debug::Printf(
+            "\r\n    Profiler msg: b 1 0 0 0x%08x 0x%08x %d 0\r\n",
+            (CLR_UINT32)s_CLR_RT_Heap.m_location,
+            s_CLR_RT_Heap.m_size,
+            g_CLR_RT_GarbageCollector.m_totalBytes);
+#endif
+
+#endif //  NANOCLR_TRACE_PROFILER_MESSAGES
     }
 }
 
@@ -785,6 +834,37 @@ void CLR_PRF_Profiler::RecordGarbageCollectionEnd()
         m_stream->WriteBits(CLR_PRF_CMDS::c_Profiling_GarbageCollect_End, CLR_PRF_CMDS::Bits::CommandHeader);
         PackAndWriteBits(g_CLR_RT_GarbageCollector.m_freeBytes);
         Stream_Send();
+
+#ifdef NANOCLR_TRACE_PROFILER_MESSAGES
+
+#if _WIN64
+        NANOCLR_FOREACH_NODE(CLR_RT_HeapCluster, hc, g_CLR_RT_ExecutionEngine.m_heap)
+        {
+            CLR_Debug::Printf("\r\n    Profiler msg: v 0x%I64X 0\r\n", (CLR_UINT32)hc->m_payloadStart);
+        }
+        NANOCLR_FOREACH_NODE_END();
+
+        CLR_Debug::Printf(
+            "\r\n    Profiler msg: b 0 0 0 0x%I64X 0x%I64X %d 0\r\n",
+            (CLR_UINT32)s_CLR_RT_Heap.m_location,
+            s_CLR_RT_Heap.m_size,
+            g_CLR_RT_GarbageCollector.m_totalBytes);
+
+#else
+        NANOCLR_FOREACH_NODE(CLR_RT_HeapCluster, hc, g_CLR_RT_ExecutionEngine.m_heap)
+        {
+            CLR_Debug::Printf("\r\n    Profiler msg: v 0x%08x 0\r\n", (CLR_UINT32)hc->m_payloadStart);
+        }
+        NANOCLR_FOREACH_NODE_END();
+
+        CLR_Debug::Printf(
+            "\r\n    Profiler msg: b 0 0 0 0x%08x 0x%08x %d 0\r\n",
+            (CLR_UINT32)s_CLR_RT_Heap.m_location,
+            s_CLR_RT_Heap.m_size,
+            g_CLR_RT_GarbageCollector.m_totalBytes);
+#endif
+
+#endif //  NANOCLR_TRACE_PROFILER_MESSAGES
     }
 }
 
@@ -804,6 +884,25 @@ void CLR_PRF_Profiler::RecordHeapCompactionBegin()
         m_stream->WriteBits(CLR_PRF_CMDS::c_Profiling_HeapCompact_Begin, CLR_PRF_CMDS::Bits::CommandHeader);
         PackAndWriteBits(g_CLR_RT_GarbageCollector.m_freeBytes);
         Stream_Send();
+
+#ifdef NANOCLR_TRACE_PROFILER_MESSAGES
+
+#if _WIN64
+        CLR_Debug::Printf(
+            "\r\n    Profiler msg: b 1 0 0 0x%I64X 0x%I64X %d 0\r\n",
+            (CLR_UINT32)s_CLR_RT_Heap.m_location,
+            s_CLR_RT_Heap.m_size,
+            g_CLR_RT_GarbageCollector.m_totalBytes);
+
+#else
+        CLR_Debug::Printf(
+            "\r\n    Profiler msg: b 1 0 0 0x%08x 0x%08x %d 0\r\n",
+            (CLR_UINT32)s_CLR_RT_Heap.m_location,
+            s_CLR_RT_Heap.m_size,
+            g_CLR_RT_GarbageCollector.m_totalBytes);
+#endif
+
+#endif //  NANOCLR_TRACE_PROFILER_MESSAGES
     }
 }
 
@@ -823,6 +922,25 @@ void CLR_PRF_Profiler::RecordHeapCompactionEnd()
         m_stream->WriteBits(CLR_PRF_CMDS::c_Profiling_HeapCompact_End, CLR_PRF_CMDS::Bits::CommandHeader);
         PackAndWriteBits(g_CLR_RT_GarbageCollector.m_freeBytes);
         Stream_Send();
+
+#ifdef NANOCLR_TRACE_PROFILER_MESSAGES
+
+#if _WIN64
+        CLR_Debug::Printf(
+            "\r\n    Profiler msg: b 0 0 0 0x%I64X 0x%I64X %d 0\r\n",
+            (CLR_UINT32)s_CLR_RT_Heap.m_location,
+            s_CLR_RT_Heap.m_size,
+            g_CLR_RT_GarbageCollector.m_totalBytes);
+
+#else
+        CLR_Debug::Printf(
+            "\r\n    Profiler msg: b 0 0 0 0x%08x 0x%08x %d 0\r\n",
+            (CLR_UINT32)s_CLR_RT_Heap.m_location,
+            s_CLR_RT_Heap.m_size,
+            g_CLR_RT_GarbageCollector.m_totalBytes);
+#endif
+
+#endif //  NANOCLR_TRACE_PROFILER_MESSAGES
     }
 }
 


### PR DESCRIPTION
## Description
- Add trace for profiler messages.

## Motivation and Context
- Allow cross check Profiler log messages generation.
- Address nanoFramework/Home#1354.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
