### PR TITLE
Properly offset managed SPI bus ID to native for ESP32C3 and S3

### DIFF
--- a/targets/ESP32/_common/Target_Windows_Storage.c
+++ b/targets/ESP32/_common/Target_Windows_Storage.c
@@ -160,7 +160,7 @@ bool Storage_MountSpi(int spiBus, uint32_t csPin, int driveIndex)
 
     sdmmc_host_t host = SDSPI_HOST_DEFAULT();
 #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
-    host.slot = spiBus;
+    host.slot = spiBus + SPI2_HOST;
 #else
     host.slot = spiBus + HSPI_HOST;
 #endif

--- a/targets/ESP32/_common/Target_Windows_Storage.c
+++ b/targets/ESP32/_common/Target_Windows_Storage.c
@@ -160,8 +160,10 @@ bool Storage_MountSpi(int spiBus, uint32_t csPin, int driveIndex)
 
     sdmmc_host_t host = SDSPI_HOST_DEFAULT();
 #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
+    // First available bus on ESP32_C3/S3 is SPI2_HOST
     host.slot = spiBus + SPI2_HOST;
 #else
+    // First available bus on ESP32 is HSPI_HOST(1)
     host.slot = spiBus + HSPI_HOST;
 #endif
 

--- a/targets/ESP32/_nanoCLR/System.Device.Spi/cpu_spi.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.Spi/cpu_spi.cpp
@@ -189,8 +189,10 @@ bool CPU_SPI_Initialize(uint8_t busIndex, const SPI_DEVICE_CONFIGURATION &spiDev
     if (ret != ESP_OK)
     {
 #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
+        // First available bus on ESP32_C3/S3 is SPI2_HOST
         ESP_LOGE(TAG, "Unable to init SPI bus %d esp_err %d", busIndex + SPI2_HOST, ret);
 #else
+        // First available bus on ESP32 is HSPI_HOST(1)
         ESP_LOGE(TAG, "Unable to init SPI bus %d esp_err %d", busIndex + HSPI_HOST, ret);
 #endif
         return false;
@@ -208,16 +210,20 @@ bool CPU_SPI_Initialize(uint8_t busIndex, const SPI_DEVICE_CONFIGURATION &spiDev
 bool CPU_SPI_Uninitialize(uint8_t busIndex)
 {
 #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
+    // First available bus on ESP32_C3/S3 is SPI2_HOST
     esp_err_t ret = spi_bus_free((spi_host_device_t)(busIndex + SPI2_HOST));
 #else
+    // First available bus on ESP32 is HSPI_HOST(1)
     esp_err_t ret = spi_bus_free((spi_host_device_t)(busIndex + HSPI_HOST));
 #endif
 
     if (ret != ESP_OK)
     {
 #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
+        // First available bus on ESP32_C3/S3 is SPI2_HOST
         ESP_LOGE(TAG, "spi_bus_free bus %d esp_err %d", busIndex + SPI2_HOST, ret);
 #else
+        // First available bus on ESP32 is HSPI_HOST(1)
         ESP_LOGE(TAG, "spi_bus_free bus %d esp_err %d", busIndex + HSPI_HOST, ret);
 #endif
 

--- a/targets/ESP32/_nanoCLR/System.Device.Spi/cpu_spi.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.Spi/cpu_spi.cpp
@@ -189,7 +189,7 @@ bool CPU_SPI_Initialize(uint8_t busIndex, const SPI_DEVICE_CONFIGURATION &spiDev
     if (ret != ESP_OK)
     {
 #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
-        ESP_LOGE(TAG, "Unable to init SPI bus %d esp_err %d", busIndex, ret);
+        ESP_LOGE(TAG, "Unable to init SPI bus %d esp_err %d", busIndex + SPI2_HOST, ret);
 #else
         ESP_LOGE(TAG, "Unable to init SPI bus %d esp_err %d", busIndex + HSPI_HOST, ret);
 #endif
@@ -208,7 +208,7 @@ bool CPU_SPI_Initialize(uint8_t busIndex, const SPI_DEVICE_CONFIGURATION &spiDev
 bool CPU_SPI_Uninitialize(uint8_t busIndex)
 {
 #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
-    esp_err_t ret = spi_bus_free((spi_host_device_t)(busIndex));
+    esp_err_t ret = spi_bus_free((spi_host_device_t)(busIndex + SPI2_HOST));
 #else
     esp_err_t ret = spi_bus_free((spi_host_device_t)(busIndex + HSPI_HOST));
 #endif
@@ -216,7 +216,7 @@ bool CPU_SPI_Uninitialize(uint8_t busIndex)
     if (ret != ESP_OK)
     {
 #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
-        ESP_LOGE(TAG, "spi_bus_free bus %d esp_err %d", busIndex, ret);
+        ESP_LOGE(TAG, "spi_bus_free bus %d esp_err %d", busIndex + SPI2_HOST, ret);
 #else
         ESP_LOGE(TAG, "spi_bus_free bus %d esp_err %d", busIndex + HSPI_HOST, ret);
 #endif


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Properly offset managed SPI bus ID to native for C3 and S3 ESP32 devices.

## Motivation and Context
So the SD card works on S3 devices.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
On device.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
