### PR TITLE
Fix ESP32 PWM when dutycycle and frequency is zero

### DIFF
--- a/targets/ESP32/_nanoCLR/System.Device.Pwm/sys_dev_pwm_native_System_Device_Pwm_PwmChannel.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.Pwm/sys_dev_pwm_native_System_Device_Pwm_PwmChannel.cpp
@@ -54,6 +54,8 @@ esp_err_t SetDutyCycle(ledc_mode_t speed_mode, ledc_channel_t channel, uint32_t 
 
 using namespace sys_dev_pwm_native_System_Device_Pwm_PwmChannelHelpers;
 
+bool isStarted;
+
 //
 //  Look up Pin number to find channel, if create true and not present then add pin
 //  return channel number or -1 if error
@@ -180,6 +182,8 @@ HRESULT sys_dev_pwm_native_System_Device_Pwm_PwmChannelHelpers::ConfigureAndStar
     {
         ledc_stop(mode, channel, polarity);
     }
+    
+    isStarted = true;
 
     NANOCLR_NOCLEANUP();
 }
@@ -286,18 +290,18 @@ HRESULT Library_sys_dev_pwm_native_System_Device_Pwm_PwmChannel::NativeSetDesire
     channel = (ledc_channel_t)GetChannel(pinNumber, timerId, false);
     dutyCycle = pThis[FIELD___dutyCycle].NumericByRef().u4;
 
+    // parameter check
+    if (desiredFrequency <= 0)
+    {
+        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+    }
+
     // Set the backing frequency field when it is zero and return
     // We need this as this native function is called before Init
-    if (channel == -1)
+    if (!isStarted || channel == -1)
     {
         pThis[FIELD___frequency].NumericByRef().s4 = desiredFrequency;
         NANOCLR_SET_AND_LEAVE(S_OK);
-    }
-
-    // parameter check
-    if (desiredFrequency < 0)
-    {
-        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
     }
 
     timer = (ledc_timer_t)(timerId & 0x03);
@@ -351,7 +355,6 @@ HRESULT Library_sys_dev_pwm_native_System_Device_Pwm_PwmChannel::NativeSetActive
     ledc_mode_t speed_mode;
     int32_t desiredFrequency;
     int32_t optimumDutyResolution;
-    int32_t privateDutyCycle;
     uint32_t calDutyCycle;
 
     NANOCLR_HEADER();
@@ -363,7 +366,6 @@ HRESULT Library_sys_dev_pwm_native_System_Device_Pwm_PwmChannel::NativeSetActive
     // Retrieves the needed parameters from private class properties or method parameters
     timerId = pThis[FIELD___pwmTimer].NumericByRef().s4;
     pinNumber = pThis[FIELD___pinNumber].NumericByRef().s4;
-    privateDutyCycle = pThis[FIELD___dutyCycle].NumericByRef().u4;
     desiredFrequency = pThis[FIELD___frequency].NumericByRef().s4;
 
     // parameter check
@@ -378,7 +380,7 @@ HRESULT Library_sys_dev_pwm_native_System_Device_Pwm_PwmChannel::NativeSetActive
 
     // Set the backing duty cycle field when it is zero and return
     // We need this as this native function is called before Init
-    if (privateDutyCycle == 0)
+    if (!isStarted)
     {
         pThis[FIELD___dutyCycle].NumericByRef().u4 = dutyCycle;
         NANOCLR_SET_AND_LEAVE(S_OK);
@@ -442,6 +444,8 @@ HRESULT Library_sys_dev_pwm_native_System_Device_Pwm_PwmChannel::NativeStop___VO
     channel = (ledc_channel_t)GetChannel(pinNumber, timerId, false);
 
     ledc_stop(speed_mode, channel, (uint32_t)polarity);
+
+    isStarted = false;
 
     NANOCLR_NOCLEANUP();
 }


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Pwm duty cycle when initialized to  zero before it is started an internal error occur therefore it needs to be called again after pwm is started.  Another edge case is when frequency is set to zero. In this case the system panic and reboot.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ESP32

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
