### PR TITLE
Align memory for SDC read on ChibiOS

### DIFF
--- a/targets/ChibiOS/_FatFS/fatfs_diskio.c
+++ b/targets/ChibiOS/_FatFS/fatfs_diskio.c
@@ -151,7 +151,7 @@ DRESULT disk_read(
         case SDC:
 
             // clear read buffer
-            memset(sd_readBuffer, 0,  MMCSD_BLOCK_SIZE * count);
+            memset(sd_readBuffer, 0, MMCSD_BLOCK_SIZE * count);
 
             if (blkGetDriverState(&FATFS_HAL_DEVICE) != BLK_READY)
             {

--- a/targets/ChibiOS/_FatFS/fatfs_syscall.c
+++ b/targets/ChibiOS/_FatFS/fatfs_syscall.c
@@ -1,6 +1,6 @@
 // clang-format off
 
-// ChibiOs version can be found at:
+// ChibiOS version can be found at:
 // https://github.com/ArduPilot/ChibiOS.svn/blob/master/os/various/fatfs_bindings/fatfs_syscall.c
 // but currently locked to R0.14b.
 // This file aligns with compatibility with R0.15+
@@ -20,7 +20,7 @@
 /* Allocate/Free a Memory Block                                           */
 /*------------------------------------------------------------------------*/
 
-void* ff_memalloc (	/* Returns pointer to the allocated memory block (null if not enough core) */
+void *ff_memalloc (	/* Returns pointer to the allocated memory block (null if not enough core) */
     UINT msize		/* Number of bytes to allocate */
 )
 {
@@ -31,7 +31,7 @@ void* ff_memalloc (	/* Returns pointer to the allocated memory block (null if no
 
 
 void ff_memfree (
-    void* mblock	/* Pointer to the memory block to free (no effect if null) */
+    void *mblock	/* Pointer to the memory block to free (no effect if null) */
 )
 {
     // NOTE: we no longer choose to use the ChibiOs memory allocation functions.

--- a/targets/ChibiOS/_include/Target_Windows_Storage.h
+++ b/targets/ChibiOS/_include/Target_Windows_Storage.h
@@ -24,19 +24,19 @@
 // this is also mapped in the FatFS configuration
 #if (HAL_USE_SDC == TRUE)
 
-#define SD_CARD_DRIVE_INDEX         "0:"
+#define SD_CARD_DRIVE_INDEX         "0"
 #define SD_CARD_DRIVE_INDEX_NUMERIC (0)
 
 #endif
 
 #if (HAL_USE_SDC == TRUE) && defined(HAL_USBH_USE_MSD)
 
-#define USB_MSD_DRIVE_INDEX         "1:"
+#define USB_MSD_DRIVE_INDEX         "1"
 #define USB_MSD_DRIVE_INDEX_NUMERIC (1)
 
 #elif (HAL_USE_SDC == FALSE) && defined(HAL_USBH_USE_MSD)
 
-#define USB_MSD_DRIVE_INDEX         "0:"
+#define USB_MSD_DRIVE_INDEX         "0"
 #define USB_MSD_DRIVE_INDEX_NUMERIC (0)
 
 #endif


### PR DESCRIPTION
## Description
There were sporatic failures with firmware releases on STM32F7 series related to the ability to read the content of files. This is a speculative fix that addresses the immediate issue, although might need applying to MMC and also write functions.

It also addresses:
* A Fix for for Drive Indexes (that should only be a single char).
* Some comments (spelling) and code formatting.

## Motivation and Context
Issues with reading from SD cards.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on an ORGPAL_THREE (though had to turn USB MSD `OFF` for the interpreter not to continually crash). Note: build dir must be cleared!

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
