### PR TITLE
Add missing monitor command declaration

### DIFF
--- a/src/CLR/Include/nanoCLR_Debugging.h
+++ b/src/CLR/Include/nanoCLR_Debugging.h
@@ -37,6 +37,7 @@ struct CLR_DBG_Commands
     static const unsigned int c_Monitor_OemInfo            = 0x0000000E;
     static const unsigned int c_Monitor_QueryConfiguration = 0x0000000F;
     static const unsigned int c_Monitor_UpdateConfiguration= 0x00000010;
+    static const unsigned int c_Monitor_StorageOperation   = 0x00000011;
     static const unsigned int c_Monitor_TargetInfo         = 0x00000020;
 
     //--//


### PR DESCRIPTION
## Description
- This one was missing when building in RTM.

## Motivation and Context
- Command missing declaration when building in RTM.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
