### PR TITLE
Use only 32-bit ARGB or RGB565 formats

### DIFF
--- a/src/nanoFramework.Graphics/Graphics/Core/Graphics.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/Graphics.cpp
@@ -31,9 +31,6 @@ bool CLR_GFX_BitmapDescription::BitmapDescription_Initialize(int width, int heig
     m_flags = 0;
     m_type = CLR_GFX_BitmapDescription::c_Type_nanoCLRBitmap;
 
-    if (GetTotalSize() < 0)
-        return false;
-
     return true;
 }
 
@@ -162,7 +159,7 @@ HRESULT CLR_GFX_Bitmap::CreateInstance(
 
         NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::CreateInstance(refUncompressed, bmUncompressed));
 
-        NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::GetInstanceFromGraphicsHeapBlock(refUncompressed, bitmap));
+        NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::GetInstanceFromManagedCSharpReference(refUncompressed, bitmap));
 
         bitmap->Decompress(data, size);
 
@@ -182,7 +179,7 @@ HRESULT CLR_GFX_Bitmap::CreateInstance(
 
         NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::CreateInstance(ref, bmNative));
 
-        NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::GetInstanceFromGraphicsHeapBlock(ref, bitmapNative));
+        NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::GetInstanceFromManagedCSharpReference(ref, bitmapNative));
 
         bitmapNative->ConvertToNative(bm, (CLR_UINT32 *)data);
     }
@@ -201,7 +198,7 @@ HRESULT CLR_GFX_Bitmap::CreateInstance(
     NANOCLR_CLEANUP_END();
 }
 
-HRESULT CLR_GFX_Bitmap::GetInstanceFromGraphicsHeapBlock(const CLR_RT_HeapBlock &ref, CLR_GFX_Bitmap *&bitmap)
+HRESULT CLR_GFX_Bitmap::GetInstanceFromManagedCSharpReference(const CLR_RT_HeapBlock &ref, CLR_GFX_Bitmap *&bitmap)
 {
     HRESULT hr;
     CLR_RT_HeapBlock *blob;
@@ -254,7 +251,7 @@ HRESULT CLR_GFX_Bitmap::CreateInstanceBmp(CLR_RT_HeapBlock &ref, const CLR_UINT8
     // Allocate the memory that the decoded bitmap would need
     NANOCLR_CHECK_HRESULT(CreateInstance(ref, bm));
 
-    NANOCLR_CHECK_HRESULT(GetInstanceFromGraphicsHeapBlock(ref, bitmap));
+    NANOCLR_CHECK_HRESULT(GetInstanceFromManagedCSharpReference(ref, bitmap));
 
     NANOCLR_CHECK_HRESULT(decoder.BmpStartOutput(bitmap));
 
@@ -421,7 +418,8 @@ CLR_UINT32 CLR_GFX_Bitmap::ConvertToNative16BppHelper(int x, int y, CLR_UINT32 f
     myParam->srcCur16BppPixel++;
     opacity = PAL_GFX_Bitmap::c_OpacityOpaque;
 
-    return (r << 16 | g << 8 | b);
+    return (r << 16) | (g << 8) | b ;
+
 }
 
 CLR_UINT32 CLR_GFX_Bitmap::GetPixel(int xPos, int yPos) const
@@ -466,7 +464,7 @@ void CLR_GFX_Bitmap::Bitmap_Initialize()
     m_palBitmap.width = m_bm.m_width;
     m_palBitmap.height = m_bm.m_height;
     m_palBitmap.data = (CLR_UINT32 *)&this[1];
-    m_palBitmap.transparentColor = PAL_GFX_Bitmap::c_InvalidColor;
+    m_palBitmap.transparentColorSet = PAL_GFX_Bitmap::c_TransparentColorNotSet;
 
     PAL_GFX_Bitmap::ResetClipping(m_palBitmap);
 }
@@ -735,7 +733,7 @@ HRESULT CLR_GFX_Bitmap::GetBitmap(CLR_RT_HeapBlock *pThis, bool fForWrite, CLR_G
     FAULT_ON_NULL(pThis);
 
     NANOCLR_CHECK_HRESULT(
-        CLR_GFX_Bitmap::GetInstanceFromGraphicsHeapBlock(pThis[CLR_GFX_Bitmap::FIELD__m_bitmap], bitmap));
+        CLR_GFX_Bitmap::GetInstanceFromManagedCSharpReference(pThis[CLR_GFX_Bitmap::FIELD__m_bitmap], bitmap));
 
     if ((bitmap->m_bm.m_flags & CLR_GFX_BitmapDescription::c_ReadOnly) && fForWrite)
         NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);

