### PR TITLE
Rework OOM exception

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Exception.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Exception.cpp
@@ -193,9 +193,13 @@ HRESULT Library_corlib_native_System_Exception::SetStackTrace(CLR_RT_HeapBlock &
 
 #if defined(NANOCLR_TRACE_EXCEPTIONS)
 
-        if (CLR_EE_DBG_IS(NoStackTraceInExceptions) || CLR_EE_DBG_IS_NOT(Enabled))
+        if (CLR_EE_DBG_IS(NoStackTraceInExceptions) || CLR_EE_DBG_IS_NOT(Enabled) || CLR_EE_IS(Compaction_Pending) ||
+            g_CLR_RT_ExecutionEngine.m_fPerformGarbageCollection)
         {
-            // stack trace is DISABLED or no debugger is attached
+            // stack trace is DISABLED or...
+            // no debugger is attached or...
+            // compaction is pending so better not mess around or...
+            // GC is requested or in progress so better not mess around
 
             (void)dst;
             (void)array;

--- a/src/CLR/CorLib/corlib_native_System_Exception.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Exception.cpp
@@ -125,9 +125,9 @@ HRESULT Library_corlib_native_System_Exception::CreateInstance(
     if (FAILED(hr = g_CLR_RT_ExecutionEngine.NewObjectFromIndex(ref, cls)))
     {
 #if defined(NANOCLR_APPDOMAINS)
-        ref.SetObjectReference(g_CLR_RT_ExecutionEngine.GetCurrentAppDomain()->m_outOfMemoryException);
+        ref.SetObjectReference(&g_CLR_RT_ExecutionEngine.GetCurrentAppDomain()->m_outOfMemoryException);
 #else
-        ref.SetObjectReference(g_CLR_RT_ExecutionEngine.m_outOfMemoryException);
+        ref.SetObjectReference(&g_CLR_RT_ExecutionEngine.m_outOfMemoryException);
 #endif
 
         hrIn = CLR_E_OUT_OF_MEMORY;

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -86,9 +86,8 @@ HRESULT CLR_RT_ExecutionEngine::ExecutionEngine_Initialize()
                                                     // CLR_RT_Thread*                      m_cctorThread;
                                                     //
 #if !defined(NANOCLR_APPDOMAINS)
-    m_globalLock = NULL;           // CLR_RT_HeapBlock*                   m_globalLock;
-    m_outOfMemoryException = NULL; // CLR_RT_HeapBlock*                   m_outOfMemoryException;
-#endif                             //
+    m_globalLock = NULL; // CLR_RT_HeapBlock*                  m_globalLock;
+#endif                   //
 
     m_currentUICulture = NULL; // CLR_RT_HeapBlock*                   m_currentUICulture;
 
@@ -438,7 +437,6 @@ void CLR_RT_ExecutionEngine::Relocate()
 
 #if !defined(NANOCLR_APPDOMAINS)
     CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_globalLock);
-    // CLR_RT_GarbageCollector::Heap_Relocate( (void**)&m_outOfMemoryException );
 #endif
 
     CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_currentUICulture);

--- a/src/CLR/Core/GarbageCollector.cpp
+++ b/src/CLR/Core/GarbageCollector.cpp
@@ -662,7 +662,6 @@ void CLR_RT_GarbageCollector::AppDomain_Mark()
 
         CheckSingleBlock_Force(appDomain->m_globalLock);
         CheckSingleBlock_Force(appDomain->m_strName);
-        CheckSingleBlock_Force(appDomain->m_outOfMemoryException);
     }
     NANOCLR_FOREACH_NODE_END();
 }

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -2276,8 +2276,8 @@ HRESULT CLR_RT_AppDomain::LoadAssembly(CLR_RT_Assembly *assm)
 
     NANOCLR_CHECK_HRESULT(CLR_RT_AppDomainAssembly::CreateInstance(this, assm, appDomainAssembly));
 
-    // Allocate an out of memory exception.  We should never get into a case where an out of memory exception
-    // cannot be thrown.
+    // Preemptively allocate an out of memory exception.
+    // We can never get into a case where an out of memory exception cannot be thrown.
 
     _ASSERTE(!strcmp(assm->m_szName, "mscorlib")); // always the first assembly to be loaded
 
@@ -4087,6 +4087,9 @@ HRESULT CLR_RT_TypeSystem::PrepareForExecution()
 #endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
 #if !defined(NANOCLR_APPDOMAINS)
+
+    // Preemptively create an out of memory exception.
+    // We can never get into a case where an out of memory exception cannot be thrown.
     NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(
         g_CLR_RT_ExecutionEngine.m_outOfMemoryException,
         g_CLR_RT_WellKnownTypes.m_OutOfMemoryException));

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -2224,7 +2224,6 @@ void CLR_RT_AppDomain::AppDomain_Initialize()
     m_id = g_CLR_RT_ExecutionEngine.m_appDomainIdNext++;
     m_globalLock = NULL;
     m_strName = NULL;
-    m_outOfMemoryException = NULL;
     m_appDomainAssemblyLastAccess = NULL;
 }
 
@@ -2277,19 +2276,14 @@ HRESULT CLR_RT_AppDomain::LoadAssembly(CLR_RT_Assembly *assm)
 
     NANOCLR_CHECK_HRESULT(CLR_RT_AppDomainAssembly::CreateInstance(this, assm, appDomainAssembly));
 
