### PR TITLE
Add implementation of Sys.IO.DriveInfo

### DIFF
--- a/CMake/Modules/FindSystem.IO.FileSystem.cmake
+++ b/CMake/Modules/FindSystem.IO.FileSystem.cmake
@@ -24,6 +24,7 @@ set(System.IO.FileSystem_SRCS
 
     nf_sys_io_filesystem_nanoFramework_System_IO_FileSystem_SDCard.cpp
     nf_sys_io_filesystem_System_IO_Directory.cpp
+    nf_sys_io_filesystem_System_IO_DriveInfo.cpp
     nf_sys_io_filesystem_System_IO_File.cpp
     nf_sys_io_filesystem_System_IO_FileStream.cpp
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ if(NF_FEATURE_HAS_SDCARD)
     set(API_Windows.Storage ON CACHE INTERNAL "Forcing Windows.Storage API option to ON")
 
     # force inclusion of System.IO.FileSystem API
-    set(API_System.IO.FileSystem ON CACHE INTERNAL "Forcing System.IO.FileSystem API option to ON")
+    # set(API_System.IO.FileSystem ON CACHE INTERNAL "Forcing System.IO.FileSystem API option to ON")
 
     message(STATUS "Support for SD Card is included")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ if(NF_FEATURE_HAS_SDCARD)
     set(API_Windows.Storage ON CACHE INTERNAL "Forcing Windows.Storage API option to ON")
 
     # force inclusion of System.IO.FileSystem API
-    # set(API_System.IO.FileSystem ON CACHE INTERNAL "Forcing System.IO.FileSystem API option to ON")
+    set(API_System.IO.FileSystem ON CACHE INTERNAL "Forcing System.IO.FileSystem API option to ON")
 
     message(STATUS "Support for SD Card is included")
 else()

--- a/src/System.IO.FileSystem/nf_sys_io_filesystem.cpp
+++ b/src/System.IO.FileSystem/nf_sys_io_filesystem.cpp
@@ -72,6 +72,17 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    Library_nf_sys_io_filesystem_System_IO_DriveInfo::DriveInfoNative___VOID__STRING,
+    NULL,
+    Library_nf_sys_io_filesystem_System_IO_DriveInfo::Format___STATIC__VOID__STRING,
+    Library_nf_sys_io_filesystem_System_IO_DriveInfo::GetDrivesNative___STATIC__SZARRAY_SystemIODriveInfo,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
     NULL,
     NULL,
     NULL,
@@ -138,9 +149,9 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_System_IO_FileSystem =
 {
     "System.IO.FileSystem",
-    0x545A6C79,
+    0xE61AAB7D,
     method_lookup,
-    { 1, 0, 0, 2 }
+    { 1, 1, 0, 0 }
 };
 
 // clang-format on

--- a/src/System.IO.FileSystem/nf_sys_io_filesystem.h
+++ b/src/System.IO.FileSystem/nf_sys_io_filesystem.h
@@ -38,6 +38,15 @@ typedef enum __nfpack StorageEventManager_StorageEventType
     StorageEventManager_StorageEventType_RemovableDeviceRemoval = 2,
 } StorageEventManager_StorageEventType;
 
+typedef enum __nfpack DriveType
+{
+    DriveType_Unknown = 0,
+    DriveType_NoRootDirectory = 1,
+    DriveType_Removable = 2,
+    DriveType_Fixed = 3,
+    DriveType_Ram = 4,
+} DriveType;
+
 typedef enum __nfpack FileAccess
 {
     FileAccess_Read = 1,
@@ -146,6 +155,19 @@ struct Library_nf_sys_io_filesystem_System_IO_Directory
     NANOCLR_NATIVE_DECLARE(GetDirectoriesNative___STATIC__SZARRAY_STRING__STRING);
     NANOCLR_NATIVE_DECLARE(GetLogicalDrivesNative___STATIC__SZARRAY_STRING);
     NANOCLR_NATIVE_DECLARE(GetLastWriteTimeNative___STATIC__SystemDateTime__STRING);
+
+    //--//
+};
+
+struct Library_nf_sys_io_filesystem_System_IO_DriveInfo
+{
+    static const int FIELD___driveType = 1;
+    static const int FIELD___name = 2;
+    static const int FIELD___totalSize = 3;
+
+    NANOCLR_NATIVE_DECLARE(DriveInfoNative___VOID__STRING);
+    NANOCLR_NATIVE_DECLARE(Format___STATIC__VOID__STRING);
+    NANOCLR_NATIVE_DECLARE(GetDrivesNative___STATIC__SZARRAY_SystemIODriveInfo);
 
     //--//
 };

