### PR TITLE
Fix dataWidth check for ESP32 MMC to enable 4-bit access

### DIFF
--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_nanoFramework_System_IO_FileSystem_SDCard.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_nanoFramework_System_IO_FileSystem_SDCard.cpp
@@ -97,7 +97,7 @@ HRESULT Library_nf_sys_io_filesystem_nanoFramework_System_IO_FileSystem_SDCard::
     {
         case SDCard_SDInterfaceType::SDCard_SDInterfaceType_Mmc:
         {
-            bool bit1Mode = (bool)(pThis[FIELD___dataWidth].NumericByRef().s4);
+            bool bit1Mode = pThis[FIELD___dataWidth].NumericByRef().s4 == SDCard_SDDataWidth::SDCard_SDDataWidth__1_bit;
 
             int count;
             int8_t *pPins;
@@ -180,7 +180,8 @@ HRESULT Library_nf_sys_io_filesystem_nanoFramework_System_IO_FileSystem_SDCard::
         // Unreserve MMC pins. I suppose they could be used for something else
         case SDCard_SDInterfaceType::SDCard_SDInterfaceType_Mmc:
         {
-            bool bit1Mode = (bool)(pThis[FIELD___dataWidth].NumericByRef().s4);
+            bool bit1Mode = pThis[FIELD___dataWidth].NumericByRef().s4 == SDCard_SDDataWidth::SDCard_SDDataWidth__1_bit;
+
             int count;
             int8_t *pPins;
 
@@ -223,7 +224,7 @@ HRESULT Library_nf_sys_io_filesystem_nanoFramework_System_IO_FileSystem_SDCard::
     {
         case SDCard_SDInterfaceType::SDCard_SDInterfaceType_Mmc:
         {
-            bool bit1Mode = (bool)(pThis[FIELD___dataWidth].NumericByRef().s4);
+            bool bit1Mode = pThis[FIELD___dataWidth].NumericByRef().s4 == SDCard_SDDataWidth::SDCard_SDDataWidth__1_bit;
 
             if (!Storage_MountMMC(bit1Mode, 0))
             {

--- a/targets/ESP32/_nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_Devices_SDCard.cpp
+++ b/targets/ESP32/_nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_Devices_SDCard.cpp
@@ -15,7 +15,7 @@ HRESULT Library_win_storage_native_Windows_Storage_Devices_SDCard::MountMMCNativ
     NANOCLR_HEADER();
 
 #if (HAL_USE_SDC == TRUE)
-    bool bit1Mode = stack.Arg0().NumericByRef().s4;
+    bool bit1Mode = (bool)stack.Arg0().NumericByRef().u1;
     if (!Storage_MountMMC(bit1Mode, 0))
     {
         NANOCLR_SET_AND_LEAVE(CLR_E_VOLUME_NOT_FOUND);


### PR DESCRIPTION
## Description
- Changed three locations in the ESP32 target where an enum with the possible values of 1 or 2 was being cast directly to a bool. It now compares the provided enum value to an enum entry itself.

## Motivation and Context
- The code in question is setting a flag that determines if the MMC card is mounted in 1-bit or 4-bit mode. The flag should be true for 1-bit and false for 4-bit. The functions are provided the value of an enum where 1-bit = 1 and 4-bit = 2. The functions cast either 1 or 2 to bool, which always results in true. Thus if from managed code you try to mount in 1-bit mode, then the 1-bit flag in native code is set to true. If you try to mount in 4-bit mode, the 1-bit flag is also set to true. This PR changes this from a bool cast to an equality comparison where we now check if the parameter is equal to the 1-bit enum. If it is, we set the 1-bit flag to true. If it is not (as in, the provided enum value for 4-bit), we set the 1-bit flag to false.
- The result of this change is that mounting an SD card in MMC mode results in at least 4x higher performance for file operations when in MMC mode.

## How Has This Been Tested?
- Produced the original problem on the release firmware. Mounting with MMC results in much slower performance than mounting with SPI, and performance is identical regardless of if MMC is set to 1-bit or 4-bit in managed code.
- Observed that the MMC performance issue only applied to the System.IO.FileSystem MMC support, when using the Windows.Storage MMC support, 4-bit had much faster performance than 1-bit as expected
- Built the firmware from source without any changes and replicated the problem and verified that 1-bit and 4-bit MMC mode had the same (slower than expected) performance.
- Added the fix and rebuilt the firmware. Verified that the MMC could still be mounted, but that performance was much faster (comparable to SPI mode for my particular ESP32 board) in 4-bit mode than 1-bit mode.
- I want to note that I checked the "I have tested everything locally" box in the checklist. I have tested locally, but I don't know what "all new and existing tests" would be. I validated that all my file operations work as before, and that the only difference between the before and after is the improved performance resulting from 4-bit access mode being correctly activated.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).

