### PR TITLE
CLR not starting on ESP32-C3 (XIAO_ESP32C3 firmware) when VS not connected

### DIFF
--- a/targets/ESP32/_IDF/esp32c3/app_main.c
+++ b/targets/ESP32/_IDF/esp32c3/app_main.c
@@ -44,14 +44,18 @@ void main_task(void *pvParameter)
 // Called from Esp32 IDF start up code before scheduler starts
 void app_main()
 {
+    UBaseType_t taskPriority = 5;
+
     // Switch off logging so as not to interfere with WireProtocol over Uart0
     esp_log_level_set("*", ESP_LOG_NONE);
 
     ESP_ERROR_CHECK(nvs_flash_init());
 
+    vTaskPrioritySet( NULL, taskPriority);
+
     // start receiver task
-    xTaskCreate(&receiver_task, "ReceiverThread", 3072, NULL, 5, &ReceiverTask);
+    xTaskCreate(&receiver_task, "ReceiverThread", 3072, NULL, taskPriority, &ReceiverTask);
 
     // start the CLR main task
-    xTaskCreate(&main_task, "main_task", 15000, NULL, 5, NULL);
+    xTaskCreate(&main_task, "main_task", 15000, NULL, taskPriority, NULL);
 }


### PR DESCRIPTION
## Description
Due to task priorities the calling task(appmain) wasn't scheduled to run after starting the wire protocol and no read data was seen from the USB-Jtag connection. This stopped the CLR being started.

This is fix for ESP32-C3. It may also be relevant to other ESP32's Also we can look at reducing CPU overhead of wire protocol thread when nothing is connected. Will look at this in later PR (IDF 5.1). As this also affects esp32-C6 & H2 cpu.

## Motivation and Context
Issue reported on discord

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Run esp32-C3 module with XIAO firmware and reproduce issue. All you had to do was disable device communication in VS device manager.

After change, CLR starts when VS not running.


## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
