### PR TITLE
Fix broken colors and partial flush for ILI9488 display

### DIFF
--- a/src/nanoFramework.Graphics/Graphics/Displays/ILI9488_480x320_SPI.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/ILI9488_480x320_SPI.cpp
@@ -296,32 +296,32 @@ void DisplayDriver::BitBlt(
 
     // only 18/24 bit is supported on SPI
     for (uint32_t y = srcY; y < srcY + height; y++)
-    for (uint32_t x = srcX; x < srcX + width; x++)
-    {
-        uint32_t i = y * Attributes.Width + x;
-        
-        uint32_t element = data[i / 2]; // Each uint32 stores 2 pixels
-        uint16_t color = (i % 2 == 0) ? (element & 0xFFFF) : (element >> 16);
-
-        uint8_t b = color & 0x1F;
-        uint8_t g = (color >> 5) & 0x3F;
-        uint8_t r = (color >> 11) & 0x1F;
-
-        b = (b << 3) | (b >> 2);
-        g = (g << 2) | (g >> 4);
-        r = (r << 3) | (r >> 2);
-
-        TransferBuffer[count++] = r;
-        TransferBuffer[count++] = g;
-        TransferBuffer[count++] = b;
-
-        // can't fit another 3 bytes
-        if (count + 3 > TransferBufferSize - 1)
+        for (uint32_t x = srcX; x < srcX + width; x++)
         {
-            g_DisplayInterface.SendBytes(TransferBuffer, count);
-            count = 0;
+            uint32_t i = y * Attributes.Width + x;
+
+            uint32_t element = data[i / 2]; // Each uint32 stores 2 pixels
+            uint16_t color = (i % 2 == 0) ? (element & 0xFFFF) : (element >> 16);
+
+            uint8_t b = color & 0x1F;
+            uint8_t g = (color >> 5) & 0x3F;
+            uint8_t r = (color >> 11) & 0x1F;
+
+            b = (b << 3) | (b >> 2);
+            g = (g << 2) | (g >> 4);
+            r = (r << 3) | (r >> 2);
+
+            TransferBuffer[count++] = r;
+            TransferBuffer[count++] = g;
+            TransferBuffer[count++] = b;
+
+            // can't fit another 3 bytes
+            if (count + 3 > TransferBufferSize - 1)
+            {
+                g_DisplayInterface.SendBytes(TransferBuffer, count);
+                count = 0;
+            }
         }
-    }
     g_DisplayInterface.SendBytes(TransferBuffer, count);
     return;
 }

--- a/src/nanoFramework.Graphics/Graphics/Displays/ILI9488_480x320_SPI.cpp
+++ b/src/nanoFramework.Graphics/Graphics/Displays/ILI9488_480x320_SPI.cpp
@@ -289,15 +289,17 @@ void DisplayDriver::BitBlt(
 
     g_DisplayInterface.SendCommand(1, Memory_Write);
 
-    uint32_t numPixels = width * height;
     uint32_t count = 0;
 
     CLR_UINT8 *TransferBuffer = Attributes.TransferBuffer;
     CLR_UINT32 TransferBufferSize = Attributes.TransferBufferSize;
 
     // only 18/24 bit is supported on SPI
-    for (uint32_t i = 0; i < numPixels; i++)
+    for (uint32_t y = srcY; y < srcY + height; y++)
+    for (uint32_t x = srcX; x < srcX + width; x++)
     {
+        uint32_t i = y * Attributes.Width + x;
+        
         uint32_t element = data[i / 2]; // Each uint32 stores 2 pixels
         uint16_t color = (i % 2 == 0) ? (element & 0xFFFF) : (element >> 16);
 
@@ -309,9 +311,9 @@ void DisplayDriver::BitBlt(
         g = (g << 2) | (g >> 4);
         r = (r << 3) | (r >> 2);
 
-        TransferBuffer[count++] = b;
-        TransferBuffer[count++] = g;
         TransferBuffer[count++] = r;
+        TransferBuffer[count++] = g;
+        TransferBuffer[count++] = b;
 
         // can't fit another 3 bytes
         if (count + 3 > TransferBufferSize - 1)


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Fixed bugs in native Ili9488 display driver:
- Corrupted colors (incorrect order BGR instead of RGB).
- Corrupted screen when using partial flush.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Tested on LILYGO TTGO T-Relay ESP32 Wireless Module board.
- Colors tested on "Primitives" examples.
- Test application code snippet for Flush (BitBlt) provided.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

Left: corrupted colors, Right: fixed

![ili9488fix1](https://github.com/nanoframework/nf-interpreter/assets/90482345/0395b07a-135c-456e-a2b0-f0956bb8203b)

Left: corrupted partial flush, Right: fixed

![ili9488fix2](https://github.com/nanoframework/nf-interpreter/assets/90482345/0a11fca5-cb7a-422f-909b-d828abf6bb29)

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).

BitBlt test app:
```
using System.Threading;
using System.Device.Gpio;
using nanoFramework.Hardware.Esp32;
using nanoFramework.UI;
using System.Drawing;

namespace nanoFrameworkIli9844DisplayTestApp
{
    public class Program
    {
        const int backLightPin = 32;
        const int chipSelectPin = 15;
        const int dataCommandPin = 2;
        const int resetPin = 4;
        
        static GpioController gpio = new();
        static SpiConfiguration spi = new SpiConfiguration(1, chipSelectPin, dataCommandPin, resetPin, backLightPin);
        static ScreenConfiguration screen = new ScreenConfiguration();

        public static void Main()
        {
            Configuration.SetPinFunction(19, DeviceFunction.SPI1_MISO);
            Configuration.SetPinFunction(23, DeviceFunction.SPI1_MOSI);
            Configuration.SetPinFunction(22, DeviceFunction.SPI1_CLOCK);

            DisplayControl.Initialize(spi, screen, 1024 * 1024);
            
            gpio.OpenPin(backLightPin, PinMode.Output).Write(PinValue.High);

            var buffer = DisplayControl.FullScreen;

            // test full flush
            for (int i = 0; i < 5; i++)
            {
                buffer.DrawRectangle(Color.White, 2, 0, 0, 480, 320, 0, 0,
                    Color.White, 0, 0,
                    Color.Black, 480, 320, Bitmap.OpacityOpaque);
                buffer.Flush();
                Thread.Sleep(500);

                buffer.Clear();
                buffer.Flush();
                Thread.Sleep(500);
            }

            buffer.DrawRectangle(Color.White, 2, 0, 0, 480, 320, 0, 0,
                  Color.White, 0, 0,
                  Color.Black, 480, 320, Bitmap.OpacityOpaque);

            // test partial flush
            for (int i = 0; i < 5; i++)
            {
                buffer.DrawRectangle(Color.White, 2, 100, 100, 200, 200, 0, 0,
                    Color.White, 100, 100,
                    Color.Blue, 300, 300, Bitmap.OpacityOpaque);
                buffer.Flush(100, 100, 200, 200);
                Thread.Sleep(500);

                buffer.DrawRectangle(Color.White, 2, 100, 100, 200, 200, 0, 0,
                 Color.Blue, 100, 100,
                 Color.White, 300, 300, Bitmap.OpacityOpaque);
                buffer.Flush(100, 100, 200, 200);
                Thread.Sleep(500);
            }

            Thread.Sleep(Timeout.Infinite);
        }
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved performance and readability of the pixel iteration logic by iterating over `x` and `y` coordinates directly, rather than using a single index.
  - Optimized the storage order of color values in the `TransferBuffer` for better efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->