--- a/targets/ChibiOS/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_DriveInfo.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_DriveInfo.cpp
@@ -1,0 +1,34 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <nf_sys_io_filesystem.h>
+
+
+HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::DriveInfoNative___VOID__STRING( CLR_RT_StackFrame &stack )
+{
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::Format___STATIC__VOID__STRING( CLR_RT_StackFrame &stack )
+{
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::GetDrivesNative___STATIC__SZARRAY_SystemIODriveInfo( CLR_RT_StackFrame &stack )
+{
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
+
+    NANOCLR_NOCLEANUP();
+}

--- a/targets/ESP32/_common/Target_Windows_Storage.c
+++ b/targets/ESP32/_common/Target_Windows_Storage.c
@@ -43,6 +43,8 @@
 
 static const char *TAG = "SDCard";
 
+sdmmc_card_t *card;
+
 //
 //  Unmount SD card ( MMC/SDIO or SPI)
 //
@@ -52,6 +54,9 @@ bool Storage_UnMountSDCard()
     {
         return false;
     }
+
+    card = NULL;
+
     return true;
 }
 
@@ -120,7 +125,6 @@ bool Storage_MountMMC(bool bit1Mode, int driveIndex)
         .max_files = SDC_MAX_OPEN_FILES,
         .allocation_unit_size = 16 * 1024};
 
-    sdmmc_card_t *card;
     errCode = esp_vfs_fat_sdmmc_mount(mountPoint, &host, &slot_config, &mount_config, &card);
     if (errCode == ESP_ERR_INVALID_STATE)
     {
@@ -165,8 +169,6 @@ bool Storage_MountSpi(int spiBus, uint32_t csPin, int driveIndex)
         .format_if_mount_failed = false,
         .max_files = 5,
         .allocation_unit_size = 16 * 1024};
-
-    sdmmc_card_t *card;
 
     // This initializes the slot without card detect (CD) and write protect (WP) signals.
     // Modify slot_config.gpio_cd and slot_config.gpio_wp if your board has these signals.

--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_Directory.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_Directory.cpp
@@ -394,6 +394,7 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_Directory::GetDirectoriesNative__
 // Enumerate drives in system
 // if array == null then only count drives
 // Return number of drives
