### PR TITLE
COM1 not available on C6 and Heap corruption

### DIFF
--- a/src/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort__.cpp
+++ b/src/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort__.cpp
@@ -65,8 +65,8 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::SetupWriteLine(
                 *isNewAllocation = true;
 
                 // concatenate both strings
-                strcat(*buffer, text);
-                strcat(*buffer, newLine);
+                memcpy(*buffer, text, textLength);
+                memcpy(*buffer + textLength, newLine, newLineLength);
             }
             else
             {

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -862,7 +862,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     }
 
     // unless the build is configure to use USB CDC, COM1 is being used for VS debug, so it's not available
-#if !defined(CONFIG_TINYUSB_CDC_ENABLED)
+#if !defined(CONFIG_TINYUSB_CDC_ENABLED) && !defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED)
     if (uart_num == 0)
     {
         NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
@@ -1430,7 +1430,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::GetDeviceSelector_
     static char deviceSelectorString[] =
 
     // unless the build is configure to use USB CDC, COM1 is being used for VS debug, so it's not available
-#if defined(CONFIG_TINYUSB_CDC_ENABLED)
+#if defined(CONFIG_TINYUSB_CDC_ENABLED) || defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED)
         "COM1,"
 #endif
 #if defined(UART_NUM_1)


### PR DESCRIPTION
## Description

For the risc-v targets ESP32_C3, C6, H2 which use the USB_JTAG interface for WP the COM1 wasn't available.

- Added test for CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED to allow COM1

While testing received some heap corruption errors when using WriteLine to serial.  
Found serial driver was overwriting end of heap buffer when concatenating on newline.

This was caused by the use of the strcat() function that adds a terminating null.
Changed to use memcpy() instead. No more corruption.






## Motivation and Context
- Fixes nanoFramework/Home#1505

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

Tested with serial sample
 
## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved performance and reliability in string handling for serial port operations.
  - Enhanced compatibility for serial port initialization and device selector string generation on ESP32 devices with specific USB CDC and ESP console serial JTAG configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->