### PR TITLE
Fix access to env var in CMake

### DIFF
--- a/CMake/toolchain.arm-none-eabi.cmake
+++ b/CMake/toolchain.arm-none-eabi.cmake
@@ -18,7 +18,7 @@ endif(WIN32)
 
 find_program(COMPILER_ON_PATH "${TARGET_TRIPLET}gcc${TOOLCHAIN_EXT}" CMAKE_FIND_ROOT_PATH_BOTH)
 
-if(DEFINED $ENV{ARM_GCC_PATH}) 
+if(DEFINED ENV{ARM_GCC_PATH}) 
     # try to find GCC using the environment variable first    
     file(TO_CMAKE_PATH $ENV{ARM_GCC_PATH} ARM_TOOLCHAIN_PATH)
     message(STATUS "Using ENV variable ARM_GCC_PATH = '${ARM_TOOLCHAIN_PATH}'")

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/target_external_memory.c
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/target_external_memory.c
@@ -69,7 +69,6 @@
 #define SDRAM_SIZE  (16 * 1024 * 1024)
 #define SDRAM_START ((void *)FSMC_Bank5_MAP_BASE)
 
-
 void SetupDeviceMemoryToEliminateUnalignedAccess();
 
 // SDRAM driver configuration structure.


### PR DESCRIPTION
## Description
if(DEFINED $ENV{ARM_GCC_PATH}) 
should be 
if(DEFINED ENV{ARM_GCC_PATH}) 
## Motivation and Context
Incorrect value returned 

## How Has This Been Tested
CMake with debugging shows that $ENV{ARM_GCC_PATH} returns "" 
while ENV{ARM_GCC_PATH} returns path

## Screenshots

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