-    if (m_outOfMemoryException == NULL)
-    {
-        // Allocate an out of memory exception.  We should never get into a case where an out of memory exception
-        // cannot be thrown.
-        CLR_RT_HeapBlock exception;
+    // Allocate an out of memory exception.  We should never get into a case where an out of memory exception
+    // cannot be thrown.
 
-        _ASSERTE(!strcmp(assm->m_szName, "mscorlib")); // always the first assembly to be loaded
+    _ASSERTE(!strcmp(assm->m_szName, "mscorlib")); // always the first assembly to be loaded
 
-        NANOCLR_CHECK_HRESULT(
-            g_CLR_RT_ExecutionEngine.NewObjectFromIndex(exception, g_CLR_RT_WellKnownTypes.m_OutOfMemoryException));
-
-        m_outOfMemoryException = exception.Dereference();
-    }
+    NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(
+        m_outOfMemoryException,
+        g_CLR_RT_WellKnownTypes.m_OutOfMemoryException));
 
     NANOCLR_CLEANUP();
 
@@ -2383,7 +2377,6 @@ void CLR_RT_AppDomain::Relocate()
     NATIVE_PROFILE_CLR_CORE();
     CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_globalLock);
     CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_strName);
-    CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_outOfMemoryException);
 }
 
 HRESULT CLR_RT_AppDomain::VerifyTypeIsLoaded(const CLR_RT_TypeDef_Index &idx)
@@ -4094,17 +4087,9 @@ HRESULT CLR_RT_TypeSystem::PrepareForExecution()
 #endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
 #if !defined(NANOCLR_APPDOMAINS)
-    if (g_CLR_RT_ExecutionEngine.m_outOfMemoryException == NULL)
-    {
-        CLR_RT_HeapBlock exception;
-
-        memset(&exception, 0, sizeof(struct CLR_RT_HeapBlock));
-
-        NANOCLR_CHECK_HRESULT(
-            g_CLR_RT_ExecutionEngine.NewObjectFromIndex(exception, g_CLR_RT_WellKnownTypes.m_OutOfMemoryException));
-
-        g_CLR_RT_ExecutionEngine.m_outOfMemoryException = exception.Dereference();
-    }
+    NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(
+        g_CLR_RT_ExecutionEngine.m_outOfMemoryException,
+        g_CLR_RT_WellKnownTypes.m_OutOfMemoryException));
 #endif
 
     // Load Runtime.Events to setup EventSink for other assemblies using it

--- a/src/CLR/Diagnostics/Profiler.cpp
+++ b/src/CLR/Diagnostics/Profiler.cpp
@@ -439,7 +439,6 @@ void CLR_PRF_Profiler::DumpObject(CLR_RT_HeapBlock *ptr)
                 DumpListOfReferences(appDomain->m_appDomainAssemblies);
                 DumpSingleReference(appDomain->m_globalLock);
                 DumpSingleReference(appDomain->m_strName);
-                DumpSingleReference(appDomain->m_outOfMemoryException);
                 break;
             }
 

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -1437,7 +1437,7 @@ struct CLR_RT_AppDomain : public CLR_RT_ObjectToEvent_Destination // EVENT HEAP 
     CLR_RT_DblLinkedList m_appDomainAssemblies;
     CLR_RT_HeapBlock *m_globalLock;                          // OBJECT HEAP - DO RELOCATION -
     CLR_RT_HeapBlock_String *m_strName;                      // OBJECT HEAP - DO RELOCATION -
-    CLR_RT_HeapBlock *m_outOfMemoryException;                // OBJECT HEAP - DO RELOCATION -
+    CLR_RT_HeapBlock m_outOfMemoryException;                 // NO RELOCATION -
     CLR_RT_AppDomainAssembly *m_appDomainAssemblyLastAccess; // EVENT HEAP  - NO RELOCATION -
     bool m_fCanBeUnloaded;
 
@@ -3651,8 +3651,8 @@ struct CLR_RT_ExecutionEngine
     CLR_RT_Thread *m_cctorThread;             // EVENT HEAP - NO RELOCATION -
 
 #if !defined(NANOCLR_APPDOMAINS)
-    CLR_RT_HeapBlock *m_globalLock;           // OBJECT HEAP - DO RELOCATION -
-    CLR_RT_HeapBlock *m_outOfMemoryException; // OBJECT HEAP - DO RELOCATION -
+    CLR_RT_HeapBlock *m_globalLock;          // OBJECT HEAP - DO RELOCATION -
+    CLR_RT_HeapBlock m_outOfMemoryException; // NO RELOCATION -
 #endif
 
     CLR_RT_HeapBlock *m_currentUICulture; // OBJECT HEAP - DO RELOCATION -


### PR DESCRIPTION
## Description
- Refactor OOM exception. It now lives in the EE struct.
- Rework code accordingly.
- Stack trace in exceptions is only created if there is a debugger attached and if a heap compaction is not pending.

## Motivation and Context
- The underlying exception mechanism and heap management calls for the need to be able to throw an OOM exception under any circumstances. With the existing approach the OOM was created at EE start (restart) but memory taken from CRT stack and the HB ref was placed in the managed heap and being shuffled in GC and compaction. With the new approach the OOM is part of the EE struct and is, definitely always available to be thrown. 
- Crawling the call stack to fill in the stack trace when an exception occurs is extremely expensive in execution time and requires creating a HB array and fill it in. Unless there is a debugger attached, there isn't any real interest on this being generated (even with debugger the current stack trace info is flaky at best). Moreover, if there is a heap compaction pending or returning from a failed HB creation that requires a GC run, this can lead to problems because it tries to create an HB array to store it.
- Addresses nanoframework/Home#1354.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Long running test heavily stressing the managed heap.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exception handling and stack trace management to enhance application stability.
  - Refined memory management processes to reduce the likelihood of out-of-memory errors.
  
- **Performance Enhancements**
  - Optimized timestamp calculations for better profiler performance.

- **Refactor**
  - Streamlined memory allocation for exceptions to improve efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->