### PR TITLE
Adjust FATFS configs to use OEM encoding

### DIFF
--- a/targets/ChibiOS/ORGPAL_PALTHREE/ffconf.h
+++ b/targets/ChibiOS/ORGPAL_PALTHREE/ffconf.h
@@ -56,7 +56,7 @@
 #define FF_USE_STRFUNC 1
 #define FF_PRINT_LLI   0
 #define FF_PRINT_FLOAT 0
-#define FF_STRF_ENCODE 3
+#define FF_STRF_ENCODE 0
 /* FF_USE_STRFUNC switches string functions, f_gets(), f_putc(), f_puts() and
 /  f_printf().
 /
@@ -127,7 +127,7 @@
 /  memory for the working buffer, memory management functions, ff_memalloc() and
 /  ff_memfree() exemplified in ffsystem.c, need to be added to the project. */
 
-#define FF_LFN_UNICODE 2
+#define FF_LFN_UNICODE 0
 /* This option switches the character encoding on the API when LFN is enabled.
 /
 /   0: ANSI/OEM in current CP (TCHAR = char)
@@ -138,8 +138,8 @@
 /  Also behavior of string I/O functions will be affected by this option.
 /  When LFN is not enabled, this option has no effect. */
 
-#define FF_LFN_BUF 765
-#define FF_SFN_BUF 34
+#define FF_LFN_BUF 255
+#define FF_SFN_BUF 12
 /* This set of options defines size of file name members in the FILINFO structure
 /  which is used to read out directory items. These values should be suffcient for
 /  the file names to read. The maximum possible length of the read file name depends

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/ffconf.h
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/ffconf.h
@@ -56,7 +56,7 @@
 #define FF_USE_STRFUNC 1
 #define FF_PRINT_LLI   0
 #define FF_PRINT_FLOAT 0
-#define FF_STRF_ENCODE 3
+#define FF_STRF_ENCODE 0
 /* FF_USE_STRFUNC switches string functions, f_gets(), f_putc(), f_puts() and
 /  f_printf().
 /
@@ -127,7 +127,7 @@
 /  memory for the working buffer, memory management functions, ff_memalloc() and
 /  ff_memfree() exemplified in ffsystem.c, need to be added to the project. */
 
-#define FF_LFN_UNICODE 2
+#define FF_LFN_UNICODE 0
 /* This option switches the character encoding on the API when LFN is enabled.
 /
 /   0: ANSI/OEM in current CP (TCHAR = char)
@@ -138,8 +138,8 @@
 /  Also behavior of string I/O functions will be affected by this option.
 /  When LFN is not enabled, this option has no effect. */
 
-#define FF_LFN_BUF 765
-#define FF_SFN_BUF 34
+#define FF_LFN_BUF 255
+#define FF_SFN_BUF 12
 /* This set of options defines size of file name members in the FILINFO structure
 /  which is used to read out directory items. These values should be suffcient for
 /  the file names to read. The maximum possible length of the read file name depends

--- a/targets/ChibiOS/_include/Target_Windows_Storage.h
+++ b/targets/ChibiOS/_include/Target_Windows_Storage.h
@@ -11,8 +11,8 @@
 #if (HAL_USE_SDC == TRUE)
 #include <ff.h>
 #else
-// use copy of FATFS define ANSI/OEM at DBCS
-#define FF_LFN_BUF 765
+// use copy of FATFS define ANSI/OEM in SBCS
+#define FF_LFN_BUF 255
 #endif
 
 #if defined(HAL_USBH_USE_MSD) && (HAL_USBH_USE_MSD == TRUE)

--- a/targets/ESP32/_nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
+++ b/targets/ESP32/_nanoCLR/Windows.Storage/win_storage_native_Windows_Storage_StorageFolder.cpp
@@ -12,8 +12,8 @@
 #if (HAL_USE_SDC == TRUE) || (HAL_USBH_USE_MSD == TRUE)
 #include <ff.h>
 #else
-// use copy of FATFS define ANSI/OEM at DBCS
-#define FF_LFN_BUF 765
+// use copy of FATFS define ANSI/OEM in SBCS
+#define FF_LFN_BUF 255
 #endif
 
 //

--- a/targets/FreeRTOS/NXP/_fatfs/ffconf.h
+++ b/targets/FreeRTOS/NXP/_fatfs/ffconf.h
@@ -58,7 +58,7 @@
 #define FF_USE_STRFUNC 1
 #define FF_PRINT_LLI   0
 #define FF_PRINT_FLOAT 0
-#define FF_STRF_ENCODE 3
+#define FF_STRF_ENCODE 0
 /* FF_USE_STRFUNC switches string functions, f_gets(), f_putc(), f_puts() and
 /  f_printf().
 /
@@ -129,7 +129,7 @@
 /  memory for the working buffer, memory management functions, ff_memalloc() and
 /  ff_memfree() exemplified in ffsystem.c, need to be added to the project. */
 
-#define FF_LFN_UNICODE 2
+#define FF_LFN_UNICODE 0
 /* This option switches the character encoding on the API when LFN is enabled.
 /
 /   0: ANSI/OEM in current CP (TCHAR = char)
@@ -140,8 +140,8 @@
 /  Also behavior of string I/O functions will be affected by this option.
 /  When LFN is not enabled, this option has no effect. */
 
-#define FF_LFN_BUF 765
-#define FF_SFN_BUF 34
+#define FF_LFN_BUF 255
+#define FF_SFN_BUF 12
 /* This set of options defines size of file name members in the FILINFO structure
 /  which is used to read out directory items. These values should be suffcient for
 /  the file names to read. The maximum possible length of the read file name depends


### PR DESCRIPTION
## Description
- This is now back to OEM encoding because setting it to UTF-8 causes issues as the FATFS code tries to encode the content.
- All targets now have their configurations in sync, including ESP32 (from IDF).

## Motivation and Context
- The UTF-8 encoding was causing data to be truncated by FATFS as it was trying to perform conversions to UTF. This is not necessary as any conversion required has to be handled by our code. FATFS has to deal with the content as it is.
- Revert changes introduced with #2899.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Runing text W/R with ORGPAL3 and ORGPALX.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).

cc @networkfusion @gligorov 
