### PR TITLE
Enable I2C Slave to most ESP32 targets

### DIFF
--- a/CMake/xtensa-esp32.json
+++ b/CMake/xtensa-esp32.json
@@ -27,6 +27,7 @@
                 "API_System.Device.Dac": "ON",
                 "API_System.Device.Gpio": "ON",
                 "API_System.Device.I2c": "ON",
+                "API_System.Device.I2c.Slave": "ON",
                 "API_System.Device.I2s": "ON",
                 "API_System.Device.Spi": "ON",
                 "API_System.Device.Pwm": "ON",

--- a/CMake/xtensa-esp32c3.json
+++ b/CMake/xtensa-esp32c3.json
@@ -27,6 +27,7 @@
                 "API_System.Device.Dac": "OFF",
                 "API_System.Device.Gpio": "ON",
                 "API_System.Device.I2c": "ON",
+                "API_System.Device.I2c.Slave": "ON",
                 "API_System.Device.I2s": "ON",
                 "API_System.Device.Spi": "ON",
                 "API_System.Device.Pwm": "ON",

--- a/CMake/xtensa-esp32s2.json
+++ b/CMake/xtensa-esp32s2.json
@@ -27,6 +27,7 @@
                 "API_System.Device.Dac": "ON",
                 "API_System.Device.Gpio": "ON",
                 "API_System.Device.I2c": "ON",
+                "API_System.Device.I2c.Slave": "ON",
                 "API_System.Device.I2s": "ON",
                 "API_System.Device.Spi": "ON",
                 "API_System.Device.Pwm": "ON",

--- a/CMake/xtensa-esp32s3.json
+++ b/CMake/xtensa-esp32s3.json
@@ -26,6 +26,7 @@
                 "API_System.Device.Adc": "ON",
                 "API_System.Device.Gpio": "ON",
                 "API_System.Device.I2c": "ON",
+                "API_System.Device.I2c.Slave": "ON",
                 "API_System.Device.I2s": "ON",
                 "API_System.Device.Spi": "ON",
                 "API_System.Device.Pwm": "ON",

--- a/targets/ESP32/CMakePresets.json
+++ b/targets/ESP32/CMakePresets.json
@@ -143,6 +143,7 @@
                 "NF_FEATURE_RTC": "ON",
                 "NF_FEATURE_HAS_SDCARD": "ON",
                 "API_System.IO.FileSystem": "ON",
+                "API_System.Device.I2c.Slave": "OFF",
                 "API_nanoFramework.Device.OneWire": "ON",
                 "API_nanoFramework.Device.Bluetooth": "ON"
             }
@@ -163,6 +164,7 @@
                 "NF_FEATURE_RTC": "ON",
                 "NF_FEATURE_HAS_SDCARD": "ON",
                 "API_System.IO.FileSystem": "ON",
+                "API_System.Device.I2c.Slave": "OFF",
                 "API_nanoFramework.Device.OneWire": "ON",
                 "API_nanoFramework.Device.Bluetooth": "ON"
             }
@@ -187,7 +189,8 @@
                 "NF_FEATURE_HAS_SDCARD": "OFF",
                 "API_System.IO.FileSystem": "ON",
                 "API_Windows.Storage": "ON",
-                "API_System.Device.I2s": "OFF"
+                "API_System.Device.I2s": "OFF",
+                "API_System.Device.I2c.Slave": "OFF"
             }
         },
         {
@@ -295,6 +298,7 @@
                 "NF_FEATURE_HAS_SDCARD": "ON",
                 "ESP32_USB_CDC": "ON",
                 "API_nanoFramework.Device.Bluetooth": "ON",
+                "API_System.Device.I2c.Slave": "ON",
                 "ESP32_RESERVED_RAM_FOR_IDF_ALLOCATION": "180"
             }
         },
@@ -421,7 +425,8 @@
                 "API_Windows.Storage": "ON",
                 "API_nanoFramework.Device.OneWire": "OFF",
                 "API_nanoFramework.Device.Bluetooth": "OFF",
