### PR TITLE
Clears cache on SPIFFs init

### DIFF
--- a/targets/AzureRTOS/ST/ORGPAL_PALTHREE/target_spiffs.c
+++ b/targets/AzureRTOS/ST/ORGPAL_PALTHREE/target_spiffs.c
@@ -6,6 +6,7 @@
 
 #include <hal.h>
 #include <hal_spiffs.h>
+#include <cache.h>
 
 #ifdef SPIFFS_SPI1
 
@@ -739,6 +740,9 @@ uint8_t target_spiffs_init()
 
     // sanity check: read device ID and unique ID
     writeBuffer[0] = READ_ID_CMD2;
+
+    // flush DMA buffer to ensure cache coherency
+    cacheBufferFlush(writeBuffer, 1);
 
     CS_SELECT;
     spiExchange(&SPID1, 4, writeBuffer, readBuffer);

--- a/targets/ChibiOS/ORGPAL_PALTHREE/target_spiffs.c
+++ b/targets/ChibiOS/ORGPAL_PALTHREE/target_spiffs.c
@@ -6,6 +6,7 @@
 
 #include <hal.h>
 #include <hal_spiffs.h>
+#include <cache.h>
 
 #ifdef SPIFFS_SPI1
 
@@ -739,6 +740,9 @@ uint8_t target_spiffs_init()
 
     // sanity check: read device ID and unique ID
     writeBuffer[0] = READ_ID_CMD2;
+
+    // flush DMA buffer to ensure cache coherency
+    cacheBufferFlush(writeBuffer, 1);
 
     CS_SELECT;
     spiExchange(&SPID1, 4, writeBuffer, readBuffer);


### PR DESCRIPTION
## Description
- Clears cache on SPIFFs init.

## Motivation and Context
- These targets were often crashing at boot because SPIFFs init failing. Turns out that it was due to cache issue on the buffer preventing the correct command being issued to SPI bus.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Local debug verifying that target boots properly.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
