### PR TITLE
ESP32_S3 not getting IP address when debugging

### DIFF
--- a/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
+++ b/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
@@ -339,12 +339,7 @@ bool NF_ESP32_Wireless_Close()
 {
     if (IsWifiInitialised)
     {
-        esp_wifi_stop();
-        esp_wifi_deinit();
-
-        // clear flags
-        IsWifiInitialised = false;
-        NF_ESP32_IsToConnect = false;
+        NF_ESP32_DeinitWifi();
     }
 
     return false;

--- a/targets/ESP32/_common/Target_Network.cpp
+++ b/targets/ESP32/_common/Target_Network.cpp
@@ -29,7 +29,7 @@ bool Network_Interface_Bind(int index)
 int Network_Interface_Open(int index)
 {
     HAL_Configuration_NetworkInterface networkConfiguration;
-
+ets_printf("Network_Interface_Open %d\n", index);
     // load network interface configuration from storage
     if (!ConfigurationManager_GetConfigurationBlock(
             (void *)&networkConfiguration,
@@ -73,6 +73,7 @@ int Network_Interface_Open(int index)
 bool Network_Interface_Close(int index)
 {
     HAL_Configuration_NetworkInterface networkConfiguration;
+ets_printf("Network_Interface_Close %d\n", index);
 
     // load network interface configuration from storage
     if (!ConfigurationManager_GetConfigurationBlock(

--- a/targets/ESP32/_common/Target_Network.cpp
+++ b/targets/ESP32/_common/Target_Network.cpp
@@ -29,7 +29,7 @@ bool Network_Interface_Bind(int index)
 int Network_Interface_Open(int index)
 {
     HAL_Configuration_NetworkInterface networkConfiguration;
-ets_printf("Network_Interface_Open %d\n", index);
+
     // load network interface configuration from storage
     if (!ConfigurationManager_GetConfigurationBlock(
             (void *)&networkConfiguration,
@@ -73,7 +73,6 @@ ets_printf("Network_Interface_Open %d\n", index);
 bool Network_Interface_Close(int index)
 {
     HAL_Configuration_NetworkInterface networkConfiguration;
-ets_printf("Network_Interface_Close %d\n", index);
 
     // load network interface configuration from storage
     if (!ConfigurationManager_GetConfigurationBlock(

--- a/targets/ESP32/_common/targetHAL_Network.cpp
+++ b/targets/ESP32/_common/targetHAL_Network.cpp
@@ -22,7 +22,7 @@ extern esp_netif_t *WifiStationEspNetif;
 
 #define WIFI_EVENT_TYPE_SCAN_COMPLETE 1
 
-#define 	PRINT_NET_EVENT 	1
+// #define 	PRINT_NET_EVENT 	1
 
 // buffer with host name
 char hostName[18] = "nanodevice_";
@@ -197,28 +197,6 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
                 }
 
                 PostAvailabilityOn(IDF_WIFI_STA_DEF);
-
-
-
-                espNetif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-                ets_printf("WIFI_EVENT_STA_CONNECTED flags %X dhcp %d\n", espNetif->flags, espNetif->dhcpc_status);
-
-
-// #ifdef PRINT_NET_EVENT
-//                 esp_netif_dhcp_status_t dhcp_status;
-//                 result = esp_netif_dhcpc_get_status(espNetif, &dhcp_status);
-//                 ets_printf("WIFI_EVENT_STA_CONNECTED dhcp status %d\n", dhcp_status);
-
-                // if (dhcp_status == ESP_NETIF_DHCP_INIT)
-                // {
-                //     result = esp_netif_dhcpc_start(espNetif);
-                //     ets_printf("esp_netif_dhcpc_start %d \n", result);
-
-                //     result = esp_netif_dhcpc_get_status(espNetif, &dhcp_status);
-                //     ets_printf("WIFI_EVENT_STA_CONNECTED dhcp again status  %d \n", dhcp_status);
-                // }
-//#endif
-
                 break;
 
             case WIFI_EVENT_STA_DISCONNECTED:
@@ -235,10 +213,6 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
                 }
 
                 PostAvailabilityOff(IDF_WIFI_STA_DEF);
-
-                // AS debug
-                espNetif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-                ets_printf("WIFI_EVENT_STA_DISCONNECTED flags %X dhcp %d\n", espNetif->flags, espNetif->dhcpc_status);
 
                 if (NF_ESP32_IsToConnect)
                 {
@@ -536,7 +510,7 @@ void nanoHAL_Network_Initialize()
     result = esp_event_loop_create_default();
 
     // If the default event loop is already created (ESP_ERR_INVALID_STATE) then don't need to register 
-    // This happens when debugging in VS as it does warm reboot 
+    // This happens when debugging in VS, as it does a warm reboot 
     if (result != ESP_ERR_INVALID_STATE)
     {
         ESP_ERROR_CHECK(result);


### PR DESCRIPTION
## Description
When debugging on ESP32_S3 the Wifi network would not get an IP address.
It was found by tracing network that the DHCP was not being started when using debug due to the warm boot.  
The logic was changed for IDF 5.1.3 release as an error was received when recreating the default event loop (esp_event_loop_create_default()).
Original code was added to delete default event loop in nanoHAL_Network_Uninitialize().  Then when restarted there was no error on re-creating event loop. 

This seemed to work OK for ESP32 devices but for ESP32_S3 the DHCP never gets started from the WIFI_EVENT_STA_CONNECTED event by IDF.  So re-creating event loop stops this IDF default action. 

This change no longer deletes/re-creates the default loop but ignores the invalid state error on creation which indicates loop is already present. (Warm boot)

## Motivation and Context
Error found by team on discord when testing latest IDF 5.1.3

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Test locally by running wifi test on esp32_s3 and esp_psram_rev3 under normal running & debug

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
