### PR TITLE
Revert "Rework WP_Message_Process (#2935)"

### DIFF
--- a/src/CLR/WireProtocol/WireProtocol_Message.c
+++ b/src/CLR/WireProtocol/WireProtocol_Message.c
@@ -41,60 +41,6 @@ extern void debug_printf(const char *format, ...);
 //////////////////////////////////////////
 // helper functions
 
-bool CheckTimeout(uint64_t expiryTicks)
-{
-    uint64_t now = HAL_Time_SysTicksToTime(HAL_Time_CurrentSysTicks());
-    return expiryTicks > now;
-}
-
-void RestartStateMachine()
-{
-    _rxState = ReceiveState_Initialize;
-}
-
-bool IsMarkerMatched(void *header, const void *marker, size_t len)
-{
-    return memcmp(header, marker, len) == 0;
-}
-
-void ShiftBufferToLeft(void *buffer, uint32_t len)
-{
-    memmove((uint8_t *)buffer, ((uint8_t *)buffer + 1), len - 1);
-}
-
-void SyncToMessageStart()
-{
-    uint32_t len;
-
-    while (true)
-    {
-        len = sizeof(_inboundMessage.m_header) - _size;
-
-        if (len <= 0)
-        {
-            break;
-        }
-
-        size_t lenCmp = min(len, sizeof(((WP_Packet *)0)->m_signature));
-
-        if (IsMarkerMatched(&_inboundMessage.m_header, MARKER_DEBUGGER_V1, lenCmp) ||
-            IsMarkerMatched(&_inboundMessage.m_header, MARKER_PACKET_V1, lenCmp))
-        {
-            break;
-        }
-
-        ShiftBufferToLeft(&_inboundMessage.m_header, len);
-
-        // update pointer and expected size
-        _pos--;
-        _size++;
-
-        // sanity checks
-        _ASSERTE(_size <= sizeof(_inboundMessage.m_header));
-        _ASSERTE(_pos >= (uint8_t *)&(_inboundMessage.m_header));
-    }
-}
-
 void WP_ReplyToCommand(WP_Message *message, uint8_t fSuccess, uint8_t fCritical, void *ptr, uint32_t size)
 {
     WP_Message msgReply;
@@ -296,6 +242,7 @@ void WP_ReportBadPacket(uint32_t flag)
 void WP_Message_Process()
 {
     uint32_t len;
+    uint64_t now;
 
     while (true)
     {
@@ -319,13 +266,10 @@ void WP_Message_Process()
                 _pos = (uint8_t *)&_inboundMessage.m_header;
                 _size = sizeof(_inboundMessage.m_header);
 
-                // reset timeout to start receiving the header
-                _receiveExpiryTicks = HAL_Time_SysTicksToTime(HAL_Time_CurrentSysTicks()) + c_HeaderTimeout;
-
                 break;
 
             case ReceiveState_WaitingForHeader:
-                // Warning: Including TRACE_VERBOSE will NOT output the following TRACE on every loop
+                // Warning: Includeing TRACE_VERBOSE will NOT output the following TRACE on every loop
                 //          of the statemachine to avoid flooding the trace.
                 TRACE0_LIMIT(TRACE_VERBOSE, 100, "RxState==WaitForHeader\n");
 
@@ -335,31 +279,58 @@ void WP_Message_Process()
 
                 if (_size == len)
                 {
-                    // no new bytes received...
-                    if (CheckTimeout(_receiveExpiryTicks))
-                    {
-                        // still waiting for header bytes
-                        break;
-                    }
-                    else
-                    {
-                        // timeout expired, something went wrong
-                        TRACE0(TRACE_ERRORS, "RxError: Header InterCharacterTimeout exceeded\n");
-
-                        RestartStateMachine();
-
-                        // exit the loop to allow other RTOS threads to run
-                        return;
-                    }
+                    // no new bytes received, bail out
+                    break;
                 }
 
-                SyncToMessageStart();
+                // Synch to the start of a message by looking for a valid MARKER
+                while (true)
+                {
+                    len = sizeof(_inboundMessage.m_header) - _size;
+
+                    if (len <= 0)
+                    {
+                        break;
+                    }
+
+                    size_t lenCmp = min(len, sizeof(((WP_Packet *)0)->m_signature));
+
+                    if (memcmp(&_inboundMessage.m_header, MARKER_DEBUGGER_V1, lenCmp) == 0)
+                    {
+                        break;
+                    }
+                    if (memcmp(&_inboundMessage.m_header, MARKER_PACKET_V1, lenCmp) == 0)
+                    {
+                        break;
+                    }
+
+                    // move buffer one position to the left
+                    memmove(
+                        (uint8_t *)&(_inboundMessage.m_header),
+                        ((uint8_t *)&(_inboundMessage.m_header) + 1),
+                        len - 1);
+
+                    // update pointer and expected size
+                    _pos--;
+                    _size++;
+
+                    // sanity checks
+                    _ASSERTE(_size <= sizeof(_inboundMessage.m_header));
+                    _ASSERTE(_pos >= (uint8_t *)&(_inboundMessage.m_header));
+                }
 
                 if (len >= sizeof(_inboundMessage.m_header.m_signature))
                 {
                     // still missing some bytes for the header
                     _rxState = ReceiveState_ReadingHeader;
-                    _receiveExpiryTicks = HAL_Time_SysTicksToTime(HAL_Time_CurrentSysTicks()) + c_HeaderTimeout;
+                    _receiveExpiryTicks = HAL_Time_CurrentSysTicks() + c_HeaderTimeout;
+                }
+
+                if (len == 0 && *_pos == 0)
+                {
+                    // this is probably just hanging and waiting for a connection, so we're better off and give
+                    // breading space to the RTOS
+                    return;
                 }
 
                 break;
@@ -370,7 +341,9 @@ void WP_Message_Process()
                 // If the time between consecutive header bytes exceeds the timeout threshold then assume that
                 // the rest of the header is not coming. Reinitialize to sync with the next header.
 
-                if (CheckTimeout(_receiveExpiryTicks))
+                now = HAL_Time_CurrentSysTicks();
+
+                if (_receiveExpiryTicks > now)
                 {
                     WP_ReceiveBytes(&_pos, &_size);
 
@@ -382,7 +355,7 @@ void WP_Message_Process()
                 else
                 {
                     TRACE0(TRACE_ERRORS, "RxError: Header InterCharacterTimeout exceeded\n");
-                    RestartStateMachine();
+                    _rxState = ReceiveState_Initialize;
 
                     return;
                 }
@@ -403,8 +376,7 @@ void WP_Message_Process()
                         {
                             if (_inboundMessage.m_payload != NULL)
                             {
-                                _receiveExpiryTicks =
-                                    HAL_Time_SysTicksToTime(HAL_Time_CurrentSysTicks()) + c_PayloadTimeout;
+                                _receiveExpiryTicks = HAL_Time_CurrentSysTicks() + c_PayloadTimeout;
                                 _pos = _inboundMessage.m_payload;
                                 _size = _inboundMessage.m_header.m_size;
 
@@ -440,7 +412,9 @@ void WP_Message_Process()
                 // If the time between consecutive payload bytes exceeds the timeout threshold then assume that
                 // the rest of the payload is not coming. Reinitialize to sync with the next header.
 
-                if (CheckTimeout(_receiveExpiryTicks))
+                now = HAL_Time_CurrentSysTicks();
+
+                if (_receiveExpiryTicks > now)
                 {
                     WP_ReceiveBytes(&_pos, &_size);
 
@@ -452,7 +426,7 @@ void WP_Message_Process()
                 else
                 {
                     TRACE0(TRACE_ERRORS, "RxError: Payload InterCharacterTimeout exceeded\n");
-                    RestartStateMachine();
+                    _rxState = ReceiveState_Initialize;
 
                     return;
                 }
@@ -472,7 +446,7 @@ void WP_Message_Process()
                     WP_ReportBadPacket(WP_Flags_c_BadPayload);
                 }
 
-                RestartStateMachine();
+                _rxState = ReceiveState_Initialize;
 
                 return;
 


### PR DESCRIPTION
This reverts commit 99bbaafcd46f0a7ac694ef5188795b9640ea0aad.

<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Reverts commit 99bbaafcd46f0a7ac694ef5188795b9640ea0aad.

## Motivation and Context
This commit broke deployment of application code to my ESP32 S3 devices.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
On device.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the message processing logic to enhance reliability and performance.
  - Streamlined functions to simplify the codebase and reduce redundancy.
- **Bug Fixes**
  - Enhanced handling of timeouts and message synchronization to prevent potential errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->