--- a/src/nanoFramework.Graphics/Graphics/Core/GraphicsDriver.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/GraphicsDriver.cpp
@@ -77,7 +77,7 @@ bool GraphicsDriver::ChangeOrientation(DisplayOrientation newOrientation)
 
 CLR_UINT32 GraphicsDriver::GetPixel(const PAL_GFX_Bitmap &bitmap, int x, int y)
 {
-    return ConvertNativeToColor(GetPixelNative(bitmap, x, y));
+    return ConvertNativeToARGB(GetPixelNative(bitmap, x, y));
 }
 
 void GraphicsDriver::SetPixel(const PAL_GFX_Bitmap &bitmap, int x, int y, CLR_UINT32 color)
@@ -777,6 +777,9 @@ void GraphicsDriver::RotateImage(
     if (degree < 0)
         degree = 360 + degree;
 
+     CLR_UINT16 nativeTransparentColor = ConvertColorToNative(src.transparentColor);
+     bool srcHasTransparentColor = (src.transparentColorSet == PAL_GFX_Bitmap::c_TransparentColorSet);
+
     // If it's just a translation, do the BitBlt instead
     if (degree == 0)
     {
@@ -849,7 +852,9 @@ void GraphicsDriver::RotateImage(
                 {
                     CLR_UINT32 mask, shift;
                     CLR_UINT32 *pbyteSrc = ComputePosition(src, xSrc, ySrc, mask, shift);
-                    if ((CLR_UINT32)pbyteSrc >= sourceMemoryBlockStart && (CLR_UINT32)pbyteSrc <= sourceMemoryBlockEnd)
+                    CLR_UINT16 rgb565Color = (*pbyteSrc & mask) >> shift;
+                    bool transparentSrcColour = srcHasTransparentColor && ( nativeTransparentColor == rgb565Color);
+                    if ((CLR_UINT32)pbyteSrc >= sourceMemoryBlockStart && (CLR_UINT32)pbyteSrc <= sourceMemoryBlockEnd  && !transparentSrcColour)
                     {
                         *pbyteDst &= ~maskDst;
                         *pbyteDst |= ((*pbyteSrc & mask) >> shift) << shiftDst;
@@ -898,7 +903,7 @@ void GraphicsDriver::DrawImage(
 
         int type = 0x0;
         CLR_UINT32 nativeTransparentColor = 0;
-        if (bitmapSrc.transparentColor != PAL_GFX_Bitmap::c_InvalidColor)
+        if (bitmapSrc.transparentColorSet == PAL_GFX_Bitmap::c_TransparentColorSet)
         {
             type |= Transparent;
             nativeTransparentColor = g_GraphicsDriver.ConvertColorToNative(bitmapSrc.transparentColor);
@@ -1033,7 +1038,7 @@ void GraphicsDriver::DrawImage(
 
             CLR_UINT16 color = *ps;
             CLR_UINT32 nativeTransparentColor = g_GraphicsDriver.ConvertColorToNative(bitmapSrc.transparentColor);
-            bool noTransparent = bitmapSrc.transparentColor == PAL_GFX_Bitmap::c_InvalidColor;
+            bool noTransparent = bitmapSrc.transparentColorSet == PAL_GFX_Bitmap::c_TransparentColorNotSet;
             bool transparent = (noTransparent == false) && (color == nativeTransparentColor);
 
             for (int x = 0; x < croppedWidth; x++, pd++)
@@ -1587,8 +1592,6 @@ void GraphicsDriver::Screen_Flush(
         return;
     if (bitmap.m_bm.m_bitsPerPixel != CLR_GFX_BitmapDescription::c_NativeBpp)
         return;
-    if (bitmap.m_palBitmap.transparentColor != PAL_GFX_Bitmap::c_InvalidColor)
-        return;
-
+  
     g_DisplayDriver.BitBlt(srcX, srcY, width, height, bitmap.m_bm.m_width, screenX, screenY, bitmap.m_palBitmap.data);
 }

--- a/src/nanoFramework.Graphics/Graphics/Core/Support/Bmp/Bitmap_Decoder.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/Support/Bmp/Bitmap_Decoder.cpp
@@ -291,5 +291,5 @@ CLR_UINT32 BmpDecoder::BmpOutputHelper(int x, int y, CLR_UINT32 flags, CLR_UINT1
             break;
     }
 
-    return r | (g << 8) | (b << 16);
+    return (r << 16) | (g << 8) | b;
 }

--- a/src/nanoFramework.Graphics/Graphics/Core/Support/Gif/Gif.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/Support/Gif/Gif.cpp
@@ -36,7 +36,7 @@ HRESULT CLR_GFX_Bitmap::CreateInstanceGif(CLR_RT_HeapBlock &ref, const CLR_UINT8
     // Allocate the memory that the decompressed bitmap would need
     NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::CreateInstance(ref, bm));
 
-    NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::GetInstanceFromGraphicsHeapBlock(ref, bitmap));
+    NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::GetInstanceFromManagedCSharpReference(ref, bitmap));
 
     NANOCLR_CHECK_HRESULT(decoder->GifStartDecompress(bitmap));
 

--- a/src/nanoFramework.Graphics/Graphics/Core/Support/Gif/GifDecoder.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/Support/Gif/GifDecoder.cpp
@@ -8,9 +8,6 @@
 #include "gif.h"
 #include "lzwread.h"
 
-// Reverse 32bit RGB Color to 24bit BGR Color
-#define REVERSECOLOR(n) ((n << 24) | (((n >> 16) << 24) >> 16) | (((n << 16) >> 24) << 16)) >> 8
-
 // Initialization routine for GifDecoder struct. When it's finished,
 // the header field would be loaded already.
 HRESULT GifDecoder::GifInitDecompress(const CLR_UINT8 *src, CLR_UINT32 srcSize)
@@ -331,7 +328,7 @@ CLR_UINT32 GifDecoder::ProcessImageChunkHelper(int x, int y, CLR_UINT32 flags, C
         myParam->flushing = false;
     }
 
-    return REVERSECOLOR(color);
+    return color;
 }
 
 #pragma GCC diagnostic pop
@@ -414,7 +411,7 @@ HRESULT GifDecoder::ReadColorTable()
     for (int i = 0; i < colorTableSize; i++)
     {
         colorTable[i] =
-            ((CLR_UINT32)curEntry->red) | (((CLR_UINT32)curEntry->green) << 8) | (((CLR_UINT32)curEntry->blue) << 16);
+            ((CLR_UINT32)curEntry->red) << 16 | ((CLR_UINT32)curEntry->green) << 8 | ((CLR_UINT32)curEntry->blue);
         if (colorTable[i] == transparentColor)
         {
             isTransparentColorUnique = false;

--- a/src/nanoFramework.Graphics/Graphics/Core/Support/Jpeg/Jpeg.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Core/Support/Jpeg/Jpeg.cpp
@@ -93,7 +93,7 @@ HRESULT CLR_GFX_Bitmap::CreateInstanceJpeg(CLR_RT_HeapBlock &ref, const CLR_UINT
     // Allocate the memory that the decompressed bitmap would need
     NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::CreateInstance(ref, bm));
 
-    NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::GetInstanceFromGraphicsHeapBlock(ref, bitmap));
+    NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::GetInstanceFromManagedCSharpReference(ref, bitmap));
 
     // Do the actual decompression
     rect.left = 0;

--- a/src/nanoFramework.Graphics/Graphics/Displays/DisplayInterface.h
+++ b/src/nanoFramework.Graphics/Graphics/Displays/DisplayInterface.h
@@ -28,6 +28,19 @@ struct DisplayInterfaceConfig
             CLR_INT8 address;
             CLR_INT8 fastMode;
         } I2c;
+        struct
+        {
+            CLR_INT16 enable;
+            CLR_INT16 control;
+            CLR_INT16 backlight;
+            CLR_INT16 Horizontal_synchronization;
+            CLR_INT16 Horizontal_back_porch;
+            CLR_INT16 Horizontal_front_porch;
+            CLR_INT16 Vertical_synchronization;
+            CLR_INT16 Vertical_back_porch;
+            CLR_INT16 Vertical_front_porch;
+            CLR_INT16 Frequency_Divider;
+        } VideoDisplay;
     };
     struct
     {

--- a/src/nanoFramework.Graphics/Graphics/Native/nanoFramework_Graphics_nanoFramework_UI_Bitmap.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Native/nanoFramework_Graphics_nanoFramework_UI_Bitmap.cpp
@@ -460,13 +460,10 @@ HRESULT Library_nanoFramework_Graphics_nanoFramework_UI_Bitmap::MakeTransparent_
     NANOCLR_HEADER();
 
     CLR_GFX_Bitmap *bitmap;
-    CLR_UINT32 color;
 
     NANOCLR_CHECK_HRESULT(GetBitmap(stack, true, bitmap));
-
-    color = stack.Arg1().NumericByRef().u4;
-
-    bitmap->m_palBitmap.transparentColor = (color & 0xFF000000) ? PAL_GFX_Bitmap::c_InvalidColor : color;
+    bitmap->m_palBitmap.transparentColor = stack.Arg1().NumericByRef().u4;
+    bitmap->m_palBitmap.transparentColorSet =  PAL_GFX_Bitmap::c_TransparentColorSet;
 
     NANOCLR_NOCLEANUP();
 }
@@ -1177,7 +1174,7 @@ HRESULT GetBitmap(CLR_RT_HeapBlock *pThis, bool fForWrite, CLR_GFX_Bitmap *&bitm
     FAULT_ON_NULL(pThis);
 
     NANOCLR_CHECK_HRESULT(
-        CLR_GFX_Bitmap::GetInstanceFromGraphicsHeapBlock(pThis[CLR_GFX_Bitmap::FIELD__m_bitmap], bitmap));
+        CLR_GFX_Bitmap::GetInstanceFromManagedCSharpReference(pThis[CLR_GFX_Bitmap::FIELD__m_bitmap], bitmap));
 
     if ((bitmap->m_bm.m_flags & CLR_GFX_BitmapDescription::c_ReadOnly) && fForWrite)
         NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);

--- a/src/nanoFramework.Graphics/Graphics/Native/nanoFramework_Graphics_nanoFramework_UI_Ink.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Native/nanoFramework_Graphics_nanoFramework_UI_Ink.cpp
@@ -47,7 +47,7 @@ HRESULT Library_nanoFramework_Graphics_nanoFramework_UI_Ink::
         // we are drawing on the object in the PAL therefore it should not move
         m_InkPinnedBitmap->Pin();
 
-        NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::GetInstanceFromGraphicsHeapBlock(
+        NANOCLR_CHECK_HRESULT(CLR_GFX_Bitmap::GetInstanceFromManagedCSharpReference(
             m_InkPinnedBitmap[CLR_GFX_Bitmap::FIELD__m_bitmap],
             bitmap));
 

--- a/src/nanoFramework.Graphics/TouchPanel/Core/Ink.cpp
+++ b/src/nanoFramework.Graphics/TouchPanel/Core/Ink.cpp
@@ -26,7 +26,7 @@ HRESULT InkDriver::Initialize()
         m_ScreenBmp.width = g_DisplayDriver.Attributes.Width;
         m_ScreenBmp.height = g_DisplayDriver.Attributes.Height;
         //   m_ScreenBmp.data = Display::GetFrameBuffer();
-        m_ScreenBmp.transparentColor = PAL_GFX_Bitmap::c_InvalidColor;
+        m_ScreenBmp.transparentColorSet = PAL_GFX_Bitmap::c_TransparentColorNotSet;
     }
 
     return S_OK;

--- a/src/nanoFramework.Graphics/TouchPanel/Core/Ink.h
+++ b/src/nanoFramework.Graphics/TouchPanel/Core/Ink.h
@@ -3,8 +3,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#ifndef GESTURES_H
-#define GESTURES_H
+#ifndef INK_H
+#define INK_H
 
 #include "Graphics.h"
 
@@ -42,4 +42,4 @@ class InkDriver
     static void InkContinuationRoutine(void *arg);
 };
 
