### PR TITLE
Fix UART config at OneWire init

### DIFF
--- a/targets/ESP32/_nanoCLR/nanoFramework.Device.OneWire/nf_dev_onewire_nanoFramework_Device_OneWire_OneWireHost.cpp
+++ b/targets/ESP32/_nanoCLR/nanoFramework.Device.OneWire/nf_dev_onewire_nanoFramework_Device_OneWire_OneWireHost.cpp
@@ -19,7 +19,7 @@ static uint8_t SerialNum[8];
 // Driver state.
 static oneWireState DriverState = ONEWIRE_UNINIT;
 
-void IRAM_ATTR oneWireStop()
+void oneWireStop()
 {
     // stop UART
     uart_driver_delete(NF_ONEWIRE_ESP32_UART_NUM);
@@ -28,19 +28,18 @@ void IRAM_ATTR oneWireStop()
     DriverState = ONEWIRE_STOP;
 }
 
-HRESULT IRAM_ATTR oneWireInit()
+HRESULT oneWireInit()
 {
     DriverState = ONEWIRE_STOP;
 
-    uart_config_t uart_config = {
-        .baud_rate = 115200,
-        .data_bits = UART_DATA_8_BITS,
-        .parity = UART_PARITY_DISABLE,
-        .stop_bits = UART_STOP_BITS_1,
-        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
-        .rx_flow_ctrl_thresh = 0,
-        .source_clk = UART_SCLK_DEFAULT
-    };
+    uart_config_t uart_config;
+    uart_config.baud_rate = 115200;
+    uart_config.data_bits = UART_DATA_8_BITS;
+    uart_config.parity = UART_PARITY_DISABLE;
+    uart_config.stop_bits = UART_STOP_BITS_1;
+    uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
+    uart_config.rx_flow_ctrl_thresh = 0;
+    uart_config.source_clk = UART_SCLK_DEFAULT;
 
     // get GPIO pins configured for UART assigned to 1-Wire
     // need to subtract one to get the correct index of UART in mapped device pins


### PR DESCRIPTION
## Description
- UART config struct is not onlined anymore to set only the required elements. 
- Remove IRAM_ATTR attributes from OneWire API. 

## Motivation and Context
- Need to address compiler warning (error) of element not set.
- No need to keep those functions on RAM. Those were probably left from initial debugging and are only taking up RAM.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved initialization process for the OneWire driver, enhancing reliability.
- **Bug Fixes**
	- Adjusted execution context for OneWire functions, potentially improving performance on ESP32 devices.
- **Refactor**
	- Updated code style for UART configuration, maintaining functionality while enhancing readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->