### PR TITLE
Add missing compiler defines for ESP32 builds

### DIFF
--- a/CMake/Modules/ESP32_C3_GCC_options.cmake
+++ b/CMake/Modules/ESP32_C3_GCC_options.cmake
@@ -21,7 +21,7 @@ macro(nf_set_compile_options)
     target_compile_options(${NFSCO_TARGET} PUBLIC ${NFSCO_EXTRA_COMPILE_OPTIONS} -Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-parameter -Wshadow -Wimplicit-fallthrough -fshort-wchar -fno-builtin -fno-common -fno-exceptions -fcheck-new )
 
     # this series has FPU 
-    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DTARGET=esp32c3 -DUSE_FPU=TRUE -DPLATFORM_ESP32) 
+    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DTARGET=esp32c3 -DUSE_FPU=TRUE -DPLATFORM_ESP32 -DESP_PLATFORM) 
 
 endmacro()
 

--- a/CMake/Modules/ESP32_GCC_options.cmake
+++ b/CMake/Modules/ESP32_GCC_options.cmake
@@ -22,7 +22,7 @@ macro(nf_set_compile_options)
     target_compile_options(${NFSCO_TARGET} PUBLIC ${NFSCO_EXTRA_COMPILE_OPTIONS} -Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-parameter -Wshadow -Wimplicit-fallthrough -fshort-wchar -fno-builtin -fno-common -fno-exceptions -fcheck-new )
 
     # this series has FPU 
-    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DTARGET=esp32 -DUSE_FPU=TRUE -DPLATFORM_ESP32) 
+    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DTARGET=esp32 -DUSE_FPU=TRUE -DPLATFORM_ESP32 -DESP_PLATFORM) 
 
 endmacro()
 

--- a/CMake/Modules/ESP32_S2_GCC_options.cmake
+++ b/CMake/Modules/ESP32_S2_GCC_options.cmake
@@ -21,7 +21,7 @@ macro(nf_set_compile_options)
     target_compile_options(${NFSCO_TARGET} PUBLIC ${NFSCO_EXTRA_COMPILE_OPTIONS} -Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-parameter -Wshadow -Wimplicit-fallthrough -fshort-wchar -fno-builtin -fno-common -fno-exceptions -fcheck-new )
 
     # this series has FPU 
-    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DTARGET=esp32s2 -DUSE_FPU=TRUE -DPLATFORM_ESP32) 
+    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DTARGET=esp32s2 -DUSE_FPU=TRUE -DPLATFORM_ESP32 -DESP_PLATFORM) 
 
 endmacro()
 

--- a/CMake/Modules/ESP32_S3_GCC_options.cmake
+++ b/CMake/Modules/ESP32_S3_GCC_options.cmake
@@ -21,7 +21,7 @@ macro(nf_set_compile_options)
     target_compile_options(${NFSCO_TARGET} PUBLIC ${NFSCO_EXTRA_COMPILE_OPTIONS} -Wall -Wextra -Werror -Wno-sign-compare -Wno-unused-parameter -Wshadow -Wimplicit-fallthrough -fshort-wchar -fno-builtin -fno-common -fno-exceptions -fcheck-new )
 
     # this series has FPU 
-    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DTARGET=esp32s3 -DUSE_FPU=TRUE -DPLATFORM_ESP32) 
+    target_compile_definitions(${NFSCO_TARGET} PUBLIC -DTARGET=esp32s3 -DUSE_FPU=TRUE -DPLATFORM_ESP32 -DESP_PLATFORM) 
 
 endmacro()
 


### PR DESCRIPTION
## Description
- Add general compiler define for all ESP32 series.
 
## Motivation and Context
- Some code and includes from our code can benefit from this IDF definition to be present, just like the series one.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
