### PR TITLE
Update cmake installed in dev containers to 3.27.6

### DIFF
--- a/.devcontainer/sources/Dockerfile.All
+++ b/.devcontainer/sources/Dockerfile.All
@@ -20,7 +20,7 @@ RUN  mkdir -p /tmp/dc-extracted/titools \
     && curl -o /tmp/dc-downloads/titools.zip $TI_TOOL_URL -L \
     && unzip -d /tmp/dc-extracted/titools /tmp/dc-downloads/titools.zip
 
-ARG CMAKE_SCRIPT=https://cmake.org/files/v3.24/cmake-3.24.0-linux-x86_64.sh
+ARG CMAKE_SCRIPT=https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-x86_64.sh
 RUN wget $CMAKE_SCRIPT \
       -q -O /tmp/cmake-install.sh \
       && chmod u+x /tmp/cmake-install.sh \

--- a/.devcontainer/sources/Dockerfile.AzureRTOS
+++ b/.devcontainer/sources/Dockerfile.AzureRTOS
@@ -14,7 +14,7 @@ RUN mkdir -p /tmp/dc-downloads /tmp/dc-extracted/gcc \
     && tar -xvf /tmp/dc-downloads/gcc-arm.tar -C /tmp/dc-extracted/gcc --strip-components 1 \
     && rm -rf /tmp/dc-extracted/gcc/share/doc/ /tmp/dc-extracted/gcc/share/gcc-arm-none-eabi/samples/
 
-ARG CMAKE_SCRIPT=https://cmake.org/files/v3.24/cmake-3.24.0-linux-x86_64.sh
+ARG CMAKE_SCRIPT=https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-x86_64.sh
 RUN wget $CMAKE_SCRIPT \
       -q -O /tmp/cmake-install.sh \
       && chmod u+x /tmp/cmake-install.sh \

--- a/.devcontainer/sources/Dockerfile.ChibiOS
+++ b/.devcontainer/sources/Dockerfile.ChibiOS
@@ -14,7 +14,7 @@ RUN mkdir -p /tmp/dc-downloads /tmp/dc-extracted/gcc \
     && tar -xvf /tmp/dc-downloads/gcc-arm.tar -C /tmp/dc-extracted/gcc --strip-components 1 \
     && rm -rf /tmp/dc-extracted/gcc/share/doc/ /tmp/dc-extracted/gcc/share/gcc-arm-none-eabi/samples/
 
-ARG CMAKE_SCRIPT=https://cmake.org/files/v3.24/cmake-3.24.0-linux-x86_64.sh
+ARG CMAKE_SCRIPT=https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-x86_64.sh
 RUN wget $CMAKE_SCRIPT \
       -q -O /tmp/cmake-install.sh \
       && chmod u+x /tmp/cmake-install.sh \

--- a/.devcontainer/sources/Dockerfile.ESP32
+++ b/.devcontainer/sources/Dockerfile.ESP32
@@ -9,7 +9,7 @@ RUN apt-get update \
 
 RUN mkdir -p /tmp/dc-downloads /tmp/dc-extracted/gcc
 
-ARG CMAKE_SCRIPT=https://cmake.org/files/v3.24/cmake-3.24.0-linux-x86_64.sh
+ARG CMAKE_SCRIPT=https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-x86_64.sh
 RUN wget $CMAKE_SCRIPT \
       -q -O /tmp/cmake-install.sh \
       && chmod u+x /tmp/cmake-install.sh \

--- a/.devcontainer/sources/Dockerfile.TI
+++ b/.devcontainer/sources/Dockerfile.TI
@@ -20,7 +20,7 @@ RUN  mkdir -p /tmp/dc-extracted/titools \
     && curl -o /tmp/dc-downloads/titools.zip $TI_TOOL_URL -L \
     && unzip -d /tmp/dc-extracted/titools /tmp/dc-downloads/titools.zip
 
-ARG CMAKE_SCRIPT=https://cmake.org/files/v3.24/cmake-3.24.0-linux-x86_64.sh
+ARG CMAKE_SCRIPT=https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-x86_64.sh
 RUN wget $CMAKE_SCRIPT \
       -q -O /tmp/cmake-install.sh \
       && chmod u+x /tmp/cmake-install.sh \


### PR DESCRIPTION
## Description
- Updated CMake to 3.27.6
- NOTE:  new URL pulled from CMakes downloads page

## Motivation and Context
- CMake 3.27.6 include better error reporting for CMakePresets.json, which can be a pain point for new contributors.

## How Has This Been Tested?
- rebuilt Docker.AzureRTOS locally and confirmed that CMake error reporting was improved for the scenarios that caused pain (failed to clone targets-community submodule, therefore its CMakePresets.json did not exist, which cause CMake to be unable to display presets in vscode.)

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [x] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
