### PR TITLE
Fix memory leak with serial port WriteString

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -722,13 +722,13 @@ jobs:
 
   strategy:
     matrix:
-      ST_B_L475E_IOT01A:
-        TargetBoard: ST_B_L475E_IOT01A
-        TargetSeries: 'stm32l4xx'
-        BuildOptions: 
-        NeedsDFU: true
-        NeedsSRECORD: false
-        CMakePreset: ST_B_L475E_IOT01A
+      # ST_B_L475E_IOT01A:
+      #   TargetBoard: ST_B_L475E_IOT01A
+      #   TargetSeries: 'stm32l4xx'
+      #   BuildOptions: 
+      #   NeedsDFU: true
+      #   NeedsSRECORD: false
+      #   CMakePreset: ST_B_L475E_IOT01A
 
       # ORGPAL_PALTHREE:
       #   TargetBoard: ORGPAL_PALTHREE

--- a/targets/AzureRTOS/ST/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/AzureRTOS/ST/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1242,6 +1242,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         // push onto the eval stack how many bytes are being pushed to the UART
         stack.PushValueI4(bufferLength);
 
+        // push onto the eval stack if the buffer was allocated
+        stack.PushValueI4(isNewAllocation ? 1 : 0);
+
         // flush DMA buffer to ensure cache coherency
         // (only required for Cortex-M7)
         cacheBufferFlush(buffer, bufferLength);
