### PR TITLE
Fix assignment of GPIO callback

### DIFF
--- a/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.Gpio/cpu_gpio.cpp
+++ b/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.Gpio/cpu_gpio.cpp
@@ -427,18 +427,20 @@ bool CPU_GPIO_EnableInputPin(
 
     GPIO_Port_TypeDef port;
     uint32_t portPin;
+    int interruptId;
     GetIoLine(pinNumber, &port, &portPin);
 
     // Link ISR ptr supplied and not already set up
     // CPU_GPIO_EnableInputPin could be called a 2nd time with changed parameters
     if (pinISR != NULL && (pState->isrPtr == NULL))
     {
+        // register nanoFramework callback and store associated interrupt ID
+        interruptId = CallbackRegisterExt(portPin, pState);
+
         // there are callbacks registered and...
         // the drive mode is input so need to setup the interrupt
-        GPIO_ExtIntConfig(port, portPin, portPin, 1, 1, true);
-
-        // TODO
-        CallbackRegisterExt(portPin, pState);
+        // need to use the interrupt ID to setup the interrupt
+        GPIO_ExtIntConfig(port, portPin, interruptId, 1, 1, true);
 
         // store parameters & configs
         pState->isrPtr = pinISR;


### PR DESCRIPTION
## Description
- Now using interrupt ID when configuring the external interrupt.

## Motivation and Context
- For this GEcko series need to use the assigned interrupt ID when configuring the interrupt.
- Fixes Skyworks-Timing-Software/MCU#91.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Using GPIO+events sample.
- Using test project in Skyworks-Timing-Software/MCU#91.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
