### PR TITLE
Add debug output for Profiler::TrackObjectDeletion

### DIFF
--- a/src/CLR/Diagnostics/Profiler.cpp
+++ b/src/CLR/Diagnostics/Profiler.cpp
@@ -17,7 +17,8 @@ HRESULT CLR_PRF_Profiler::CreateInstance()
     g_CLR_PRF_Profiler.m_packetSeqId = 0;
     g_CLR_PRF_Profiler.m_stream = NULL;
     g_CLR_PRF_Profiler.m_lastTimestamp =
-        (CLR_UINT32)((CLR_UINT64)(HAL_Time_CurrentTime() + ((1ull << CLR_PRF_CMDS::Bits::TimestampShift) - 1)) >> CLR_PRF_CMDS::Bits::TimestampShift);
+        (CLR_UINT32)((CLR_UINT64)(HAL_Time_CurrentTime() + ((1ull << CLR_PRF_CMDS::Bits::TimestampShift) - 1)) >>
+                     CLR_PRF_CMDS::Bits::TimestampShift);
     g_CLR_PRF_Profiler.m_currentAssembly = 0;
     g_CLR_PRF_Profiler.m_currentThreadPID = 0;
     NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_MemoryStream::CreateInstance(g_CLR_PRF_Profiler.m_stream, NULL, 0));
@@ -543,7 +544,8 @@ void CLR_PRF_Profiler::Timestamp()
     NATIVE_PROFILE_CLR_DIAGNOSTICS();
     // Send Profiling Timestamp
     CLR_UINT32 time =
-        (CLR_UINT32)((HAL_Time_CurrentTime() + ((CLR_UINT64)((1ull << CLR_PRF_CMDS::Bits::TimestampShift) - 1))) >> CLR_PRF_CMDS::Bits::TimestampShift);
+        (CLR_UINT32)((HAL_Time_CurrentTime() + ((CLR_UINT64)((1ull << CLR_PRF_CMDS::Bits::TimestampShift) - 1))) >>
+                     CLR_PRF_CMDS::Bits::TimestampShift);
     if (time > m_lastTimestamp)
     {
         m_stream->WriteBits(CLR_PRF_CMDS::c_Profiling_Timestamp, CLR_PRF_CMDS::Bits::CommandHeader);
@@ -797,21 +799,21 @@ void CLR_PRF_Profiler::TrackObjectDeletion(CLR_RT_HeapBlock *ptr)
         }
 
 #ifdef NANOCLR_TRACE_PROFILER_MESSAGES
-            CLR_UINT16 dataSize = ptr->DataSize();
+        CLR_UINT16 dataSize = ptr->DataSize();
 
 #ifdef _WIN64
-            CLR_Debug::Printf(
-                "\r\n    Profiler info: * (0x0x%I64X | %d) %d bytes\r\n",
-                (size_t)((CLR_UINT8 *)ptr),
-                (CLR_UINT32)((size_t *)ptr - s_CLR_RT_Heap.m_location),
-                (dataSize * sizeof(CLR_RT_HeapBlock)));
+        CLR_Debug::Printf(
+            "\r\n    Profiler info: * (0x0x%I64X | %d) %d bytes\r\n",
+            (size_t)((CLR_UINT8 *)ptr),
+            (CLR_UINT32)((size_t *)ptr - s_CLR_RT_Heap.m_location),
+            (dataSize * sizeof(CLR_RT_HeapBlock)));
 
 #else
-            CLR_Debug::Printf(
-                "\r\n    Profiler info: * (0x%08X | %d) %d bytes\r\n",
-                (CLR_UINT32)((CLR_UINT8 *)ptr),
-                (CLR_UINT32)((CLR_UINT8 *)ptr - s_CLR_RT_Heap.m_location),
-                (dataSize * sizeof(CLR_RT_HeapBlock)));
+        CLR_Debug::Printf(
+            "\r\n    Profiler info: * (0x%08X | %d) %d bytes\r\n",
+            (CLR_UINT32)((CLR_UINT8 *)ptr),
+            (CLR_UINT32)((CLR_UINT8 *)ptr - s_CLR_RT_Heap.m_location),
+            (dataSize * sizeof(CLR_RT_HeapBlock)));
 #endif
 
 #endif // NANOCLR_TRACE_PROFILER_MESSAGES

--- a/src/CLR/Diagnostics/Profiler.cpp
+++ b/src/CLR/Diagnostics/Profiler.cpp
@@ -795,6 +795,26 @@ void CLR_PRF_Profiler::TrackObjectDeletion(CLR_RT_HeapBlock *ptr)
             DumpPointer(ptr);
             Stream_Send();
         }
+
+#ifdef NANOCLR_TRACE_PROFILER_MESSAGES
+            CLR_UINT16 dataSize = ptr->DataSize();
+
+#ifdef _WIN64
+            CLR_Debug::Printf(
+                "\r\n    Profiler info: * (0x0x%I64X | %d) %d bytes\r\n",
+                (size_t)((CLR_UINT8 *)ptr),
+                (CLR_UINT32)((size_t *)ptr - s_CLR_RT_Heap.m_location),
+                (dataSize * sizeof(CLR_RT_HeapBlock)));
+
+#else
+            CLR_Debug::Printf(
+                "\r\n    Profiler info: * (0x%08X | %d) %d bytes\r\n",
+                (CLR_UINT32)((CLR_UINT8 *)ptr),
+                (CLR_UINT32)((CLR_UINT8 *)ptr - s_CLR_RT_Heap.m_location),
+                (dataSize * sizeof(CLR_RT_HeapBlock)));
+#endif
+
+#endif // NANOCLR_TRACE_PROFILER_MESSAGES
     }
 }
 


### PR DESCRIPTION
## Description
- Add debug output for Profiler::TrackObjectDeletion.

## Motivation and Context
- Need to cross check object deletion messages and handling on Profiler.
- Addresses nanoFramework/Home#1354.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
