### PR TITLE
Rework launch booter API to include error code

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1066,7 +1066,7 @@ bool CLR_DBG_Debugger::Monitor_Reboot(WP_Message *msg)
     if (CLR_DBG_Commands::Monitor_Reboot::c_EnterNanoBooter ==
         (cmd->m_flags & CLR_DBG_Commands::Monitor_Reboot::c_EnterNanoBooter))
     {
-        success = RequestToLaunchNanoBooter();
+        success = RequestToLaunchNanoBooter(0);
     }
     else if (
         CLR_DBG_Commands::Monitor_Reboot::c_EnterProprietaryBooter ==

--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -404,7 +404,7 @@ void ClrStartup(CLR_SETTINGS params)
                 CLR_Debug::Printf("Ready.\r\n");
 #endif
 
-                (void)g_CLR_RT_ExecutionEngine.Execute(NULL, params.MaxContextSwitches);
+                hr = g_CLR_RT_ExecutionEngine.Execute(NULL, params.MaxContextSwitches);
 
 #if !defined(BUILD_RTM)
                 CLR_Debug::Printf("Done.\r\n");
@@ -435,7 +435,8 @@ void ClrStartup(CLR_SETTINGS params)
                     // no proprietary bootloader available, launch nanoBooter
 
 #if (TARGET_HAS_NANOBOOTER == TRUE)
-                    RequestToLaunchNanoBooter();
+
+                    RequestToLaunchNanoBooter(hr);
                     CPU_Reset();
 #endif // TARGET_HAS_NANOBOOTER
                 }

--- a/src/HAL/Include/nanoHAL_Boot.h
+++ b/src/HAL/Include/nanoHAL_Boot.h
@@ -42,7 +42,7 @@ typedef struct __nfpack BootClipboard
     BootRequest_Options BootRequest;
     uint32_t BootParameters;
     BootExecution_Options BootExecution;
-    uint32_t ErrorCode;
+    int32_t ErrorCode;
 
     VersionInfo BooterVersion;
     VersionInfo CLRVersion;
@@ -73,9 +73,9 @@ extern "C"
     // Returns true if the there is a request to remain in nanoBooter
     bool IsToRemainInBooter();
 
-    // Request to launch nanoBooter
+    // Request to launch nanoBooter and set an error code
     // Returns false in case it's not supported (which is considered the default).
-    bool RequestToLaunchNanoBooter();
+    bool RequestToLaunchNanoBooter(int32_t errorCode);
 
     // Request to launch proprietary bootloader
     // Returns false in case it's not supported (which is considered the default).

--- a/src/HAL/nanoHAL_Boot.c
+++ b/src/HAL/nanoHAL_Boot.c
@@ -61,14 +61,15 @@ inline bool IsToRemainInBooter()
 #endif
 }
 
-// Request to launch nanoBooter
+// Request to launch nanoBooter and report error code
 // Returns false in case it's not supported (which is considered the default).
-inline bool RequestToLaunchNanoBooter()
+inline bool RequestToLaunchNanoBooter(int32_t errorCode)
 {
 #if (TARGET_HAS_NANOBOOTER == TRUE)
     if (Target_HasNanoBooter())
     {
         g_BootClipboard.BootRequest = BootRequest_NanoBooter;
+        g_BootClipboard.ErrorCode = errorCode;
         return true;
     }
 #endif

--- a/targets/win32/Include/targetHAL.h
+++ b/targets/win32/Include/targetHAL.h
@@ -83,8 +83,10 @@ inline bool RequestToLaunchProprietaryBootloader()
     return false;
 };
 
-inline bool RequestToLaunchNanoBooter()
+inline bool RequestToLaunchNanoBooter(int32_t errorCode)
 {
+    (void)errorCode;
+
     return false;
 };
 


### PR DESCRIPTION
## Description
- Struct updated to allow storing negative error codes (required for CLR error codes).
- Declaration updated to take parameter with error code.
- Code updated accordingly.

## Motivation and Context
- Add a convenient way to report to booter what was the cause for rebooting so it can act accordingly.
- Addresses nanoFramework/Home#1359.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
