### PR TITLE
Provide source clock frequency on RMT channel

### DIFF
--- a/targets/ESP32/_nanoCLR/nanoFramework.Hardware.Esp32.Rmt/nanoFramework_hardware_esp32_rmt_native.cpp
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Hardware.Esp32.Rmt/nanoFramework_hardware_esp32_rmt_native.cpp
@@ -84,10 +84,12 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
-    NULL,
     Library_nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Esp32_Rmt_RmtChannel::NativeSetGpioPin___VOID__I4__U1__I4__BOOLEAN,
     Library_nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Esp32_Rmt_RmtChannel::NativeSetClockDivider___VOID__U1,
     Library_nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Esp32_Rmt_RmtChannel::NativeSetNumberOfMemoryBlocks___VOID__U1,
+    NULL,
+    NULL,
+    Library_nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Esp32_Rmt_RmtChannel::NativeGetSourceClockFrequency___STATIC__I4,
     NULL,
     NULL,
     NULL,
@@ -141,9 +143,9 @@ static const CLR_RT_MethodHandler method_lookup[] =
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_nanoFramework_Hardware_Esp32_Rmt =
 {
     "nanoFramework.Hardware.Esp32.Rmt",
-    0x608C5658,
+    0xB97BFDE3,
     method_lookup,
-    { 100, 0, 4, 0 }
+    { 100, 0, 5, 0 }
 };
 
 // clang-format on

--- a/targets/ESP32/_nanoCLR/nanoFramework.Hardware.Esp32.Rmt/nanoFramework_hardware_esp32_rmt_native.h
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Hardware.Esp32.Rmt/nanoFramework_hardware_esp32_rmt_native.h
@@ -91,6 +91,7 @@ struct Library_nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Es
     NANOCLR_NATIVE_DECLARE(NativeSetGpioPin___VOID__I4__U1__I4__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(NativeSetClockDivider___VOID__U1);
     NANOCLR_NATIVE_DECLARE(NativeSetNumberOfMemoryBlocks___VOID__U1);
+    NANOCLR_NATIVE_DECLARE(NativeGetSourceClockFrequency___STATIC__I4);
 
     //--//
 

--- a/targets/ESP32/_nanoCLR/nanoFramework.Hardware.Esp32.Rmt/nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Esp32_Rmt_RmtChannel.cpp
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Hardware.Esp32.Rmt/nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Esp32_Rmt_RmtChannel.cpp
@@ -127,3 +127,17 @@ bool Library_nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Esp3
 
     return true;
 }
+
+HRESULT Library_nanoFramework_hardware_esp32_rmt_native_nanoFramework_Hardware_Esp32_Rmt_RmtChannel::NativeGetSourceClockFrequency___STATIC__I4( CLR_RT_StackFrame &stack )
+{
+    NANOCLR_HEADER();
+
+// Currently we use the default clock for all targets. This is 80Mhz except for H2 where it is 32Mhz.
+#if defined(CONFIG_IDF_TARGET_ESP32H2)
+    stack.SetResult_I4(32000000);
+#else
+    stack.SetResult_I4(80000000);
+#endif
+
+    NANOCLR_NOCLEANUP_NOLABEL();
+}


### PR DESCRIPTION
## Description
The RMT doesn't work correctly with esp32_h2 as the default source clock is not 80Mhz like other chips which throws out timings.  The source clock defaults to 32Mhz for esp32_h2

This change adds the source clock frequency to the RmtChannel.

Also needs change to RMT managed assembly.

Note:
The RMT needs to be updated to latest API which comes with IDF 5.1.x and later

## Motivation and Context
Fix RMT on ESP32-H2

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally with modified neopixel driver

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to retrieve the source clock frequency for ESP32 RMT, which provides either 32Mhz for ESP32H2 or 80Mhz for other targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->