### PR TITLE
Revert Add call to WP PrepareReception to allow target specific code (#2917)

### DIFF
--- a/targets/ChibiOS/_common/WireProtocol_ReceiverThread.c
+++ b/targets/ChibiOS/_common/WireProtocol_ReceiverThread.c
@@ -19,6 +19,8 @@ __attribute__((noreturn)) void ReceiverThread(void const *argument)
 {
     (void)argument;
 
+    osDelay(500);
+
     WP_Message_PrepareReception();
 
     // loop until thread receives a request to terminate
@@ -51,12 +53,7 @@ __attribute__((noreturn)) void ReceiverThread(void const *argument)
     // this function never returns
 }
 
-__nfweak void WP_Message_PrepareReception_Target()
-{
-    // empty on purpose, to be implemented by target if needed
-}
-
 void WP_Message_PrepareReception_Platform()
 {
-    WP_Message_PrepareReception_Target();
+    // empty on purpose, nothing to configure
 }


### PR DESCRIPTION
## Description
- This reverts commit 3990335a8690d6dbef4dd7f0b563639c5fe00c3a.

## Motivation and Context
- Improvement is not actually improving anything.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
