### PR TITLE
Improvements in Syst.IO.Port implementations

### DIFF
--- a/src/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort__.cpp
+++ b/src/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort__.cpp
@@ -92,11 +92,11 @@ bool Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetLineFromRxBuffer(
     uint8_t *&line)
 {
     const char *newLine;
-    uint32_t newLineLength;
-    uint32_t newLineIndex;
-    int32_t compareIndex;
+    uint32_t newLineLength = 0;
+    uint32_t newLineIndex = 0;
+    int32_t compareIndex = 0;
     uint8_t *buffer;
-    uint8_t *comparison;
+    uint8_t *comparison = NULL;
     uint32_t matchCount = 0;
     uint32_t index = 0;
 
@@ -108,7 +108,16 @@ bool Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetLineFromRxBuffer(
     {
         // get "new line" from field
         newLine = serialDevice[FIELD___newLine].RecoverString();
-        newLineLength = hal_strlen_s(newLine);
+
+        if (newLine != NULL)
+        {
+            newLineLength = hal_strlen_s(newLine);
+        }
+        else
+        {
+            // TODO: maybe handle the error more appropriately
+            return false;
+        }
 
         // need to subtract one because we are 0 indexed
         newLineIndex = newLineLength - 1;
@@ -143,12 +152,16 @@ bool Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetLineFromRxBuffer(
 
                     do
                     {
+                        // Ensure comparison does not point to a location before the start of the buffer
+                        if (comparison < ringBuffer->Reader())
+                        {
+                            break;
+                        }
+
                         if (*comparison == newLine[compareIndex])
                         {
                             // found another match
                             matchCount++;
-
-                            //
                         }
 
                         // move comparer to position before
@@ -162,8 +175,7 @@ bool Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetLineFromRxBuffer(
             buffer++;
             index++;
 
-        } while (index < ringBuffer->Length() || matchCount < newLineLength);
-
+        } while (index < ringBuffer->Length() && matchCount < newLineLength);
         // sequence found?
         if (matchCount == newLineLength)
         {

--- a/targets/AzureRTOS/ST/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/AzureRTOS/ST/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -570,11 +570,12 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     NF_PAL_UART *palUart = NULL;
 
     uint8_t *line = NULL;
-    const char *newLine;
+    const char *newLine = NULL;
     uint32_t newLineLength;
 
     int64_t *timeoutTicks;
     bool eventResult = true;
+    bool newLineFound = false;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock *pThis = stack.This();
@@ -599,7 +600,11 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     if (stack.m_customState == 1)
     {
         // check if there is a full line available to read
-        if (GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line))
+        GLOBAL_LOCK();
+        newLineFound = GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line);
+        GLOBAL_UNLOCK();
+
+        if (newLineFound)
         {
             // got one!
             eventResult = false;
@@ -608,13 +613,19 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
         {
             // get new line from field
             newLine = pThis[FIELD___newLine].RecoverString();
+
+            // sanity check for NULL string
+            if (newLine == NULL)
+            {
+                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+            }
+
             newLineLength = hal_strlen_s(newLine);
-            // need to subtract one because we are 0 indexed
-            newLineLength--;
 
             // set new line char as the last one in the string
             // only if this one is found it will have a chance of the others being there
-            palUart->NewLineChar = newLine[newLineLength];
+            // need to subtract one because we are 0 indexed
+            palUart->NewLineChar = newLine[newLineLength - 1];
 
             stack.m_customState = 2;
         }
@@ -631,7 +642,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
 
         if (eventResult)
         {
+            GLOBAL_LOCK();
             GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line);
+            GLOBAL_UNLOCK();
 
             // done here
             break;

--- a/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -572,11 +572,12 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     NF_PAL_UART *palUart = NULL;
 
     uint8_t *line = NULL;
-    const char *newLine;
+    const char *newLine = NULL;
     uint32_t newLineLength;
 
     int64_t *timeoutTicks;
     bool eventResult = true;
+    bool newLineFound = false;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock *pThis = stack.This();
@@ -601,7 +602,11 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     if (stack.m_customState == 1)
     {
         // check if there is a full line available to read
-        if (GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line))
+        GLOBAL_LOCK();
+        newLineFound = GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line);
+        GLOBAL_UNLOCK();
+
+        if (newLineFound)
         {
             // got one!
             eventResult = false;
@@ -610,13 +615,19 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
         {
             // get new line from field
             newLine = pThis[FIELD___newLine].RecoverString();
+
+            // sanity check for NULL string
+            if (newLine == NULL)
+            {
+                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+            }
+
             newLineLength = hal_strlen_s(newLine);
-            // need to subtract one because we are 0 indexed
-            newLineLength--;
 
             // set new line char as the last one in the string
             // only if this one is found it will have a chance of the others being there
-            palUart->NewLineChar = newLine[newLineLength];
+            // need to subtract one because we are 0 indexed
+            palUart->NewLineChar = newLine[newLineLength - 1];
 
             stack.m_customState = 2;
         }
@@ -633,7 +644,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
 
         if (eventResult)
         {
+            GLOBAL_LOCK();
             GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line);
+            GLOBAL_UNLOCK();
 
             // done here
             break;

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -7,6 +7,7 @@
 #include <nanoHAL_Time.h>
 #include "sys_io_ser_native_target.h"
 #include <Esp32_DeviceMapping.h>
+#include <esp32_idf.h>
 
 // in UWP the COM ports are named COM1, COM2, COM3. But ESP32 uses internally UART0, UART1, UART2. This maps the port
 // index 1, 2 or 3 to the uart number 0, 1 or 2
@@ -25,36 +26,32 @@ NF_PAL_UART Uart2_PAL;
 
 NF_PAL_UART *GetPalUartFromUartNum_sys(int uart_num)
 {
-    NF_PAL_UART *palUart = NULL;
-
     switch (uart_num)
     {
         case UART_NUM_0:
             // set UART PAL
-            palUart = &Uart0_PAL;
-            break;
+            return &Uart0_PAL;
 
         case UART_NUM_1:
             // set UART PAL
-            palUart = &Uart1_PAL;
-            break;
+            return &Uart1_PAL;
 
 #if defined(UART_NUM_2)
         case UART_NUM_2:
             // set UART PAL
-            palUart = &Uart2_PAL;
-            break;
+            return &Uart2_PAL;
 #endif
 
         default:
             break;
     }
-    return palUart;
+
+    return NULL;
 }
 
 void UninitializePalUart_sys(NF_PAL_UART *palUart)
 {
-    if (palUart && palUart->SerialDevice)
+    if (palUart && palUart->UartEventTask)
     {
         // send the exit signal to the UART event handling queue
         uart_event_t event;
@@ -68,7 +65,6 @@ void UninitializePalUart_sys(NF_PAL_UART *palUart)
         // null all pointers
         palUart->RxBuffer = NULL;
         palUart->TxBuffer = NULL;
-        palUart->SerialDevice = NULL;
 
         // delete driver
         uart_driver_delete((uart_port_t)palUart->UartNum);
@@ -158,7 +154,7 @@ void uart_event_task_sys(void *pvParameters)
                     if (buffer)
                     {
                         // try to read RX FIFO
-                        readCount = uart_read_bytes(palUart->UartNum, buffer, bufferedSize, 1);
+                        readCount = uart_read_bytes(palUart->UartNum, buffer, bufferedSize, portMAX_DELAY);
 
                         // push to UART RX buffer
                         palUart->RxRingBuffer.Push(buffer, readCount);
@@ -201,19 +197,13 @@ void uart_event_task_sys(void *pvParameters)
                             {
                                 // post a managed event with the port index and event code (check if there is a watch
                                 // char in the buffer or just any char)
-                                //  check if callbacks are registered so this is called only if there is anyone
-                                //  listening otherwise don't bother
-                                if (palUart
-                                        ->SerialDevice[Library_sys_io_ser_native_System_IO_Ports_SerialPort::
-                                                           FIELD___callbacksDataReceivedEvent]
-                                        .Dereference() != NULL)
-                                {
-                                    PostManagedEvent(
-                                        EVENT_SERIAL,
-                                        0,
-                                        UART_NUM_TO_PORT_INDEX(palUart->UartNum),
-                                        (watchCharPos > -1) ? SerialData_WatchChar : SerialData_Chars);
-                                }
+                                // TODO: check if callbacks are registered so this is called only if there is anyone
+                                // listening otherwise don't bother
+                                PostManagedEvent(
+                                    EVENT_SERIAL,
+                                    0,
+                                    UART_NUM_TO_PORT_INDEX(palUart->UartNum),
+                                    (watchCharPos > -1) ? SerialData_WatchChar : SerialData_Chars);
                             }
                         }
 
@@ -335,7 +325,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::set_InvertSignalLe
     }
 
     // check if UART it's already opened
-    if (palUart->SerialDevice)
+    if (palUart->UartEventTask)
     {
         // it is opened, so we can't change the signal levels
         NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_OPERATION);
@@ -565,11 +555,12 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     uart_port_t uart_num;
 
     uint8_t *line = NULL;
-    const char *newLine;
+    const char *newLine = NULL;
     uint32_t newLineLength;
 
     int64_t *timeoutTicks;
     bool eventResult = true;
+    bool newLineFound = false;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock *pThis = stack.This();
@@ -597,7 +588,11 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     if (stack.m_customState == 1)
     {
         // check if there is a full line available to read
-        if (GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line))
+        GLOBAL_LOCK();
+        newLineFound = GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line);
+        GLOBAL_UNLOCK();
+
+        if (newLineFound)
         {
             // got one!
             eventResult = false;
@@ -606,13 +601,19 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
         {
             // get new line from field
             newLine = pThis[FIELD___newLine].RecoverString();
+
+            // sanity check for NULL string
+            if (newLine == NULL)
+            {
+                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+            }
+
             newLineLength = hal_strlen_s(newLine);
-            // need to subtract one because we are 0 indexed
-            newLineLength--;
 
             // set new line char as the last one in the string
             // only if this one is found it will have a chance of the others being there
-            palUart->NewLineChar = newLine[newLineLength];
+            // need to subtract one because we are 0 indexed
+            palUart->NewLineChar = newLine[newLineLength - 1];
 
             stack.m_customState = 2;
         }
@@ -629,7 +630,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
 
         if (eventResult)
         {
+            GLOBAL_LOCK();
             GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line);
+            GLOBAL_UNLOCK();
 
             // done here
             break;
@@ -889,7 +892,6 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     palUart->RxRingBuffer.Initialize(palUart->RxBuffer, bufferSize);
 
     // set/reset all the rest
-    palUart->SerialDevice = stack.This();
     palUart->UartNum = uart_num;
     palUart->TxOngoingCount = 0;
     palUart->RxBytesToRead = 0;
@@ -900,7 +902,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     esp_err = uart_driver_install(
         uart_num,
         // rx_buffer_size
-        bufferSize,
+        bufferSize / 2,
         // tx_buffer_size, not buffered
         0,
         // queue_size
@@ -917,9 +919,6 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
 
     // Get the watch char
     watchChar = (uint8_t)pThis[FIELD___watchChar].NumericByRef().u1;
-
-    // get watch character
-    watchChar = pThis[FIELD___watchChar].NumericByRef().u1;
 
     // set watch char, if set
     if (watchChar != 0)
@@ -1064,7 +1063,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeConfig___VOI
         }
 
         // Already Initialised ?
-        if (GetPalUartFromUartNum_sys(uart_num)->SerialDevice)
+        if (GetPalUartFromUartNum_sys(uart_num)->UartEventTask)
         {
             int errors = 0;
 

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_target.h
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_target.h
@@ -15,8 +15,6 @@ typedef struct
     TaskHandle_t UartEventTask;
     QueueHandle_t UartEventQueue;
 
-    CLR_RT_HeapBlock *SerialDevice;
-
     uint8_t *TxBuffer;
     uint16_t TxOngoingCount;
 

--- a/targets/FreeRTOS/NXP/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/FreeRTOS/NXP/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -422,11 +422,12 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     uint8_t uartNum = 0;
 
     uint8_t *line = NULL;
-    const char *newLine;
+    const char *newLine = NULL;
     uint32_t newLineLength;
 
     int64_t *timeoutTicks;
     bool eventResult = true;
+    bool newLineFound = false;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock *pThis = stack.This();
@@ -455,7 +456,12 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     if (stack.m_customState == 1)
     {
         // check if there is a full line available to read
-        if (GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line))
+        GLOBAL_LOCK();
+        newLineFound = GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line);
+        GLOBAL_UNLOCK();
+
+        // check if there is a full line available to read
+        if (newLineFound)
         {
             // got one!
             eventResult = false;
@@ -464,13 +470,19 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
         {
             // get new line from field
             newLine = pThis[FIELD___newLine].RecoverString();
+
+            // sanity check for NULL string
+            if (newLine == NULL)
+            {
+                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+            }
+
             newLineLength = hal_strlen_s(newLine);
-            // need to subtract one because we are 0 indexed
-            newLineLength--;
 
             // set new line char as the last one in the string
             // only if this one is found it will have a chance of the others being there
-            palUart->NewLineChar = newLine[newLineLength];
+            // need to subtract one because we are 0 indexed
+            palUart->NewLineChar = newLine[newLineLength - 1];
 
             stack.m_customState = 2;
         }
@@ -487,7 +499,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
 
         if (eventResult)
         {
+            GLOBAL_LOCK();
             GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line);
+            GLOBAL_UNLOCK();
 
             // done here
             break;

--- a/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -452,11 +452,12 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     uint8_t uartNum;
 
     uint8_t *line = NULL;
-    const char *newLine;
+    const char *newLine = NULL;
     uint32_t newLineLength;
 
     int64_t *timeoutTicks;
     bool eventResult = true;
+    bool newLineFound = false;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock *pThis = stack.This();
@@ -483,7 +484,11 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     if (stack.m_customState == 1)
     {
         // check if there is a full line available to read
-        if (GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line))
+        GLOBAL_LOCK();
+        newLineFound = GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line;
+        GLOBAL_UNLOCK();
+
+        if (newLineFound)
         {
             // got one!
             eventResult = false;
@@ -492,13 +497,19 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
         {
             // get new line from field
             newLine = pThis[FIELD___newLine].RecoverString();
+
+            // sanity check for NULL string
+            if (newLine == NULL)
+            {
+                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+            }
+
             newLineLength = hal_strlen_s(newLine);
-            // need to subtract one because we are 0 indexed
-            newLineLength--;
 
             // set new line char as the last one in the string
             // only if this one is found it will have a chance of the others being there
-            palUart->NewLineChar = newLine[newLineLength];
+            // need to subtract one because we are 0 indexed
+            palUart->NewLineChar = newLine[newLineLength - 1];
 
             stack.m_customState = 2;
         }
@@ -515,7 +526,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
 
         if (eventResult)
         {
+            GLOBAL_LOCK();
             GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line);
+            GLOBAL_UNLOCK();
 
             // done here
             break;


### PR DESCRIPTION
## Description
- Add memalloc success and buffer underrun checks in GetLineFromRxBuffer.
- Add missing var initializers in GetLineFromRxBuffer.
- ReadLine on all platforms now performs a global lock/unlock when calling GetLineFromRxBuffer.
- General code improvements in ReadLine in all platforms.
- Remove SerialDevice from ESP32 NF_PAL_UART, adjust code accordingly.
- Reading bytes from UART on ESP32 interrupt handler doesn't have timeout anymore.
- Uart event handler in ESP32 doesn't check if callbacks are registered anymore.

## Motivation and Context
- General code robustness improvements.
- Need to protect access to UART ring buffer when performing potentially long operation to find read line chars. During this time, the UART interrrupt handler could access the ring buffer and add more chars to it, having the potential to break the code.
- Removing the check for registered callbacks in ESP32 is no big deal as it imposes an imperceptible execution penalty (this happens on all other platforms). In turn it removes the pointer to the SerialPort heap block from the PAL UART struct. This was doomed to cause failure in the event of a heap reallocation operation. 
- Resolves nanoFramework/Home#1424 and possibly other recent reports of misbehaviors in serial ports.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Sample application that floods the serial port with a barrage of data. Run for 5 minutes without issues. The same application was causing a hard fault in ORGPAL3 and core panic in ESP32.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
