### PR TITLE
Updating `System.IO.Path` signature

### DIFF
--- a/src/System.IO.FileSystem/nf_sys_io_filesystem.cpp
+++ b/src/System.IO.FileSystem/nf_sys_io_filesystem.cpp
@@ -131,14 +131,19 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
 };
 
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_System_IO_FileSystem =
 {
     "System.IO.FileSystem",
-    0x91DFAE15,
+    0x831E32E8,
     method_lookup,
-    { 1, 0, 0, 1 }
+    { 1, 0, 0, 2 }
 };
 
 // clang-format on

--- a/src/System.IO.FileSystem/nf_sys_io_filesystem.cpp
+++ b/src/System.IO.FileSystem/nf_sys_io_filesystem.cpp
@@ -133,15 +133,12 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
-    NULL,
-    NULL,
-    NULL,
 };
 
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_System_IO_FileSystem =
 {
     "System.IO.FileSystem",
-    0x831E32E8,
+    0x545A6C79,
     method_lookup,
     { 1, 0, 0, 2 }
 };

--- a/src/System.IO.FileSystem/nf_sys_io_filesystem.h
+++ b/src/System.IO.FileSystem/nf_sys_io_filesystem.h
@@ -186,12 +186,13 @@ struct Library_nf_sys_io_filesystem_System_IO_File
 struct Library_nf_sys_io_filesystem_System_IO_Path
 {
     static const int FIELD_STATIC__DirectorySeparatorChar = 3;
-    static const int FIELD_STATIC__InvalidPathChars = 4;
-    static const int FIELD_STATIC__m_illegalCharacters = 5;
+    static const int FIELD_STATIC__AltDirectorySeparatorChar = 4;
+    static const int FIELD_STATIC__VolumeSeparatorChar = 5;
+    static const int FIELD_STATIC__PathSeparator = 6;
 
     //--//
 };
 
 extern const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_System_IO_FileSystem;
 
-#endif //_NF_SYS_IO_FILESYSTEM_H_
+#endif // NF_SYS_IO_FILESYSTEM_H


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Updating signatures for https://github.com/nanoframework/System.IO.FileSystem/pull/91/

## Motivation and Context
Required for library updates

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Unit tests
- On device

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [x] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
