### PR TITLE
Fix SPI CS handling

### DIFF
--- a/src/System.Device.Spi/nanoHAL_Spi.cpp
+++ b/src/System.Device.Spi/nanoHAL_Spi.cpp
@@ -20,7 +20,7 @@
 
 #define GetBusFromHandle(handle)    ((handle >> 8) & 0x00ff);
 #define GetTypeFromHandle(handle)   ((handle >> 16) & 0x00ff);
-#define GetDeviceFromHandle(handle) ((handle)&0x00ff);
+#define GetDeviceFromHandle(handle) ((handle) & 0x00ff);
 
 // Saved config for each available SPI bus
 nanoSPI_BusConfig spiconfig[NUM_SPI_BUSES];
@@ -349,6 +349,12 @@ HRESULT nanoSPI_OpenDeviceEx(
 
             return CLR_E_FAIL;
         }
+
+        // Set CS pin to output and inactive
+        CPU_GPIO_EnableOutputPin(
+            (GPIO_PIN)spiDeviceConfig.DeviceChipSelect,
+            (GpioPinValue)!spiDeviceConfig.ChipSelectActiveState,
+            PinMode_Output);
     }
 
     // Compute rough estimate on the time to tx/rx a byte (in milliseconds)
@@ -365,6 +371,17 @@ HRESULT nanoSPI_OpenDeviceEx(
 
     // Return unique generated device handle
     handle = CreateSpiHandle(spiDeviceConfig.Spi_Bus, deviceIndex);
+
+    // perform dummy SPI transaction to ensure that the device is ready and leaving signals in a known state
+    SPI_WRITE_READ_SETTINGS wrc{
+        false,
+        0,
+        spiDeviceConfig.DataIs16bits,
+        NULL,
+        spiDeviceConfig.DeviceChipSelect,
+        spiDeviceConfig.ChipSelectActiveState};
+    uint8_t buffer[2] = {0, 0};
+    nanoSPI_Write_Read(handle, wrc, buffer, 2, buffer, 2);
 
     return S_OK;
 }

--- a/targets/ChibiOS/_nanoCLR/System.Device.Spi/cpu_spi.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.Device.Spi/cpu_spi.cpp
@@ -554,7 +554,7 @@ HRESULT CPU_SPI_nWrite_nRead(
             if (wrc.DeviceChipSelect >= 0)
             {
                 // de-assert pin based on CS active level
-                CPU_GPIO_SetPinState(wrc.DeviceChipSelect, (GpioPinValue)wrc.ChipSelectActiveState);
+                CPU_GPIO_SetPinState(wrc.DeviceChipSelect, (GpioPinValue)!wrc.ChipSelectActiveState);
             }
         }
         else


### PR DESCRIPTION
## Description
- CS is now set to known (inactive) state when SPI device is created.
- CS is now deaserted (inactive) after transaction when CS is managed by the driver.
- Following opening an SPI device a dummy transaction is performed to leave signals at a known good state.

## Motivation and Context
- CS wasn't being properly init on device open and deasserted following a transaction when the driver was to handle CS.
- SPI signals not being properly set were causing issues on some devices and not following a strict implementation of the SPI protocol.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SPI device initialization process with improved Chip Select (CS) pin configuration.
	- Added a dummy SPI transaction to ensure device readiness before communication.
  
- **Bug Fixes**
	- Adjusted logic for Chip Select (CS) pin state to ensure correct operation based on active state settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->