### PR TITLE
Fix hang when AP configured on latest firmware (IDF 5.x)

### DIFF
--- a/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
+++ b/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
@@ -153,7 +153,11 @@ esp_err_t NF_ESP32_InitaliseWifi()
         if (expectedWifiMode & WIFI_MODE_AP)
         {
             // create AP (ignoring return)
-            esp_netif_create_default_wifi_ap();
+            esp_netif_t * nap = esp_netif_create_default_wifi_ap();
+
+            // Remove DHCP server flag as not configured in sdkconfig, DHCP server done in managed code
+            // Otherwise startup hangs
+            nap->flags = (esp_netif_flags_t)(ESP_NETIF_FLAG_AUTOUP);
         }
 
         // Initialise WiFi, allocate resource for WiFi driver, such as WiFi control structure,


### PR DESCRIPTION
## Description

When running the WifiAP sample the device would loose contact with Visual Studio.

This was caused by firmware waiting to get the net interface number after STA + AP had been initialised.
The init failed without error due to the espressif DHCP server being configured for Wifi AP without it in the build.
As we use managed code for DHCP to be cross platform added code to disable DHCP server in esp_netif flags field.

This is something that has been added in IDF 5.x

## Motivation and Context
Reported on discord
https://discord.com/channels/478725473862549535/1245741914448461836


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested with ESP32_Rev3 firmware and WifiAP sample

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WiFi initialization for the ESP32 module to prevent startup hangs when configuring the WiFi access point (AP).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->