-                "API_nanoFramework.Graphics": "OFF"
+                "API_nanoFramework.Graphics": "OFF",
+                "API_System.Device.I2c.Slave": "OFF"
             }
         },
         {
@@ -497,6 +502,7 @@
                 "ETH_PHY_RST_GPIO": "5",
                 "ETH_RMII_CLK_OUT_GPIO": "17",
                 "API_System.IO.FileSystem": "ON",
+                "API_System.Device.I2c.Slave": "OFF",
                 "API_nanoFramework.Device.OneWire": "ON"
             }
         },
@@ -520,7 +526,8 @@
                 "ETH_PHY_RST_GPIO": "12",
                 "ETH_RMII_CLK_OUT_GPIO": "17",
                 "API_System.IO.FileSystem": "ON",
-                "API_nanoFramework.Device.OneWire": "ON"
+                "API_nanoFramework.Device.OneWire": "ON",
+                "API_System.Device.I2c.Slave": "OFF"
             }
         },
         {
@@ -540,6 +547,7 @@
                 "API_System.IO.FileSystem": "ON",
                 "API_nanoFramework.Device.OneWire": "ON",
                 "API_nanoFramework.Graphics": "ON",
+                "API_System.Device.I2c.Slave": "OFF",
                 "GRAPHICS_DISPLAY": "ST7789V_240x320_SPI.cpp",
                 "TOUCHPANEL_DEVICE": "XPT2046.cpp",
                 "GRAPHICS_DISPLAY_INTERFACE": "Spi_To_Display.cpp",
@@ -563,6 +571,7 @@
                 "NF_FEATURE_RTC": "OFF",
                 "NF_FEATURE_HAS_SDCARD": "OFF",
                 "API_System.IO.FileSystem": "OFF",
+                "API_System.Device.I2c.Slave": "OFF",
                 "API_nanoFramework.Graphics": "ON",
                 "API_nanoFramework.Device.OneWire": "OFF",
                 "API_nanoFramework.Device.Bluetooth": "ON",
@@ -595,7 +604,8 @@
                 "ETH_PHY_ADDR": "1",
                 "API_System.IO.FileSystem": "ON",
                 "API_nanoFramework.Device.OneWire": "ON",
-                "API_nanoFramework.Device.Bluetooth": "ON"
+                "API_nanoFramework.Device.Bluetooth": "ON",
+                "API_System.Device.I2c.Slave": "OFF"
             }
         },
         {
@@ -618,7 +628,8 @@
                 "ETH_PHY_ADDR": "1",
                 "ETH_PHY_RST_GPIO": "16",
                 "API_System.IO.FileSystem": "ON",
-                "API_nanoFramework.Device.OneWire": "ON"
+                "API_nanoFramework.Device.OneWire": "ON",
+                "API_System.Device.I2c.Slave": "OFF"
             }
         },
         {
@@ -666,6 +677,7 @@
                 "API_System.IO.FileSystem": "ON",
                 "API_nanoFramework.Device.OneWire": "ON",
                 "API_nanoFramework.Graphics": "ON",
+                "API_System.Device.I2c.Slave": "OFF",
                 "GRAPHICS_DISPLAY": "ST7735S_SPI.cpp",
                 "TOUCHPANEL_DEVICE": "XPT2046.cpp",
                 "GRAPHICS_DISPLAY_INTERFACE": "Spi_To_Display.cpp",
@@ -690,6 +702,7 @@
                 "NF_FEATURE_RTC": "ON",
                 "API_System.IO.FileSystem": "ON",
                 "API_nanoFramework.Device.OneWire": "ON",
+                "API_System.Device.I2c.Slave": "OFF",
                 "API_nanoFramework.Graphics": "ON",
                 "GRAPHICS_DISPLAY": "ST7789V_240x320_SPI.cpp",
                 "TOUCHPANEL_DEVICE": "XPT2046.cpp",


### PR DESCRIPTION
## Description
- Update Cmake presets to enable I2C Slave to most ESP32 targets.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
