### PR TITLE
Fix WP header processor

### DIFF
--- a/src/CLR/WireProtocol/WireProtocol_App_Interface.c
+++ b/src/CLR/WireProtocol/WireProtocol_App_Interface.c
@@ -17,12 +17,6 @@ uint32_t WireProtocolLastPacketSequence = 0x00FEFFFF;
 
 uint8_t WP_App_ProcessHeader(WP_Message *message)
 {
-    // check for reception buffer overflow
-    if (message->m_header.m_size > WP_PACKET_SIZE)
-    {
-        return false;
-    }
-
     message->m_payload = receptionBuffer;
 
     return true;


### PR DESCRIPTION
## Description
- Moving data backwards now is moving correct amount of bytes.
- Add extra check to prevent unnecessary processing when no data was received.
- Check for payload size was moved to correct function.
- Add asserts for WP header processing.

## Motivation and Context
- Could cause issues accessing memory outside the expected bounds (even out of address space).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Virtual CLR and Silabs GG1 target.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