@@ -1274,8 +1277,13 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         if (eventResult)
         {
             // event occurred
-            // get from the eval stack how many bytes were buffered to Tx
-            length = stack.m_evalStack[1].NumericByRef().s4;
+
+            // pop "isNewAllocation" from the eval stack
+            isNewAllocation = stack.m_evalStack[2].NumericByRef().s4 == 1
+                ? true
+
+                  // get from the eval stack how many bytes were buffered to Tx
+                  length = stack.m_evalStack[1].NumericByRef().s4;
 
             // done here
             break;
@@ -1289,15 +1297,18 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
     // pop "length" heap block from stack
     stack.PopValue();
 
+    // pop "isNewAllocation" heap block from stack
+    stack.PopValue();
+
     // pop "hbTimeout" heap block from stack
     stack.PopValue();
 
     stack.SetResult_U4(length);
 
     // free memory, if it was allocated
-    if (isNewAllocation && buffer)
+    if (isNewAllocation)
     {
-        platform_free(buffer);
+        platform_free(palUart->TxBuffer);
     }
 
     // null pointers and vars

--- a/targets/AzureRTOS/ST/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/AzureRTOS/ST/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1279,11 +1279,10 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
             // event occurred
 
             // pop "isNewAllocation" from the eval stack
-            isNewAllocation = stack.m_evalStack[2].NumericByRef().s4 == 1
-                ? true
+            isNewAllocation = stack.m_evalStack[2].NumericByRef().s4 == 1 ? true : false;
 
-                  // get from the eval stack how many bytes were buffered to Tx
-                  length = stack.m_evalStack[1].NumericByRef().s4;
+            // get from the eval stack how many bytes were buffered to Tx
+            length = stack.m_evalStack[1].NumericByRef().s4;
 
             // done here
             break;

--- a/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -939,6 +939,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         // push onto the eval stack how many bytes are being pushed to the UART
         stack.PushValueI4(bufferLength);
 
+        // push onto the eval stack if the buffer was allocated
+        stack.PushValueI4(isNewAllocation ? 1 : 0);
+
         // store pointer
         palUart->TxBuffer = (uint8_t *)buffer;
 
@@ -968,6 +971,10 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         if (eventResult)
         {
             // event occurred
+
+            // pop "isNewAllocation" from the eval stack
+            isNewAllocation = stack.m_evalStack[2].NumericByRef().s4 == 1 ? true : false;
+
             // get from the eval stack how many bytes were buffered to Tx
             length = stack.m_evalStack[1].NumericByRef().s4;
 
@@ -983,15 +990,18 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
     // pop "length" heap block from stack
     stack.PopValue();
 
+    // pop "isNewAllocation" heap block from stack
+    stack.PopValue();
+
     // pop "hbTimeout" heap block from stack
     stack.PopValue();
 
     stack.SetResult_U4(length);
 
     // free memory, if it was allocated
-    if (isNewAllocation && buffer)
+    if (isNewAllocation)
     {
-        platform_free(buffer);
+        platform_free(palUart->TxBuffer);
     }
 
     // null pointers and vars

--- a/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1244,6 +1244,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         // push onto the eval stack how many bytes are being pushed to the UART
         stack.PushValueI4(bufferLength);
 
+        // push onto the eval stack if the buffer was allocated
+        stack.PushValueI4(isNewAllocation ? 1 : 0);
+
         // flush DMA buffer to ensure cache coherency
         // (only required for Cortex-M7)
         cacheBufferFlush(buffer, bufferLength);
@@ -1276,6 +1279,10 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         if (eventResult)
         {
             // event occurred
+
+            // pop "isNewAllocation" from the eval stack
+            isNewAllocation = stack.m_evalStack[2].NumericByRef().s4 == 1 ? true : false;
+
             // get from the eval stack how many bytes were buffered to Tx
             length = stack.m_evalStack[1].NumericByRef().s4;
 
@@ -1291,15 +1298,18 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
     // pop "length" heap block from stack
     stack.PopValue();
 
+    // pop "isNewAllocation" heap block from stack
+    stack.PopValue();
+
     // pop "hbTimeout" heap block from stack
     stack.PopValue();
 
     stack.SetResult_U4(length);
 
     // free memory, if it was allocated
-    if (isNewAllocation && buffer)
+    if (isNewAllocation)
     {
-        platform_free(buffer);
+        platform_free(palUart->TxBuffer);
     }
 
     // null pointers and vars

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1281,7 +1281,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
 
             // push buffer pointer to eval stack
             // need this to release the buffer later, because the pointer is changed
-            stack.PushValueU4(buffer);
+            stack.PushValueU4((CLR_UINT32)&bufferPointer);
 
             // Create a task to handle UART event from ISR
             char task_name[16];
@@ -1315,7 +1315,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
             // event occurred
 
             // pop "buffer pointer" from the eval stack
-            buffer = (char *)stack.m_evalStack[3].NumericByRef().s4.u4;
+            buffer = (char *)stack.m_evalStack[3].NumericByRef().u4;
 
             // pop "isNewAllocation" from the eval stack
             isNewAllocation = stack.m_evalStack[2].NumericByRef().s4 == 1 ? true : false;

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1204,6 +1204,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
 
     bool isNewAllocation = false;
     char *buffer = NULL;
+    const char *bufferPointer = NULL;
     uint32_t bufferLength;
     int32_t length = 0;
 
@@ -1242,7 +1243,12 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         // Try to send buffer to fifo first.
         // if not all data written then use long running operation to complete.
         palUart->IsLongRunning = false;
+
+        // store pointer because it will be changed after this call
+        bufferPointer = buffer;
+
         int txCount = uart_tx_chars(uart_num, (const char *)buffer, bufferLength);
+
         if (txCount < (int)bufferLength)
         {
             palUart->IsLongRunning = true;
@@ -1250,7 +1256,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
             {
                 // Any written then update ptr / count
                 bufferLength -= txCount;
-                buffer += txCount;
+                bufferPointer += txCount;
             }
         }
 
@@ -1262,13 +1268,20 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
             NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeoutTicks));
 
             // store pointer
-            palUart->TxBuffer = (uint8_t *)buffer;
+            palUart->TxBuffer = (uint8_t *)bufferPointer;
 
             // set TX count
             palUart->TxOngoingCount = bufferLength;
 
             // push onto the eval stack how many bytes are being pushed to the UART
             stack.PushValueI4(bufferLength);
+
+            // push onto the eval stack if the buffer was allocated
+            stack.PushValueI4(isNewAllocation ? 1 : 0);
+
+            // push buffer pointer to eval stack
+            // need this to release the buffer later, because the pointer is changed
+            stack.PushValueU4(buffer);
 
             // Create a task to handle UART event from ISR
             char task_name[16];
@@ -1300,6 +1313,13 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         if (eventResult)
         {
             // event occurred
+
+            // pop "buffer pointer" from the eval stack
+            buffer = (char *)stack.m_evalStack[3].NumericByRef().s4.u4;
+
+            // pop "isNewAllocation" from the eval stack
+            isNewAllocation = stack.m_evalStack[2].NumericByRef().s4 == 1 ? true : false;
+
             // get from the eval stack how many bytes were buffered to TX
             length = stack.m_evalStack[1].NumericByRef().s4;
 
@@ -1320,6 +1340,12 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         // pop "length" heap block from stack
         stack.PopValue();
 
+        // pop "isNewAllocation" heap block from stack
+        stack.PopValue();
+
+        // pop "buffer" heap block from stack
+        stack.PopValue();
+
         // pop "hbTimeout" heap block from stack
         stack.PopValue();
     }
@@ -1327,7 +1353,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
     stack.SetResult_U4(length);
 
     // free memory, if it was allocated
-    if (isNewAllocation && buffer)
+    if (isNewAllocation && buffer != NULL)
     {
         platform_free(buffer);
     }

--- a/targets/FreeRTOS/NXP/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/FreeRTOS/NXP/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -1013,7 +1013,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
 
     // pop "length" heap block from stack
     stack.PopValue();
-    
+
     // pop "isNewAllocation" heap block from stack
     stack.PopValue();
 

--- a/targets/FreeRTOS/NXP/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/FreeRTOS/NXP/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -961,6 +961,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         // push onto the eval stack how many bytes are being pushed to the UART
         stack.PushValueI4(bufferLength);
 
+        // push onto the eval stack if the buffer was allocated
+        stack.PushValueI4(isNewAllocation ? 1 : 0);
+
         // store pointer
         palUart->TxBuffer = (uint8_t *)buffer;
 
@@ -987,6 +990,10 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         if (eventResult)
         {
             // event occurred
+
+            // pop "isNewAllocation" from the eval stack
+            isNewAllocation = stack.m_evalStack[2].NumericByRef().s4 == 1 ? true : false;
+
             // get from the eval stack how many bytes were buffered to Tx
             length = stack.m_evalStack[1].NumericByRef().s4;
 
@@ -1006,6 +1013,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
 
     // pop "length" heap block from stack
     stack.PopValue();
+    
+    // pop "isNewAllocation" heap block from stack
+    stack.PopValue();
 
     // pop "hbTimeout" heap block from stack
     stack.PopValue();
@@ -1013,9 +1023,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
     stack.SetResult_U4(length);
 
     // free memory, if it was allocated
-    if (isNewAllocation && buffer)
+    if (isNewAllocation)
     {
-        platform_free(buffer);
+        platform_free(palUart->TxBuffer);
     }
 
     // null pointers and vars

--- a/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -976,6 +976,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         // push onto the eval stack how many bytes are being pushed to the UART
         stack.PushValueI4(bufferLength);
 
+        // push onto the eval stack if the buffer was allocated
+        stack.PushValueI4(isNewAllocation ? 1 : 0);
+
         // store pointer
         palUart->TxBuffer = (uint8_t *)buffer;
 
@@ -997,6 +1000,10 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
         if (eventResult)
         {
             // event occurred
+
+            // pop "isNewAllocation" from the eval stack
+            isNewAllocation = stack.m_evalStack[2].NumericByRef().s4 == 1 ? true : false;
+
             // get from the eval stack how many bytes were buffered to Tx
             length = stack.m_evalStack[1].NumericByRef().s4;
 
@@ -1014,15 +1021,18 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeWriteString_
     // pop "length" heap block from stack
     stack.PopValue();
 
+    // pop "isNewAllocation" heap block from stack
+    stack.PopValue();
+
     // pop "hbTimeout" heap block from stack
     stack.PopValue();
 
     stack.SetResult_U4(length);
 
     // free memory, if it was allocated
-    if (isNewAllocation && buffer)
+    if (isNewAllocation)
     {
-        platform_free(buffer);
+        platform_free(palUart->TxBuffer);
     }
 
     // null pointers and vars


### PR DESCRIPTION
## Description
- Now storing in the eval stack a flag if new allocation was made.
- Popping this after event return and free memory if allocated.
- Slight implementation difference for ESP32 as the stored buffer pointer may not be the allocation pointer.

## Motivation and Context
- Fixes memory leak with all serial port implementations for WriteString. The existing code was never releasing the allocated memory upon return from the event because both the flag and pointer weren't being restored. There is a slight difference in the ESP32 implementation because the allocation pointer gets changed in case there is a partial output before the long run operation occurs.
- This was found when testing the fix in #2834 during a long run the target eventually ended up without heap memory pointing to a memory leak with the serial code.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Long run on serial sample.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
