### PR TITLE
I2C device unable to open with bus id 2 with latest firmware for IDF 5.x

### DIFF
--- a/targets/ESP32/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -68,11 +68,7 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::NativeInit___VOI
         // subtract 1 to get ESP32 bus number
         i2c_port_t bus = (i2c_port_t)(pConfig[I2cConnectionSettings::FIELD___busId].NumericByRef().s4 - 1);
 
-        if (bus != I2C_NUM_0
-#if I2C_NUM_MAX > 1
-            && bus != I2C_NUM_1
-#endif
-        )
+        if (bus < I2C_NUM_0 || bus >= SOC_I2C_NUM)
         {
             NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
         }


### PR DESCRIPTION
## Description

Invalid Argument when using bus id 2 with I2cDevice

For reason the #if is no longer working
#if I2C_NUM_MAX > 1

This maybe a compiler change or the fact that I2C_NUM_MAX is enum
Change code to not use #if 


## Motivation and Context
Reported on discord
https://discord.com/channels/478725473862549535/1240979604462637146/1240979607604428882
- Fixes nanoframework/Home#1486.


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Wrote simple test to open device on  bus id  0 & 1 on ESP32 rev3
Checked bus 0 & 3 give errors

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved I2C device initialization to ensure compatibility with a broader range of bus numbers, enhancing device connectivity and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->