### PR TITLE
ESP32 sleep compile options wrong

### DIFF
--- a/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_Sleep.cpp
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Hardware.ESP32/nanoFramework_hardware_esp32_native_Hardware_Esp32_Sleep.cpp
@@ -18,7 +18,6 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
     NativeEnableWakeupByTimer___STATIC__nanoFrameworkHardwareEsp32EspNativeError__U8(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
-#if !defined(CONFIG_IDF_TARGET_ESP32H2)
     {
         uint64_t time_us = (uint64_t)stack.Arg0().NumericByRef().s8;
 
@@ -28,10 +27,6 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
         stack.SetResult_I4((int)err);
     }
     NANOCLR_NOCLEANUP_NOLABEL();
-#else
-    NANOCLR_SET_AND_LEAVE(CLR_E_NOT_SUPPORTED);
-    NANOCLR_NOCLEANUP();
-#endif
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::
@@ -40,7 +35,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
 {
     NANOCLR_HEADER();
 
-#if SOC_PM_SUPPORT_EXT_WAKEUP
+#if CONFIG_SOC_PM_SUPPORT_EXT0_WAKEUP
 
     gpio_num_t gpio_num;
     esp_err_t err;
@@ -85,7 +80,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
 {
     NANOCLR_HEADER();
 
-#if SOC_PM_SUPPORT_EXT_WAKEUP
+#if CONFIG_SOC_PM_SUPPORT_EXT1_WAKEUP
 
     uint64_t mask = (uint64_t)stack.Arg0().NumericByRef().s8;
     esp_sleep_ext1_wakeup_mode_t mode = (esp_sleep_ext1_wakeup_mode_t)stack.Arg1().NumericByRef().s4;
@@ -112,7 +107,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
 {
     NANOCLR_HEADER();
 
-#if SOC_PM_SUPPORT_EXT_WAKEUP
+#if CONFIG_SOC_PM_SUPPORT_TOUCH_SENSOR_WAKEUP
     esp_err_t err;
     int pad1;
     int coefficient;
@@ -263,7 +258,6 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
     NativeStartLightSleep___STATIC__nanoFrameworkHardwareEsp32EspNativeError(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
-#if !defined(CONFIG_IDF_TARGET_ESP32H2)
     {
         esp_err_t err = esp_light_sleep_start();
 
@@ -271,10 +265,6 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
         stack.SetResult_I4((int)err);
     }
     NANOCLR_NOCLEANUP_NOLABEL();
-#else
-    NANOCLR_SET_AND_LEAVE(CLR_E_NOT_SUPPORTED);
-    NANOCLR_NOCLEANUP();
-#endif
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::
@@ -310,22 +300,12 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
 {
     NANOCLR_HEADER();
 
-#if SOC_PM_SUPPORT_EXT_WAKEUP
-
     esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
 
     // Return value to the managed application
     stack.SetResult_I4((int32_t)cause);
 
     NANOCLR_NOCLEANUP_NOLABEL();
-
-#else
-
-    NANOCLR_SET_AND_LEAVE(CLR_E_NOT_SUPPORTED);
-
-    NANOCLR_NOCLEANUP();
-
-#endif
 }
 
 HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32_Sleep::
@@ -333,7 +313,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
 {
     NANOCLR_HEADER();
 
-#if SOC_PM_SUPPORT_EXT_WAKEUP
+#if CONFIG_SOC_PM_SUPPORT_EXT1_WAKEUP
 
     int64_t pin = (int64_t)esp_sleep_get_ext1_wakeup_status();
 
@@ -356,7 +336,7 @@ HRESULT Library_nanoFramework_hardware_esp32_native_nanoFramework_Hardware_Esp32
 {
     NANOCLR_HEADER();
 
-#if SOC_PM_SUPPORT_EXT_WAKEUP
+#if CONFIG_SOC_PM_SUPPORT_TOUCH_SENSOR_WAKEUP
 
     touch_pad_t touch_pad = esp_sleep_get_touchpad_wakeup_status();
     int retValue = (int)touch_pad;


### PR DESCRIPTION
## Description

Some of the sleep options where giving a NOT SUPPORTED error when they should have been available,

Reworked code using latest compile options for  ESP32 SOC configuration.
 

## Motivation and Context
Reported on discord for latest IDF 5.1.3 build
Get wakeup cause giving NOT SUPPORTED error on C3 targets.
This would have been the case for also C6 & H2

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested built locally for ESP32, ESP32_S3, ESP32_C3, EP32_C6 & ESP32_H2

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
