### PR TITLE
Ethernet interface not re-starting on debug

### DIFF
--- a/targets/ESP32/_Network/NF_ESP32_Ethernet.cpp
+++ b/targets/ESP32/_Network/NF_ESP32_Ethernet.cpp
@@ -45,6 +45,11 @@ esp_err_t NF_ESP32_InitialiseEthernet(uint8_t *pMacAdr)
 
 #ifdef ESP32_ETHERNET_SUPPORT
 
+    if (eth_handle != NULL)
+    {
+        return esp_eth_start(eth_handle);
+    }
+
     esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
     esp_netif_t *eth_netif = esp_netif_new(&cfg);
 

--- a/targets/ESP32/_common/targetHAL_ConfigurationManager.cpp
+++ b/targets/ESP32/_common/targetHAL_ConfigurationManager.cpp
@@ -173,7 +173,7 @@ void ConfigurationManager_EnumerateConfigurationBlocks()
         ethernetEnabled = true;
 #endif
 
-#ifdef HAL_USE_THREAD
+#if HAL_USE_THREAD == TRUE
         netTypes[networkCount++] = NetworkInterfaceType_Thread;
 #endif
         // allocate memory for ONE network configuration


### PR DESCRIPTION
## Description

With latest IDF 5.1.3 firmware the Ethernet interface was not working when debugged under VS.  
Also noticed OpenThread network interface being created due to a code typo.
 

## Motivation and Context
Issue reported on Discord
https://discord.com/channels/478725473862549535/1239278902136934463

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

**For normal running and under Debug** 
- Tested Ethernet interface link comes up and IP address is received.
- Datetime also received via SNTP.



## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
