### PR TITLE
Fix BlockStorage init and uninit

### DIFF
--- a/src/PAL/BlockStorage/nanoPAL_BlockStorage.c
+++ b/src/PAL/BlockStorage/nanoPAL_BlockStorage.c
@@ -809,14 +809,31 @@ void BlockStorageList_Initialize()
 // walk through list of devices and calls Init() function
 bool BlockStorageList_InitializeDevices()
 {
-    // TODO FIXME
+    for (int i = 0; i < TARGET_BLOCKSTORAGE_COUNT; i++)
+    {
+        if (g_BlockStorage.DeviceList[i] != NULL)
+        {
+            BlockStorageDevice_InitializeDevice(g_BlockStorage.DeviceList[i]);
+        }
+    }
+
     return true;
 }
 
 // walk through list of devices and calls UnInit() function
 bool BlockStorageList_UnInitializeDevices()
 {
-    // TODO FIXME
+    for (int i = 0; i < TARGET_BLOCKSTORAGE_COUNT; i++)
+    {
+        if (g_BlockStorage.DeviceList[i] != NULL)
+        {
+            BlockStorageDevice_UninitializeDevice(g_BlockStorage.DeviceList[i]);
+            g_BlockStorage.DeviceList[i] = NULL;
+
+            g_BlockStorage.DeviceCount--;
+        }
+    }
+
     return true;
 }
 

--- a/targets/ESP32/ESP32/target_BlockStorage.c
+++ b/targets/ESP32/ESP32/target_BlockStorage.c
@@ -13,11 +13,10 @@ extern IBlockStorageDevice ESP32Flash_BlockStorageInterface;
 
 void BlockStorage_AddDevices()
 {
-    // add device AND request initialization
-    // required to setup flash partitions memory mapping
+    // add device
     BlockStorageList_AddDevice(
         (BlockStorageDevice *)&Device_BlockStorage,
         &ESP32Flash_BlockStorageInterface,
         &Device_BlockStorageConfig,
-        true);
+        false);
 }

--- a/targets/ESP32/ESP32_C3/target_BlockStorage.c
+++ b/targets/ESP32/ESP32_C3/target_BlockStorage.c
@@ -13,11 +13,10 @@ extern IBlockStorageDevice ESP32Flash_BlockStorageInterface;
 
 void BlockStorage_AddDevices()
 {
-    // add device AND request initialization
-    // required to setup flash partitions memory mapping
+    // add device
     BlockStorageList_AddDevice(
         (BlockStorageDevice *)&Device_BlockStorage,
         &ESP32Flash_BlockStorageInterface,
         &Device_BlockStorageConfig,
-        true);
+        false);
 }

--- a/targets/ESP32/ESP32_S2/target_BlockStorage.c
+++ b/targets/ESP32/ESP32_S2/target_BlockStorage.c
@@ -13,11 +13,10 @@ extern IBlockStorageDevice ESP32Flash_BlockStorageInterface;
 
 void BlockStorage_AddDevices()
 {
-    // add device AND request initialization
-    // required to setup flash partitions memory mapping
+    // add device
     BlockStorageList_AddDevice(
         (BlockStorageDevice *)&Device_BlockStorage,
         &ESP32Flash_BlockStorageInterface,
         &Device_BlockStorageConfig,
-        true);
+        false);
 }

--- a/targets/ESP32/ESP32_S3/target_BlockStorage.c
+++ b/targets/ESP32/ESP32_S3/target_BlockStorage.c
@@ -13,11 +13,10 @@ extern IBlockStorageDevice ESP32Flash_BlockStorageInterface;
 
 void BlockStorage_AddDevices()
 {
-    // add device AND request initialization
-    // required to setup flash partitions memory mapping
+    // add device
     BlockStorageList_AddDevice(
         (BlockStorageDevice *)&Device_BlockStorage,
         &ESP32Flash_BlockStorageInterface,
         &Device_BlockStorageConfig,
-        true);
+        false);
 }

--- a/targets/ESP32/_nanoCLR/targetHAL.cpp
+++ b/targets/ESP32/_nanoCLR/targetHAL.cpp
@@ -75,6 +75,7 @@ void nanoHAL_Initialize()
     // initialize block storage devices
     BlockStorage_AddDevices();
 
+    // required to setup flash partitions memory mapping
     BlockStorageList_InitializeDevices();
 
     // allocate & clear managed heap region
@@ -138,6 +139,7 @@ void nanoHAL_Uninitialize(bool isPoweringDown)
     // Network_Uninitialize();
 #endif
 
+    // required to remove flash partitions memory mapping
     BlockStorageList_UnInitializeDevices();
 
 #if (HAL_USE_SPI == TRUE)

--- a/targets/TI_SimpleLink/TI_CC1352R1_LAUNCHXL/target_BlockStorage.c
+++ b/targets/TI_SimpleLink/TI_CC1352R1_LAUNCHXL/target_BlockStorage.c
@@ -15,5 +15,5 @@ void BlockStorage_AddDevices()
         (BlockStorageDevice *)&Device_BlockStorage,
         &CC13xx_26xxFlash_BlockStorageInterface,
         &Device_BlockStorageConfig,
-        true);
+        false);
 }

--- a/targets/TI_SimpleLink/TI_CC3220SF_LAUNCHXL/target_BlockStorage.c
+++ b/targets/TI_SimpleLink/TI_CC3220SF_LAUNCHXL/target_BlockStorage.c
@@ -5,11 +5,15 @@
 
 #include <nanoPAL_BlockStorage.h>
 
-extern struct BlockStorageDevice    Device_BlockStorage;
-extern struct MEMORY_MAPPED_NOR_BLOCK_CONFIG   Device_BlockStorageConfig;
+extern struct BlockStorageDevice Device_BlockStorage;
+extern struct MEMORY_MAPPED_NOR_BLOCK_CONFIG Device_BlockStorageConfig;
 extern IBlockStorageDevice CC32xxFlash_BlockStorageInterface;
 
 void BlockStorage_AddDevices()
 {
-    BlockStorageList_AddDevice( (BlockStorageDevice*)&Device_BlockStorage, &CC32xxFlash_BlockStorageInterface, &Device_BlockStorageConfig, true);
+    BlockStorageList_AddDevice(
+        (BlockStorageDevice *)&Device_BlockStorage,
+        &CC32xxFlash_BlockStorageInterface,
+        &Device_BlockStorageConfig,
+        false);
 }


### PR DESCRIPTION
## Description
- Add code what was missing to perform init and uninit.
- Remove request to init block storage device when adding for ESP32 and TI target.
- Code style fixes.

## Motivation and Context
- Improves block storage init and uninit. Required only for ESP32 and TI. So far it was working with unnoticeable issues in ESP32 when performing CLR reboot on debug session. Thank you @AdrianSoundy for investigating this.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
