### PR TITLE
Rework exception processing

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Exception.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Exception.cpp
@@ -240,7 +240,10 @@ HRESULT Library_corlib_native_System_Exception::SetStackTrace(CLR_RT_HeapBlock &
             if (!g_CLR_RT_ExecutionEngine.m_fShuttingDown)
 #endif
             {
-                CLR_RT_DUMP::EXCEPTION(*stack, ref);
+                if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
+                {
+                    CLR_RT_DUMP::EXCEPTION(*stack, ref);
+                }
             }
         }
 

--- a/src/CLR/Core/Thread.cpp
+++ b/src/CLR/Core/Thread.cpp
@@ -610,6 +610,10 @@ HRESULT CLR_RT_Thread::ProcessException_EndFilter()
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
+#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+    bool fBreakpointsDisabledSav = false;
+#endif
+
     CLR_RT_StackFrame *stack = CurrentFrame();
     CLR_INT32 choice = stack->PopValue().NumericByRef().s4;
 
@@ -621,30 +625,37 @@ HRESULT CLR_RT_Thread::ProcessException_EndFilter()
     us.m_stack = NULL;
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-    // We don't want to send any breakpoints until after we set the IP appropriately
-    bool fBreakpointsDisabledSav = CLR_EE_DBG_IS(BreakpointsDisabled);
-    CLR_EE_DBG_SET(BreakpointsDisabled);
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+    if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
+    {
+        // We don't want to send any breakpoints until after we set the IP appropriately
+        fBreakpointsDisabledSav = CLR_EE_DBG_IS(BreakpointsDisabled);
+        CLR_EE_DBG_SET(BreakpointsDisabled);
+    }
+#endif
 
     stack->Pop();
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-    if (!fBreakpointsDisabledSav)
+    if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && !fBreakpointsDisabledSav)
     {
         CLR_EE_DBG_CLR(BreakpointsDisabled);
     }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
     if (choice == 1)
     {
         // The filter signaled that it will handle this exception. Update the phase state
         us.SetPhase(UnwindStack::p_2_RunningFinallys_0);
+
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-        g_CLR_RT_ExecutionEngine.Breakpoint_Exception(
-            us.m_handlerStack,
-            CLR_DBG_Commands::Debugging_Execution_BreakpointDef::c_DEPTH_EXCEPTION_HANDLER_FOUND,
-            us.m_handlerBlockStart);
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
+        {
+            g_CLR_RT_ExecutionEngine.Breakpoint_Exception(
+                us.m_handlerStack,
+                CLR_DBG_Commands::Debugging_Execution_BreakpointDef::c_DEPTH_EXCEPTION_HANDLER_FOUND,
+                us.m_handlerBlockStart);
+        }
+#endif
     }
     else
     {
@@ -657,13 +668,13 @@ HRESULT CLR_RT_Thread::ProcessException_EndFilter()
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
     // We must stop if we sent out a Catch Handler found message.
-    if (CLR_EE_DBG_IS(Stopped))
+    if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && CLR_EE_DBG_IS(Stopped))
     { // If the debugger stopped because of the messages we sent, then we should break out of Execute_IL, drop down,
         // and wait for the debugger to continue.
         m_currentException.SetObjectReference(us.m_exception);
         NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
     }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
     (void)ProcessException();
 
@@ -718,11 +729,11 @@ HRESULT CLR_RT_Thread::ProcessException_EndFinally()
         }
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-        if (stack->m_flags & CLR_RT_StackFrame::c_HasBreakpoint)
+        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && stack->m_flags & CLR_RT_StackFrame::c_HasBreakpoint)
         {
             g_CLR_RT_ExecutionEngine.Breakpoint_StackFrame_Step(stack, stack->m_IP);
         }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
         NANOCLR_SET_AND_LEAVE(S_OK);
     }
@@ -758,6 +769,10 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
+#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+    bool fBreakpointsDisabledSav = false;
+#endif
+
     // Load the UnwindStack entry to process, as created/loaded by ProcessException
     UnwindStack &us = m_nestedExceptions[m_nestedExceptionsPos - 1];
 