-#endif // GESTURES_H
+#endif // INK_H


### PR DESCRIPTION
## Description
The code has been modified to only use ARGB or RGR565 format.

Code was also modified to the RotateImage method to properly rotate images with a transparent background.
This was not in place, although it was already in place for stretch image.

## Motivation and Context
Problems with colours. This eliminates some confusion with the formats in memory.

## How Has This Been Tested?
The modifed code was tested on

STM32769I_Discovery board
ESP32 Wrover Kit v4.1
ESP32 Wrover Kit 4.1 with Generic SPI class and C# class of ili9341 from the Managed Drivers.
All three tests showed the same resulting colours.
See the following testing notes below

### Testing notes

A selection of 9 ARGB colours were selected to test operation

During native debugging, examination of the memory buffer of the Bitmap showed that it was correctly in the RGB565 format stored as little endian.

Many references to native color format are in the code and this native format is the RGB565 format.
There are assumptions in the code that a pixel is 2 bytes, this can be seen in the image manipulation routines which operate on memory copy of bytes assuming 16-bit pixels.

JPEG test was created using Paint.net to set 9 pixels to the ARGB colours then saved to disk and re-read. The values re-read from the disk are "compressed" so are slightly different. The expected values were found using the eye-dropper tool of paint.net to get the hex colour values.