+// TO BE REMOVED AFTER managed Directory.GetLogicalDrives() is removed
 static HRESULT EnumerateDrives(CLR_RT_HeapBlock *array, int &count)
 {
     NANOCLR_HEADER();

--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_DriveInfo.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_DriveInfo.cpp
@@ -1,0 +1,197 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <nf_sys_io_filesystem.h>
+#include <esp_vfs_fat.h>
+#include <sdmmc_host.h>
+#include <diskio_impl.h>
+#include <targetHAL_FileOperation.h>
+#include <targetHAL_ConfigStorage.h>
+
+typedef Library_nf_sys_io_filesystem_System_IO_DriveInfo DriveInfo;
+static HRESULT EnumerateDrives(CLR_RT_HeapBlock *array, int &count);
+
+extern bool IsInternalFilePath(const char *filePath);
+extern "C" sdmmc_card_t *card;
+
+HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::DriveInfoNative___VOID__STRING(CLR_RT_StackFrame &stack)
+{
+    NANOCLR_HEADER();
+
+    const char *drivePath = stack.Arg1().RecoverString();
+    FAULT_ON_NULL_ARG(drivePath);
+
+#if (HAL_USE_SDC == TRUE)
+
+    // check if SD card is mounted
+    if (card != NULL)
+    {
+        // format it
+        const size_t workbuf_size = 4096;
+
+        void *workbuf = NULL;
+        BYTE pdrv;
+        DWORD plist[] = {100, 0, 0, 0};
+
+        workbuf = ff_memalloc(workbuf_size);
+        if (workbuf == NULL)
+        {
+            return ESP_ERR_NO_MEM;
+        }
+
+        ff_diskio_get_drive(&pdrv);
+
+        f_fdisk(pdrv, plist, workbuf);
+    }
+    else
+    {
+        // SD card is not mounted
+        // return error
+        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+    }
+#endif // HAL_USE_SDC
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::Format___STATIC__VOID__STRING(CLR_RT_StackFrame &stack)
+{
+    NANOCLR_HEADER();
+
+    char workingDrive[DRIVE_LETTER_LENGTH];
+    char *vfsPath = NULL;
+    int operationResult;
+    struct stat fno;
+
+    CLR_RT_TypeDef_Index driveInfoTypeDef;
+    CLR_RT_HeapBlock *driveInfo;
+
+    CLR_RT_HeapBlock &top = stack.PushValue();
+
+    const char *drivePath = stack.Arg1().RecoverString();
+    FAULT_ON_NULL_ARG(drivePath);
+
+    // copy the first 2 letters of the path for the drive
+    // path is 'D:\folder\file.txt', so we need 'D:'
+    memcpy(workingDrive, drivePath, DRIVE_LETTER_LENGTH);
+
+    // start composing the reply
+    // find <DriveInfo> type definition, don't bother checking the result as it exists for sure
+    g_CLR_RT_TypeSystem.FindTypeDef("DriveInfo", "System.IO", driveInfoTypeDef);
+
+    // create an instance of <DriveInfo>
+    NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, driveInfoTypeDef));
+
+    // get a pointer to DriveInfo
+    driveInfo = (CLR_RT_HeapBlock *)top.Dereference();
+
+    if (IsInternalFilePath(workingDrive))
+    {
+        // get the drive info from SPIFFs
+        size_t total = 0, used = 0;
+        esp_spiffs_info(SPIFFS_PARTITION_LABEL, &total, &used);
+
+        // fill in the drive info namaged fields
+        driveInfo[FIELD___driveType].SetInteger(DriveType_Fixed);
+        CLR_RT_HeapBlock_String::CreateInstance(driveInfo[FIELD___name], drivePath);
+        driveInfo[FIELD___totalSize].SetInteger((CLR_UINT32)total);
+    }
+    else
+
+#if (HAL_USE_SDC == TRUE)
+
+    {
+        // assume "0:"" as we're always mounting 1 FATFS drive
+
+        operationResult = stat(vfsPath, &fno);
+        if (operationResult == 0)
+        {
+            // fill in the drive info namaged fields
+            driveInfo[FIELD___driveType].SetInteger(DriveType_Removable);
+            CLR_RT_HeapBlock_String::CreateInstance(driveInfo[FIELD___name], drivePath);
+            driveInfo[FIELD___totalSize].SetInteger((CLR_UINT32)fno.st_size);
+        }
+        else
+        {
+            // failed to get drive info
+            NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
+        }
+    }
+
+#endif // HAL_USE_SDC
+
+    {
+        // unsupported drive
+        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+    }
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::GetDrivesNative___STATIC__SZARRAY_SystemIODriveInfo(
+    CLR_RT_StackFrame &stack)
+{
+    NANOCLR_HEADER();
+
+    int count = 0;
+
+    CLR_RT_HeapBlock &top = stack.PushValueAndClear();
+
+    // 1st pass find number of drives
+    NANOCLR_CHECK_HRESULT(EnumerateDrives(NULL, count));
+
+    // create an array of files paths <String> for count drives
+    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance(top, count, g_CLR_RT_WellKnownTypes.m_String));
+
+    // 2nd pass fill array with drives
+    NANOCLR_CHECK_HRESULT(EnumerateDrives(&top, count));
+
+    NANOCLR_NOCLEANUP();
+}
+
+// Enumerate drives in system
+// if array == null then only count drives
+// Return number of drives
+static HRESULT EnumerateDrives(CLR_RT_HeapBlock *array, int &count)
+{
+    NANOCLR_HEADER();
+    {
+        CLR_RT_HeapBlock *storageFolder = NULL;
+        DIR *currentDirectory;
+        char outputDrive[] = INDEX0_DRIVE_PATH;
+        char workingDrive[] = "/D/";
+
+        if (array)
+        {
+            // get a pointer to the first object in the array (which is of type <String>)
+            storageFolder = (CLR_RT_HeapBlock *)array->DereferenceArray()->GetFirstElement();
+        }
+
+        count = 0;
+        for (char drive = INDEX0_DRIVE_LETTER[0]; drive <= INTERNAL_DRIVE0_LETTER[0]; drive++)
+        {
+            workingDrive[1] = drive;
+            currentDirectory = opendir(workingDrive);
+            if (currentDirectory != NULL)
+            {
+                count++;
+                closedir(currentDirectory);
+
+                if (array)
+                {
+                    // Add entry to array
+                    outputDrive[0] = drive;
+
+                    // set the drive letter in string array
+                    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_String::CreateInstance(*storageFolder, outputDrive));
+
+                    // Next element in array
+                    storageFolder++;
+                }
+            }
+        }
+    }
+    NANOCLR_NOCLEANUP();
+}