@@ -781,10 +796,12 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
     // Search for a willing catch handler.
     while (stack->Caller() != NULL)
     {
+
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-        if (g_CLR_RT_ExecutionEngine.m_breakpointsNum &&
+        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && g_CLR_RT_ExecutionEngine.m_breakpointsNum &&
             us.GetPhase() < UnwindStack::p_1_SearchingForHandler_2_SentUsersChance && stack->m_IP)
-        { // We have a debugger attached and we need to send some messages before we start searching.
+        {
+            // We have a debugger attached and we need to send some messages before we start searching.
             // These messages should only get sent when the search reaches managed code. Stack::Push sets m_IP to NULL
             // for native code, so therefore we need IP to be non-NULL
 
@@ -869,19 +886,22 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
                         CLR_UINT8 numArgs = stack->m_call.m_target->numArgs;
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-                        // We don't want to send any breakpoints until after we set the IP appropriately
-                        bool fBreakpointsDisabledSav = CLR_EE_DBG_IS(BreakpointsDisabled);
-                        CLR_EE_DBG_SET(BreakpointsDisabled);
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+                        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
+                        {
+                            // We don't want to send any breakpoints until after we set the IP appropriately
+                            fBreakpointsDisabledSav = CLR_EE_DBG_IS(BreakpointsDisabled);
+                            CLR_EE_DBG_SET(BreakpointsDisabled);
+                        }
+#endif
 
                         hr = CLR_RT_StackFrame::Push(stack->m_owningThread, stack->m_call, numArgs);
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-                        if (!fBreakpointsDisabledSav)
+                        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && !fBreakpointsDisabledSav)
                         {
                             CLR_EE_DBG_CLR(BreakpointsDisabled);
                         }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
                         if (FAILED(hr))
                         { // We probably ran out of memory. In either case, don't run this handler.
@@ -918,11 +938,13 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
                         m_currentException.SetObjectReference(NULL);
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-                        g_CLR_RT_ExecutionEngine.Breakpoint_StackFrame_Push(
-                            newStack,
-                            CLR_DBG_Commands::Debugging_Execution_BreakpointDef::c_DEPTH_STEP_INTERCEPT);
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-
+                        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
+                        {
+                            g_CLR_RT_ExecutionEngine.Breakpoint_StackFrame_Push(
+                                newStack,
+                                CLR_DBG_Commands::Debugging_Execution_BreakpointDef::c_DEPTH_STEP_INTERCEPT);
+                        }
+#endif
                         // Return a success value to break out of ProcessException and to signal that execution of IL
                         // can continue.
                         NANOCLR_SET_AND_LEAVE(S_OK);
@@ -933,7 +955,7 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
                         us.SetPhase(UnwindStack::p_2_RunningFinallys_0);
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-                        if (g_CLR_RT_ExecutionEngine.m_breakpointsNum)
+                        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && g_CLR_RT_ExecutionEngine.m_breakpointsNum)
                         {
                             g_CLR_RT_ExecutionEngine.Breakpoint_Exception(
                                 stack,
@@ -944,7 +966,7 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
                                 goto ContinueAndExit;
                             }
                         }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
                         // We want to continue running EH "goo" code so leave m_currentException set and return
                         // PROCESS_EXCEPTION
@@ -963,7 +985,7 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
             us.SetPhase(UnwindStack::p_2_RunningFinallys_0);
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-            if (g_CLR_RT_ExecutionEngine.m_breakpointsNum)
+            if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && g_CLR_RT_ExecutionEngine.m_breakpointsNum)
             {
                 // Send the IP offset -1 for a catch handler in the case of an appdomain transition to mimic the
                 // desktop.
@@ -976,7 +998,7 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
                     goto ContinueAndExit;
                 }
             }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
             NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
         }
@@ -1012,7 +1034,7 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
     us.SetPhase(UnwindStack::p_2_RunningFinallys_0);
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-    if (g_CLR_RT_ExecutionEngine.m_breakpointsNum)
+    if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && g_CLR_RT_ExecutionEngine.m_breakpointsNum)
     {
         g_CLR_RT_ExecutionEngine.Breakpoint_Exception_Uncaught(this);
         if (CLR_EE_DBG_IS(Stopped))
@@ -1020,7 +1042,7 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
             goto ContinueAndExit;
         }
     }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
     // We want to continue running EH "goo" code so leave m_currentException set and return PROCESS_EXCEPTION
     NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
@@ -1053,10 +1075,12 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    /*
-     * Start running through the stack frames, running all finally handlers and popping them off until
-     * we hit our target catch handler, if any.
-     */
+#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+    bool fBreakpointsDisabledSav = false;
+#endif
+
+    // Start running through the stack frames, running all finally handlers and popping them off until we hit our target
+    // catch handler, if any.
 
     UnwindStack &us = m_nestedExceptions[m_nestedExceptionsPos - 1];
 
