### PR TITLE
Console.Write now produces output on all build flavours

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Diagnostics_Debug.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Diagnostics_Debug.cpp
@@ -1,6 +1,5 @@
 //
 // Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
 //
 
@@ -11,15 +10,13 @@ HRESULT Library_corlib_native_System_Diagnostics_Debug::WriteLineNative___STATIC
 {
     NANOCLR_HEADER();
 
-#ifdef BUILD_RTM
-    stack.NotImplementedStub();
-#else
-
     const char *szText0 = stack.Arg0().RecoverString();
     bool addLineFeed = (bool)stack.Arg1().NumericByRef().u1;
 
     if (!szText0)
+    {
         szText0 = "<null>";
+    }
 
     CLR_Debug::Emit(szText0, -1);
 
@@ -27,8 +24,6 @@ HRESULT Library_corlib_native_System_Diagnostics_Debug::WriteLineNative___STATIC
     {
         CLR_Debug::Emit("\r\n", -1);
     }
-
-#endif
 
     NANOCLR_NOCLEANUP_NOLABEL();
 }


### PR DESCRIPTION
## Description
- Remove condition throwing exception on RTM builds.

## Motivation and Context
- It's too harsh disabling `Console.Write` in RTM. There could be situations where it's desirable to have this output (profiling for example). On top of that, throwing a `NotImplementedException` is definitely not a good implementation.
- Addresses nanoFramework/Home#1360.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
