### PR TITLE
Fix config for new ESP32_OLIMEX_WROVER target

### DIFF
--- a/targets/ESP32/CMakePresets.json
+++ b/targets/ESP32/CMakePresets.json
@@ -648,7 +648,7 @@
                 "API_System.Device.I2c.Slave": "ON",
                 "ESP32_ETHERNET_SUPPORT": "ON",
                 "ETH_PHY_RST_GPIO": "12",
-                "ETH_RMII_CLK_OUT_GPIO": "0"
+                "ETH_RMII_CLK_OUT_GPIO": "00"
             }
         },
         {


### PR DESCRIPTION
## Description

Adjust config for target due to build issue when using values of "0" in cmakedefine 
Didn't define value as it saw value as false

Using "00" is OK and creates define

Clocking now being configured properly

## Motivation and Context
Discord thread
https://discord.com/channels/478725473862549535/1239278902136934463

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

Tested parameters were correct locally by enabling log output.
but unable to test hardware as not available.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Ethernet configuration for ESP32 targets to ensure proper functionality by updating the `ETH_RMII_CLK_OUT_GPIO` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->