### PR TITLE
Fix lwIP init and adapter config

### DIFF
--- a/src/PAL/Lwip/lwIP_Sockets.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets.cpp
@@ -283,7 +283,10 @@ bool LWIP_SOCKETS_Driver::Initialize()
 
         g_LWIP_SOCKETS_Driver.m_interfaces[i].m_interfaceNumber = interfaceNumber;
 
-        UpdateAdapterConfiguration(i, (NetworkInterface_UpdateOperation_Dns), &networkConfiguration);
+        UpdateAdapterConfiguration(
+            i,
+            (NetworkInterface_UpdateOperation_Dhcp | NetworkInterface_UpdateOperation_Dns),
+            &networkConfiguration);
 
         networkInterface = netif_find_interface(interfaceNumber);
 
@@ -1343,12 +1346,6 @@ HRESULT LWIP_SOCKETS_Driver::UpdateAdapterConfiguration(
         else if (0 != (updateFlags & NetworkInterface_UpdateOperation_DhcpRenew))
         {
             dhcp_renew(networkInterface);
-        }
-        else if (
-            0 !=
-            (updateFlags & (NetworkInterface_UpdateOperation_DhcpRelease | NetworkInterface_UpdateOperation_DhcpRenew)))
-        {
-            return CLR_E_INVALID_PARAMETER;
         }
     }
 #endif


### PR DESCRIPTION
## Description
- On lwIP sockets initialization call update config with DHCP flag.
- On update adapter config remove unnecessary code to check for DHCP flags.

## Motivation and Context
- Resolves issue with network boot on which the DHCP worflow could fail. Adding the DHCP flag to the update config makes sure the DHCP workflow is started (if DHCP is enabled for the configuration). Previously the DHCP could fail the initial DHCP offer.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
