### PR TITLE
Add sanity checks for heap out of bounds

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapCluster.cpp
+++ b/src/CLR/Core/CLR_RT_HeapCluster.cpp
@@ -108,8 +108,12 @@ CLR_RT_HeapBlock *CLR_RT_HeapCluster::ExtractBlocks(CLR_UINT32 dataType, CLR_UIN
             {
                 res = ptr;
 
-                _ASSERTE((void *)res >= (void *)s_CLR_RT_Heap.m_location);
-                _ASSERTE((void *)res < (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size));
+                // sanity checks for out of bounds
+                if ((void *)res < (void *)s_CLR_RT_Heap.m_location ||
+                    (void *)res >= (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size))
+                {
+                    return NULL;
+                }
 
                 break;
             }
@@ -124,10 +128,14 @@ CLR_RT_HeapBlock *CLR_RT_HeapCluster::ExtractBlocks(CLR_UINT32 dataType, CLR_UIN
 
         available -= length;
 
-        _ASSERTE((void *)next >= (void *)s_CLR_RT_Heap.m_location);
-        _ASSERTE((void *)next < (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size));
-        _ASSERTE((void *)prev >= (void *)s_CLR_RT_Heap.m_location);
-        _ASSERTE((void *)prev < (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size));
+        // sanity checks for out of bounds
+        if (((void *)next < (void *)s_CLR_RT_Heap.m_location) ||
+            (void *)next >= (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size) ||
+            (void *)prev < (void *)s_CLR_RT_Heap.m_location ||
+            (void *)prev >= (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size))
+        {
+            return NULL;
+        }
 
         if (available != 0)
         {
@@ -137,15 +145,23 @@ CLR_RT_HeapBlock *CLR_RT_HeapCluster::ExtractBlocks(CLR_UINT32 dataType, CLR_UIN
 
                 res += available;
 
-                _ASSERTE((void *)res >= (void *)s_CLR_RT_Heap.m_location);
-                _ASSERTE((void *)res < (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size));
+                // sanity checks for out of bounds
+                if ((void *)res < (void *)s_CLR_RT_Heap.m_location ||
+                    (void *)res >= (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size))
+                {
+                    return NULL;
+                }
             }
             else
             {
                 CLR_RT_HeapBlock_Node *ptr = &res[length];
 
-                _ASSERTE((void *)ptr >= (void *)s_CLR_RT_Heap.m_location);
-                _ASSERTE((void *)ptr < (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size));
+                // sanity checks for out of bounds
+                if ((void *)ptr < (void *)s_CLR_RT_Heap.m_location ||
+                    (void *)ptr >= (void *)(s_CLR_RT_Heap.m_location + s_CLR_RT_Heap.m_size))
+                {
+                    return NULL;
+                }
 
                 //
                 // Relink to the new free block.


### PR DESCRIPTION
## Description
- These perform sanity checks for heap nodes being assigned to memory outside the managed heap.

## Motivation and Context
- Prevent hard faults and other unwanted behaviors with heap nodes being used/pointed outside of managed heap memory region. 
- Addresses nanoFramework/Home#1354.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Long running app making extensive use of GC and heap compaction.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
