### PR TITLE
Fix issue with Wifi AP stopping debug in VS for IDF 5.x

### DIFF
--- a/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
+++ b/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
@@ -16,6 +16,10 @@ static wifi_mode_t wifiMode;
 
 // flag to store if Wi-Fi has been initialized
 static bool IsWifiInitialised = false;
+
+static esp_netif_t * wifiStaNetif = NULL;
+static esp_netif_t * wifiAPNetif = NULL;
+
 // flag to signal if connect is to happen
 bool NF_ESP32_IsToConnect = false;
 
@@ -116,6 +120,11 @@ void NF_ESP32_DeinitWifi()
 
     esp_wifi_stop();
 
+    esp_netif_destroy_default_wifi(wifiStaNetif);
+    wifiStaNetif = NULL;
+    esp_netif_destroy_default_wifi(wifiAPNetif);
+    wifiAPNetif = NULL;
+
     esp_wifi_deinit();
 }
 
@@ -144,7 +153,7 @@ esp_err_t NF_ESP32_InitaliseWifi()
     if (!IsWifiInitialised)
     {
         // create Wi-Fi STA (ignoring return)
-        esp_netif_create_default_wifi_sta();
+        wifiStaNetif = esp_netif_create_default_wifi_sta();
 
         // We need to start the WIFI stack before the station can Connect
         // Also we can only get the NetIf number used by ESP IDF after it has been started.
@@ -153,11 +162,14 @@ esp_err_t NF_ESP32_InitaliseWifi()
         if (expectedWifiMode & WIFI_MODE_AP)
         {
             // create AP (ignoring return)
-            esp_netif_t *nap = esp_netif_create_default_wifi_ap();
+            wifiAPNetif = esp_netif_create_default_wifi_ap();
 
             // Remove DHCP server flag as not configured in sdkconfig, DHCP server done in managed code
             // Otherwise startup hangs
-            nap->flags = (esp_netif_flags_t)(ESP_NETIF_FLAG_AUTOUP);
+            if (wifiAPNetif)
+            {
+                wifiAPNetif->flags = (esp_netif_flags_t)(ESP_NETIF_FLAG_AUTOUP);
+            }
         }
 
         // Initialise WiFi, allocate resource for WiFi driver, such as WiFi control structure,


### PR DESCRIPTION
## Description

When you start a debug session the nanoClr is warm restarted.

With latest IDF we now have to make sure the created esp_netif(esp  network interfaces) are destroyed when wifi & wifi AP are closed on soft reboot otherwise it fails to create new ones on new start creating an exception when netif is accessed.

- Destroy esp_netif for both wifi station and AP on close.

## Motivation and Context
- Fixes nanoFramework/Home#1488
- Fixes nanoFramework/Home#1493

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

Tested on mini S3 device using WifiAP sample.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
