### PR TITLE
Fix Wifi failed to connect on non PSRAM hardware with SPIRAM configuration

### DIFF
--- a/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
+++ b/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
@@ -157,6 +157,17 @@ esp_err_t NF_ESP32_InitaliseWifi()
         // Initialise WiFi, allocate resource for WiFi driver, such as WiFi control structure,
         // RX/TX buffer, WiFi NVS structure etc, this WiFi also start WiFi task.
         wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+
+#if CONFIG_SPIRAM_IGNORE_NOTFOUND
+        //The comment out function below is only avaliable in ESP IDF 5.1x
+        //if (!esp_psram_is_initialized()){ 
+        if (heap_caps_get_total_size(MALLOC_CAP_SPIRAM) == 0)
+        {
+          cfg.cache_tx_buf_num = 0;
+          cfg.feature_caps &= ~CONFIG_FEATURE_CACHE_TX_BUF_BIT;
+        }
+#endif
+
         ec = esp_wifi_init(&cfg);
 
         if (ec != ESP_OK)


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
WIFI will not connect when using firmware with PSRAM option on non PSRAM hardware.   For example using ESP32_PSRAM_REV3 firmware on ESP32 WROOM hardware.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
Reported the issue espressif/esp-idf#11971 in ESP IDF and the same issue also happens in micropython.  The issue arise due to the way ESP-IDF allocates [cache](https://github.com/espressif/esp-idf/blob/e8bdaf91986a41678adc6be13888fc037b1acb68/components/esp_wifi/src/wifi_init.c#L49C18-L49C18) memory for WIFI when PSRAM/SPIRAM option is enabled.  On runtime WIFI cache will still be allocated when PSRAM is unavailable and this causes OOM.   

This fix will check for PSRAM availability at runtime and disable the WIFI cache thus allowing for WIFI to connect.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on ESP32 REV0, REV3 (with and without PSRAM),  ESP32 S3 

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
