### PR TITLE
Add check for device connected WP_ReceiveBytes and WP_TransmitMessage

### DIFF
--- a/targets/AzureRTOS/SiliconLabs/_common/WireProtocol_HAL_Interface.c
+++ b/targets/AzureRTOS/SiliconLabs/_common/WireProtocol_HAL_Interface.c
@@ -33,6 +33,7 @@ void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
     // save for later comparison
     uint32_t requestedSize = *size;
     sl_status_t requestResult;
+    bool conn = false;
 
 #if HAL_WP_USE_SERIAL == TRUE
     size_t bytesRead;
@@ -43,6 +44,15 @@ void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
     // check for requests with 0 size
     if (*size)
     {
+        // check if device is connected
+        sl_usbd_cdc_acm_is_enabled(sl_usbd_cdc_acm_acm0_number, &conn);
+
+        if (!conn)
+        {
+            // device is not connected
+            return;
+        }
+
 #if HAL_WP_USE_SERIAL == TRUE
         // blocking receive as SL API does not support non-blocking
         requestResult = sl_iostream_read(sl_iostream_vcom_handle, *ptr, requestedSize, &bytesRead);

--- a/targets/AzureRTOS/SiliconLabs/_common/WireProtocol_HAL_Interface.c
+++ b/targets/AzureRTOS/SiliconLabs/_common/WireProtocol_HAL_Interface.c
@@ -33,17 +33,18 @@ void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
     // save for later comparison
     uint32_t requestedSize = *size;
     sl_status_t requestResult;
-    bool conn = false;
 
 #if HAL_WP_USE_SERIAL == TRUE
     size_t bytesRead;
 #elif HAL_WP_USE_USB_CDC == TRUE
+    bool conn = false;
     uint32_t bytesRead;
 #endif
 
     // check for requests with 0 size
     if (*size)
     {
+#if HAL_WP_USE_USB_CDC == TRUE
         // check if device is connected
         sl_usbd_cdc_acm_is_enabled(sl_usbd_cdc_acm_acm0_number, &conn);
 
@@ -52,6 +53,7 @@ void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
             // device is not connected
             return;
         }
+#endif
 
 #if HAL_WP_USE_SERIAL == TRUE
         // blocking receive as SL API does not support non-blocking
@@ -85,14 +87,14 @@ void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
 
 uint8_t WP_TransmitMessage(WP_Message *message)
 {
-    bool conn = false;
-
 #if HAL_WP_USE_USB_CDC == TRUE
+    bool conn = false;
     uint32_t dummy = 0;
 #endif
 
     TRACE_WP_HEADER(WP_TXMSG, message);
 
+#if HAL_WP_USE_USB_CDC == TRUE
     // check if device is connected
     sl_usbd_cdc_acm_is_enabled(sl_usbd_cdc_acm_acm0_number, &conn);
 
@@ -101,6 +103,7 @@ uint8_t WP_TransmitMessage(WP_Message *message)
         // device is not connected
         return false;
     }
+#endif
 
 #if HAL_WP_USE_SERIAL == TRUE
     // non-blocking transmit

--- a/targets/AzureRTOS/SiliconLabs/_common/WireProtocol_HAL_Interface.c
+++ b/targets/AzureRTOS/SiliconLabs/_common/WireProtocol_HAL_Interface.c
@@ -85,11 +85,22 @@ void WP_ReceiveBytes(uint8_t **ptr, uint32_t *size)
 
 uint8_t WP_TransmitMessage(WP_Message *message)
 {
+    bool conn = false;
+
 #if HAL_WP_USE_USB_CDC == TRUE
     uint32_t dummy = 0;
 #endif
 
     TRACE_WP_HEADER(WP_TXMSG, message);
+
+    // check if device is connected
+    sl_usbd_cdc_acm_is_enabled(sl_usbd_cdc_acm_acm0_number, &conn);
+
+    if (!conn)
+    {
+        // device is not connected
+        return false;
+    }
 
 #if HAL_WP_USE_SERIAL == TRUE
     // non-blocking transmit


### PR DESCRIPTION
## Description
- Add check if USB device is connected before attempting to read/write.

## Motivation and Context
- Make sure device is presente before attempting operation on USB endpoints.
- Not performing this check has reportedly caused device hangs on Silab based targets following Gecko SDK 4.4.0.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).

cc @sky9mike