### PR TITLE
Improve initialization of Heap blocks and type related vars

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Array.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Array.cpp
@@ -14,6 +14,9 @@ HRESULT Library_corlib_native_System_Array::System_Collections_IList_get_Item___
     int index = stack.Arg1().NumericByRef().s4;
 
     CLR_RT_HeapBlock ref;
+
+    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
+
     NANOCLR_CHECK_HRESULT(ref.InitializeArrayReference(thisRef, index));
 
     {
@@ -36,6 +39,9 @@ HRESULT Library_corlib_native_System_Array::System_Collections_IList_set_Item___
     int index = stack.Arg1().NumericByRef().s4;
 
     CLR_RT_HeapBlock ref;
+
+    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
+
     NANOCLR_CHECK_HRESULT(ref.InitializeArrayReference(thisRef, index));
 
     NANOCLR_SET_AND_LEAVE(stack.Arg2().StoreToReference(ref, 0));

--- a/src/CLR/CorLib/corlib_native_System_Exception.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Exception.cpp
@@ -42,17 +42,22 @@ HRESULT Library_corlib_native_System_Exception::get_StackTrace___STRING(CLR_RT_S
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock_Array *pArray;
-    StackTrace *pStackTrace;
-    CLR_RT_HeapBlock *pBlkString;
     char buf[512];
     char *strName;
     size_t iName;
+    int depth = 0;
+
+    CLR_RT_HeapBlock_Array *pArray;
+    StackTrace *pStackTrace;
+    CLR_RT_HeapBlock *pBlkString;
     CLR_RT_HeapBlock tmpArray;
+    CLR_RT_HeapBlock *pThis;
+
+    memset(&tmpArray, 0, sizeof(struct CLR_RT_HeapBlock));
     tmpArray.SetObjectReference(NULL);
     CLR_RT_ProtectFromGC gc(tmpArray);
-    int depth = 0;
-    CLR_RT_HeapBlock *pThis = stack.This();
+
+    pThis = stack.This();
     FAULT_ON_NULL(pThis);
 
     pArray = pThis[FIELD___stackTrace].DereferenceArray();

--- a/src/CLR/CorLib/corlib_native_System_GC.cpp
+++ b/src/CLR/CorLib/corlib_native_System_GC.cpp
@@ -36,7 +36,7 @@ HRESULT Library_corlib_native_System_GC::ReRegisterForFinalize___STATIC__VOID__O
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
     CLR_RT_HeapBlock *pObj = stack.Arg0().Dereference();
     FAULT_ON_NULL(pObj);
 

--- a/src/CLR/CorLib/corlib_native_System_Number.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Number.cpp
@@ -962,7 +962,7 @@ HRESULT Library_corlib_native_System_Number::
     FAULT_ON_NULL(numberGroupSizes);
 
     {
-        CLR_RT_TypeDescriptor desc;
+        CLR_RT_TypeDescriptor desc{};
         NANOCLR_CHECK_HRESULT(desc.InitializeFromObject(*value));
         NANOCLR_CHECK_HRESULT(value->PerformUnboxing(desc.m_handlerCls));
     }

--- a/src/CLR/CorLib/corlib_native_System_Object.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Object.cpp
@@ -34,7 +34,7 @@ HRESULT Library_corlib_native_System_Object::GetType___SystemType(CLR_RT_StackFr
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
     CLR_RT_ReflectionDef_Index idx;
     CLR_RT_HeapBlock &arg0 = stack.Arg0();
     CLR_RT_HeapBlock *pObj;

--- a/src/CLR/CorLib/corlib_native_System_Reflection_Assembly.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Reflection_Assembly.cpp
@@ -295,6 +295,8 @@ HRESULT Library_corlib_native_System_Reflection_Assembly::Load___STATIC__SystemR
 
     header = (CLR_RECORD_ASSEMBLY *)array->GetFirstElement();
 
+    memset(&hbTimeout, 0, sizeof(struct CLR_RT_HeapBlock));
+
     // !! need to cast to CLR_INT64 otherwise it wont setup a proper timeout
     hbTimeout.SetInteger((CLR_INT64)2 * CLR_RT_Thread::c_TimeQuantum_Milliseconds * TIME_CONVERSION__TO_MILLISECONDS);
 

--- a/src/CLR/CorLib/corlib_native_System_Reflection_FieldInfo.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Reflection_FieldInfo.cpp
@@ -19,6 +19,8 @@ HRESULT Library_corlib_native_System_Reflection_FieldInfo::SetValue___VOID__OBJE
     bool fValueType;
     CLR_RT_HeapBlock &srcVal = stack.Arg2();
     CLR_RT_HeapBlock val;
+
+    memset(&val, 0, sizeof(struct CLR_RT_HeapBlock));
     val.Assign(srcVal);
     CLR_RT_ProtectFromGC gc(val);
 

--- a/src/CLR/CorLib/corlib_native_System_Reflection_RuntimeFieldInfo.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Reflection_RuntimeFieldInfo.cpp
@@ -54,7 +54,7 @@ HRESULT Library_corlib_native_System_Reflection_RuntimeFieldInfo::get_FieldType_
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
     CLR_RT_FieldDef_Instance fd;
     CLR_RT_HeapBlock *hbField = stack.Arg0().Dereference();
 
@@ -85,6 +85,8 @@ HRESULT Library_corlib_native_System_Reflection_RuntimeFieldInfo::GetValue___OBJ
     const CLR_RECORD_FIELDDEF *fd;
     CLR_RT_HeapBlock *obj;
     CLR_RT_HeapBlock dst;
+
+    memset(&dst, 0, sizeof(struct CLR_RT_HeapBlock));
 
     NANOCLR_CHECK_HRESULT(Library_corlib_native_System_Reflection_FieldInfo::Initialize(stack, instFD, instTD, obj));
 

--- a/src/CLR/CorLib/corlib_native_System_RuntimeType.cpp
+++ b/src/CLR/CorLib/corlib_native_System_RuntimeType.cpp
@@ -183,7 +183,7 @@ HRESULT Library_corlib_native_System_RuntimeType::GetElementType___SystemType(CL
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
     CLR_RT_TypeDescriptor descSub;
     CLR_RT_HeapBlock &top = stack.PushValueAndClear();
     CLR_RT_HeapBlock *hbType = stack.Arg0().Dereference();
@@ -342,7 +342,7 @@ HRESULT Library_corlib_native_System_RuntimeType::GetCustomAttributes(
             attributeEnumerator.GetCurrent(&instanceTypeDef);
 
             // setup attribute parser
-            CLR_RT_AttributeParser parser;
+            CLR_RT_AttributeParser parser{};
             NANOCLR_CHECK_HRESULT(parser.Initialize(attributeEnumerator));
 
             while (true)

--- a/src/CLR/CorLib/corlib_native_System_Runtime_CompilerServices_RuntimeHelpers.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Runtime_CompilerServices_RuntimeHelpers.cpp
@@ -145,6 +145,8 @@ HRESULT Library_corlib_native_System_Runtime_CompilerServices_RuntimeHelpers::
                 CLR_RT_HeapBlock tmp;
                 CLR_UINT32 *ptr = (CLR_UINT32 *)ptrDst;
 
+                memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
+
                 for (; lenSrc; lenSrc--, ptr++)
                 {
                     NANOCLR_CHECK_HRESULT(tmp.SetFloatIEEE754(*ptr));
@@ -158,6 +160,8 @@ HRESULT Library_corlib_native_System_Runtime_CompilerServices_RuntimeHelpers::
             {
                 CLR_RT_HeapBlock tmp;
                 CLR_UINT64 *ptr = (CLR_UINT64 *)ptrDst;
+
+                memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
 
                 for (; lenSrc; lenSrc--, ptr++)
                 {

--- a/src/CLR/CorLib/corlib_native_System_String.cpp
+++ b/src/CLR/CorLib/corlib_native_System_String.cpp
@@ -197,11 +197,16 @@ HRESULT Library_corlib_native_System_String::_ctor___VOID__CHAR__I4(CLR_RT_Stack
 
     CLR_UINT16 ch = stack.Arg1().NumericByRef().u2;
     int len = stack.Arg2().NumericByRef().s4;
+    
     if (len < 0)
+    {
         NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_RANGE);
+    }
 
     {
         CLR_RT_HeapBlock tmp;
+
+        memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
         tmp.SetObjectReference(NULL);
         CLR_RT_ProtectFromGC gc(tmp);
 
@@ -856,11 +861,13 @@ HRESULT Library_corlib_native_System_String::ChangeCase(CLR_RT_StackFrame &stack
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
+    CLR_UINT16 *ptr;
+    CLR_RT_HeapBlock_Array *arrayTmp;
     CLR_RT_HeapBlock refTmp;
+
+    memset(&refTmp, 0, sizeof(struct CLR_RT_HeapBlock));
     refTmp.SetObjectReference(NULL);
     CLR_RT_ProtectFromGC gc(refTmp);
-    CLR_RT_HeapBlock_Array *arrayTmp;
-    CLR_UINT16 *ptr;
 
     NANOCLR_CHECK_HRESULT(ConvertToCharArray(stack, refTmp, arrayTmp, 0, -1));
 
@@ -897,10 +904,12 @@ HRESULT Library_corlib_native_System_String::Substring(CLR_RT_StackFrame &stack,
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
+    CLR_RT_HeapBlock_Array *arrayTmp;
     CLR_RT_HeapBlock refTmp;
+
+    memset(&refTmp, 0, sizeof(struct CLR_RT_HeapBlock));
     refTmp.SetObjectReference(NULL);
     CLR_RT_ProtectFromGC gc(refTmp);
-    CLR_RT_HeapBlock_Array *arrayTmp;
 
     NANOCLR_CHECK_HRESULT(ConvertToCharArray(stack, refTmp, arrayTmp, 0, -1));
 
@@ -934,13 +943,16 @@ HRESULT Library_corlib_native_System_String::Trim(
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock refTmp;
-    refTmp.SetObjectReference(NULL);
-    CLR_RT_ProtectFromGC gc(refTmp);
-    CLR_RT_HeapBlock_Array *arrayTmp;
     CLR_UINT16 *pSrcStart;
     CLR_UINT16 *pSrcEnd;
 
+    CLR_RT_HeapBlock refTmp;
+    CLR_RT_HeapBlock_Array *arrayTmp;
+    
+    memset(&refTmp, 0, sizeof(struct CLR_RT_HeapBlock));
+    refTmp.SetObjectReference(NULL);
+    CLR_RT_ProtectFromGC gc(refTmp);
+    
     NANOCLR_CHECK_HRESULT(ConvertToCharArray(stack, refTmp, arrayTmp, 0, -1));
 
     pSrcStart = (CLR_UINT16 *)arrayTmp->GetFirstElement();
@@ -1050,6 +1062,8 @@ HRESULT Library_corlib_native_System_String::Split(CLR_RT_StackFrame &stack, CLR
 
         {
             CLR_RT_HeapBlock refSrc;
+
+            memset(&refSrc, 0, sizeof(struct CLR_RT_HeapBlock));
             refSrc.SetObjectReference(NULL);
             CLR_RT_ProtectFromGC gc(refSrc);
 

--- a/src/CLR/CorLib/corlib_native_System_Threading_Interlocked.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Threading_Interlocked.cpp
@@ -9,18 +9,24 @@ HRESULT Library_corlib_native_System_Threading_Interlocked::Increment___STATIC__
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
-    {
-        CLR_RT_HeapBlock heapLocation;
-        NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
-        signed int &location = heapLocation.NumericByRef().s4;
 
-        // Increment the value passed by reference
-        location++;
+    CLR_RT_HeapBlock heapLocation;
 
-        SetResult_INT32(stack, location);
+    signed int locationValue = 0;
+    signed int &location = locationValue;
 
-        NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
-    }
+    memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
+
+    NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
+    location = heapLocation.NumericByRef().s4;
+
+    // Increment the value passed by reference
+    location++;
+
+    SetResult_INT32(stack, location);
+
+    NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
+
     NANOCLR_NOCLEANUP();
 }
 
@@ -28,18 +34,24 @@ HRESULT Library_corlib_native_System_Threading_Interlocked::Decrement___STATIC__
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
-    {
-        CLR_RT_HeapBlock heapLocation;
-        NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
-        signed int &location = heapLocation.NumericByRef().s4;
 
-        // Decrement the value passed by reference
-        location--;
+    CLR_RT_HeapBlock heapLocation;
 
-        SetResult_INT32(stack, location);
+    signed int locationValue = 0;
+    signed int &location = locationValue;
 
-        NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
-    }
+    memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
+
+    NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
+    location = heapLocation.NumericByRef().s4;
+
+    // Decrement the value passed by reference
+    location--;
+
+    SetResult_INT32(stack, location);
+
+    NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
+
     NANOCLR_NOCLEANUP();
 }
 
@@ -48,20 +60,28 @@ HRESULT Library_corlib_native_System_Threading_Interlocked::Exchange___STATIC__I
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
-    {
-        CLR_RT_HeapBlock heapLocation;
-        NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
-        signed int &location = heapLocation.NumericByRef().s4;
 
-        // Always return value of first parameter
-        signed int retVal = location;
-        // Move second parameter into the first.
-        location = stack.Arg1().NumericByRef().s4;
+    CLR_RT_HeapBlock heapLocation;
 
-        SetResult_INT32(stack, retVal);
+    signed int retVal;
+    signed int locationValue = 0;
+    signed int &location = locationValue;
 
-        NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
-    }
+    memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
+
+    NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
+    location = heapLocation.NumericByRef().s4;
+
+    // Always return value of first parameter
+    retVal = location;
+
+    // Move second parameter into the first.
+    location = stack.Arg1().NumericByRef().s4;
+
+    SetResult_INT32(stack, retVal);
+
+    NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
+
     NANOCLR_NOCLEANUP();
 }
 
@@ -70,22 +90,30 @@ HRESULT Library_corlib_native_System_Threading_Interlocked::CompareExchange___ST
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
+
+    CLR_RT_HeapBlock heapLocation;
+
+    signed int retVal;
+    signed int locationValue = 0;
+    signed int &location = locationValue;
+
+    memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
+
+    NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
+    location = heapLocation.NumericByRef().s4;
+
+    // Always return value of first parameter
+    retVal = location;
+
+    // Exchange value if first and third parameters has equal value.
+    if (stack.Arg2().NumericByRef().s4 == location)
     {
-        CLR_RT_HeapBlock heapLocation;
-        NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
-        signed int &location = heapLocation.NumericByRef().s4;
-
-        // Always return value of first parameter
-        signed int retVal = location;
-        // Exchange value if first and third parameters has equal value.
-        if (stack.Arg2().NumericByRef().s4 == location)
-        {
-            location = stack.Arg1().NumericByRef().s4;
-        }
-
-        SetResult_INT32(stack, retVal);
-
-        NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
+        location = stack.Arg1().NumericByRef().s4;
     }
+
+    SetResult_INT32(stack, retVal);
+
+    NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
+
     NANOCLR_NOCLEANUP();
 }

--- a/src/CLR/CorLib/corlib_native_System_Threading_Interlocked.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Threading_Interlocked.cpp
@@ -9,24 +9,20 @@ HRESULT Library_corlib_native_System_Threading_Interlocked::Increment___STATIC__
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
+    {
+        CLR_RT_HeapBlock heapLocation;
+        memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
 
-    CLR_RT_HeapBlock heapLocation;
+        NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
+        signed int &location = heapLocation.NumericByRef().s4;
 
-    signed int locationValue = 0;
-    signed int &location = locationValue;
+        // Increment the value passed by reference
+        location++;
 
-    memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
+        SetResult_INT32(stack, location);
 
-    NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
-    location = heapLocation.NumericByRef().s4;
-
-    // Increment the value passed by reference
-    location++;
-
-    SetResult_INT32(stack, location);
-
-    NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
-
+        NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
+    }
     NANOCLR_NOCLEANUP();
 }
 
@@ -34,24 +30,20 @@ HRESULT Library_corlib_native_System_Threading_Interlocked::Decrement___STATIC__
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
+    {
+        CLR_RT_HeapBlock heapLocation;
+        memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
 
-    CLR_RT_HeapBlock heapLocation;
+        NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
+        signed int &location = heapLocation.NumericByRef().s4;
 
-    signed int locationValue = 0;
-    signed int &location = locationValue;
+        // Decrement the value passed by reference
+        location--;
 
-    memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
+        SetResult_INT32(stack, location);
 
-    NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
-    location = heapLocation.NumericByRef().s4;
-
-    // Decrement the value passed by reference
-    location--;
-
-    SetResult_INT32(stack, location);
-
-    NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
-
+        NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
+    }
     NANOCLR_NOCLEANUP();
 }
 
@@ -60,28 +52,22 @@ HRESULT Library_corlib_native_System_Threading_Interlocked::Exchange___STATIC__I
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
+    {
+        CLR_RT_HeapBlock heapLocation;
+        memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
 
-    CLR_RT_HeapBlock heapLocation;
+        NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
+        signed int &location = heapLocation.NumericByRef().s4;
 
-    signed int retVal;
-    signed int locationValue = 0;
-    signed int &location = locationValue;
+        // Always return value of first parameter
+        signed int retVal = location;
+        // Move second parameter into the first.
+        location = stack.Arg1().NumericByRef().s4;
 
-    memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
+        SetResult_INT32(stack, retVal);
 
-    NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
-    location = heapLocation.NumericByRef().s4;
-
-    // Always return value of first parameter
-    retVal = location;
-
-    // Move second parameter into the first.
-    location = stack.Arg1().NumericByRef().s4;
-
-    SetResult_INT32(stack, retVal);
-
-    NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
-
+        NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
+    }
     NANOCLR_NOCLEANUP();
 }
 
@@ -90,30 +76,24 @@ HRESULT Library_corlib_native_System_Threading_Interlocked::CompareExchange___ST
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
-
-    CLR_RT_HeapBlock heapLocation;
-
-    signed int retVal;
-    signed int locationValue = 0;
-    signed int &location = locationValue;
-
-    memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
-
-    NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
-    location = heapLocation.NumericByRef().s4;
-
-    // Always return value of first parameter
-    retVal = location;
-
-    // Exchange value if first and third parameters has equal value.
-    if (stack.Arg2().NumericByRef().s4 == location)
     {
-        location = stack.Arg1().NumericByRef().s4;
+        CLR_RT_HeapBlock heapLocation;
+        memset(&heapLocation, 0, sizeof(struct CLR_RT_HeapBlock));
+
+        NANOCLR_CHECK_HRESULT(heapLocation.LoadFromReference(stack.Arg0()));
+        signed int &location = heapLocation.NumericByRef().s4;
+
+        // Always return value of first parameter
+        signed int retVal = location;
+        // Exchange value if first and third parameters has equal value.
+        if (stack.Arg2().NumericByRef().s4 == location)
+        {
+            location = stack.Arg1().NumericByRef().s4;
+        }
+
+        SetResult_INT32(stack, retVal);
+
+        NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
     }
-
-    SetResult_INT32(stack, retVal);
-
-    NANOCLR_CHECK_HRESULT(heapLocation.StoreToReference(stack.Arg0(), 0));
-
     NANOCLR_NOCLEANUP();
 }

--- a/src/CLR/CorLib/corlib_native_System_Threading_SpinWait.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Threading_SpinWait.cpp
@@ -55,6 +55,8 @@ HRESULT Library_corlib_native_System_Threading_SpinWait::Spin(CLR_RT_StackFrame 
     bool longRunning;
     bool eventResult = true;
 
+    memset(&hbTimeout, 0, sizeof(struct CLR_RT_HeapBlock));
+
     if (isTimeSpan)
     {
         timeout = Library_corlib_native_System_TimeSpan::GetValuePtr(stack.Arg0());

--- a/src/CLR/CorLib/corlib_native_System_TimeSpan.cpp
+++ b/src/CLR/CorLib/corlib_native_System_TimeSpan.cpp
@@ -149,6 +149,9 @@ HRESULT Library_corlib_native_System_TimeSpan::Compare___STATIC__I4__SystemTimeS
     CLR_RT_HeapBlock resLeft;
     CLR_RT_HeapBlock resRight;
 
+    memset(&resLeft, 0, sizeof(struct CLR_RT_HeapBlock));
+    memset(&resRight, 0, sizeof(struct CLR_RT_HeapBlock));
+
     pLeft = Library_corlib_native_System_TimeSpan::GetValuePtr(stack);
     FAULT_ON_NULL(pLeft);
     pRight = Library_corlib_native_System_TimeSpan::GetValuePtr(stack.Arg1());

--- a/src/CLR/CorLib/corlib_native_System_Type.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Type.cpp
@@ -49,7 +49,7 @@ HRESULT Library_corlib_native_System_Type::IsInstanceOfType___BOOLEAN__OBJECT(CL
     NANOCLR_HEADER();
 
     CLR_RT_TypeDescriptor descTarget;
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
     CLR_RT_HeapBlock *hbType = stack.Arg0().Dereference();
 
     if (hbType->DataType() != DATATYPE_REFLECTION)

--- a/src/CLR/CorLib/corlib_native_System_WeakReference.cpp
+++ b/src/CLR/CorLib/corlib_native_System_WeakReference.cpp
@@ -122,9 +122,12 @@ HRESULT CLR_RT_HeapBlock_WeakReference::GetTarget(CLR_RT_HeapBlock &targetRefere
             else
             {
                 CLR_RT_HeapBlock input;
-                input.SetObjectReference(m_targetSerialized);
-
                 CLR_RT_HeapBlock output;
+
+                memset(&input, 0, sizeof(struct CLR_RT_HeapBlock));
+                memset(&output, 0, sizeof(struct CLR_RT_HeapBlock));
+
+                input.SetObjectReference(m_targetSerialized);
                 output.SetObjectReference(NULL);
 
                 {

--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -237,7 +237,7 @@ HRESULT CLR_RT_HeapBlock::SetReflection(const CLR_RT_TypeSpec_Index &sig)
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
 
     NANOCLR_CHECK_HRESULT(desc.InitializeFromTypeSpec(sig));
 
@@ -388,6 +388,8 @@ HRESULT CLR_RT_HeapBlock::LoadFromReference(CLR_RT_HeapBlock &ref)
     CLR_RT_HeapBlock *obj;
     CLR_DataType dt = ref.DataType();
 
+    memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
+
     if (dt == DATATYPE_ARRAY_BYREF)
     {
         CLR_RT_HeapBlock_Array *array = ref.m_data.arrayReference.array;
@@ -530,6 +532,9 @@ HRESULT CLR_RT_HeapBlock::StoreToReference(CLR_RT_HeapBlock &ref, int size)
                 {
                     CLR_DataType dtElem = (CLR_DataType)array->m_typeOfElement;
                     CLR_RT_HeapBlock blk;
+
+                    memset(&blk, 0, sizeof(struct CLR_RT_HeapBlock));
+
                     blk.Assign(*this);
 
                     NANOCLR_CHECK_HRESULT(blk.Convert(
@@ -651,6 +656,8 @@ HRESULT CLR_RT_HeapBlock::Reassign(const CLR_RT_HeapBlock &value)
     CLR_RT_HeapBlock *obj;
     CLR_RT_HeapBlock ref;
 
+    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
+
     if (this->DataType() == DATATYPE_BYREF)
     {
         obj = this->Dereference();
@@ -696,6 +703,9 @@ HRESULT CLR_RT_HeapBlock::Reassign(const CLR_RT_HeapBlock &value)
         _ASSERTE(false); // not tested
 
         CLR_RT_HeapBlock valueT;
+
+        memset(&valueT, 0, sizeof(struct CLR_RT_HeapBlock));
+
         valueT.Assign(value);
 
         NANOCLR_CHECK_HRESULT(ref.LoadFromReference(valueT));
@@ -781,7 +791,7 @@ HRESULT CLR_RT_HeapBlock::PerformBoxingIfNeeded()
 
     if (fBox)
     {
-        CLR_RT_TypeDescriptor desc;
+        CLR_RT_TypeDescriptor desc{};
 
         NANOCLR_CHECK_HRESULT(desc.InitializeFromObject(*this));
 
@@ -799,6 +809,8 @@ HRESULT CLR_RT_HeapBlock::PerformBoxing(const CLR_RT_TypeDef_Instance &cls)
     CLR_RT_HeapBlock tmp;
     CLR_RT_HeapBlock *obj = this;
     CLR_DataType dt = obj->DataType();
+
+    memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
 
     //
     // System.DateTime and System.TimeSpan are real value types, so sometimes they are passed by reference.
@@ -1630,6 +1642,9 @@ CLR_INT32 CLR_RT_HeapBlock::Compare_Values(const CLR_RT_HeapBlock &left, const C
                 const CLR_RT_HeapBlock *ptrRight;
                 CLR_RT_HeapBlock hbLeft;
                 CLR_RT_HeapBlock hbRight;
+
+                memset(&hbLeft, 0, sizeof(struct CLR_RT_HeapBlock));
+                memset(&hbRight, 0, sizeof(struct CLR_RT_HeapBlock));
 
                 if (left.ReflectionDataConst().m_kind != right.ReflectionDataConst().m_kind)
                 {

--- a/src/CLR/Core/CLR_RT_HeapBlock_Array.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Array.cpp
@@ -95,6 +95,10 @@ HRESULT CLR_RT_HeapBlock_Array::CreateInstance(
     CLR_RT_TypeDef_Instance cls;
     CLR_RT_TypeSpec_Instance def;
 
+    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
+    memset(&cls, 0, sizeof(CLR_RT_TypeDef_Instance));
+    memset(&def, 0, sizeof(CLR_RT_TypeSpec_Instance));
+
     if (cls.ResolveToken(tk, assm))
     {
         ref.SetReflection(cls);
@@ -382,6 +386,12 @@ HRESULT CLR_RT_HeapBlock_Array::Copy(
             CLR_RT_TypeDescriptor descDst;
             CLR_RT_HeapBlock ref;
             CLR_RT_HeapBlock elem;
+
+            memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
+            memset(&elem, 0, sizeof(struct CLR_RT_HeapBlock));
+            memset(&descSrc, 0, sizeof(CLR_RT_TypeDescriptor));
+            memset(&descDst, 0, sizeof(CLR_RT_TypeDescriptor));
+
             elem.SetObjectReference(NULL);
             CLR_RT_ProtectFromGC gc(elem);
 

--- a/src/CLR/Core/CLR_RT_HeapBlock_ArrayList.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_ArrayList.cpp
@@ -46,7 +46,7 @@ HRESULT CLR_RT_HeapBlock_ArrayList::Add(CLR_RT_HeapBlock *value, CLR_INT32 &inde
         // Protect value from GC, in case EnsureCapacity triggers one
         CLR_RT_HeapBlock valueHB;
 
-        memset(&valueHB, 0, sizeof(CLR_RT_HeapBlock));
+        memset(&valueHB, 0, sizeof(struct CLR_RT_HeapBlock));
         valueHB.SetObjectReference(value);
         CLR_RT_ProtectFromGC gc(valueHB);
 
@@ -94,8 +94,8 @@ HRESULT CLR_RT_HeapBlock_ArrayList::Insert(CLR_INT32 index, CLR_RT_HeapBlock *va
     {
         // Protect value from GC, in case EnsureCapacity triggers one
         CLR_RT_HeapBlock valueHB;
-
-        memset(&valueHB, 0, sizeof(CLR_RT_HeapBlock));
+        
+        memset(&valueHB, 0, sizeof(struct CLR_RT_HeapBlock));
         valueHB.SetObjectReference(value);
         CLR_RT_ProtectFromGC gc(valueHB);
 
@@ -171,7 +171,7 @@ HRESULT CLR_RT_HeapBlock_ArrayList::SetCapacity(CLR_UINT32 newCapacity)
         CLR_RT_HeapBlock newItemsHB;
         CLR_RT_HeapBlock_Array *newItems;
 
-        memset(&newItemsHB, 0, sizeof(CLR_RT_HeapBlock));
+        memset(&newItemsHB, 0, sizeof(struct CLR_RT_HeapBlock));
 
         if (newCapacity < size)
             NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_RANGE);
@@ -188,7 +188,7 @@ HRESULT CLR_RT_HeapBlock_ArrayList::SetCapacity(CLR_UINT32 newCapacity)
 
         if (size > 0)
         {
-            memcpy(newItems->GetFirstElement(), items->GetFirstElement(), size * sizeof(CLR_RT_HeapBlock));
+            memcpy(newItems->GetFirstElement(), items->GetFirstElement(), size * sizeof(struct CLR_RT_HeapBlock));
         }
 
         SetItems(newItems);

--- a/src/CLR/Core/CLR_RT_HeapBlock_Delegate.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Delegate.cpp
@@ -54,8 +54,9 @@ HRESULT CLR_RT_HeapBlock_Delegate::CreateInstance(
 #if defined(NANOCLR_DELEGATE_PRESERVE_STACK)
     dlg->m_numOfStackFrames = length;
 #endif
-
-    dlg->m_object.SetObjectReference(NULL);
+    
+    memset(&dlg->m_object, 0, sizeof(struct CLR_RT_HeapBlock));
+    dlg->m_object.SetObjectReference( NULL );
 
 #if defined(NANOCLR_APPDOMAINS)
     dlg->m_appDomain = g_CLR_RT_ExecutionEngine.GetCurrentAppDomain();

--- a/src/CLR/Core/CLR_RT_HeapBlock_Delegate_List.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Delegate_List.cpp
@@ -12,7 +12,7 @@ HRESULT CLR_RT_HeapBlock_Delegate_List::CreateInstance(CLR_RT_HeapBlock_Delegate
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_UINT32 totLength = (CLR_UINT32)(sizeof(CLR_RT_HeapBlock_Delegate_List) + length * sizeof(CLR_RT_HeapBlock));
+    CLR_UINT32 totLength = (CLR_UINT32)(sizeof(CLR_RT_HeapBlock_Delegate_List) + length * sizeof(struct CLR_RT_HeapBlock));
 
     list = (CLR_RT_HeapBlock_Delegate_List *)
                g_CLR_RT_ExecutionEngine.ExtractHeapBytesForObjects(DATATYPE_DELEGATELIST_HEAD, 0, totLength);
@@ -90,6 +90,8 @@ HRESULT CLR_RT_HeapBlock_Delegate_List::Change(
     if (dlg->DataType() == DATATYPE_DELEGATELIST_HEAD)
     {
         CLR_RT_HeapBlock intermediate;
+
+        memset(&intermediate, 0, sizeof(struct CLR_RT_HeapBlock));
         intermediate.Assign(delegateSrc);
         CLR_RT_ProtectFromGC gc(intermediate);
 

--- a/src/CLR/Core/CLR_RT_HeapBlock_Lock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Lock.cpp
@@ -25,6 +25,7 @@ HRESULT CLR_RT_HeapBlock_Lock::CreateInstance(
 
     lock->m_owningThread = th;                   // CLR_RT_Thread*          m_owningThread;
                                                  //
+    memset(&lock->m_resource, 0, sizeof(struct CLR_RT_HeapBlock)); 
     lock->m_resource.Assign(resource);           // CLR_RT_HeapBlock        m_resource;
                                                  //
     lock->m_owners.DblLinkedList_Initialize();   // CLR_RT_DblLinkedList    m_owners;

--- a/src/CLR/Core/CLR_RT_HeapBlock_Queue.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Queue.cpp
@@ -50,8 +50,12 @@ HRESULT CLR_RT_HeapBlock_Queue::Enqueue(CLR_RT_HeapBlock *value)
         // Set new capacity
         CLR_RT_HeapBlock newArrayHB;
 
+        memset(&newArrayHB, 0, sizeof(struct CLR_RT_HeapBlock));
+
         // Protect value from GC, in case CreateInstance triggers one
         CLR_RT_HeapBlock valueHB;
+
+        memset(&valueHB, 0, sizeof(struct CLR_RT_HeapBlock));
         valueHB.SetObjectReference(value);
         CLR_RT_ProtectFromGC gc(valueHB);
 
@@ -133,7 +137,7 @@ HRESULT CLR_RT_HeapBlock_Queue::ObjArrayMemcpy(
 {
     NANOCLR_HEADER();
 
-    memcpy(arraySrc->GetElement(indexSrc), arrayDst->GetElement(indexDst), length * sizeof(CLR_RT_HeapBlock));
+    memcpy(arraySrc->GetElement(indexSrc), arrayDst->GetElement(indexDst), length * sizeof(struct CLR_RT_HeapBlock));
 
     NANOCLR_NOCLEANUP_NOLABEL();
 }

--- a/src/CLR/Core/CLR_RT_HeapBlock_Stack.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Stack.cpp
@@ -49,8 +49,12 @@ HRESULT CLR_RT_HeapBlock_Stack::Push(CLR_RT_HeapBlock *value)
         CLR_RT_HeapBlock newArrayHB;
         CLR_RT_HeapBlock_Array *newArray;
 
+        memset(&newArrayHB, 0, sizeof(struct CLR_RT_HeapBlock));
+
         // Protect value from GC, in case CreateInstance triggers one
         CLR_RT_HeapBlock valueHB;
+
+        memset(&valueHB, 0, sizeof(struct CLR_RT_HeapBlock));
         valueHB.SetObjectReference(value);
         CLR_RT_ProtectFromGC gc(valueHB);
 
@@ -61,7 +65,7 @@ HRESULT CLR_RT_HeapBlock_Stack::Push(CLR_RT_HeapBlock *value)
 
         newArray = newArrayHB.DereferenceArray();
 
-        memcpy(newArray->GetElement(size), array->GetFirstElement(), size * sizeof(CLR_RT_HeapBlock));
+        memcpy(newArray->GetElement(size), array->GetFirstElement(), size * sizeof(struct CLR_RT_HeapBlock));
 
         SetArray(newArray);
         array = newArray;

--- a/src/CLR/Core/CLR_RT_HeapBlock_WaitForObject.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_WaitForObject.cpp
@@ -29,7 +29,7 @@ HRESULT CLR_RT_HeapBlock_WaitForObject::CreateInstance(
 
     _ASSERTE(sizeof(CLR_RT_HeapBlock_WaitForObject) % 4 == 0);
 
-    CLR_UINT32 totLength = (CLR_UINT32)(sizeof(CLR_RT_HeapBlock_WaitForObject) + cObjects * sizeof(CLR_RT_HeapBlock));
+    CLR_UINT32 totLength = (CLR_UINT32)(sizeof(CLR_RT_HeapBlock_WaitForObject) + cObjects * sizeof(struct CLR_RT_HeapBlock));
 
     CLR_RT_HeapBlock_WaitForObject *wait = EVENTCACHE_EXTRACT_NODE_AS_BYTES(
         g_CLR_RT_EventCache,
@@ -44,7 +44,7 @@ HRESULT CLR_RT_HeapBlock_WaitForObject::CreateInstance(
     wait->m_cObjects = cObjects;
     wait->m_fWaitAll = fWaitAll;
 
-    memcpy(wait->GetWaitForObjects(), objects, sizeof(CLR_RT_HeapBlock) * cObjects);
+    memcpy(wait->GetWaitForObjects(), objects, sizeof(struct CLR_RT_HeapBlock) * cObjects);
 
     caller->m_waitForObject = wait;
     caller->m_status = CLR_RT_Thread::TH_S_Waiting;

--- a/src/CLR/Core/CLR_RT_HeapCluster.cpp
+++ b/src/CLR/Core/CLR_RT_HeapCluster.cpp
@@ -12,7 +12,7 @@ void CLR_RT_HeapCluster::HeapCluster_Initialize(CLR_UINT32 size, CLR_UINT32 bloc
     NATIVE_PROFILE_CLR_CORE();
     GenericNode_Initialize();
 
-    size = (size - sizeof(*this)) / sizeof(CLR_RT_HeapBlock);
+    size = (size - sizeof(*this)) / sizeof(struct CLR_RT_HeapBlock);
 
     m_freeList.DblLinkedList_Initialize();              // CLR_RT_DblLinkedList    m_freeList;
     m_payloadStart = (CLR_RT_HeapBlock_Node *)&this[1]; // CLR_RT_HeapBlock_Node*  m_payloadStart;

--- a/src/CLR/Core/CLR_RT_Memory.cpp
+++ b/src/CLR/Core/CLR_RT_Memory.cpp
@@ -55,7 +55,7 @@ void *CLR_RT_Memory::SubtractFromSystem(size_t len)
 #define DEBUG_POINTER_INCREMENT(ptr, size) ptr = (void *)((char *)ptr + (size))
 #define DEBUG_POINTER_DECREMENT(ptr, size) ptr = (void *)((char *)ptr - (size))
 
-const CLR_UINT32 c_extra = sizeof(CLR_RT_HeapBlock) * 2;
+const CLR_UINT32 c_extra = sizeof(struct CLR_RT_HeapBlock) * 2;
 
 #endif
 
@@ -205,7 +205,7 @@ void *CLR_RT_Memory::ReAllocate(void *ptr, size_t len)
     {
         CLR_RT_HeapBlock_BinaryBlob *pThis = CLR_RT_HeapBlock_BinaryBlob::GetBlob(ptr);
 
-        size_t prevLen = pThis->DataSize() * sizeof(CLR_RT_HeapBlock);
+        size_t prevLen = pThis->DataSize() * sizeof(struct CLR_RT_HeapBlock);
 
         memcpy(p, ptr, len > prevLen ? prevLen : len);
 

--- a/src/CLR/Core/CLR_RT_StackFrame.cpp
+++ b/src/CLR/Core/CLR_RT_StackFrame.cpp
@@ -573,6 +573,8 @@ HRESULT CLR_RT_StackFrame::MakeCall(
     int argsOffset = 0;
     CLR_RT_StackFrame *stackSub;
     CLR_RT_HeapBlock tmp;
+    
+    memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
     tmp.SetObjectReference(NULL);
     CLR_RT_ProtectFromGC gc(tmp);
 
@@ -652,7 +654,7 @@ HRESULT CLR_RT_StackFrame::MakeCall(
 
         if (numArgs)
         {
-            memcpy(&stackSub->m_arguments[argsOffset], args, sizeof(CLR_RT_HeapBlock) * numArgs);
+            memcpy(&stackSub->m_arguments[argsOffset], args, sizeof(struct CLR_RT_HeapBlock) * numArgs);
         }
     }
 
@@ -754,6 +756,9 @@ HRESULT CLR_RT_StackFrame::HandleSynchronized(bool fAcquire, bool fGlobal)
     CLR_RT_HeapBlock ref;
     CLR_RT_HeapBlock **ppGlobalLock;
     CLR_RT_HeapBlock *pGlobalLock;
+
+    memset(&refType, 0, sizeof(struct CLR_RT_HeapBlock));
+    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
 
     if (fGlobal)
     {
@@ -971,7 +976,7 @@ void CLR_RT_StackFrame::Pop()
                     CLR_RT_SignatureParser sig;
                     sig.Initialize_MethodSignature(this->m_call.m_assm, this->m_call.m_target);
                     CLR_RT_SignatureParser::Element res;
-                    CLR_RT_TypeDescriptor desc;
+                    CLR_RT_TypeDescriptor desc{};
 
                     dst->Assign(this->TopValue());
 

--- a/src/CLR/Core/GarbageCollector.cpp
+++ b/src/CLR/Core/GarbageCollector.cpp
@@ -237,7 +237,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteGarbageCollection()
                     "Type %02X (%-20s): %8d bytes\r\n",
                     dt,
                     c_CLR_RT_DataTypeLookup[dt].m_name,
-                    countBlocks[dt] * sizeof(CLR_RT_HeapBlock));
+                    countBlocks[dt] * sizeof(struct CLR_RT_HeapBlock));
 
                 if (dt == DATATYPE_SZARRAY)
                 {
@@ -249,7 +249,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteGarbageCollection()
                                 "   Type %02X (%-17s): %8d bytes\r\n",
                                 dt2,
                                 c_CLR_RT_DataTypeLookup[dt2].m_name,
-                                countArryBlocks[dt2] * sizeof(CLR_RT_HeapBlock));
+                                countArryBlocks[dt2] * sizeof(struct CLR_RT_HeapBlock));
                         }
                     }
                 }
@@ -850,7 +850,7 @@ CLR_UINT32 CLR_RT_GarbageCollector::Heap_ComputeAliveVsDeadRatio()
     NANOCLR_FOREACH_NODE_END();
 
     m_totalBytes = totalBytes;
-    m_freeBytes = freeBlocks * sizeof(CLR_RT_HeapBlock);
+    m_freeBytes = freeBlocks * sizeof(struct CLR_RT_HeapBlock);
 
     return m_freeBytes;
 }

--- a/src/CLR/Core/GarbageCollector_Info.cpp
+++ b/src/CLR/Core/GarbageCollector_Info.cpp
@@ -38,12 +38,12 @@ void CLR_RT_GarbageCollector::GC_Stats(
                 if (ptr->IsEvent())
                 {
                     resNumberEvents += 1;
-                    resSizeEvents += size * sizeof(CLR_RT_HeapBlock);
+                    resSizeEvents += size * sizeof(struct CLR_RT_HeapBlock);
                 }
                 else
                 {
                     resNumberObjects += 1;
-                    resSizeObjects += size * sizeof(CLR_RT_HeapBlock);
+                    resSizeObjects += size * sizeof(struct CLR_RT_HeapBlock);
                 }
             }
 

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -2123,7 +2123,7 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                             }
                             else
                             {
-                                memmove(&pThis[0], &pThis[1], calleeInst.m_target->numArgs * sizeof(CLR_RT_HeapBlock));
+                                memmove(&pThis[0], &pThis[1], calleeInst.m_target->numArgs * sizeof(struct CLR_RT_HeapBlock));
 
                                 evalPos--;
                             }
@@ -2290,6 +2290,8 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                         // Save the pointer to the object to load/copy and protect it from GC.
                         //
                         CLR_RT_HeapBlock safeSource;
+
+                        memset(&safeSource, 0, sizeof(struct CLR_RT_HeapBlock));
                         safeSource.Assign(evalPos[0]);
                         CLR_RT_ProtectFromGC gc(safeSource);
 
@@ -2749,6 +2751,8 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                         //"ldobj"
                         {
                             CLR_RT_HeapBlock safeSource;
+
+                            memset(&safeSource, 0, sizeof(struct CLR_RT_HeapBlock));
                             safeSource.Assign(evalPos[0]);
                             CLR_RT_ProtectFromGC gc(safeSource);
 
@@ -2859,6 +2863,9 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     // then dereference it.
                     //
                     CLR_RT_HeapBlock ref;
+
+                    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
+
                     NANOCLR_CHECK_HRESULT(ref.InitializeArrayReference(evalPos[0], evalPos[1].NumericByRef().s4));
 
                     NANOCLR_CHECK_HRESULT(evalPos[0].LoadFromReference(ref));
@@ -2902,6 +2909,8 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     {
                         // Save the pointer to the object to load/copy and protect it from GC.
                         CLR_RT_HeapBlock safeSource;
+
+                        memset(&safeSource, 0, sizeof(struct CLR_RT_HeapBlock));
                         safeSource.Assign(evalPos[0]);
                         CLR_RT_ProtectFromGC gc(safeSource);
 
@@ -3002,7 +3011,11 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     // then dereference it.
                     //
                     CLR_RT_HeapBlock ref;
+
+                    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
+
                     NANOCLR_CHECK_HRESULT(ref.InitializeArrayReference(evalPos[1], evalPos[2].NumericByRef().s4));
+                    
                     int size = 0;
 
                     switch (op)
@@ -3353,12 +3366,12 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
 
                     if (clsInst.m_target->dataType)
                     {
-                        len = sizeof(CLR_RT_HeapBlock);
+                        len = sizeof(struct CLR_RT_HeapBlock);
                     }
                     else
                     {
                         len = (CLR_RT_HeapBlock::HB_Object_Fields_Offset + clsInst.CrossReference().m_totalFields) *
-                              sizeof(CLR_RT_HeapBlock);
+                              sizeof(struct CLR_RT_HeapBlock);
                     }
 
                     evalPos++;

--- a/src/CLR/Core/Serialization/BinaryFormatter.cpp
+++ b/src/CLR/Core/Serialization/BinaryFormatter.cpp
@@ -67,6 +67,7 @@ HRESULT CLR_RT_BinaryFormatter::TypeHandler::SetValue(CLR_RT_HeapBlock *v)
 
     m_value = NULL;
     m_type = NULL;
+    memset(&m_value_tmp, 0, sizeof(struct CLR_RT_HeapBlock));
 
     v = TypeHandler::FixNull(v);
     if (v)
@@ -504,6 +505,7 @@ HRESULT CLR_RT_BinaryFormatter::TypeHandler::ReadSignature(int &res)
 
     m_value = NULL;
     m_type = NULL;
+    memset(&m_value_tmp, 0, sizeof(struct CLR_RT_HeapBlock));
 
     if (m_typeForced)
     {
@@ -1141,9 +1143,9 @@ HRESULT CLR_RT_BinaryFormatter::State::CreateInstance(
     NANOCLR_HEADER();
 
     CLR_RT_TypeDef_Instance inst;
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
     CLR_RT_TypeDescriptor *pDesc;
-    SerializationHintsAttribute hintsTmp;
+    SerializationHintsAttribute hintsTmp{};
 
     if (type && CLR_RT_ReflectionDef_Index::Convert(*type, inst, NULL))
     {
@@ -1215,7 +1217,7 @@ HRESULT CLR_RT_BinaryFormatter::State::FindHints(SerializationHintsAttribute &hi
 
         if (en.MatchNext(&inst, NULL))
         {
-            CLR_RT_AttributeParser parser;
+            CLR_RT_AttributeParser parser{};
 
             NANOCLR_CHECK_HRESULT(parser.Initialize(en));
 
@@ -1252,7 +1254,7 @@ HRESULT CLR_RT_BinaryFormatter::State::FindHints(
 
         if (en.MatchNext(&inst, NULL))
         {
-            CLR_RT_AttributeParser parser;
+            CLR_RT_AttributeParser parser{};
 
             NANOCLR_CHECK_HRESULT(parser.Initialize(en));
 
@@ -1363,6 +1365,9 @@ HRESULT CLR_RT_BinaryFormatter::State::AssignAndFixBoxing(CLR_RT_HeapBlock &dst)
                     case REFLECTION_FIELD:
                         cls = &g_CLR_RT_WellKnownTypes.m_FieldInfo;
                         break;
+
+                    default:
+						NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                 }
 
                 //
@@ -1432,8 +1437,12 @@ HRESULT CLR_RT_BinaryFormatter::State::GetValue()
     if (prev->m_array_NeedProcessing)
     {
         CLR_RT_HeapBlock ref;
-        ref.InitializeArrayReferenceDirect(*prev->m_array, prev->m_array_CurrentPos - 1);
         CLR_RT_HeapBlock val;
+
+        memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
+        memset(&val, 0, sizeof(struct CLR_RT_HeapBlock));
+
+        ref.InitializeArrayReferenceDirect(*prev->m_array, prev->m_array_CurrentPos - 1);
 
         NANOCLR_CHECK_HRESULT(val.LoadFromReference(ref));
 
@@ -1466,6 +1475,8 @@ HRESULT CLR_RT_BinaryFormatter::State::SetValueAndDestroyInstance()
             if (prev->m_array_NeedProcessing)
             {
                 CLR_RT_HeapBlock ref;
+
+                memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
                 ref.InitializeArrayReferenceDirect(*prev->m_array, prev->m_array_CurrentPos - 1);
 
                 NANOCLR_CHECK_HRESULT(AssignAndFixBoxing(ref));
@@ -1545,7 +1556,7 @@ HRESULT CLR_RT_BinaryFormatter::State::Advance()
                             case REFLECTION_FIELD:
                             {
                                 CLR_RT_FieldDef_Instance inst;
-                                CLR_RT_TypeDescriptor desc;
+                                CLR_RT_TypeDescriptor desc{};
 
                                 if (!inst.InitializeFromIndex(value->ReflectionDataConst().m_data.m_field))
                                 {
@@ -1673,7 +1684,7 @@ HRESULT CLR_RT_BinaryFormatter::State::AdvanceToTheNextField()
             if ((inst.m_target->flags & CLR_RECORD_FIELDDEF::FD_NotSerialized) == 0)
             {
                 SerializationHintsAttribute hints;
-                CLR_RT_TypeDescriptor desc;
+                CLR_RT_TypeDescriptor desc{};
 
                 if (m_value.m_type->m_flags & CLR_RT_DataTypeLookup::c_Enum)
                 {
@@ -1789,6 +1800,7 @@ HRESULT CLR_RT_BinaryFormatter::CreateInstance(CLR_UINT8 *buf, int len, CLR_RT_B
                                               // NO RELOCATION - list of CLR_RT_BinaryFormatter::State
                                               //
     ptr->m_fDeserialize = (buf != NULL);      // bool                           m_fDeserialize;
+    memset(&ptr->m_value, 0, sizeof(struct CLR_RT_HeapBlock));
     ptr->m_value.SetObjectReference(NULL);    // CLR_RT_HeapBlock               m_value;
     ptr->m_value_desc.TypeDescriptor_Initialize(); // CLR_RT_TypeDescriptor          m_value_desc;
 
@@ -1852,6 +1864,7 @@ HRESULT CLR_RT_BinaryFormatter::Serialize(CLR_RT_HeapBlock &refData, CLR_RT_Heap
     CLR_RT_HeapBlock cls;
     CLR_UINT32 flags = 0;
 
+    memset(&cls, 0, sizeof(struct CLR_RT_HeapBlock));
     cls.SetObjectReference(NULL);
 
     // unbox reflection types
@@ -1906,6 +1919,7 @@ HRESULT CLR_RT_BinaryFormatter::Deserialize(
 
     CLR_RT_HeapBlock cls;
 
+    memset(&cls, 0, sizeof(struct CLR_RT_HeapBlock));
     cls.SetObjectReference(NULL);
 
     // unbox reflection types

--- a/src/CLR/Core/Thread.cpp
+++ b/src/CLR/Core/Thread.cpp
@@ -208,13 +208,14 @@ HRESULT CLR_RT_Thread::CreateInstance(int pid, int priority, CLR_RT_Thread *&th,
 
         th->Initialize();
 
-        th->m_pid = pid;                                 // int                        m_pid;
-        th->m_status = TH_S_Unstarted;                   // CLR_UINT32                 m_status;
-        th->m_flags = flags;                             // CLR_UINT32                 m_flags;
-        th->m_executionCounter = 0;                      // int                        m_executionCounter;
-        th->m_timeQuantumExpired = false;                // bool                       m_timeQuantumExpired;
-                                                         //
-        th->m_dlg = NULL;                                // CLR_RT_HeapBlock_Delegate* m_dlg;
+        th->m_pid = pid;                  // int                        m_pid;
+        th->m_status = TH_S_Unstarted;    // CLR_UINT32                 m_status;
+        th->m_flags = flags;              // CLR_UINT32                 m_flags;
+        th->m_executionCounter = 0;       // int                        m_executionCounter;
+        th->m_timeQuantumExpired = false; // bool                       m_timeQuantumExpired;
+                                          //
+        th->m_dlg = NULL;                 // CLR_RT_HeapBlock_Delegate* m_dlg;
+        memset(&th->m_currentException, 0, sizeof(struct CLR_RT_HeapBlock));
         th->m_currentException.SetObjectReference(NULL); // CLR_RT_HeapBlock           m_currentException;
                                                          // UnwindStack m_nestedExceptions[c_MaxStackUnwindDepth];
         th->m_nestedExceptionsPos = 0;                   // int                        m_nestedExceptionsPos;
@@ -596,12 +597,12 @@ void CLR_RT_Thread::ProcessException_FilterPseudoFrameCopyVars(CLR_RT_StackFrame
 
     if (numArgs)
     {
-        memcpy(to->m_arguments, from->m_arguments, sizeof(CLR_RT_HeapBlock) * numArgs);
+        memcpy(to->m_arguments, from->m_arguments, sizeof(struct CLR_RT_HeapBlock) * numArgs);
     }
 
     if (from->m_call.m_target->numLocals)
     {
-        memcpy(to->m_locals, from->m_locals, sizeof(CLR_RT_HeapBlock) * from->m_call.m_target->numLocals);
+        memcpy(to->m_locals, from->m_locals, sizeof(struct CLR_RT_HeapBlock) * from->m_call.m_target->numLocals);
     }
 }
 
@@ -918,7 +919,7 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
                         // Copy local variables and arguments so the filter has access to them.
                         if (numArgs)
                         {
-                            memcpy(newStack->m_arguments, stack->m_arguments, sizeof(CLR_RT_HeapBlock) * numArgs);
+                            memcpy(newStack->m_arguments, stack->m_arguments, sizeof(struct CLR_RT_HeapBlock) * numArgs);
                         }
 
                         if (stack->m_call.m_target->numLocals)
@@ -926,7 +927,7 @@ HRESULT CLR_RT_Thread::ProcessException_Phase1()
                             memcpy(
                                 newStack->m_locals,
                                 stack->m_locals,
-                                sizeof(CLR_RT_HeapBlock) * stack->m_call.m_target->numLocals);
+                                sizeof(struct CLR_RT_HeapBlock) * stack->m_call.m_target->numLocals);
                         }
 
                         newStack->PushValueAndAssign(m_currentException);

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -345,7 +345,7 @@ HRESULT CLR_RT_SignatureParser::Advance(Element &res)
 
         case c_Object:
         {
-            CLR_RT_TypeDescriptor desc;
+            CLR_RT_TypeDescriptor desc{};
             CLR_RT_HeapBlock *ptr = m_lst++;
 
             if (m_flags)
@@ -1339,7 +1339,7 @@ HRESULT CLR_RT_TypeDescriptor::ExtractTypeIndexFromObject(const CLR_RT_HeapBlock
 
     if (NANOCLR_INDEX_IS_INVALID(res))
     {
-        CLR_RT_TypeDescriptor desc;
+        CLR_RT_TypeDescriptor desc{};
 
         NANOCLR_CHECK_HRESULT(desc.InitializeFromObject(ref))
 
@@ -1643,7 +1643,7 @@ HRESULT CLR_RT_Assembly::CreateInstance(const CLR_RECORD_ASSEMBLY *header, CLR_R
         }
 
 #if !defined(NANOCLR_APPDOMAINS)
-        offsets.iStaticFields = ROUNDTOMULTIPLE(skeleton->m_iStaticFields * sizeof(CLR_RT_HeapBlock), CLR_UINT32);
+        offsets.iStaticFields = ROUNDTOMULTIPLE(skeleton->m_iStaticFields * sizeof(struct CLR_RT_HeapBlock), CLR_UINT32);
 #endif
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
@@ -1680,8 +1680,8 @@ HRESULT CLR_RT_Assembly::CreateInstance(const CLR_RECORD_ASSEMBLY *header, CLR_R
             CLR_RT_HeapBlock *src = skeleton;
             CLR_RT_HeapBlock *dst = assm;
 
-            memset(&dst[1], 0, iTotalRamSize - sizeof(CLR_RT_HeapBlock));
-            memcpy(&dst[1], &src[1], sizeof(*assm) - sizeof(CLR_RT_HeapBlock));
+            memset(&dst[1], 0, iTotalRamSize - sizeof(struct CLR_RT_HeapBlock));
+            memcpy(&dst[1], &src[1], sizeof(*assm) - sizeof(struct CLR_RT_HeapBlock));
         }
 
         assm->Assembly_Initialize(offsets);
@@ -3952,7 +3952,7 @@ HRESULT CLR_RT_TypeSystem::ResolveAll()
                     CLR_UINT32);
 
 #if !defined(NANOCLR_APPDOMAINS)
-                offsets.iStaticFields += ROUNDTOMULTIPLE(pASSM->m_iStaticFields * sizeof(CLR_RT_HeapBlock), CLR_UINT32);
+                offsets.iStaticFields += ROUNDTOMULTIPLE(pASSM->m_iStaticFields * sizeof(struct CLR_RT_HeapBlock), CLR_UINT32);
 #endif
 
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
@@ -4092,6 +4092,8 @@ HRESULT CLR_RT_TypeSystem::PrepareForExecution()
     if (g_CLR_RT_ExecutionEngine.m_outOfMemoryException == NULL)
     {
         CLR_RT_HeapBlock exception;
+
+        memset(&exception, 0, sizeof(struct CLR_RT_HeapBlock));
 
         NANOCLR_CHECK_HRESULT(
             g_CLR_RT_ExecutionEngine.NewObjectFromIndex(exception, g_CLR_RT_WellKnownTypes.m_OutOfMemoryException));
@@ -4636,6 +4638,7 @@ HRESULT CLR_RT_AttributeParser::Next(Value *&res)
 
         m_lastValue.m_mode = Value::c_DefaultConstructor;
         m_lastValue.m_name = NULL;
+        memset(&m_lastValue.m_value, 0, sizeof(struct CLR_RT_HeapBlock));
 
         NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObject(m_lastValue.m_value, m_td));
 
@@ -4651,6 +4654,7 @@ HRESULT CLR_RT_AttributeParser::Next(Value *&res)
 
         m_lastValue.m_mode = Value::c_ConstructorArgument;
         m_lastValue.m_name = NULL;
+        memset(&m_lastValue.m_value, 0, sizeof(struct CLR_RT_HeapBlock));
 
         // get type
         NANOCLR_CHECK_HRESULT(m_parser.Advance(m_res));
@@ -4845,7 +4849,7 @@ HRESULT CLR_RT_AttributeParser::ReadString(CLR_RT_HeapBlock *&value)
 
     CLR_UINT32 tk;
 
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
     NANOCLR_CHECK_HRESULT(desc.InitializeFromType(g_CLR_RT_WellKnownTypes.m_String));
 
     NANOCLR_READ_UNALIGNED_UINT16(tk, m_blob);
@@ -4866,7 +4870,7 @@ HRESULT CLR_RT_AttributeParser::ReadNumericValue(
 {
     NANOCLR_HEADER();
 
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
     NANOCLR_CHECK_HRESULT(desc.InitializeFromType(*m_cls));
 
     NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(*value, g_CLR_RT_WellKnownTypes.m_TypeStatic));

--- a/src/CLR/Core/TypeSystemLookup.cpp
+++ b/src/CLR/Core/TypeSystemLookup.cpp
@@ -38,7 +38,7 @@
 #define DT_I4 sizeof(CLR_INT32)
 #define DT_U8 sizeof(CLR_UINT64)
 #define DT_I8 sizeof(CLR_INT64)
-#define DT_BL sizeof(CLR_RT_HeapBlock)
+#define DT_BL sizeof(struct CLR_RT_HeapBlock)
 
 #define DT_T(x)   (CLR_UINT8)DATATYPE_##x
 #define DT_CNV(x) (CLR_UINT8)ELEMENT_TYPE_##x

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1768,7 +1768,7 @@ static bool FillValues(
 
     CLR_DBG_Commands::Debugging_Value *dst = array++;
     num--;
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
 
     memset(dst, 0, sizeof(*dst));
 
@@ -2081,8 +2081,11 @@ static HRESULT Debugging_Thread_Create_Helper(CLR_RT_MethodDef_Index &md, CLR_RT
     NANOCLR_HEADER();
 
     CLR_RT_HeapBlock ref;
+
+    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
     ref.SetObjectReference(NULL);
     CLR_RT_ProtectFromGC gc(ref);
+
     CLR_RT_Thread *realThread = (pid != 0) ? CLR_DBG_Debugger::GetThreadFromPid(pid) : NULL;
 
     th = NULL;
@@ -2341,7 +2344,7 @@ bool CLR_DBG_Debugger::Debugging_Thread_Get(WP_Message *msg)
 
     if (!fFound)
     {
-        pThread = (CLR_RT_HeapBlock *)platform_malloc(sizeof(CLR_RT_HeapBlock));
+        pThread = (CLR_RT_HeapBlock *)platform_malloc(sizeof(struct CLR_RT_HeapBlock));
 
         // Create the managed thread.
         // This implies that there is no state in the managed object.  This is not exactly true, as the managed thread
@@ -2514,7 +2517,7 @@ static bool IsBlockEnumMaybe(CLR_RT_HeapBlock *blk)
     NATIVE_PROFILE_CLR_DEBUGGER();
     const CLR_UINT32 c_MaskForPrimitive = CLR_RT_DataTypeLookup::c_Integer | CLR_RT_DataTypeLookup::c_Numeric;
 
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
 
     if (FAILED(desc.InitializeFromObject(*blk)))
         return false;
@@ -2533,6 +2536,8 @@ static bool SetBlockHelper(CLR_RT_HeapBlock *blk, CLR_DataType dt, CLR_UINT8 *bu
     {
         CLR_DataType dtDst;
         CLR_RT_HeapBlock src;
+
+        memset(&src, 0, sizeof(struct CLR_RT_HeapBlock));
 
         dtDst = blk->DataType();
 
@@ -2583,6 +2588,9 @@ static CLR_RT_HeapBlock *GetScratchPad_Helper(int idx)
     CLR_RT_HeapBlock tmp;
     CLR_RT_HeapBlock ref;
 
+    memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
+    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
+
     tmp.SetObjectReference(array);
 
     if (SUCCEEDED(ref.InitializeArrayReference(tmp, idx)))
@@ -2601,7 +2609,10 @@ bool CLR_DBG_Debugger::Debugging_Value_ResizeScratchPad(WP_Message *msg)
 
     CLR_DBG_Commands::Debugging_Value_ResizeScratchPad *cmd =
         (CLR_DBG_Commands::Debugging_Value_ResizeScratchPad *)msg->m_payload;
+    
     CLR_RT_HeapBlock ref;
+
+    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
 
     if (cmd->m_size == 0)
     {
@@ -2619,7 +2630,7 @@ bool CLR_DBG_Debugger::Debugging_Value_ResizeScratchPad(WP_Message *msg)
                 memcpy(
                     pNew->GetFirstElement(),
                     pOld->GetFirstElement(),
-                    sizeof(CLR_RT_HeapBlock) * __min(pNew->m_numOfElements, pOld->m_numOfElements));
+                    sizeof(struct CLR_RT_HeapBlock) * __min(pNew->m_numOfElements, pOld->m_numOfElements));
             }
 
             g_CLR_RT_ExecutionEngine.m_scratchPadArray = pNew;
@@ -2702,12 +2713,14 @@ bool CLR_DBG_Debugger::Debugging_Value_GetStack(WP_Message *msg)
         CLR_RT_TypeDef_Instance *pTD = NULL;
         CLR_RT_TypeDef_Instance td;
 
+        memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
+
         if (cmd->m_kind != CLR_DBG_Commands::Debugging_Value_GetStack::c_EvalStack && IsBlockEnumMaybe(blk))
         {
             CLR_UINT32 iElement = cmd->m_index;
             CLR_RT_SignatureParser parser;
             CLR_RT_SignatureParser::Element res;
-            CLR_RT_TypeDescriptor desc;
+            CLR_RT_TypeDescriptor desc{};
 
             if (cmd->m_kind == CLR_DBG_Commands::Debugging_Value_GetStack::c_Argument)
             {
@@ -2778,11 +2791,15 @@ bool CLR_DBG_Debugger::Debugging_Value_GetField(WP_Message *msg)
     CLR_RT_HeapBlock *blk = cmd->m_heapblock;
     CLR_RT_HeapBlock *reference = NULL;
     CLR_RT_HeapBlock tmp;
-    CLR_RT_TypeDescriptor desc;
+    CLR_RT_TypeDescriptor desc{};
     CLR_RT_TypeDef_Instance td;
     CLR_RT_TypeDef_Instance *pTD = NULL;
     CLR_RT_FieldDef_Instance inst;
     CLR_UINT32 offset;
+
+    memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
+    memset(&inst, 0, sizeof(CLR_RT_FieldDef_Instance));
+    memset(&desc, 0, sizeof(CLR_RT_TypeDescriptor));
 
     if (blk != NULL && cmd->m_offset > 0)
     {
@@ -2891,6 +2908,10 @@ bool CLR_DBG_Debugger::Debugging_Value_GetArray(WP_Message *msg)
     CLR_RT_TypeDef_Instance *pTD = NULL;
     CLR_RT_TypeDef_Instance td;
 
+    memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
+    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
+    memset(&td, 0, sizeof(CLR_RT_TypeDef_Instance));
+
     tmp.SetObjectReference(cmd->m_heapblock);
 
     if (SUCCEEDED(ref.InitializeArrayReference(tmp, cmd->m_index)))
@@ -2974,6 +2995,8 @@ bool CLR_DBG_Debugger::Debugging_Value_SetArray(WP_Message *msg)
     CLR_RT_HeapBlock_Array *array = cmd->m_heapblock;
     CLR_RT_HeapBlock tmp;
 
+    memset(&tmp, 0, sizeof(struct CLR_RT_HeapBlock));
+
     tmp.SetObjectReference(cmd->m_heapblock);
 
     //
@@ -2982,6 +3005,8 @@ bool CLR_DBG_Debugger::Debugging_Value_SetArray(WP_Message *msg)
     if (array != NULL && !array->m_fReference)
     {
         CLR_RT_HeapBlock ref;
+
+        memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
 
         if (SUCCEEDED(ref.InitializeArrayReference(tmp, cmd->m_index)))
         {
@@ -3229,6 +3254,8 @@ static HRESULT Assign_Helper(CLR_RT_HeapBlock *blkDst, CLR_RT_HeapBlock *blkSrc)
     AnalyzeObject aoDst;
     AnalyzeObject aoSrc;
     CLR_RT_HeapBlock srcVal;
+
+    memset(&srcVal, 0, sizeof(struct CLR_RT_HeapBlock));
     srcVal.SetObjectReference(NULL);
     CLR_RT_ProtectFromGC gc(srcVal);
 
@@ -3305,8 +3332,10 @@ bool CLR_DBG_Debugger::Debugging_TypeSys_Assemblies(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_RT_Assembly_Index assemblies[CLR_RT_TypeSystem::c_MaxAssemblies];
     int num = 0;
+    CLR_RT_Assembly_Index assemblies[CLR_RT_TypeSystem::c_MaxAssemblies];
+
+    memset(assemblies, 0, sizeof(assemblies));
 
     NANOCLR_FOREACH_ASSEMBLY(g_CLR_RT_TypeSystem)
     {

--- a/src/CLR/Diagnostics/Profiler.cpp
+++ b/src/CLR/Diagnostics/Profiler.cpp
@@ -228,8 +228,8 @@ void CLR_PRF_Profiler::DumpObject(CLR_RT_HeapBlock *ptr)
     CLR_DataType dt = ptr->DataType();
     _ASSERTE(dt < DATATYPE_FIRST_INVALID);
     _ASSERTE(
-        sizeof(CLR_RT_HeapBlock) ==
-        12); // HeapBlockObjectPacket in ProfilerPackets.cs assumes sizeof(CLR_RT_HeapBlock) == 12
+        sizeof(struct CLR_RT_HeapBlock) ==
+        12); // HeapBlockObjectPacket in ProfilerPackets.cs assumes sizeof(struct CLR_RT_HeapBlock) == 12
 
     if (dt != DATATYPE_FREEBLOCK && dt != DATATYPE_CACHEDBLOCK)
     {
@@ -705,7 +705,7 @@ void CLR_PRF_Profiler::TrackObjectCreation(CLR_RT_HeapBlock *ptr)
                     (size_t)((CLR_UINT8 *)ptr),
                     (CLR_UINT32)((size_t *)ptr - s_CLR_RT_Heap.m_location),
                     (CLR_UINT32)dt,
-                    (dataSize * sizeof(CLR_RT_HeapBlock)),
+                    (dataSize * sizeof(struct CLR_RT_HeapBlock)),
                     idx.m_data);
 
 #else
@@ -714,7 +714,7 @@ void CLR_PRF_Profiler::TrackObjectCreation(CLR_RT_HeapBlock *ptr)
                     (CLR_UINT32)((CLR_UINT8 *)ptr),
                     (CLR_UINT32)((CLR_UINT8 *)ptr - s_CLR_RT_Heap.m_location),
                     (CLR_UINT32)dt,
-                    (dataSize * sizeof(CLR_RT_HeapBlock)),
+                    (dataSize * sizeof(struct CLR_RT_HeapBlock)),
                     idx.m_data);
 #endif
 
@@ -736,7 +736,7 @@ void CLR_PRF_Profiler::TrackObjectCreation(CLR_RT_HeapBlock *ptr)
                     (CLR_UINT32)((size_t *)ptr - s_CLR_RT_Heap.m_location),
                     (CLR_UINT32)dt,
                     elementIdx.m_data,
-                    (dataSize * sizeof(CLR_RT_HeapBlock)));
+                    (dataSize * sizeof(struct CLR_RT_HeapBlock)));
 
 #else
                 CLR_Debug::Printf(
@@ -745,7 +745,7 @@ void CLR_PRF_Profiler::TrackObjectCreation(CLR_RT_HeapBlock *ptr)
                     (CLR_UINT32)((CLR_UINT8 *)ptr - s_CLR_RT_Heap.m_location),
                     (CLR_UINT32)dt,
                     elementIdx.m_data,
-                    (dataSize * sizeof(CLR_RT_HeapBlock)));
+                    (dataSize * sizeof(struct CLR_RT_HeapBlock)));
 #endif
 #endif // NANOCLR_TRACE_PROFILER_MESSAGES
             }
@@ -758,7 +758,7 @@ void CLR_PRF_Profiler::TrackObjectCreation(CLR_RT_HeapBlock *ptr)
                     (size_t)((CLR_UINT8 *)ptr),
                     (CLR_UINT32)((size_t *)ptr - s_CLR_RT_Heap.m_location),
                     (CLR_UINT32)dt,
-                    (dataSize * sizeof(CLR_RT_HeapBlock)));
+                    (dataSize * sizeof(struct CLR_RT_HeapBlock)));
 
 #else
                 CLR_Debug::Printf(
@@ -766,7 +766,7 @@ void CLR_PRF_Profiler::TrackObjectCreation(CLR_RT_HeapBlock *ptr)
                     (CLR_UINT32)((CLR_UINT8 *)ptr),
                     (CLR_UINT32)((CLR_UINT8 *)ptr - s_CLR_RT_Heap.m_location),
                     (CLR_UINT32)dt,
-                    (dataSize * sizeof(CLR_RT_HeapBlock)));
+                    (dataSize * sizeof(struct CLR_RT_HeapBlock)));
 #endif
             }
 #endif // NANOCLR_TRACE_PROFILER_MESSAGES
@@ -806,14 +806,14 @@ void CLR_PRF_Profiler::TrackObjectDeletion(CLR_RT_HeapBlock *ptr)
             "\r\n    Profiler info: * (0x0x%I64X | %d) %d bytes\r\n",
             (size_t)((CLR_UINT8 *)ptr),
             (CLR_UINT32)((size_t *)ptr - s_CLR_RT_Heap.m_location),
-            (dataSize * sizeof(CLR_RT_HeapBlock)));
+            (dataSize * sizeof(struct CLR_RT_HeapBlock)));
 
 #else
         CLR_Debug::Printf(
             "\r\n    Profiler info: * (0x%08X | %d) %d bytes\r\n",
             (CLR_UINT32)((CLR_UINT8 *)ptr),
             (CLR_UINT32)((CLR_UINT8 *)ptr - s_CLR_RT_Heap.m_location),
-            (dataSize * sizeof(CLR_RT_HeapBlock)));
+            (dataSize * sizeof(struct CLR_RT_HeapBlock)));
 #endif
 
 #endif // NANOCLR_TRACE_PROFILER_MESSAGES

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -949,7 +949,6 @@ class UnicodeString
 {
   private:
     CLR_RT_UnicodeHelper m_unicodeHelper;
-    CLR_RT_HeapBlock m_uHeapBlock;
     CLR_UINT16 *m_wCharArray;
     int m_length; /// Length in wide characters (not bytes).
 
@@ -3899,12 +3898,12 @@ extern CLR_UINT32 g_buildCRC;
 //
 
 #ifdef _WIN64
-CT_ASSERT(sizeof(CLR_RT_HeapBlock) == 20)
+CT_ASSERT(sizeof(struct CLR_RT_HeapBlock) == 20)
 #else
-CT_ASSERT(sizeof(CLR_RT_HeapBlock) == 12)
+CT_ASSERT(sizeof(struct CLR_RT_HeapBlock) == 12)
 #endif // _WIN64
 
-CT_ASSERT(sizeof(CLR_RT_HeapBlock_Raw) == sizeof(CLR_RT_HeapBlock))
+CT_ASSERT(sizeof(CLR_RT_HeapBlock_Raw) == sizeof(struct CLR_RT_HeapBlock))
 
 #if defined(NANOCLR_TRACE_MEMORY_STATS)
 #define NANOCLR_TRACE_MEMORY_STATS_EXTRA_SIZE sizeof(const char *)

--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -2217,7 +2217,7 @@ struct CLR_RT_HeapBlock_MemoryStream : public CLR_RT_HeapBlock_Node // EVENT HEA
     struct Buffer : public CLR_RT_HeapBlock_Node // EVENT HEAP - NO RELOCATION -
     {
         static const int c_NumOfBlocks = 32;
-        static const int c_PayloadSize = c_NumOfBlocks * sizeof(CLR_RT_HeapBlock) - sizeof(CLR_UINT8 *) - sizeof(int);
+        static const int c_PayloadSize = c_NumOfBlocks * sizeof(struct CLR_RT_HeapBlock) - sizeof(CLR_UINT8 *) - sizeof(int);
 
         CLR_UINT8 *m_data;
         int m_length;

--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -369,7 +369,7 @@ void ClrStartup(CLR_SETTINGS params)
 {
     NATIVE_PROFILE_CLR_STARTUP();
     Settings settings;
-    ASSERT(sizeof(CLR_RT_HeapBlock_Raw) == sizeof(CLR_RT_HeapBlock));
+    ASSERT(sizeof(CLR_RT_HeapBlock_Raw) == sizeof(struct CLR_RT_HeapBlock));
     bool softReboot;
 
     do

--- a/src/HAL/Include/nanoHAL_v2.h
+++ b/src/HAL/Include/nanoHAL_v2.h
@@ -358,7 +358,7 @@ extern "C"
 
 // developer note: if "size of something" needs to be output at compile time use this
 // char checker(int);
-// char checkSizeOfWhathever[sizeof(CLR_RT_HeapBlock)] = {checker(&checkSizeOfWhathever)};
+// char checkSizeOfWhathever[sizeof(struct CLR_RT_HeapBlock)] = {checker(&checkSizeOfWhathever)};
 
 #ifdef __cplusplus
 extern "C"

--- a/src/nanoFramework.Runtime.Native/nf_rt_native_nanoFramework_Runtime_Hardware_SystemInfo.cpp
+++ b/src/nanoFramework.Runtime.Native/nf_rt_native_nanoFramework_Runtime_Hardware_SystemInfo.cpp
@@ -21,6 +21,11 @@ HRESULT Library_nf_rt_native_nanoFramework_Runtime_Native_SystemInfo::
 
         NFReleaseInfo releaseInfo;
 
+        memset(&hbMajor, 0, sizeof(struct CLR_RT_HeapBlock));
+        memset(&hbMinor, 0, sizeof(struct CLR_RT_HeapBlock));
+        memset(&hbBuild, 0, sizeof(struct CLR_RT_HeapBlock));
+        memset(&hbRevision, 0, sizeof(struct CLR_RT_HeapBlock));
+
         Target_GetReleaseInfo(releaseInfo);
 
         hbMajor.SetInteger(releaseInfo.Version.usMajor);

--- a/src/nanoFramework.System.Collections/nf_system_collections_System_Collections_Hashtable.cpp
+++ b/src/nanoFramework.System.Collections/nf_system_collections_System_Collections_Hashtable.cpp
@@ -234,6 +234,8 @@ HRESULT Library_nf_system_collections_System_Collections_Hashtable::InsertNative
             CLR_RT_TypeDef_Index bucketTypeDef;
             CLR_RT_HeapBlock newBucket;
 
+            memset(&newBucket, 0, sizeof(struct CLR_RT_HeapBlock));
+
             if (bucket == NULL)
             {
                 // find <Bucket> type, don't bother checking the result as it exists for sure
@@ -423,6 +425,7 @@ HRESULT Library_nf_system_collections_System_Collections_Hashtable::Expand(CLR_R
     g_CLR_RT_TypeSystem.FindTypeDef("Bucket", "System.Collections", bucketTypeDef);
 
     // create a new array of <Bucket>
+    memset(&newBucketsHB, 0, sizeof(struct CLR_RT_HeapBlock));
     NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance(newBucketsHB, newSize, bucketTypeDef))
     newBuckets = newBucketsHB.DereferenceArray();
 
@@ -449,6 +452,7 @@ HRESULT Library_nf_system_collections_System_Collections_Hashtable::Expand(CLR_R
                     // create a new <Bucket>
                     CLR_RT_HeapBlock newBucket;
 
+                    memset(&newBucket, 0, sizeof(struct CLR_RT_HeapBlock));
                     NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(newBucket, bucketTypeDef))
                     newBucketElement->LoadFromReference(newBucket);
                     bucket = newBucketElement->Dereference();

--- a/src/nanoFramework.System.Text/nf_system_text_System_Text_UTF8Encoding.cpp
+++ b/src/nanoFramework.System.Text/nf_system_text_System_Text_UTF8Encoding.cpp
@@ -100,15 +100,18 @@ HRESULT Library_nf_system_text_System_Text_UTF8Encoding::Helper__GetChars(CLR_RT
     NANOCLR_HEADER();
 
     const char *szText;
+    int cBytesCopy;
     CLR_RT_HeapBlock ref;
+    CLR_RT_HeapBlock_Array *pArrayBytesCopy;
+    CLR_RT_HeapBlock_Array *arrTmp;
+
+    memset(&ref, 0, sizeof(struct CLR_RT_HeapBlock));
     ref.SetObjectReference(NULL);
     CLR_RT_ProtectFromGC gc(ref);
+
     CLR_RT_HeapBlock_Array *pArrayBytes = stack.Arg1().DereferenceArray();
     CLR_INT32 byteIdx = fIndexed ? stack.Arg2().NumericByRef().s4 : 0;
     CLR_INT32 byteCnt = fIndexed ? stack.Arg3().NumericByRef().s4 : pArrayBytes->m_numOfElements;
-    CLR_RT_HeapBlock_Array *pArrayBytesCopy;
-    CLR_RT_HeapBlock_Array *arrTmp;
-    int cBytesCopy;
 
     FAULT_ON_NULL(pArrayBytes);
 

--- a/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
+++ b/targets/netcore/nanoFramework.nanoCLR/CLRStartup.cpp
@@ -565,7 +565,7 @@ void ClrStartup(CLR_SETTINGS params)
 {
     NATIVE_PROFILE_CLR_STARTUP();
     // Settings settings;
-    ASSERT(sizeof(CLR_RT_HeapBlock_Raw) == sizeof(CLR_RT_HeapBlock));
+    ASSERT(sizeof(CLR_RT_HeapBlock_Raw) == sizeof(struct CLR_RT_HeapBlock));
     bool softReboot;
 
     do

--- a/targets/win32/nanoCLR/CLRStartup.cpp
+++ b/targets/win32/nanoCLR/CLRStartup.cpp
@@ -597,7 +597,7 @@ void ClrStartup(CLR_SETTINGS params)
 {
     NATIVE_PROFILE_CLR_STARTUP();
     // Settings settings;
-    ASSERT(sizeof(CLR_RT_HeapBlock_Raw) == sizeof(CLR_RT_HeapBlock));
+    ASSERT(sizeof(CLR_RT_HeapBlock_Raw) == sizeof(struct CLR_RT_HeapBlock));
     bool softReboot;
 
     do


### PR DESCRIPTION
## Description
- Following a local declaration of a CLR_RT_HeapBlock memory is now cleared.
- Same for strutcs that contain heap blocks elements. These are cleared on creation or initialization.
- Add initializer to structs declarations.

## Motivation and Context
- Ensures that memory for the structs is cleared after declaration.
- Ensures that struts are properly initialized.
- Addresses nanoFramework/Home#1354.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Long running app making extensive use of GC and heap compaction.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
