### PR TITLE
Add call to WP PrepareReception to allow target specific code

### DIFF
--- a/targets/ChibiOS/_common/WireProtocol_ReceiverThread.c
+++ b/targets/ChibiOS/_common/WireProtocol_ReceiverThread.c
@@ -19,8 +19,6 @@ __attribute__((noreturn)) void ReceiverThread(void const *argument)
 {
     (void)argument;
 
-    osDelay(500);
-
     WP_Message_PrepareReception();
 
     // loop until thread receives a request to terminate
@@ -53,7 +51,12 @@ __attribute__((noreturn)) void ReceiverThread(void const *argument)
     // this function never returns
 }
 
+__nfweak void WP_Message_PrepareReception_Target()
+{
+    // empty on purpose, to be implemented by target if needed
+}
+
 void WP_Message_PrepareReception_Platform()
 {
-    // empty on purpose, nothing to configure
+    WP_Message_PrepareReception_Target();
 }


### PR DESCRIPTION
## Description
- Add weak implementation to allow strong one being provided at target level.
- Remove unnecessary delay at beginning of Receiver thread.

## Motivation and Context
- Targets implementing USB CDC can randomly misbehave at CLR boot with the COM port not being available after reboot. This makes the USB config/reconfig happening later in the boot thus improving this potential problem.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Successively rebooting NESHTEC_NESHNODE_V1 from VS after a debug session.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