@@ -1067,9 +1091,10 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
     // Unwind the stack, running finally's as we go
     while (iterStack->Caller() != NULL)
     {
+
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-        if (g_CLR_RT_ExecutionEngine.m_breakpointsNum && iterStack == us.m_handlerStack &&
-            (us.m_flags & UnwindStack::c_MagicCatchForInteceptedException) != 0)
+        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && g_CLR_RT_ExecutionEngine.m_breakpointsNum &&
+            iterStack == us.m_handlerStack && (us.m_flags & UnwindStack::c_MagicCatchForInteceptedException) != 0)
         {
             // We've reached the frame we want to "handle" this exception. However, since the handler doesn't really
             // exist, we want to remove the UnwindStack entry.
@@ -1089,11 +1114,12 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
             NANOCLR_SET_AND_LEAVE(S_OK);
         }
         else
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
+        {
             if (iterStack->m_call.m_target->flags & CLR_RECORD_METHODDEF::MD_HasExceptionHandlers)
             {
-                if (iterStack
-                        ->m_IP) // No IP? Either out of memory during allocation of iterStack frame or native method.
+                // No IP? Either out of memory during allocation of iterStack frame or native method.
+                if (iterStack->m_IP)
                 {
                     // handlerBlockStart is used to not execute finally's who's protected blocks contain the handler
                     // itself. NULL is used when we're not in the handler stack frame to make it work in the case of
@@ -1120,13 +1146,16 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
                         iterStack->m_flags &= ~CLR_RT_StackFrame::c_InvalidIP;
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-#ifndef NANOCLR_NO_IL_INLINE
-                        if (iterStack->m_inlineFrame == NULL)
-#endif
+                        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
                         {
-                            g_CLR_RT_ExecutionEngine.Breakpoint_StackFrame_Pop(iterStack, true);
+#ifndef NANOCLR_NO_IL_INLINE
+                            if (iterStack->m_inlineFrame == NULL)
+#endif
+                            {
+                                g_CLR_RT_ExecutionEngine.Breakpoint_StackFrame_Pop(iterStack, true);
+                            }
                         }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
                         NANOCLR_SET_AND_LEAVE(S_OK);
                     }
@@ -1157,13 +1186,16 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
                             m_currentException.SetObjectReference(NULL);
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-#ifndef NANOCLR_NO_IL_INLINE
-                            if (iterStack->m_inlineFrame == NULL)
-#endif
+                            if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
                             {
-                                g_CLR_RT_ExecutionEngine.Breakpoint_StackFrame_Pop(iterStack, true);
+#ifndef NANOCLR_NO_IL_INLINE
+                                if (iterStack->m_inlineFrame == NULL)
+#endif
+                                {
+                                    g_CLR_RT_ExecutionEngine.Breakpoint_StackFrame_Pop(iterStack, true);
+                                }
                             }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
                             // Return a success value to break out of ProcessException and to signal that execution of
                             // IL can continue.
@@ -1172,6 +1204,7 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
                     }
                 }
             }
+        }
 
         // We didn't find a finally block at this level...
         // Check to see if we trickled up to a pseudoiterStack frame that we created to execute a filter handler:
@@ -1196,19 +1229,22 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
             otherUnwindStack.m_stack = NULL; // Prevent Pop from taking this handler off the stack.
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-            // We don't want to send any breakpoints until after we set the IP appropriately
-            bool fBreakpointsDisabledSav = CLR_EE_DBG_IS(BreakpointsDisabled);
-            CLR_EE_DBG_SET(BreakpointsDisabled);
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+            if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
+            {
+                // We don't want to send any breakpoints until after we set the IP appropriately
+                fBreakpointsDisabledSav = CLR_EE_DBG_IS(BreakpointsDisabled);
+                CLR_EE_DBG_SET(BreakpointsDisabled);
+            }
+#endif
 
             iterStack->Pop(); // No finally's for the current ip in this method, pop to the next.
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-            if (!fBreakpointsDisabledSav)
+            if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && !fBreakpointsDisabledSav)
             {
                 CLR_EE_DBG_CLR(BreakpointsDisabled);
             }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
             m_currentException.SetObjectReference(otherUnwindStack.m_exception); // Drop current exception, use old one.
 