--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_DriveInfo.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_DriveInfo.cpp
@@ -20,46 +20,6 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::DriveInfoNative___VOID
 {
     NANOCLR_HEADER();
 
-    const char *drivePath = stack.Arg1().RecoverString();
-    FAULT_ON_NULL_ARG(drivePath);
-
-#if (HAL_USE_SDC == TRUE)
-
-    // check if SD card is mounted
-    if (card != NULL)
-    {
-        // format it
-        const size_t workbuf_size = 4096;
-
-        void *workbuf = NULL;
-        BYTE pdrv;
-        DWORD plist[] = {100, 0, 0, 0};
-
-        workbuf = ff_memalloc(workbuf_size);
-        if (workbuf == NULL)
-        {
-            return ESP_ERR_NO_MEM;
-        }
-
-        ff_diskio_get_drive(&pdrv);
-
-        f_fdisk(pdrv, plist, workbuf);
-    }
-    else
-    {
-        // SD card is not mounted
-        // return error
-        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-    }
-#endif // HAL_USE_SDC
-
-    NANOCLR_NOCLEANUP();
-}
-
-HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::Format___STATIC__VOID__STRING(CLR_RT_StackFrame &stack)
-{
-    NANOCLR_HEADER();
-
     char workingDrive[DRIVE_LETTER_LENGTH];
 
 #if (HAL_USE_SDC == TRUE)
@@ -129,6 +89,46 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::Format___STATIC__VOID_
         // unsupported drive
         NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
     }
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::Format___STATIC__VOID__STRING(CLR_RT_StackFrame &stack)
+{
+    NANOCLR_HEADER();
+
+    const char *drivePath = stack.Arg1().RecoverString();
+    FAULT_ON_NULL_ARG(drivePath);
+
+#if (HAL_USE_SDC == TRUE)
+
+    // check if SD card is mounted
+    if (card != NULL)
+    {
+        // format it
+        const size_t workbuf_size = 4096;
+
+        void *workbuf = NULL;
+        BYTE pdrv;
+        DWORD plist[] = {100, 0, 0, 0};
+
+        workbuf = ff_memalloc(workbuf_size);
+        if (workbuf == NULL)
+        {
+            return ESP_ERR_NO_MEM;
+        }
+
+        ff_diskio_get_drive(&pdrv);
+
+        f_fdisk(pdrv, plist, workbuf);
+    }
+    else
+    {
+        // SD card is not mounted
+        // return error
+        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+    }
+#endif // HAL_USE_SDC
 
     NANOCLR_NOCLEANUP();
 }

--- a/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_DriveInfo.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_DriveInfo.cpp
@@ -61,9 +61,12 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::Format___STATIC__VOID_
     NANOCLR_HEADER();
 
     char workingDrive[DRIVE_LETTER_LENGTH];
+
+#if (HAL_USE_SDC == TRUE)
     char *vfsPath = NULL;
     int operationResult;
     struct stat fno;
+#endif
 
     CLR_RT_TypeDef_Index driveInfoTypeDef;
     CLR_RT_HeapBlock *driveInfo;

--- a/targets/FreeRTOS/NXP/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_DriveInfo.cpp
+++ b/targets/FreeRTOS/NXP/_nanoCLR/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_DriveInfo.cpp
@@ -1,0 +1,34 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include <nf_sys_io_filesystem.h>
+
+
+HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::DriveInfoNative___VOID__STRING( CLR_RT_StackFrame &stack )
+{
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::Format___STATIC__VOID__STRING( CLR_RT_StackFrame &stack )
+{
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_nf_sys_io_filesystem_System_IO_DriveInfo::GetDrivesNative___STATIC__SZARRAY_SystemIODriveInfo( CLR_RT_StackFrame &stack )
+{
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
+
+    NANOCLR_NOCLEANUP();
+}


### PR DESCRIPTION
## Description
- Add implementation for Sys.IO.DriveInfo.
- Add code to support it in ESP32.
- Update CMake.

## Motivation and Context
- Following nanoframework/System.IO.FileSystem#94

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