Bitmaps saved in the resource file are all converted to RGB565 format before being embedded into the assembly and deployed to flash. (This is by design)

The graphics code supports reading in bitmaps of 32-bit, 24-bit and 8-bit indexed, usually from file. For this test the bitmaps are included as a C# byte arrays to eliminate the need to have a file system.

#### Restoring RGB565 to ARGB

Restored results are inexact values due to the loss of 3 bits red, 2 bits green and 3 bits blue. The restoration code uses an algorithm originally from .NetMF to approximate the original ARGB colour.

Gif values should be the same as SetPixel, GetPixel, unlike Jpeg GIF uses lossless compression.


```
// |-------------------|---------------|----------------|---------------|--------------| 
// |     Colours       | 32-bit ARGB   |   Set Pixel    |  Get Pixel    |      JPEG    |
// |                   |  Source       | 16-bit RGB565  | Restored ARGB | Restored RGB |
// |-------------------|---------------|----------------|---------------|--------------|
// | Color.DarkRed     |  0xFF8B0000   |    0x8800      |  0xFF8F0000   |   0x8F0000   |
// | Color.Red         |  0xFFFF0000   |    0xF800      |  0xFFFF0000   |   0xFE0000   |
// | Color.LightPink   |  0xFFFFB6C1   |    0xFDB8      |  0xFFFFB7C0   |   0xFFB6C1   |
// | Color.LightGreen  |  0xFF90EE90   |    0x9772      |  0xFF90EF90   |   0x90EE90   |
// | Color.Green       |  0xFF008000   |    0x0400      |  0xFF008000   |   0x008001   |
// | Color.DarkGreen   |  0xFF006400   |    0x0320      |  0xFF006700   |   0x006401   |
// | Color.LightBlue   |  0xFFADD8E6   |    0xAEDC      |  0xFFAFD8E0   |   0xAFD9E6   |
// | Color.Blue        |  0xFF0000FF   |    0x001F      |  0xFF0000FF   |   0x0000FE   |
// | Color.DarkBlue);  |  0xFF00008B   |    0x0011      |  0xFF00008F   |   0x01008C   |
// |-------------------|---------------|----------------|---------------|--------------|
```


Screenshots

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything local that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