@@ -1232,9 +1268,12 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
             m_nestedExceptionsPos--; // Take off the pseudo-handler
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-            bool fBreakpointsDisabledSav = CLR_EE_DBG_IS(BreakpointsDisabled);
-            CLR_EE_DBG_SET(BreakpointsDisabled);
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+            if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
+            {
+                fBreakpointsDisabledSav = CLR_EE_DBG_IS(BreakpointsDisabled);
+                CLR_EE_DBG_SET(BreakpointsDisabled);
+            }
+#endif
 
 #ifndef NANOCLR_NO_IL_INLINE
             if (iterStack->m_inlineFrame)
@@ -1248,11 +1287,11 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
             }
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-            if (!fBreakpointsDisabledSav)
+            if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && !fBreakpointsDisabledSav)
             {
                 CLR_EE_DBG_CLR(BreakpointsDisabled);
             }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
 
             // We are not ready to execute IL yet so do NOT clear m_currentException flag.
             // There still remains hope for this thread so return S_OK so ProcessException can get called again via
@@ -1264,10 +1303,13 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
         us.m_stack = NULL; // Don't pop off the handler when we pop this stack frame
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-        // We don't want to send any breakpoints until after we set the IP appropriately
-        bool fBreakpointsDisabledSav = CLR_EE_DBG_IS(BreakpointsDisabled);
-        CLR_EE_DBG_SET(BreakpointsDisabled);
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
+        {
+            // We don't want to send any breakpoints until after we set the IP appropriately
+            fBreakpointsDisabledSav = CLR_EE_DBG_IS(BreakpointsDisabled);
+            CLR_EE_DBG_SET(BreakpointsDisabled);
+        }
+#endif
 
 #ifndef NANOCLR_NO_IL_INLINE
         if (iterStack->m_inlineFrame)
@@ -1282,11 +1324,11 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
         iterStack = CurrentFrame();
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-        if (!fBreakpointsDisabledSav)
+        if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && !fBreakpointsDisabledSav)
         {
             CLR_EE_DBG_CLR(BreakpointsDisabled);
         }
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
     }
 
     // If we reached this point, we've unwound the entire thread and have an unhandled exception.
@@ -1295,19 +1337,25 @@ HRESULT CLR_RT_Thread::ProcessException_Phase2()
     // At this point, no hope remains.
     // m_currentException is still set, but we return PROCESS_EXCEPTION signalling that there is no hope for the thread,
     // which causes Thread::Execute to terminate it.
+
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
-#if !defined(BUILD_RTM)
-    // special case thread abort exception
-    if ((this->m_flags & CLR_RT_Thread::TH_F_Aborted) == 0)
+    if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions))
     {
-        CLR_Debug::Printf(" Uncaught exception \r\n");
-        // Perhaps some stronger notification is needed.  Consider CLR 2.0's fail-fast work
-        // We could kill the application, and perhaps even store relevant data to dump to the user
-        // when they connect to the PC.  Save the state so the debug API for the uncaught exception could be
-        // retrieved?
+
+#if !defined(BUILD_RTM)
+        // special case thread abort exception
+        if ((this->m_flags & CLR_RT_Thread::TH_F_Aborted) == 0)
+        {
+            CLR_Debug::Printf(" Uncaught exception \r\n");
+            // Perhaps some stronger notification is needed.  Consider CLR 2.0's fail-fast work
+            // We could kill the application, and perhaps even store relevant data to dump to the user
+            // when they connect to the PC.  Save the state so the debug API for the uncaught exception could be
+            // retrieved?
+        }
+#endif
     }
-#endif //! BUILD_RTM
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+#endif
+
     NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
     NANOCLR_NOCLEANUP();
 }


### PR DESCRIPTION
## Description
- Kept only absolute minimum code required to process an exception. Everything else was made dependent on debugger flag `NoStackTraceInExceptions`.

## Motivation and Context
- This is kind of a follow-up on #2678. It turns out that there is a lot more code that's "only" crawling the call stack, building the stack trace and reporting it back to VS. When the developer chooses to disable exception stack trace processing in VS nanoFramework options, mostly likely he/shw is not interested at all on the stack trace and related. Therefore this improvement take it to maximum possible processing time saving skipping all that. Pretty much equivalent to the behavior seem with RTM build.
- Resolves nanoFramework/Home#1360.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
