### PR TITLE
Add assert to Heap_Relocate

### DIFF
--- a/src/CLR/Core/GarbageCollector_Compaction.cpp
+++ b/src/CLR/Core/GarbageCollector_Compaction.cpp
@@ -439,6 +439,10 @@ void CLR_RT_GarbageCollector::Heap_Relocate(void **ref)
     NATIVE_PROFILE_CLR_CORE();
     CLR_UINT8 *dst = (CLR_UINT8 *)*ref;
 
+#if NANOCLR_VALIDATE_HEAP != NANOCLR_VALIDATE_HEAP_0_None
+    void *destinationAddress;
+#endif
+
 #if NANOCLR_VALIDATE_HEAP > NANOCLR_VALIDATE_HEAP_0_None
     if (g_CLR_RT_GarbageCollector.m_relocWorker)
     {
@@ -468,7 +472,11 @@ void CLR_RT_GarbageCollector::Heap_Relocate(void **ref)
                 }
                 else
                 {
-                    *ref = (void *)(dst + relocCurrent.m_offset);
+                    destinationAddress = (void *)(dst + relocCurrent.m_offset);
+                    _ASSERTE(destinationAddress >= (void *)s_CLR_RT_Heap.m_location);
+                    _ASSERTE(destinationAddress < (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size));
+
+                    *ref = destinationAddress;
 
                     return;
                 }

--- a/src/CLR/Core/GarbageCollector_Compaction.cpp
+++ b/src/CLR/Core/GarbageCollector_Compaction.cpp
@@ -439,7 +439,7 @@ void CLR_RT_GarbageCollector::Heap_Relocate(void **ref)
     NATIVE_PROFILE_CLR_CORE();
     CLR_UINT8 *dst = (CLR_UINT8 *)*ref;
 
-#if NANOCLR_VALIDATE_HEAP != NANOCLR_VALIDATE_HEAP_0_None
+#if NANOCLR_VALIDATE_HEAP == NANOCLR_VALIDATE_HEAP_0_None
     void *destinationAddress;
 #endif
 


### PR DESCRIPTION
## Description
- Rework code to add assert checking if destination address is inside heap region.

## Motivation and Context
- Part of nanoFramework/Home#1354

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
