### PR TITLE
Booter state is now updated on launch CLR

### DIFF
--- a/targets/AzureRTOS/ST/_common/LaunchCLR.c
+++ b/targets/AzureRTOS/ST/_common/LaunchCLR.c
@@ -14,6 +14,9 @@ void LaunchCLR(uint32_t address)
     // function pointer to load nanoCLR ResetHandler address
     irq_vector_t JumpToNanoCLR;
 
+    // report successfull nanoBooter execution
+    ReportSuccessfullNanoBooter();
+
     // load nanoCLR vector table
     const vectors_t *nanoCLRVectorTable = (vectors_t *)address;
 

--- a/targets/AzureRTOS/SiliconLabs/_common/LaunchCLR.c
+++ b/targets/AzureRTOS/SiliconLabs/_common/LaunchCLR.c
@@ -15,6 +15,9 @@ void LaunchCLR(uint32_t address)
     // function pointer to load nanoCLR ResetHandler address
     irq_vector_t JumpToNanoCLR;
 
+    // report successfull nanoBooter execution
+    ReportSuccessfullNanoBooter();
+
     // load nanoCLR vector table
     const vectors_t *nanoCLRVectorTable = (vectors_t *)address;
 

--- a/targets/ChibiOS/_common/LaunchCLR.c
+++ b/targets/ChibiOS/_common/LaunchCLR.c
@@ -18,7 +18,7 @@ void LaunchCLR(uint32_t address)
     ReportSuccessfullNanoBooter();
 
     // load nanoCLR vector table
-    const vectors_t* nanoCLRVectorTable = (vectors_t*) address;
+    const vectors_t *nanoCLRVectorTable = (vectors_t *)address;
 
     // load the jump address with the nanoCLR ResetHandler address
     JumpToNanoCLR = nanoCLRVectorTable->reset_handler;
@@ -41,55 +41,55 @@ bool CheckValidCLRImage(uint32_t address)
     uint32_t resetVectorAddress;
 
     // load nanoCLR vector table
-    const vectors_t* nanoCLRVectorTable = (vectors_t*) address;
+    const vectors_t *nanoCLRVectorTable = (vectors_t *)address;
 
     // 1st check: the flash content pointed by the address can't be all 0's neither all F's
     // meaning that the Flash is neither 'all burnt' or erased
-    if( (uint32_t)(*(uint32_t**)((uint32_t*)address)) == 0xFFFFFFFF ||
-        (uint32_t)(*(uint32_t**)((uint32_t*)address)) == 0x00000000 )
+    if ((uint32_t)(*(uint32_t **)((uint32_t *)address)) == 0xFFFFFFFF ||
+        (uint32_t)(*(uint32_t **)((uint32_t *)address)) == 0x00000000)
     {
         // check failed, there is no valid CLR image
         return false;
     }
-    
-    // 2nd check: the content pointed by the reset vector has to be 0xE002 
-    // that's an assembly "b.n" (branch instruction) the very first one in the Reset_Handler function
-    // see os\common\startup\ARMCMx\compilers\GCC\vectors.S
 
+// 2nd check: the content pointed by the reset vector has to be 0xE002
+// that's an assembly "b.n" (branch instruction) the very first one in the Reset_Handler function
+// see os\common\startup\ARMCMx\compilers\GCC\vectors.S
 
-    // for series that have ART Accelerator the handlers addresses stored in the vector table are for ITCM access 
-    // need to parsed them to reach the equivalent address in AXI access
-    #ifdef FLASHITCM_BASE
-    
+// for series that have ART Accelerator the handlers addresses stored in the vector table are for ITCM access
+// need to parsed them to reach the equivalent address in AXI access
+#ifdef FLASHITCM_BASE
+
     // read address (ITCM)
-    resetVectorAddress = (uint32_t)((uint32_t*)nanoCLRVectorTable->reset_handler);
+    resetVectorAddress = (uint32_t)((uint32_t *)nanoCLRVectorTable->reset_handler);
     // parse it to get the address in the AXI range
     resetVectorAddress -= FLASHITCM_BASE;
     resetVectorAddress += FLASHAXI_BASE;
 
-    #else
-    
+#else
+
     // "regular" address mapping
-    resetVectorAddress = (uint32_t)((uint32_t*)nanoCLRVectorTable->reset_handler);
-    
-    #endif
+    resetVectorAddress = (uint32_t)((uint32_t *)nanoCLRVectorTable->reset_handler);
+
+#endif
 
     // sanity check for invalid address (out of flash range which causes a hard fault)
-    if( resetVectorAddress <= FLASH1_MEMORY_StartAddress ||
-        resetVectorAddress >= (FLASH1_MEMORY_StartAddress + FLASH1_MEMORY_Size) )
+    if (resetVectorAddress <= FLASH1_MEMORY_StartAddress ||
+        resetVectorAddress >= (FLASH1_MEMORY_StartAddress + FLASH1_MEMORY_Size))
     {
         // check failed, doesn't seem to be a valid CLR image
         return false;
     }
 
-    // the linker can place this anywhere on the address space because of optimizations so we better check where the reset pointer points to
-    uint32_t opCodeAddress = (uint32_t)((uint32_t**)nanoCLRVectorTable->reset_handler);
+    // the linker can place this anywhere on the address space because of optimizations so we better check where the
+    // reset pointer points to
+    uint32_t opCodeAddress = (uint32_t)((uint32_t **)nanoCLRVectorTable->reset_handler);
 
     // real address is -1
     opCodeAddress -= 1;
 
-    uint32_t opCode = *((uint32_t*)opCodeAddress);
-    if((uint16_t)opCode == 0xE002)
+    uint32_t opCode = *((uint32_t *)opCodeAddress);
+    if ((uint16_t)opCode == 0xE002)
     {
         // check, there seems to be a valid CLR image
         return true;

--- a/targets/ChibiOS/_common/LaunchCLR.c
+++ b/targets/ChibiOS/_common/LaunchCLR.c
@@ -8,6 +8,7 @@
 #include <hal.h>
 #include <vectors.h>
 #include <target_common.h>
+#include <targetHAL.h>
 
 void LaunchCLR(uint32_t address)
 {

--- a/targets/ChibiOS/_common/LaunchCLR.c
+++ b/targets/ChibiOS/_common/LaunchCLR.c
@@ -14,6 +14,9 @@ void LaunchCLR(uint32_t address)
     // function pointer to load nanoCLR ResetHandler address
     irq_vector_t JumpToNanoCLR;
 
+    // report successfull nanoBooter execution
+    ReportSuccessfullNanoBooter();
+
     // load nanoCLR vector table
     const vectors_t* nanoCLRVectorTable = (vectors_t*) address;
 


### PR DESCRIPTION
## Description
- Before launching CLR from nanoBooter the code now goes through ReportSuccessfullNanoBooter.

## Motivation and Context
- The booter request and error codes weren't being updated on regular launch of CLR. This had the potential to wrong pass the information to the CLR that the booter hadn't executed correctly. Now the error code and boot request are updated, not only on regular booter execution but also before launching the CLR.
- Addresses nanoFramework/Home#1359.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
