### PR TITLE
Improvements in network boot

### DIFF
--- a/src/PAL/Lwip/lwIP_Sockets.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets.cpp
@@ -1311,7 +1311,7 @@ HRESULT LWIP_SOCKETS_Driver::UpdateAdapterConfiguration(
         else
         {
             // stop DHCP
-            dhcp_stop(networkInterface);
+            dhcp_release_and_stop(networkInterface);
 
             // need to convert these first
             ip_addr_t ipAddress, mask, gateway;
@@ -1341,7 +1341,7 @@ HRESULT LWIP_SOCKETS_Driver::UpdateAdapterConfiguration(
 
         if (0 != (updateFlags & NetworkInterface_UpdateOperation_DhcpRelease))
         {
-            dhcp_release(networkInterface);
+            dhcp_release_and_stop(networkInterface);
         }
         else if (0 != (updateFlags & NetworkInterface_UpdateOperation_DhcpRenew))
         {

--- a/src/PAL/Lwip/lwIP_Sockets.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets.cpp
@@ -1333,12 +1333,6 @@ HRESULT LWIP_SOCKETS_Driver::UpdateAdapterConfiguration(
 
     if (enableDHCP)
     {
-        // developer note: on legacy source there was a hack of trying to renew before release and
-        // also setting the release flag in managed call when the intent was to renew only
-        // nowadays lwIP seems to be doing what is told, so no need for these hacks anymore
-        // also it's NOT possible to renew & release on the same pass, so adding an extra else-if for that
-        // just in case it's request from the managed code
-
         if (0 != (updateFlags & NetworkInterface_UpdateOperation_DhcpRelease))
         {
             dhcp_release_and_stop(networkInterface);

--- a/targets/ChibiOS/_lwIP/nf_lwipthread.c
+++ b/targets/ChibiOS/_lwIP/nf_lwipthread.c
@@ -275,7 +275,7 @@ void lwipDefaultLinkDownCB(void *p)
 #if LWIP_DHCP
     if (addressMode == NET_ADDRESS_DHCP)
     {
-        dhcp_stop(ifc);
+        dhcp_release_and_stop(ifc);
     }
 #endif
 
@@ -500,7 +500,9 @@ static void do_reconfigure(void *p)
         case NET_ADDRESS_DHCP:
         {
             if (netif_is_up(&thisif))
-                dhcp_stop(&thisif);
+            {
+                dhcp_release_and_stop(&thisif);
+            }
             break;
         }
 #endif
@@ -532,8 +534,7 @@ static void do_reconfigure(void *p)
 #if LWIP_DHCP
         case NET_ADDRESS_DHCP:
         {
-            if (netif_is_up(&thisif))
-                dhcp_start(&thisif);
+            dhcp_start(&thisif);
             break;
         }
 #endif


### PR DESCRIPTION
## Description
- Replace deprecated lwIP calls with correct ones.
- DHCP is now started in ChibiOS regardless of network being up or not.

## Motivation and Context
- Need to use current lwIP API.
- DHCP start/restart on network up/down is now properly handled by lwIP, so better to just start it at network start.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running TLS sample on NESHTEC_NESHNODE_V1.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).

cc @thwr
