### PR TITLE
Fix protecting HB from GC

### DIFF
--- a/src/System.Device.Spi/sys_dev_spi_native_System_Device_Spi_SpiDevice.cpp
+++ b/src/System.Device.Spi/sys_dev_spi_native_System_Device_Spi_SpiDevice.cpp
@@ -73,289 +73,302 @@ HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeTransfer(
     bool data16Bits)
 {
     NANOCLR_HEADER();
-    {
-        CLR_RT_HeapBlock *writeSpanByte;
-        CLR_RT_HeapBlock *readSpanByte;
-        uint8_t *writeData = NULL;
-        uint8_t *readData = NULL;
-        int16_t writeSize = 0;
-        int16_t readSize = 0;
-        int16_t readOffset = 0;
-        int16_t writeOffset = 0;
-        SPI_WRITE_READ_SETTINGS rws;
 
-        bool isLongRunningOperation;
-        uint32_t estimatedDurationMiliseconds;
-        CLR_RT_HeapBlock hbTimeout;
-        CLR_INT64 *timeout;
-        bool eventResult = true;
+    CLR_RT_HeapBlock *writeSpanByte;
+    CLR_RT_HeapBlock *readSpanByte;
+    CLR_RT_HeapBlock_Array *writeBuffer;
+    CLR_RT_HeapBlock_Array *readBuffer;
+    uint8_t *writeData = NULL;
+    uint8_t *readData = NULL;
+    int16_t writeSize = 0;
+    int16_t readSize = 0;
+    int16_t readOffset = 0;
+    int16_t writeOffset = 0;
+    SPI_WRITE_READ_SETTINGS rws;
 
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock *pThis = stack.This();
-        CLR_RT_HeapBlock *connectionSettings;
-        FAULT_ON_NULL(pThis);
-
-        // get device handle saved on open
-        uint32_t deviceId =
-            pThis[Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::FIELD___deviceId].NumericByRef().u4;
-
-        if (stack.m_customState == 0)
-        {
-            // Buffers used either for the SpanBye either for the Byte array
-            CLR_RT_HeapBlock_Array *writeBuffer;
-            CLR_RT_HeapBlock_Array *readBuffer;
-
-            // For 16 bits, it's directly a buffer, for 8 bits, it's a SpanByte
-            if (data16Bits)
-            {
-                writeBuffer = stack.Arg1().DereferenceArray();
-                if (writeBuffer != NULL)
-                {
-                    // grab the pointer to the array by getting the first element of the array
-                    writeData = (unsigned char *)writeBuffer->GetFirstElementUInt16();
-
-                    // get the size of the buffer by reading the number of elements in the HeapBlock array
-                    writeSize = writeBuffer->m_numOfElements;
-                }
-
-                readBuffer = stack.Arg2().DereferenceArray();
-                if (readBuffer != NULL)
-                {
-                    // grab the pointer to the array by getting the first element of the array
-                    readData = (unsigned char *)readBuffer->GetFirstElementUInt16();
-
-                    // get the size of the buffer by reading the number of elements in the HeapBlock array
-                    readSize = readBuffer->m_numOfElements;
-                }
-            }
-            else
-            {
-                // dereference the write and read SpanByte from the arguments
-                writeSpanByte = stack.Arg1().Dereference();
-                if (writeSpanByte != NULL)
-                {
-                    // get buffer
-                    writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
-                    if (writeBuffer != NULL)
-                    {
-                        // Get the write offset, only the elements defined by the span must be written, not the whole
-                        // array
-                        writeOffset = writeSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
-
-                        // use the span length as write size, only the elements defined by the span must be written
-                        writeSize = writeSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
-                        writeData = (unsigned char *)writeBuffer->GetElement(writeOffset);
-                    }
-                }
-
-                if (writeData == NULL)
-                {
-                    // nothing to write, have to zero this
-                    writeSize = 0;
-                }
-
-                readSpanByte = stack.Arg2().Dereference();
-                if (readSpanByte != NULL)
-                {
-                    // get buffer
-                    readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
-                    if (readBuffer != NULL)
-                    {
-                        // Get the read offset, only the elements defined by the span must be read, not the whole array
-                        readOffset = readSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
-
-                        // use the span length as read size, only the elements defined by the span must be read
-                        readSize = readSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
-                        readData = (unsigned char *)readBuffer->GetElement(readOffset);
-                    }
-                }
-
-                if (readData == NULL)
-                {
-                    // nothing to read, have to zero this
-                    readSize = 0;
-                }
-            }
-            // Are we using SPI full-duplex for transfer ?
-            bool fullDuplex = (bool)stack.Arg3().NumericByRef().u1;
-
-            // Set up read/write settings for SPI_Write_Read call
-            // Gets the CS and active state
-            connectionSettings =
-                pThis[Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::FIELD___connectionSettings].Dereference();
-            int32_t chipSelect =
-                connectionSettings[Library_sys_dev_spi_native_System_Device_Spi_SpiConnectionSettings::FIELD___csLine]
-                    .NumericByRef()
-                    .s4;
-            bool chipSelectActiveState =
-                (bool)connectionSettings[Library_sys_dev_spi_native_System_Device_Spi_SpiConnectionSettings::
-                                             FIELD___chipSelectLineActiveState]
-                    .NumericByRef()
-                    .u1;
-            rws = {fullDuplex, 0, data16Bits, 0, chipSelect, chipSelectActiveState};
-
-            // Check to see if we should run async so as not to hold up other tasks
-            isLongRunningOperation = System_Device_IsLongRunningOperation(
-                writeSize,
-                readSize,
-                fullDuplex,
-                data16Bits,
-                nanoSPI_GetByteTime(deviceId),
-                (uint32_t &)estimatedDurationMiliseconds);
-
-            if (isLongRunningOperation)
-            {
-                // if this is a long running operation, set a timeout equal to the estimated transaction duration in
-                // milliseconds this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() below
-
-                // Use twice the estimated Duration as timeout
-                estimatedDurationMiliseconds *= 2;
-
-                hbTimeout.SetInteger((CLR_INT64)estimatedDurationMiliseconds * TIME_CONVERSION__TO_MILLISECONDS);
-
-                // if m_customState == 0 then push timeout on to eval stack[0] then move to m_customState = 1
-                // Return current timeout value
-                NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
-
-                // protect the buffers from GC so DMA can find them where they are supposed to be
-                if (writeData != NULL)
-                {
-                    CLR_RT_ProtectFromGC gcWriteBuffer(*writeBuffer);
-                }
-                if (readData != NULL)
-                {
-                    CLR_RT_ProtectFromGC gcReadBuffer(*readBuffer);
-                }
-
-                // Set callback for async calls to nano spi
-                rws.callback = System_Device_nano_spi_callback;
-            }
-
-            // Start SPI transfer
-            // We can ask for async transfer by setting callback but it depends if underlying supports it
-            // return of CLR_E_BUSY means async started
-            hr = nanoSPI_Write_Read(
-                deviceId,
-                rws,
-                (uint8_t *)writeData,
-                (int32_t)writeSize,
-                (uint8_t *)readData,
-                (int32_t)readSize);
-
-            // Async transfer started, go to custom 2 state ( wait completion )
-            if (hr == CLR_E_BUSY)
-            {
-                stack.m_customState = 2;
-            }
-        }
-
-        // Waiting for Async operation to complete
-        if (stack.m_customState == 2)
-        {
-            // Get timeout from eval stack we set up
-            stack.SetupTimeoutFromTicks(hbTimeout, timeout);
-
-            while (eventResult)
-            {
-                // Has it completed ?
-                if (nanoSPI_Op_Status(deviceId) == SPI_OP_COMPLETE)
-                {
-                    // SPI driver is ready meaning that the SPI transaction(s) is(are) completed
-                    break;
-                }
-
-                // non-blocking wait allowing other threads to run while we wait for the Spi transaction to complete
-                NANOCLR_CHECK_HRESULT(
-                    g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_SpiMaster, eventResult));
-
-                if (!eventResult)
-                {
-                    // Timeout
-                    NANOCLR_SET_AND_LEAVE(CLR_E_TIMEOUT);
-                }
-            }
-
-            // pop timeout heap block from stack
-            stack.PopValue();
-
-            // null pointers and vars
-            pThis = NULL;
-        }
-    }
-
-    NANOCLR_NOCLEANUP();
-}
-
-HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeOpenDevice___I4(CLR_RT_StackFrame &stack)
-{
-    NANOCLR_HEADER();
-
-    uint32_t handle = -1;
-    SPI_DEVICE_CONFIGURATION spiConfig;
-    CLR_RT_HeapBlock *config = NULL;
+    bool isLongRunningOperation;
+    uint32_t estimatedDurationMiliseconds;
+    CLR_RT_HeapBlock hbTimeout;
+    CLR_INT64 *timeout;
+    bool eventResult = true;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock *pThis = stack.This();
+    CLR_RT_HeapBlock *connectionSettings;
     FAULT_ON_NULL(pThis);
 
-    // Get reference to manage code SPI settings
-    config = pThis[Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::FIELD___connectionSettings].Dereference();
+    // get device handle saved on open
+    uint32_t deviceId =
+        pThis[Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::FIELD___deviceId].NumericByRef().u4;
 
-    spiConfig.BusMode = SpiBusMode_master;
-    spiConfig.DataIs16bits = false;
-
-    // internally SPI bus ID is zero based, so better take care of that here
-    spiConfig.Spi_Bus = config[SpiConnectionSettings::FIELD___busId].NumericByRef().s4 - 1;
-
-    spiConfig.DeviceChipSelect = config[SpiConnectionSettings::FIELD___csLine].NumericByRef().s4;
-
-    // sanity check chip select line
-    if (spiConfig.DeviceChipSelect < -1)
+    if (stack.m_customState == 0)
     {
-        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        // For 16 bits, it's directly a buffer, for 8 bits, it's a SpanByte
+        if (data16Bits)
+        {
+            writeBuffer = stack.Arg1().DereferenceArray();
+            if (writeBuffer != NULL)
+            {
+                // grab the pointer to the array by getting the first element of the array
+                writeData = (unsigned char *)writeBuffer->GetFirstElementUInt16();
+
+                // get the size of the buffer by reading the number of elements in the HeapBlock array
+                writeSize = writeBuffer->m_numOfElements;
+
+                // pin the buffer
+                writeBuffer->Pin();
+            }
+
+            readBuffer = stack.Arg2().DereferenceArray();
+            if (readBuffer != NULL)
+            {
+                // grab the pointer to the array by getting the first element of the array
+                readData = (unsigned char *)readBuffer->GetFirstElementUInt16();
+
+                // get the size of the buffer by reading the number of elements in the HeapBlock array
+                readSize = readBuffer->m_numOfElements;
+
+                // pin the buffer
+                readBuffer->Pin();
+            }
+        }
+        else
+        {
+            // dereference the write and read SpanByte from the arguments
+            writeSpanByte = stack.Arg1().Dereference();
+            if (writeSpanByte != NULL)
+            {
+                // get buffer
+                writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
+                if (writeBuffer != NULL)
+                {
+                    // Get the write offset, only the elements defined by the span must be written, not the whole
+                    // array
+                    writeOffset = writeSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+
+                    // use the span length as write size, only the elements defined by the span must be written
+                    writeSize = writeSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
+                    writeData = (unsigned char *)writeBuffer->GetElement(writeOffset);
+
+                    // pin the buffer
+                    writeBuffer->Pin();
+                }
+            }
+
+            if (writeData == NULL)
+            {
+                // nothing to write, have to zero this
+                writeSize = 0;
+            }
+
+            readSpanByte = stack.Arg2().Dereference();
+            if (readSpanByte != NULL)
+            {
+                // get buffer
+                readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
+                if (readBuffer != NULL)
+                {
+                    // Get the read offset, only the elements defined by the span must be read, not the whole array
+                    readOffset = readSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+
+                    // use the span length as read size, only the elements defined by the span must be read
+                    readSize = readSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
+                    readData = (unsigned char *)readBuffer->GetElement(readOffset);
+
+                    // pin the buffer
+                    readBuffer->Pin();
+                }
+            }
+
+            if (readData == NULL)
+            {
+                // nothing to read, have to zero this
+                readSize = 0;
+            }
+        }
+        // Are we using SPI full-duplex for transfer ?
+        bool fullDuplex = (bool)stack.Arg3().NumericByRef().u1;
+
+        // Set up read/write settings for SPI_Write_Read call
+        // Gets the CS and active state
+        connectionSettings =
+            pThis[Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::FIELD___connectionSettings].Dereference();
+        int32_t chipSelect =
+            connectionSettings[Library_sys_dev_spi_native_System_Device_Spi_SpiConnectionSettings::FIELD___csLine]
+                .NumericByRef()
+                .s4;
+        bool chipSelectActiveState =
+            (bool)connectionSettings
+                [Library_sys_dev_spi_native_System_Device_Spi_SpiConnectionSettings::FIELD___chipSelectLineActiveState]
+                    .NumericByRef()
+                    .u1;
+        rws = {fullDuplex, 0, data16Bits, 0, chipSelect, chipSelectActiveState};
+
+        // Check to see if we should run async so as not to hold up other tasks
+        isLongRunningOperation = System_Device_IsLongRunningOperation(
+            writeSize,
+            readSize,
+            fullDuplex,
+            data16Bits,
+            nanoSPI_GetByteTime(deviceId),
+            (uint32_t &)estimatedDurationMiliseconds);
+
+        if (isLongRunningOperation)
+        {
+            // if this is a long running operation, set a timeout equal to the estimated transaction duration in
+            // milliseconds this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() below
+
+            // Use twice the estimated Duration as timeout
+            estimatedDurationMiliseconds *= 2;
+
+            hbTimeout.SetInteger((CLR_INT64)estimatedDurationMiliseconds * TIME_CONVERSION__TO_MILLISECONDS);
+
+            // if m_customState == 0 then push timeout on to eval stack[0] then move to m_customState = 1
+            // Return current timeout value
+            NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
+
+            // Set callback for async calls to nano spi
+            rws.callback = System_Device_nano_spi_callback;
+        }
+
+        // Start SPI transfer
+        // We can ask for async transfer by setting callback but it depends if underlying supports it
+        // return of CLR_E_BUSY means async started
+        hr = nanoSPI_Write_Read(
+            deviceId,
+            rws,
+            (uint8_t *)writeData,
+            (int32_t)writeSize,
+            (uint8_t *)readData,
+            (int32_t)readSize);
+
+        // Async transfer started, go to custom 2 state ( wait completion )
+        if (hr == CLR_E_BUSY)
+        {
+            stack.m_customState = 2;
+        }
     }
 
-    // load CS active state from config (which is always PinValue.Low or PinValue.High
-    spiConfig.ChipSelectActiveState =
-        (bool)config[SpiConnectionSettings::FIELD___chipSelectLineActiveState].NumericByRef().s4;
-
-    spiConfig.Spi_Mode = (SpiMode)config[SpiConnectionSettings::FIELD___spiMode].NumericByRef().s4;
-    spiConfig.DataOrder16 = (DataBitOrder)config[SpiConnectionSettings::FIELD___dataFlow].NumericByRef().s4;
-    spiConfig.Clock_RateHz = config[SpiConnectionSettings::FIELD___clockFrequency].NumericByRef().s4;
-    spiConfig.BusConfiguration =
-        (SpiBusConfiguration)config[SpiConnectionSettings::FIELD___busConfiguration].NumericByRef().s4;
-
-    // Returns handle to device
-    hr = nanoSPI_OpenDevice(spiConfig, handle);
-    NANOCLR_CHECK_HRESULT(hr);
-
-    // Return device handle
-    stack.SetResult_I4(handle);
-
-    NANOCLR_NOCLEANUP();
-}
-
-HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeInit___VOID(CLR_RT_StackFrame &stack)
-{
-    NANOCLR_HEADER();
+    // Waiting for Async operation to complete
+    if (stack.m_customState == 2)
     {
-        (void)stack;
+        // Get timeout from eval stack we set up
+        stack.SetupTimeoutFromTicks(hbTimeout, timeout);
+
+        while (eventResult)
+        {
+            // Has it completed ?
+            if (nanoSPI_Op_Status(deviceId) == SPI_OP_COMPLETE)
+            {
+                // SPI driver is ready meaning that the SPI transaction(s) is(are) completed
+                break;
+            }
+
+            // non-blocking wait allowing other threads to run while we wait for the Spi transaction to complete
+            NANOCLR_CHECK_HRESULT(
+                g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_SpiMaster, eventResult));
+
+            if (!eventResult)
+            {
+                // Timeout
+                NANOCLR_SET_AND_LEAVE(CLR_E_TIMEOUT);
+            }
+        }
+
+        // pop timeout heap block from stack
+        stack.PopValue();
+
+        // null pointers and vars
+        pThis = NULL;
+
+        NANOCLR_CLEANUP();
+
+        if (hr != CLR_E_THREAD_WAITING)
+        {
+            // unpin buffers
+            if (writeBuffer != NULL && writeBuffer->IsPinned())
+            {
+                writeBuffer->Unpin();
+            }
+
+            if (readBuffer != NULL && readBuffer->IsPinned())
+            {
+                readBuffer->Unpin();
+            }
+        }
     }
-    NANOCLR_NOCLEANUP_NOLABEL();
-}
 
-HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::DisposeNative___VOID(CLR_RT_StackFrame &stack)
-{
-    NANOCLR_HEADER();
+    HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeOpenDevice___I4(CLR_RT_StackFrame & stack)
     {
+        NANOCLR_HEADER();
+
+        uint32_t handle = -1;
+        SPI_DEVICE_CONFIGURATION spiConfig;
+        CLR_RT_HeapBlock *config = NULL;
+
         // get a pointer to the managed object instance and check that it's not NULL
         CLR_RT_HeapBlock *pThis = stack.This();
+        FAULT_ON_NULL(pThis);
 
-        // get device handle
-        int32_t deviceId =
-            pThis[Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::FIELD___deviceId].NumericByRef().s4;
+        // Get reference to manage code SPI settings
+        config =
+            pThis[Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::FIELD___connectionSettings].Dereference();
 
-        nanoSPI_CloseDevice(deviceId);
+        spiConfig.BusMode = SpiBusMode_master;
+        spiConfig.DataIs16bits = false;
+
+        // internally SPI bus ID is zero based, so better take care of that here
+        spiConfig.Spi_Bus = config[SpiConnectionSettings::FIELD___busId].NumericByRef().s4 - 1;
+
+        spiConfig.DeviceChipSelect = config[SpiConnectionSettings::FIELD___csLine].NumericByRef().s4;
+
+        // sanity check chip select line
+        if (spiConfig.DeviceChipSelect < -1)
+        {
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+        }
+
+        // load CS active state from config (which is always PinValue.Low or PinValue.High
+        spiConfig.ChipSelectActiveState =
+            (bool)config[SpiConnectionSettings::FIELD___chipSelectLineActiveState].NumericByRef().s4;
+
+        spiConfig.Spi_Mode = (SpiMode)config[SpiConnectionSettings::FIELD___spiMode].NumericByRef().s4;
+        spiConfig.DataOrder16 = (DataBitOrder)config[SpiConnectionSettings::FIELD___dataFlow].NumericByRef().s4;
+        spiConfig.Clock_RateHz = config[SpiConnectionSettings::FIELD___clockFrequency].NumericByRef().s4;
+        spiConfig.BusConfiguration =
+            (SpiBusConfiguration)config[SpiConnectionSettings::FIELD___busConfiguration].NumericByRef().s4;
+
+        // Returns handle to device
+        hr = nanoSPI_OpenDevice(spiConfig, handle);
+        NANOCLR_CHECK_HRESULT(hr);
+
+        // Return device handle
+        stack.SetResult_I4(handle);
+
+        NANOCLR_NOCLEANUP();
     }
-    NANOCLR_NOCLEANUP_NOLABEL();
-}
+
+    HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeInit___VOID(CLR_RT_StackFrame & stack)
+    {
+        NANOCLR_HEADER();
+        {
+            (void)stack;
+        }
+        NANOCLR_NOCLEANUP_NOLABEL();
+    }
+
+    HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::DisposeNative___VOID(CLR_RT_StackFrame & stack)
+    {
+        NANOCLR_HEADER();
+        {
+            // get a pointer to the managed object instance and check that it's not NULL
+            CLR_RT_HeapBlock *pThis = stack.This();
+
+            // get device handle
+            int32_t deviceId =
+                pThis[Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::FIELD___deviceId].NumericByRef().s4;
+
+            nanoSPI_CloseDevice(deviceId);
+        }
+        NANOCLR_NOCLEANUP_NOLABEL();
+    }

--- a/src/System.Device.Spi/sys_dev_spi_native_System_Device_Spi_SpiDevice.cpp
+++ b/src/System.Device.Spi/sys_dev_spi_native_System_Device_Spi_SpiDevice.cpp
@@ -76,8 +76,8 @@ HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeTransfer(
 
     CLR_RT_HeapBlock *writeSpanByte;
     CLR_RT_HeapBlock *readSpanByte;
-    CLR_RT_HeapBlock_Array *writeBuffer;
-    CLR_RT_HeapBlock_Array *readBuffer;
+    CLR_RT_HeapBlock_Array *writeBuffer = NULL;
+    CLR_RT_HeapBlock_Array *readBuffer = NULL;
     uint8_t *writeData = NULL;
     uint8_t *readData = NULL;
     int16_t writeSize = 0;
@@ -298,6 +298,8 @@ HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeTransfer(
             readBuffer->Unpin();
         }
     }
+
+    NANOCLR_CLEANUP_END();
 }
 
 HRESULT Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeOpenDevice___I4(CLR_RT_StackFrame &stack)

--- a/targets/AzureRTOS/ST/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/AzureRTOS/ST/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -389,350 +389,366 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
     NativeTransmit___SystemDeviceI2cI2cTransferResult__SystemSpanByte__SystemSpanByte(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
+
+    uint8_t busIndex;
+    NF_PAL_I2C *palI2c = NULL;
+    bool isLongRunningOperation = false;
+    msg_t transactionResult = MSG_OK;
+
+    CLR_RT_HeapBlock hbTimeout;
+    CLR_INT64 *timeout;
+    bool eventResult = true;
+    uint32_t estimatedDurationMiliseconds;
+
+    CLR_RT_HeapBlock *result;
+    CLR_RT_HeapBlock *writeSpanByte;
+    CLR_RT_HeapBlock *readSpanByte;
+    CLR_RT_HeapBlock *connectionSettings;
+    CLR_RT_HeapBlock_Array *writeBuffer = NULL;
+    CLR_RT_HeapBlock_Array *readBuffer = NULL;
+    int readOffset = 0;
+    int writeOffset = 0;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock *pThis = stack.This();
+    FAULT_ON_NULL(pThis);
+
+    // get pointer to connection settings field
+    connectionSettings = pThis[FIELD___connectionSettings].Dereference();
+
+    // get bus index
+    busIndex = (uint8_t)connectionSettings[I2cConnectionSettings::FIELD___busId].NumericByRef().s4;
+
+    // get the driver for the I2C bus
+    switch (busIndex)
     {
-        uint8_t busIndex;
-        NF_PAL_I2C *palI2c = NULL;
-        bool isLongRunningOperation = false;
-        msg_t transactionResult = MSG_OK;
-
-        CLR_RT_HeapBlock hbTimeout;
-        CLR_INT64 *timeout;
-        bool eventResult = true;
-        uint32_t estimatedDurationMiliseconds;
-
-        CLR_RT_HeapBlock *result;
-        CLR_RT_HeapBlock *writeSpanByte;
-        CLR_RT_HeapBlock *readSpanByte;
-        CLR_RT_HeapBlock_Array *writeBuffer = NULL;
-        CLR_RT_HeapBlock_Array *readBuffer = NULL;
-        int readOffset = 0;
-        int writeOffset = 0;
-
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock *pThis = stack.This();
-        FAULT_ON_NULL(pThis);
-
-        // get pointer to connection settings field
-        CLR_RT_HeapBlock *connectionSettings = pThis[FIELD___connectionSettings].Dereference();
-
-        // get bus index
-        busIndex = (uint8_t)connectionSettings[I2cConnectionSettings::FIELD___busId].NumericByRef().s4;
-
-        // get the driver for the I2C bus
-        switch (busIndex)
-        {
 #if (STM32_I2C_USE_I2C1 == TRUE)
-            case 1:
-                palI2c = &I2C1_PAL;
-                break;
+        case 1:
+            palI2c = &I2C1_PAL;
+            break;
 #endif
 #if defined(STM32_I2C_USE_I2C2) && (STM32_I2C_USE_I2C2 == TRUE)
-            case 2:
-                palI2c = &I2C2_PAL;
-                break;
+        case 2:
+            palI2c = &I2C2_PAL;
+            break;
 #endif
 #if defined(STM32_I2C_USE_I2C3) && (STM32_I2C_USE_I2C3 == TRUE)
-            case 3:
-                palI2c = &I2C3_PAL;
-                break;
+        case 3:
+            palI2c = &I2C3_PAL;
+            break;
 #endif
 #if defined(STM32_I2C_USE_I2C4) && (STM32_I2C_USE_I2C4 == TRUE)
-            case 4:
-                palI2c = &I2C4_PAL;
-                break;
+        case 4:
+            palI2c = &I2C4_PAL;
+            break;
 #endif
-            default:
-                // the requested I2C bus is not valid
-                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-                break;
-        }
+        default:
+            // the requested I2C bus is not valid
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+            break;
+    }
 
-        // dereference the write and read SpanByte from the arguments
-        writeSpanByte = stack.Arg1().Dereference();
-        if (writeSpanByte != NULL)
+    // dereference the write and read SpanByte from the arguments
+    writeSpanByte = stack.Arg1().Dereference();
+    if (writeSpanByte != NULL)
+    {
+        // get buffer
+        writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
+        if (writeBuffer != NULL)
         {
-            // get buffer
-            writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
-            if (writeBuffer != NULL)
-            {
-                // Get the write offset, only the elements defined by the span must be written, not the whole array
-                writeOffset = writeSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+            // Get the write offset, only the elements defined by the span must be written, not the whole array
+            writeOffset = writeSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
 
-                // use the span length as write size, only the elements defined by the span must be written
-                palI2c->WriteSize = writeSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
-            }
+            // use the span length as write size, only the elements defined by the span must be written
+            palI2c->WriteSize = writeSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
+
+            // pin the buffer so DMA can find it where its supposed to be
+            writeBuffer->Pin();
         }
+    }
 
-        if (writeBuffer == NULL)
+    if (writeBuffer == NULL)
+    {
+        // nothing to write, have to zero this
+        palI2c->WriteSize = 0;
+    }
+
+    readSpanByte = stack.Arg2().Dereference();
+    if (readSpanByte != NULL)
+    {
+        // get buffer
+        readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
+        if (readBuffer != NULL)
         {
-            // nothing to write, have to zero this
-            palI2c->WriteSize = 0;
+            // Get the read offset, only the elements defined by the span must be read, not the whole array
+            readOffset = readSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+
+            // use the span length as read size, only the elements defined by the span must be read
+            palI2c->ReadSize = readSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
+
+            // pin the buffer so DMA can find it where its supposed to be
+            readBuffer->Pin();
         }
+    }
 
-        readSpanByte = stack.Arg2().Dereference();
-        if (readSpanByte != NULL)
-        {
-            // get buffer
-            readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
-            if (readBuffer != NULL)
-            {
-                // Get the read offset, only the elements defined by the span must be read, not the whole array
-                readOffset = readSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+    if (readBuffer == NULL)
+    {
+        // nothing to read, have to zero this
+        palI2c->ReadSize = 0;
+    }
 
-                // use the span length as read size, only the elements defined by the span must be read
-                palI2c->ReadSize = readSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
-            }
-        }
+    // check if this is a long running operation
+    isLongRunningOperation = IsLongRunningOperation(
+        palI2c->WriteSize,
+        palI2c->ReadSize,
+        palI2c->ByteTime,
+        (uint32_t &)estimatedDurationMiliseconds);
 
-        if (readBuffer == NULL)
-        {
-            // nothing to read, have to zero this
-            palI2c->ReadSize = 0;
-        }
+    if (isLongRunningOperation)
+    {
+        // if this is a long running operation, set a timeout equal to the estimated transaction duration in
+        // milliseconds this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() below
+        hbTimeout.SetInteger((CLR_INT64)estimatedDurationMiliseconds * TIME_CONVERSION__TO_MILLISECONDS);
 
-        // check if this is a long running operation
-        isLongRunningOperation = IsLongRunningOperation(
-            palI2c->WriteSize,
-            palI2c->ReadSize,
-            palI2c->ByteTime,
-            (uint32_t &)estimatedDurationMiliseconds);
+        NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
+    }
 
-        if (isLongRunningOperation)
-        {
-            // if this is a long running operation, set a timeout equal to the estimated transaction duration in
-            // milliseconds this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() below
-            hbTimeout.SetInteger((CLR_INT64)estimatedDurationMiliseconds * TIME_CONVERSION__TO_MILLISECONDS);
+    // this is going to be used to check for the right event in case of simultaneous I2C transaction
+    if (!isLongRunningOperation || stack.m_customState == 1)
+    {
+        // get slave address from connection settings field
+        palI2c->Address = (i2caddr_t)connectionSettings[I2cConnectionSettings::FIELD___deviceAddress].NumericByRef().s4;
 
-            NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
-
-            // protect the buffers from GC so DMA can find them where they are supposed to be
-            CLR_RT_ProtectFromGC gcWriteBuffer(*writeBuffer);
-            CLR_RT_ProtectFromGC gcReadBuffer(*readBuffer);
-        }
-
-        // this is going to be used to check for the right event in case of simultaneous I2C transaction
-        if (!isLongRunningOperation || stack.m_customState == 1)
-        {
-            // get slave address from connection settings field
-            palI2c->Address =
-                (i2caddr_t)connectionSettings[I2cConnectionSettings::FIELD___deviceAddress].NumericByRef().s4;
-
-            // when using I2Cv1 driver the address needs to be loaded in the I2C driver struct
+        // when using I2Cv1 driver the address needs to be loaded in the I2C driver struct
 #if defined(STM32F1XX) || defined(STM32F4XX) || defined(STM32L1XX)
-            palI2c->Driver->addr = palI2c->Address;
+        palI2c->Driver->addr = palI2c->Address;
 #endif
 
-            if (writeBuffer != NULL)
-            {
-                // grab the pointer to the array by starting and the offset specified in the span
-                palI2c->WriteBuffer = (uint8_t *)writeBuffer->GetElement(writeOffset);
+        if (writeBuffer != NULL)
+        {
+            // grab the pointer to the array by starting and the offset specified in the span
+            palI2c->WriteBuffer = (uint8_t *)writeBuffer->GetElement(writeOffset);
 
-                // flush DMA buffer to ensure cache coherency
-                // (only required for Cortex-M7)
-                cacheBufferFlush(palI2c->WriteBuffer, palI2c->WriteSize);
-            }
-
-            if (readBuffer != NULL)
-            {
-                // grab the pointer to the array by starting and the offset specified in the span
-                palI2c->ReadBuffer = (uint8_t *)readBuffer->GetElement(readOffset);
-            }
-
-            // because the bus access is shared, acquire the appropriate bus
-            i2cAcquireBus(palI2c->Driver);
-            i2cStart(palI2c->Driver, &palI2c->Configuration);
+            // flush DMA buffer to ensure cache coherency
+            // (only required for Cortex-M7)
+            cacheBufferFlush(palI2c->WriteBuffer, palI2c->WriteSize);
         }
 
-        if (isLongRunningOperation)
+        if (readBuffer != NULL)
         {
-            // this is a long running operation and hasn't started yet
-            // perform I2C transaction using driver's ASYNC API which is launching a thread to perform it
-            if (stack.m_customState == 1)
+            // grab the pointer to the array by starting and the offset specified in the span
+            palI2c->ReadBuffer = (uint8_t *)readBuffer->GetElement(readOffset);
+        }
+
+        // because the bus access is shared, acquire the appropriate bus
+        i2cAcquireBus(palI2c->Driver);
+        i2cStart(palI2c->Driver, &palI2c->Configuration);
+    }
+
+    if (isLongRunningOperation)
+    {
+        // this is a long running operation and hasn't started yet
+        // perform I2C transaction using driver's ASYNC API which is launching a thread to perform it
+        if (stack.m_customState == 1)
+        {
+            // spawn working thread to perform the I2C transaction
+
+            // 1. allocate memory for I2C thread
+            palI2c->WorkingThreadStack = (uint32_t *)platform_malloc(I2C_THREAD_STACK_SIZE);
+
+            if (palI2c->WorkingThreadStack == NULL)
             {
-                // spawn working thread to perform the I2C transaction
-
-                // 1. allocate memory for I2C thread
-                palI2c->WorkingThreadStack = (uint32_t *)platform_malloc(I2C_THREAD_STACK_SIZE);
-
-                if (palI2c->WorkingThreadStack == NULL)
-                {
-                    NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
-                }
-
-                // 2. create thread
-                uint16_t status = tx_thread_create(
-                    palI2c->WorkingThread,
-#if !defined(BUILD_RTM)
-                    (CHAR *)"I2C Thread",
-#else
-                    NULL,
-#endif
-                    I2CWorkingThread_entry,
-                    (uint32_t)palI2c,
-                    palI2c->WorkingThreadStack,
-                    I2C_THREAD_STACK_SIZE,
-                    I2C_THREAD_PRIORITY,
-                    I2C_THREAD_PRIORITY,
-                    TX_NO_TIME_SLICE,
-                    TX_AUTO_START);
-
-                if (status != TX_SUCCESS)
-                {
-                    NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
-                }
-
-                // bump custom state
-                stack.m_customState = 2;
+                NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
             }
+
+            // 2. create thread
+            uint16_t status = tx_thread_create(
+                palI2c->WorkingThread,
+#if !defined(BUILD_RTM)
+                (CHAR *)"I2C Thread",
+#else
+                NULL,
+#endif
+                I2CWorkingThread_entry,
+                (uint32_t)palI2c,
+                palI2c->WorkingThreadStack,
+                I2C_THREAD_STACK_SIZE,
+                I2C_THREAD_PRIORITY,
+                I2C_THREAD_PRIORITY,
+                TX_NO_TIME_SLICE,
+                TX_AUTO_START);
+
+            if (status != TX_SUCCESS)
+            {
+                NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
+            }
+
+            // bump custom state
+            stack.m_customState = 2;
+        }
+    }
+    else
+    {
+        // this is NOT a long running operation
+        // perform I2C transaction using driver's SYNC API
+
+        if (palI2c->ReadSize != 0 && palI2c->WriteSize != 0)
+        {
+            // this is a Write/Read transaction
+            transactionResult = i2cMasterTransmitTimeout(
+                palI2c->Driver,
+                palI2c->Address,
+                palI2c->WriteBuffer,
+                palI2c->WriteSize,
+                palI2c->ReadBuffer,
+                palI2c->ReadSize,
+                TX_TICKS_PER_MILLISEC(20));
         }
         else
         {
-            // this is NOT a long running operation
-            // perform I2C transaction using driver's SYNC API
-
-            if (palI2c->ReadSize != 0 && palI2c->WriteSize != 0)
+            if (palI2c->ReadSize == 0)
             {
-                // this is a Write/Read transaction
+                // this is Write only transaction
                 transactionResult = i2cMasterTransmitTimeout(
                     palI2c->Driver,
                     palI2c->Address,
                     palI2c->WriteBuffer,
                     palI2c->WriteSize,
-                    palI2c->ReadBuffer,
-                    palI2c->ReadSize,
+                    NULL,
+                    0,
                     TX_TICKS_PER_MILLISEC(20));
             }
             else
             {
-                if (palI2c->ReadSize == 0)
-                {
-                    // this is Write only transaction
-                    transactionResult = i2cMasterTransmitTimeout(
-                        palI2c->Driver,
-                        palI2c->Address,
-                        palI2c->WriteBuffer,
-                        palI2c->WriteSize,
-                        NULL,
-                        0,
-                        TX_TICKS_PER_MILLISEC(20));
-                }
-                else
-                {
-                    // this is a Read only transaction
-                    transactionResult = i2cMasterReceiveTimeout(
-                        palI2c->Driver,
-                        palI2c->Address,
-                        palI2c->ReadBuffer,
-                        palI2c->ReadSize,
-                        TX_TICKS_PER_MILLISEC(20));
-                }
-            }
-        }
-
-        while (eventResult)
-        {
-            if (!isLongRunningOperation)
-            {
-                // this is not a long running operation so nothing to do here
-                break;
-            }
-
-            if (palI2c->WorkingThread->tx_thread_state == TX_TERMINATED)
-            {
-                // I2C working thread is now complete
-                break;
-            }
-
-            // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
-            NANOCLR_CHECK_HRESULT(
-                g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_I2cMaster, eventResult));
-        }
-
-        if (isLongRunningOperation)
-        {
-            // pop timeout heap block from stack
-            stack.PopValue();
-        }
-
-        if (eventResult || !isLongRunningOperation)
-        {
-            // event occurred
-            // OR this is NOT a long running operation
-
-            i2cReleaseBus(palI2c->Driver);
-
-            // create the return object (I2cTransferResult)
-            // only at this point we are sure that there will be a return from this thread so it's OK to use the
-            // managed stack
-            CLR_RT_HeapBlock &top = stack.PushValueAndClear();
-            NANOCLR_CHECK_HRESULT(
-                g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
-            result = top.Dereference();
-            FAULT_ON_NULL(result);
-
-            if (isLongRunningOperation)
-            {
-                // get transaction result from I2C struct
-                transactionResult = palI2c->TransactionResult;
-
-                // delete thread
-                tx_thread_delete(palI2c->WorkingThread);
-
-                // free stack memory
-                platform_free(palI2c->WorkingThreadStack);
-
-                // clear pointers
-                palI2c->WorkingThread = NULL;
-                palI2c->WorkingThreadStack = NULL;
-            }
-
-            // get the result from the working thread execution
-            if (transactionResult != MSG_OK)
-            {
-                // error in transaction
-                int errors = i2cGetErrors(palI2c->Driver);
-
-                // figure out what was the error and set the status field
-                switch (errors)
-                {
-                    case I2C_ACK_FAILURE:
-                        result[I2cTransferResult::FIELD___status].SetInteger(
-                            (CLR_UINT32)I2cTransferStatus_SlaveAddressNotAcknowledged);
-                        break;
-
-                    case I2C_TIMEOUT:
-                        result[I2cTransferResult::FIELD___status].SetInteger(
-                            (CLR_UINT32)I2cTransferStatus_ClockStretchTimeout);
-                        break;
-
-                    default:
-                        result[I2cTransferResult::FIELD___status].SetInteger(
-                            (CLR_UINT32)I2cTransferStatus_UnknownError);
-                }
-
-                // set the bytes transferred count to 0 because we don't have a way to know how many bytes were
-                // actually sent/received
-                result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(0);
-            }
-            else
-            {
-                // successful transaction
-                // set the result field
-                result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
-
-                // set the bytes transferred field
-                result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(
-                    (CLR_UINT32)(palI2c->WriteSize + palI2c->ReadSize));
-            }
-
-            if (palI2c->ReadSize > 0)
-            {
-                // invalidate cache over read buffer to ensure that content from DMA is read
-                // (only required for Cortex-M7)
-                cacheBufferInvalidate(palI2c->ReadBuffer, palI2c->ReadSize);
+                // this is a Read only transaction
+                transactionResult = i2cMasterReceiveTimeout(
+                    palI2c->Driver,
+                    palI2c->Address,
+                    palI2c->ReadBuffer,
+                    palI2c->ReadSize,
+                    TX_TICKS_PER_MILLISEC(20));
             }
         }
     }
 
-    NANOCLR_NOCLEANUP();
+    while (eventResult)
+    {
+        if (!isLongRunningOperation)
+        {
+            // this is not a long running operation so nothing to do here
+            break;
+        }
+
+        if (palI2c->WorkingThread->tx_thread_state == TX_TERMINATED)
+        {
+            // I2C working thread is now complete
+            break;
+        }
+
+        // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
+        NANOCLR_CHECK_HRESULT(
+            g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_I2cMaster, eventResult));
+    }
+
+    if (isLongRunningOperation)
+    {
+        // pop timeout heap block from stack
+        stack.PopValue();
+    }
+
+    if (eventResult || !isLongRunningOperation)
+    {
+        // event occurred
+        // OR this is NOT a long running operation
+
+        i2cReleaseBus(palI2c->Driver);
+
+        // create the return object (I2cTransferResult)
+        // only at this point we are sure that there will be a return from this thread so it's OK to use the
+        // managed stack
+        CLR_RT_HeapBlock &top = stack.PushValueAndClear();
+        NANOCLR_CHECK_HRESULT(
+            g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+        result = top.Dereference();
+        FAULT_ON_NULL(result);
+
+        if (isLongRunningOperation)
+        {
+            // get transaction result from I2C struct
+            transactionResult = palI2c->TransactionResult;
+
+            // delete thread
+            tx_thread_delete(palI2c->WorkingThread);
+
+            // free stack memory
+            platform_free(palI2c->WorkingThreadStack);
+
+            // clear pointers
+            palI2c->WorkingThread = NULL;
+            palI2c->WorkingThreadStack = NULL;
+        }
+
+        // get the result from the working thread execution
+        if (transactionResult != MSG_OK)
+        {
+            // error in transaction
+            int errors = i2cGetErrors(palI2c->Driver);
+
+            // figure out what was the error and set the status field
+            switch (errors)
+            {
+                case I2C_ACK_FAILURE:
+                    result[I2cTransferResult::FIELD___status].SetInteger(
+                        (CLR_UINT32)I2cTransferStatus_SlaveAddressNotAcknowledged);
+                    break;
+
+                case I2C_TIMEOUT:
+                    result[I2cTransferResult::FIELD___status].SetInteger(
+                        (CLR_UINT32)I2cTransferStatus_ClockStretchTimeout);
+                    break;
+
+                default:
+                    result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_UnknownError);
+            }
+
+            // set the bytes transferred count to 0 because we don't have a way to know how many bytes were
+            // actually sent/received
+            result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(0);
+        }
+        else
+        {
+            // successful transaction
+            // set the result field
+            result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
+
+            // set the bytes transferred field
+            result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(
+                (CLR_UINT32)(palI2c->WriteSize + palI2c->ReadSize));
+        }
+
+        if (palI2c->ReadSize > 0)
+        {
+            // invalidate cache over read buffer to ensure that content from DMA is read
+            // (only required for Cortex-M7)
+            cacheBufferInvalidate(palI2c->ReadBuffer, palI2c->ReadSize);
+        }
+    }
+
+    NANOCLR_CLEANUP();
+
+    if (hr != CLR_E_THREAD_WAITING)
+    {
+        // un-pin the buffers
+        if (writeBuffer != NULL && writeBuffer->IsPinned())
+        {
+            writeBuffer->Unpin();
+        }
+
+        if (readBuffer != NULL && readBuffer->IsPinned())
+        {
+            readBuffer->Unpin();
+        }
+    }
+
+    NANOCLR_CLEANUP_END();
 }

--- a/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -396,354 +396,353 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
     NativeTransmit___SystemDeviceI2cI2cTransferResult__SystemSpanByte__SystemSpanByte(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
-    
-        uint8_t busIndex;
-        NF_PAL_I2C *palI2c = NULL;
-        bool isLongRunningOperation = false;
 
-        CLR_RT_HeapBlock hbTimeout;
-        CLR_INT64 *timeout;
-        bool eventResult = true;
-        uint32_t estimatedDurationMiliseconds;
+    uint8_t busIndex;
+    NF_PAL_I2C *palI2c = NULL;
+    bool isLongRunningOperation = false;
 
-        CLR_RT_HeapBlock *result;
-        CLR_RT_HeapBlock *writeSpanByte;
-        CLR_RT_HeapBlock *readSpanByte;
-        CLR_RT_HeapBlock *connectionSettings;
-        CLR_RT_HeapBlock_Array *writeBuffer = NULL;
-        CLR_RT_HeapBlock_Array *readBuffer = NULL;
-        int readOffset = 0;
-        int writeOffset = 0;
-        I2C_TransferSeq_TypeDef i2cTransfer;
-        I2C_TransferReturn_TypeDef transactionResult = i2cTransferInProgress;
+    CLR_RT_HeapBlock hbTimeout;
+    CLR_INT64 *timeout;
+    bool eventResult = true;
+    uint32_t estimatedDurationMiliseconds;
 
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock *pThis = stack.This();
-        FAULT_ON_NULL(pThis);
+    CLR_RT_HeapBlock *result;
+    CLR_RT_HeapBlock *writeSpanByte;
+    CLR_RT_HeapBlock *readSpanByte;
+    CLR_RT_HeapBlock *connectionSettings;
+    CLR_RT_HeapBlock_Array *writeBuffer = NULL;
+    CLR_RT_HeapBlock_Array *readBuffer = NULL;
+    int readOffset = 0;
+    int writeOffset = 0;
+    I2C_TransferSeq_TypeDef i2cTransfer;
+    I2C_TransferReturn_TypeDef transactionResult = i2cTransferInProgress;
 
-        // get pointer to connection settings field
-        connectionSettings = pThis[FIELD___connectionSettings].Dereference();
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock *pThis = stack.This();
+    FAULT_ON_NULL(pThis);
 
-        // get bus index
-        busIndex = (uint8_t)connectionSettings[I2cConnectionSettings::FIELD___busId].NumericByRef().s4;
+    // get pointer to connection settings field
+    connectionSettings = pThis[FIELD___connectionSettings].Dereference();
 
-        // get the driver for the I2C bus
-        switch (busIndex)
-        {
-            ////////////////////////////////////
-            // Gecko I2C bus index is 0 based //
-            ////////////////////////////////////
+    // get bus index
+    busIndex = (uint8_t)connectionSettings[I2cConnectionSettings::FIELD___busId].NumericByRef().s4;
+
+    // get the driver for the I2C bus
+    switch (busIndex)
+    {
+        ////////////////////////////////////
+        // Gecko I2C bus index is 0 based //
+        ////////////////////////////////////
 
 #if defined(I2C0) && (GECKO_USE_I2C0 == TRUE)
-            case 1:
-                palI2c = &I2C0_PAL;
-                break;
+        case 1:
+            palI2c = &I2C0_PAL;
+            break;
 #endif
 
 #if defined(I2C1) && (GECKO_USE_I2C1 == TRUE)
-            case 2:
-                palI2c = &I2C1_PAL;
-                break;
+        case 2:
+            palI2c = &I2C1_PAL;
+            break;
 #endif
 
 #if defined(I2C2) && (GECKO_USE_I2C2 == TRUE)
-            case 3:
-                palI2c = &I2C2_PAL;
-                break;
+        case 3:
+            palI2c = &I2C2_PAL;
+            break;
 #endif
 
-            default:
-                // the requested I2C bus is not valid
-                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-                break;
+        default:
+            // the requested I2C bus is not valid
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+            break;
+    }
+
+    // dereference the write and read SpanByte from the arguments
+    writeSpanByte = stack.Arg1().Dereference();
+
+    if (writeSpanByte != NULL)
+    {
+        // get buffer
+        writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
+
+        if (writeBuffer != NULL)
+        {
+            // Get the write offset, only the elements defined by the span must be written, not the whole array
+            writeOffset = writeSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+
+            // use the span length as write size, only the elements defined by the span must be written
+            palI2c->WriteSize = writeSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
+
+            // pin the buffer so DMA can find it where its supposed to be
+            writeBuffer->Pin();
+        }
+    }
+
+    if (writeBuffer == NULL)
+    {
+        // nothing to write, have to zero this
+        palI2c->WriteSize = 0;
+    }
+
+    readSpanByte = stack.Arg2().Dereference();
+
+    if (readSpanByte != NULL)
+    {
+        // get buffer
+        readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
+
+        if (readBuffer != NULL)
+        {
+            // Get the read offset, only the elements defined by the span must be read, not the whole array
+            readOffset = readSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+
+            // use the span length as read size, only the elements defined by the span must be read
+            palI2c->ReadSize = readSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
+
+            // pin the buffer so DMA can find it where its supposed to be
+            readBuffer->Pin();
+        }
+    }
+
+    if (readBuffer == NULL)
+    {
+        // nothing to read, have to zero this
+        palI2c->ReadSize = 0;
+    }
+
+    // check if this is a long running operation
+    isLongRunningOperation = IsLongRunningOperation(
+        palI2c->WriteSize,
+        palI2c->ReadSize,
+        palI2c->ByteTime,
+        (uint32_t &)estimatedDurationMiliseconds);
+
+    if (isLongRunningOperation)
+    {
+        // if this is a long running operation, set a timeout equal to the estimated transaction duration in
+        // milliseconds this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() below
+        hbTimeout.SetInteger((CLR_INT64)estimatedDurationMiliseconds * TIME_CONVERSION__TO_MILLISECONDS);
+
+        NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
+    }
+
+    // this is going to be used to check for the right event in case of simultaneous I2C transaction
+    if (!isLongRunningOperation || stack.m_customState == 1)
+    {
+
+        // get slave address from connection settings field
+        i2cTransfer.addr = (uint16_t)connectionSettings[I2cConnectionSettings::FIELD___deviceAddress].NumericByRef().s4
+                           << 1;
+
+        if (writeBuffer != NULL)
+        {
+            // grab the pointer to the array by starting and the offset specified in the span
+            palI2c->WriteBuffer = (uint8_t *)writeBuffer->GetElement(writeOffset);
         }
 
-        // dereference the write and read SpanByte from the arguments
-        writeSpanByte = stack.Arg1().Dereference();
-
-        if (writeSpanByte != NULL)
+        if (readBuffer != NULL)
         {
-            // get buffer
-            writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
+            // grab the pointer to the array by starting and the offset specified in the span
+            palI2c->ReadBuffer = (uint8_t *)readBuffer->GetElement(readOffset);
+        }
+    }
 
-            if (writeBuffer != NULL)
+    if (isLongRunningOperation)
+    {
+        // this is a long running operation and hasn't started yet
+        // perform I2C transaction using driver's ASYNC API which is launching a thread to perform it
+        if (stack.m_customState == 1)
+        {
+            // spawn working thread to perform the I2C transaction
+
+            // 1. allocate memory for I2C thread
+            palI2c->WorkingThreadStack = (uint32_t *)platform_malloc(I2C_THREAD_STACK_SIZE);
+
+            if (palI2c->WorkingThreadStack == NULL)
             {
-                // Get the write offset, only the elements defined by the span must be written, not the whole array
-                writeOffset = writeSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
-
-                // use the span length as write size, only the elements defined by the span must be written
-                palI2c->WriteSize = writeSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
-
-                // pin the buffer so DMA can find it where its supposed to be
-                writeBuffer->Pin();
+                NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
             }
-        }
 
-        if (writeBuffer == NULL)
-        {
-            // nothing to write, have to zero this
-            palI2c->WriteSize = 0;
-        }
-
-        readSpanByte = stack.Arg2().Dereference();
-
-        if (readSpanByte != NULL)
-        {
-            // get buffer
-            readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
-
-            if (readBuffer != NULL)
-            {
-                // Get the read offset, only the elements defined by the span must be read, not the whole array
-                readOffset = readSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
-
-                // use the span length as read size, only the elements defined by the span must be read
-                palI2c->ReadSize = readSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
-
-                // pin the buffer so DMA can find it where its supposed to be
-                readBuffer->Pin();
-            }
-        }
-
-        if (readBuffer == NULL)
-        {
-            // nothing to read, have to zero this
-            palI2c->ReadSize = 0;
-        }
-
-        // check if this is a long running operation
-        isLongRunningOperation = IsLongRunningOperation(
-            palI2c->WriteSize,
-            palI2c->ReadSize,
-            palI2c->ByteTime,
-            (uint32_t &)estimatedDurationMiliseconds);
-
-        if (isLongRunningOperation)
-        {
-            // if this is a long running operation, set a timeout equal to the estimated transaction duration in
-            // milliseconds this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() below
-            hbTimeout.SetInteger((CLR_INT64)estimatedDurationMiliseconds * TIME_CONVERSION__TO_MILLISECONDS);
-
-            NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
-        }
-
-        // this is going to be used to check for the right event in case of simultaneous I2C transaction
-        if (!isLongRunningOperation || stack.m_customState == 1)
-        {
-
-            // get slave address from connection settings field
-            i2cTransfer.addr =
-                (uint16_t)connectionSettings[I2cConnectionSettings::FIELD___deviceAddress].NumericByRef().s4 << 1;
-
-            if (writeBuffer != NULL)
-            {
-                // grab the pointer to the array by starting and the offset specified in the span
-                palI2c->WriteBuffer = (uint8_t *)writeBuffer->GetElement(writeOffset);
-            }
-
-            if (readBuffer != NULL)
-            {
-                // grab the pointer to the array by starting and the offset specified in the span
-                palI2c->ReadBuffer = (uint8_t *)readBuffer->GetElement(readOffset);
-            }
-        }
-
-        if (isLongRunningOperation)
-        {
-            // this is a long running operation and hasn't started yet
-            // perform I2C transaction using driver's ASYNC API which is launching a thread to perform it
-            if (stack.m_customState == 1)
-            {
-                // spawn working thread to perform the I2C transaction
-
-                // 1. allocate memory for I2C thread
-                palI2c->WorkingThreadStack = (uint32_t *)platform_malloc(I2C_THREAD_STACK_SIZE);
-
-                if (palI2c->WorkingThreadStack == NULL)
-                {
-                    NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
-                }
-
-                // 2. create thread
-                uint16_t status = tx_thread_create(
-                    palI2c->WorkingThread,
+            // 2. create thread
+            uint16_t status = tx_thread_create(
+                palI2c->WorkingThread,
 #if !defined(BUILD_RTM)
-                    (CHAR *)"I2C Thread",
+                (CHAR *)"I2C Thread",
 #else
-                    NULL,
+                NULL,
 #endif
-                    I2CWorkingThread_entry,
-                    (uint32_t)palI2c,
-                    palI2c->WorkingThreadStack,
-                    I2C_THREAD_STACK_SIZE,
-                    I2C_THREAD_PRIORITY,
-                    I2C_THREAD_PRIORITY,
-                    TX_NO_TIME_SLICE,
-                    TX_AUTO_START);
+                I2CWorkingThread_entry,
+                (uint32_t)palI2c,
+                palI2c->WorkingThreadStack,
+                I2C_THREAD_STACK_SIZE,
+                I2C_THREAD_PRIORITY,
+                I2C_THREAD_PRIORITY,
+                TX_NO_TIME_SLICE,
+                TX_AUTO_START);
 
-                if (status != TX_SUCCESS)
-                {
-                    NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
-                }
-
-                // bump custom state
-                stack.m_customState = 2;
+            if (status != TX_SUCCESS)
+            {
+                NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
             }
+
+            // bump custom state
+            stack.m_customState = 2;
+        }
+    }
+    else
+    {
+        // this is NOT a long running operation
+        // perform I2C transaction
+
+        if (palI2c->ReadSize != 0 && palI2c->WriteSize != 0)
+        {
+            // this is a Write/Read transaction
+            i2cTransfer.flags = I2C_FLAG_WRITE_READ;
+
+            i2cTransfer.buf[0].data = palI2c->WriteBuffer;
+            i2cTransfer.buf[0].len = palI2c->WriteSize;
+            i2cTransfer.buf[1].data = palI2c->ReadBuffer;
+            i2cTransfer.buf[1].len = palI2c->ReadSize;
+
+            // Perform the transfer and return status from the transfer
+            transactionResult = I2CSPM_Transfer(palI2c->Configuration->port, &i2cTransfer);
         }
         else
         {
-            // this is NOT a long running operation
-            // perform I2C transaction
-
-            if (palI2c->ReadSize != 0 && palI2c->WriteSize != 0)
+            if (palI2c->ReadSize == 0)
             {
-                // this is a Write/Read transaction
-                i2cTransfer.flags = I2C_FLAG_WRITE_READ;
+                // this is Write only transaction
+                i2cTransfer.flags = I2C_FLAG_WRITE;
 
                 i2cTransfer.buf[0].data = palI2c->WriteBuffer;
                 i2cTransfer.buf[0].len = palI2c->WriteSize;
-                i2cTransfer.buf[1].data = palI2c->ReadBuffer;
-                i2cTransfer.buf[1].len = palI2c->ReadSize;
 
                 // Perform the transfer and return status from the transfer
                 transactionResult = I2CSPM_Transfer(palI2c->Configuration->port, &i2cTransfer);
             }
             else
             {
-                if (palI2c->ReadSize == 0)
-                {
-                    // this is Write only transaction
-                    i2cTransfer.flags = I2C_FLAG_WRITE;
+                // this is a Read only transaction
+                i2cTransfer.flags = I2C_FLAG_READ;
+                i2cTransfer.buf[0].data = palI2c->ReadBuffer;
+                i2cTransfer.buf[0].len = palI2c->ReadSize;
 
-                    i2cTransfer.buf[0].data = palI2c->WriteBuffer;
-                    i2cTransfer.buf[0].len = palI2c->WriteSize;
-
-                    // Perform the transfer and return status from the transfer
-                    transactionResult = I2CSPM_Transfer(palI2c->Configuration->port, &i2cTransfer);
-                }
-                else
-                {
-                    // this is a Read only transaction
-                    i2cTransfer.flags = I2C_FLAG_READ;
-                    i2cTransfer.buf[0].data = palI2c->ReadBuffer;
-                    i2cTransfer.buf[0].len = palI2c->ReadSize;
-
-                    // Perform the transfer and return status from the transfer
-                    transactionResult = I2CSPM_Transfer(palI2c->Configuration->port, &i2cTransfer);
-                }
+                // Perform the transfer and return status from the transfer
+                transactionResult = I2CSPM_Transfer(palI2c->Configuration->port, &i2cTransfer);
             }
         }
+    }
 
-        while (eventResult)
+    while (eventResult)
+    {
+        if (!isLongRunningOperation)
         {
-            if (!isLongRunningOperation)
-            {
-                // this is not a long running operation so nothing to do here
-                break;
-            }
-
-            if (palI2c->WorkingThread->tx_thread_state == TX_TERMINATED)
-            {
-                // I2C working thread is now complete
-                break;
-            }
-
-            // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
-            NANOCLR_CHECK_HRESULT(
-                g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_I2cMaster, eventResult));
+            // this is not a long running operation so nothing to do here
+            break;
         }
+
+        if (palI2c->WorkingThread->tx_thread_state == TX_TERMINATED)
+        {
+            // I2C working thread is now complete
+            break;
+        }
+
+        // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
+        NANOCLR_CHECK_HRESULT(
+            g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_I2cMaster, eventResult));
+    }
+
+    if (isLongRunningOperation)
+    {
+        // pop timeout heap block from stack
+        stack.PopValue();
+    }
+
+    if (eventResult || !isLongRunningOperation)
+    {
+        // event occurred
+        // OR this is NOT a long running operation
+
+        // create the return object (I2cTransferResult)
+        // only at this point we are sure that there will be a return from this thread so it's OK to use the
+        // managed stack
+        CLR_RT_HeapBlock &top = stack.PushValueAndClear();
+        NANOCLR_CHECK_HRESULT(
+            g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+        result = top.Dereference();
+        FAULT_ON_NULL(result);
 
         if (isLongRunningOperation)
         {
-            // pop timeout heap block from stack
-            stack.PopValue();
+            // get transaction result from I2C struct
+            transactionResult = palI2c->TransactionResult;
+
+            // delete thread
+            tx_thread_delete(palI2c->WorkingThread);
+
+            // free stack memory
+            platform_free(palI2c->WorkingThreadStack);
+
+            // clear pointers
+            palI2c->WorkingThread = NULL;
+            palI2c->WorkingThreadStack = NULL;
         }
 
-        if (eventResult || !isLongRunningOperation)
+        // get the result from the working thread execution
+        if (transactionResult != i2cTransferDone)
         {
-            // event occurred
-            // OR this is NOT a long running operation
-
-            // create the return object (I2cTransferResult)
-            // only at this point we are sure that there will be a return from this thread so it's OK to use the
-            // managed stack
-            CLR_RT_HeapBlock &top = stack.PushValueAndClear();
-            NANOCLR_CHECK_HRESULT(
-                g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
-            result = top.Dereference();
-            FAULT_ON_NULL(result);
-
-            if (isLongRunningOperation)
+            // figure out what was the error and set the status field
+            switch (transactionResult)
             {
-                // get transaction result from I2C struct
-                transactionResult = palI2c->TransactionResult;
+                case i2cTransferNack:
+                    result[I2cTransferResult::FIELD___status].SetInteger(
+                        (CLR_UINT32)I2cTransferStatus_SlaveAddressNotAcknowledged);
+                    break;
 
-                // delete thread
-                tx_thread_delete(palI2c->WorkingThread);
+                case i2cTransferBusErr:
+                case i2cTransferArbLost:
+                case i2cTransferUsageFault:
+                case i2cTransferSwFault:
+                    result[I2cTransferResult::FIELD___status].SetInteger(
+                        (CLR_UINT32)I2cTransferStatus_ClockStretchTimeout);
+                    break;
 
-                // free stack memory
-                platform_free(palI2c->WorkingThreadStack);
-
-                // clear pointers
-                palI2c->WorkingThread = NULL;
-                palI2c->WorkingThreadStack = NULL;
+                default:
+                    result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_UnknownError);
             }
 
-            // get the result from the working thread execution
-            if (transactionResult != i2cTransferDone)
-            {
-                // figure out what was the error and set the status field
-                switch (transactionResult)
-                {
-                    case i2cTransferNack:
-                        result[I2cTransferResult::FIELD___status].SetInteger(
-                            (CLR_UINT32)I2cTransferStatus_SlaveAddressNotAcknowledged);
-                        break;
-
-                    case i2cTransferBusErr:
-                    case i2cTransferArbLost:
-                    case i2cTransferUsageFault:
-                    case i2cTransferSwFault:
-                        result[I2cTransferResult::FIELD___status].SetInteger(
-                            (CLR_UINT32)I2cTransferStatus_ClockStretchTimeout);
-                        break;
-
-                    default:
-                        result[I2cTransferResult::FIELD___status].SetInteger(
-                            (CLR_UINT32)I2cTransferStatus_UnknownError);
-                }
-
-                // set the bytes transferred count to 0 because we don't have a way to know how many bytes were
-                // actually sent/received
-                result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(0);
-            }
-            else
-            {
-                // successful transaction
-                // set the result field
-                result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
-
-                // set the bytes transferred field
-                result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(
-                    (CLR_UINT32)(palI2c->WriteSize + palI2c->ReadSize));
-            }
+            // set the bytes transferred count to 0 because we don't have a way to know how many bytes were
+            // actually sent/received
+            result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(0);
         }
-
-        NANOCLR_CLEANUP();
-
-        if (hr != CLR_E_THREAD_WAITING)
+        else
         {
-            // un-pin the buffers
-            if (writeBuffer != NULL && writeBuffer->IsPinned())
-            {
-                writeBuffer->Unpin();
-            }
+            // successful transaction
+            // set the result field
+            result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
 
-            if (readBuffer != NULL && readBuffer->IsPinned())
-            {
-                readBuffer->Unpin();
-            }
+            // set the bytes transferred field
+            result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(
+                (CLR_UINT32)(palI2c->WriteSize + palI2c->ReadSize));
         }
-
-        NANOCLR_CLEANUP_END();
     }
+
+    NANOCLR_CLEANUP();
+
+    if (hr != CLR_E_THREAD_WAITING)
+    {
+        // un-pin the buffers
+        if (writeBuffer != NULL && writeBuffer->IsPinned())
+        {
+            writeBuffer->Unpin();
+        }
+
+        if (readBuffer != NULL && readBuffer->IsPinned())
+        {
+            readBuffer->Unpin();
+        }
+    }
+
+    NANOCLR_CLEANUP_END();
+}

--- a/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.UsbStream/sys_dev_usbstream_native_System_Device_Usb_UsbStream.cpp
+++ b/targets/AzureRTOS/SiliconLabs/_nanoCLR/System.Device.UsbStream/sys_dev_usbstream_native_System_Device_Usb_UsbStream.cpp
@@ -105,6 +105,7 @@ HRESULT Library_sys_dev_usbstream_native_System_Device_Usb_UsbStream::Read___I4_
     // dereference the data buffer from the argument
     dataBuffer = stack.Arg1().DereferenceArray();
     FAULT_ON_NULL_ARG(dataBuffer);
+    dataBuffer->Pin();
 
     offset = stack.Arg2().NumericByRef().s4;
     count = stack.Arg3().NumericByRef().s4;
@@ -199,7 +200,18 @@ HRESULT Library_sys_dev_usbstream_native_System_Device_Usb_UsbStream::Read___I4_
     // set result with count of bytes received
     stack.SetResult_I4(UsbStream_PAL.RxBytesReceived);
 
-    NANOCLR_NOCLEANUP();
+    NANOCLR_CLEANUP();
+
+    if (hr != CLR_E_THREAD_WAITING)
+    {
+        // need to clean up the buffer, if this was not rescheduled
+        if (dataBuffer != NULL && dataBuffer->IsPinned())
+        {
+            dataBuffer->Unpin();
+        }
+    }
+
+    NANOCLR_CLEANUP_END();
 }
 
 HRESULT Library_sys_dev_usbstream_native_System_Device_Usb_UsbStream::Write___VOID__SZARRAY_U1__I4__I4(
@@ -235,6 +247,7 @@ HRESULT Library_sys_dev_usbstream_native_System_Device_Usb_UsbStream::Write___VO
     // dereference the data buffer from the argument
     dataBuffer = stack.Arg1().DereferenceArray();
     FAULT_ON_NULL_ARG(dataBuffer);
+    dataBuffer->Pin();
 
     offset = stack.Arg2().NumericByRef().s4;
     count = stack.Arg3().NumericByRef().s4;
@@ -347,7 +360,18 @@ HRESULT Library_sys_dev_usbstream_native_System_Device_Usb_UsbStream::Write___VO
     // pop timeout heap block from stack
     stack.PopValue();
 
-    NANOCLR_NOCLEANUP();
+    NANOCLR_CLEANUP();
+
+    if (isLongRunning && hr != CLR_E_THREAD_WAITING)
+    {
+        // need to clean up the buffer, if this was not rescheduled
+        if (dataBuffer != NULL && dataBuffer->IsPinned())
+        {
+            dataBuffer->Unpin();
+        }
+    }
+
+    NANOCLR_CLEANUP_END();
 }
 
 HRESULT Library_sys_dev_usbstream_native_System_Device_Usb_UsbStream::get_IsConnected___BOOLEAN(

--- a/targets/ChibiOS/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -348,322 +348,334 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
     NativeTransmit___SystemDeviceI2cI2cTransferResult__SystemSpanByte__SystemSpanByte(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
+
+    uint8_t busIndex;
+    NF_PAL_I2C *palI2c = NULL;
+    bool isLongRunningOperation = false;
+    msg_t transactionResult = MSG_OK;
+
+    CLR_RT_HeapBlock hbTimeout;
+    CLR_INT64 *timeout;
+    bool eventResult = true;
+    uint32_t estimatedDurationMiliseconds;
+
+    CLR_RT_HeapBlock *result;
+    CLR_RT_HeapBlock *writeSpanByte;
+    CLR_RT_HeapBlock *readSpanByte;
+    CLR_RT_HeapBlock *connectionSettings;
+    CLR_RT_HeapBlock_Array *writeBuffer = NULL;
+    CLR_RT_HeapBlock_Array *readBuffer = NULL;
+    int readOffset = 0;
+    int writeOffset = 0;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock *pThis = stack.This();
+    FAULT_ON_NULL(pThis);
+
+    // get pointer to connection settings field
+    connectionSettings = pThis[FIELD___connectionSettings].Dereference();
+
+    // get bus index
+    busIndex = (uint8_t)connectionSettings[I2cConnectionSettings::FIELD___busId].NumericByRef().s4;
+
+    // get the driver for the I2C bus
+    switch (busIndex)
     {
-        uint8_t busIndex;
-        NF_PAL_I2C *palI2c = NULL;
-        bool isLongRunningOperation = false;
-        msg_t transactionResult = MSG_OK;
-
-        CLR_RT_HeapBlock hbTimeout;
-        CLR_INT64 *timeout;
-        bool eventResult = true;
-        uint32_t estimatedDurationMiliseconds;
-
-        CLR_RT_HeapBlock *result;
-        CLR_RT_HeapBlock *writeSpanByte;
-        CLR_RT_HeapBlock *readSpanByte;
-        CLR_RT_HeapBlock_Array *writeBuffer = NULL;
-        CLR_RT_HeapBlock_Array *readBuffer = NULL;
-        int readOffset = 0;
-        int writeOffset = 0;
-
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock *pThis = stack.This();
-        FAULT_ON_NULL(pThis);
-
-        // get pointer to connection settings field
-        CLR_RT_HeapBlock *connectionSettings = pThis[FIELD___connectionSettings].Dereference();
-
-        // get bus index
-        busIndex = (uint8_t)connectionSettings[I2cConnectionSettings::FIELD___busId].NumericByRef().s4;
-
-        // get the driver for the I2C bus
-        switch (busIndex)
-        {
 #if (STM32_I2C_USE_I2C1 == TRUE)
-            case 1:
-                palI2c = &I2C1_PAL;
-                break;
+        case 1:
+            palI2c = &I2C1_PAL;
+            break;
 #endif
 #if defined(STM32_I2C_USE_I2C2) && (STM32_I2C_USE_I2C2 == TRUE)
-            case 2:
-                palI2c = &I2C2_PAL;
-                break;
+        case 2:
+            palI2c = &I2C2_PAL;
+            break;
 #endif
 #if defined(STM32_I2C_USE_I2C3) && (STM32_I2C_USE_I2C3 == TRUE)
-            case 3:
-                palI2c = &I2C3_PAL;
-                break;
+        case 3:
+            palI2c = &I2C3_PAL;
+            break;
 #endif
 #if defined(STM32_I2C_USE_I2C4) && (STM32_I2C_USE_I2C4 == TRUE)
-            case 4:
-                palI2c = &I2C4_PAL;
-                break;
+        case 4:
+            palI2c = &I2C4_PAL;
+            break;
 #endif
-            default:
-                // the requested I2C bus is not valid
-                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-                break;
-        }
+        default:
+            // the requested I2C bus is not valid
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+            break;
+    }
 
-        // dereference the write and read SpanByte from the arguments
-        writeSpanByte = stack.Arg1().Dereference();
-        if (writeSpanByte != NULL)
+    // dereference the write and read SpanByte from the arguments
+    writeSpanByte = stack.Arg1().Dereference();
+    if (writeSpanByte != NULL)
+    {
+        // get buffer
+        writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
+        if (writeBuffer != NULL)
         {
-            // get buffer
-            writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
-            if (writeBuffer != NULL)
-            {
-                // Get the write offset, only the elements defined by the span must be written, not the whole array
-                writeOffset = writeSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+            // Get the write offset, only the elements defined by the span must be written, not the whole array
+            writeOffset = writeSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
 
-                // use the span length as write size, only the elements defined by the span must be written
-                palI2c->WriteSize = writeSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
-            }
+            // use the span length as write size, only the elements defined by the span must be written
+            palI2c->WriteSize = writeSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
+
+            // pin the buffer so DMA can find it where its supposed to be
+            writeBuffer->Pin();
         }
+    }
 
-        if (writeBuffer == NULL)
+    if (writeBuffer == NULL)
+    {
+        // nothing to write, have to zero this
+        palI2c->WriteSize = 0;
+    }
+
+    readSpanByte = stack.Arg2().Dereference();
+    if (readSpanByte != NULL)
+    {
+        // get buffer
+        readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
+        if (readBuffer != NULL)
         {
-            // nothing to write, have to zero this
-            palI2c->WriteSize = 0;
+            // Get the read offset, only the elements defined by the span must be read, not the whole array
+            readOffset = readSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+
+            // use the span length as read size, only the elements defined by the span must be read
+            palI2c->ReadSize = readSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
+
+            // pin the buffer so DMA can find it where its supposed to be
+            readBuffer->Pin();
         }
+    }
 
-        readSpanByte = stack.Arg2().Dereference();
-        if (readSpanByte != NULL)
-        {
-            // get buffer
-            readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
-            if (readBuffer != NULL)
-            {
-                // Get the read offset, only the elements defined by the span must be read, not the whole array
-                readOffset = readSpanByte[SpanByte::FIELD___start].NumericByRef().s4;
+    if (readBuffer == NULL)
+    {
+        // nothing to read, have to zero this
+        palI2c->ReadSize = 0;
+    }
 
-                // use the span length as read size, only the elements defined by the span must be read
-                palI2c->ReadSize = readSpanByte[SpanByte::FIELD___length].NumericByRef().s4;
-            }
-        }
+    // check if this is a long running operation
+    isLongRunningOperation = IsLongRunningOperation(
+        palI2c->WriteSize,
+        palI2c->ReadSize,
+        palI2c->ByteTime,
+        (uint32_t &)estimatedDurationMiliseconds);
 
-        if (readBuffer == NULL)
-        {
-            // nothing to read, have to zero this
-            palI2c->ReadSize = 0;
-        }
+    if (isLongRunningOperation)
+    {
+        // if this is a long running operation, set a timeout equal to the estimated transaction duration in
+        // milliseconds this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() below
+        hbTimeout.SetInteger((CLR_INT64)estimatedDurationMiliseconds * TIME_CONVERSION__TO_MILLISECONDS);
 
-        // check if this is a long running operation
-        isLongRunningOperation = IsLongRunningOperation(
-            palI2c->WriteSize,
-            palI2c->ReadSize,
-            palI2c->ByteTime,
-            (uint32_t &)estimatedDurationMiliseconds);
+        NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
+    }
 
-        if (isLongRunningOperation)
-        {
-            // if this is a long running operation, set a timeout equal to the estimated transaction duration in
-            // milliseconds this value has to be in ticks to be properly loaded by SetupTimeoutFromTicks() below
-            hbTimeout.SetInteger((CLR_INT64)estimatedDurationMiliseconds * TIME_CONVERSION__TO_MILLISECONDS);
+    // this is going to be used to check for the right event in case of simultaneous I2C transaction
+    if (!isLongRunningOperation || stack.m_customState == 1)
+    {
+        // get slave address from connection settings field
+        palI2c->Address = (i2caddr_t)connectionSettings[I2cConnectionSettings::FIELD___deviceAddress].NumericByRef().s4;
 
-            NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
-
-            // protect the buffers from GC so DMA can find them where they are supposed to be
-            CLR_RT_ProtectFromGC gcWriteBuffer(*writeBuffer);
-            CLR_RT_ProtectFromGC gcReadBuffer(*readBuffer);
-        }
-
-        // this is going to be used to check for the right event in case of simultaneous I2C transaction
-        if (!isLongRunningOperation || stack.m_customState == 1)
-        {
-            // get slave address from connection settings field
-            palI2c->Address =
-                (i2caddr_t)connectionSettings[I2cConnectionSettings::FIELD___deviceAddress].NumericByRef().s4;
-
-            // when using I2Cv1 driver the address needs to be loaded in the I2C driver struct
+        // when using I2Cv1 driver the address needs to be loaded in the I2C driver struct
 #if defined(STM32F1XX) || defined(STM32F4XX) || defined(STM32L1XX)
-            palI2c->Driver->addr = palI2c->Address;
+        palI2c->Driver->addr = palI2c->Address;
 #endif
 
-            if (writeBuffer != NULL)
-            {
-                // grab the pointer to the array by starting and the offset specified in the span
-                palI2c->WriteBuffer = (uint8_t *)writeBuffer->GetElement(writeOffset);
+        if (writeBuffer != NULL)
+        {
+            // grab the pointer to the array by starting and the offset specified in the span
+            palI2c->WriteBuffer = (uint8_t *)writeBuffer->GetElement(writeOffset);
 
-                // flush DMA buffer to ensure cache coherency
-                // (only required for Cortex-M7)
-                cacheBufferFlush(palI2c->WriteBuffer, palI2c->WriteSize);
-            }
-
-            if (readBuffer != NULL)
-            {
-                // grab the pointer to the array by starting and the offset specified in the span
-                palI2c->ReadBuffer = (uint8_t *)readBuffer->GetElement(readOffset);
-            }
-
-            // because the bus access is shared, acquire the appropriate bus
-            i2cAcquireBus(palI2c->Driver);
-            i2cStart(palI2c->Driver, &palI2c->Configuration);
+            // flush DMA buffer to ensure cache coherency
+            // (only required for Cortex-M7)
+            cacheBufferFlush(palI2c->WriteBuffer, palI2c->WriteSize);
         }
 
-        if (isLongRunningOperation)
+        if (readBuffer != NULL)
         {
-            // this is a long running operation and hasn't started yet
-            // perform I2C transaction using driver's ASYNC API which is launching a thread to perform it
-            if (stack.m_customState == 1)
+            // grab the pointer to the array by starting and the offset specified in the span
+            palI2c->ReadBuffer = (uint8_t *)readBuffer->GetElement(readOffset);
+        }
+
+        // because the bus access is shared, acquire the appropriate bus
+        i2cAcquireBus(palI2c->Driver);
+        i2cStart(palI2c->Driver, &palI2c->Configuration);
+    }
+
+    if (isLongRunningOperation)
+    {
+        // this is a long running operation and hasn't started yet
+        // perform I2C transaction using driver's ASYNC API which is launching a thread to perform it
+        if (stack.m_customState == 1)
+        {
+            // spawn working thread to perform the I2C transaction
+            palI2c->WorkingThread =
+                chThdCreateFromHeap(NULL, THD_WORKING_AREA_SIZE(256), "I2CWT", NORMALPRIO, I2CWorkingThread, palI2c);
+
+            if (palI2c->WorkingThread == NULL)
             {
-                // spawn working thread to perform the I2C transaction
-                palI2c->WorkingThread = chThdCreateFromHeap(
-                    NULL,
-                    THD_WORKING_AREA_SIZE(256),
-                    "I2CWT",
-                    NORMALPRIO,
-                    I2CWorkingThread,
-                    palI2c);
-
-                if (palI2c->WorkingThread == NULL)
-                {
-                    NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
-                }
-
-                // bump custom state
-                stack.m_customState = 2;
+                NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
             }
+
+            // bump custom state
+            stack.m_customState = 2;
+        }
+    }
+    else
+    {
+        // this is NOT a long running operation
+        // perform I2C transaction using driver's SYNC API
+
+        if (palI2c->ReadSize != 0 && palI2c->WriteSize != 0)
+        {
+            // this is a Write/Read transaction
+            transactionResult = i2cMasterTransmitTimeout(
+                palI2c->Driver,
+                palI2c->Address,
+                palI2c->WriteBuffer,
+                palI2c->WriteSize,
+                palI2c->ReadBuffer,
+                palI2c->ReadSize,
+                TIME_MS2I(20));
         }
         else
         {
-            // this is NOT a long running operation
-            // perform I2C transaction using driver's SYNC API
-
-            if (palI2c->ReadSize != 0 && palI2c->WriteSize != 0)
+            if (palI2c->ReadSize == 0)
             {
-                // this is a Write/Read transaction
+                // this is Write only transaction
                 transactionResult = i2cMasterTransmitTimeout(
                     palI2c->Driver,
                     palI2c->Address,
                     palI2c->WriteBuffer,
                     palI2c->WriteSize,
-                    palI2c->ReadBuffer,
-                    palI2c->ReadSize,
+                    NULL,
+                    0,
                     TIME_MS2I(20));
             }
             else
             {
-                if (palI2c->ReadSize == 0)
-                {
-                    // this is Write only transaction
-                    transactionResult = i2cMasterTransmitTimeout(
-                        palI2c->Driver,
-                        palI2c->Address,
-                        palI2c->WriteBuffer,
-                        palI2c->WriteSize,
-                        NULL,
-                        0,
-                        TIME_MS2I(20));
-                }
-                else
-                {
-                    // this is a Read only transaction
-                    transactionResult = i2cMasterReceiveTimeout(
-                        palI2c->Driver,
-                        palI2c->Address,
-                        palI2c->ReadBuffer,
-                        palI2c->ReadSize,
-                        TIME_MS2I(20));
-                }
-            }
-        }
-
-        while (eventResult)
-        {
-            if (!isLongRunningOperation)
-            {
-                // this is not a long running operation so nothing to do here
-                break;
-            }
-
-            if (palI2c->WorkingThread->state == CH_STATE_FINAL)
-            {
-                // I2C working thread is now complete
-                break;
-            }
-
-            // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
-            NANOCLR_CHECK_HRESULT(
-                g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_I2cMaster, eventResult));
-        }
-
-        if (isLongRunningOperation)
-        {
-            // pop timeout heap block from stack
-            stack.PopValue();
-        }
-
-        if (eventResult || !isLongRunningOperation)
-        {
-            // event occurred
-            // OR this is NOT a long running operation
-
-            i2cReleaseBus(palI2c->Driver);
-
-            // create the return object (I2cTransferResult)
-            // only at this point we are sure that there will be a return from this thread so it's OK to use the
-            // managed stack
-            CLR_RT_HeapBlock &top = stack.PushValueAndClear();
-            NANOCLR_CHECK_HRESULT(
-                g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
-            result = top.Dereference();
-            FAULT_ON_NULL(result);
-
-            if (isLongRunningOperation)
-            {
-                // ChibiOS requirement: need to call chThdWait for I2C working thread in order to have it's memory
-                // released to the heap, otherwise it won't be returned
-                transactionResult = chThdWait(palI2c->WorkingThread);
-            }
-
-            // get the result from the working thread execution
-            if (transactionResult != MSG_OK)
-            {
-                // error in transaction
-                int errors = i2cGetErrors(palI2c->Driver);
-
-                // figure out what was the error and set the status field
-                switch (errors)
-                {
-                    case I2C_ACK_FAILURE:
-                        result[I2cTransferResult::FIELD___status].SetInteger(
-                            (CLR_UINT32)I2cTransferStatus_SlaveAddressNotAcknowledged);
-                        break;
-
-                    case I2C_TIMEOUT:
-                        result[I2cTransferResult::FIELD___status].SetInteger(
-                            (CLR_UINT32)I2cTransferStatus_ClockStretchTimeout);
-                        break;
-
-                    default:
-                        result[I2cTransferResult::FIELD___status].SetInteger(
-                            (CLR_UINT32)I2cTransferStatus_UnknownError);
-                }
-
-                // set the bytes transferred count to 0 because we don't have a way to know how many bytes were
-                // actually sent/received
-                result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(0);
-            }
-            else
-            {
-                // successful transaction
-                // set the result field
-                result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
-
-                // set the bytes transferred field
-                result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(
-                    (CLR_UINT32)(palI2c->WriteSize + palI2c->ReadSize));
-            }
-
-            if (palI2c->ReadSize > 0)
-            {
-                // invalidate cache over read buffer to ensure that content from DMA is read
-                // (only required for Cortex-M7)
-                cacheBufferInvalidate(palI2c->ReadBuffer, palI2c->ReadSize);
+                // this is a Read only transaction
+                transactionResult = i2cMasterReceiveTimeout(
+                    palI2c->Driver,
+                    palI2c->Address,
+                    palI2c->ReadBuffer,
+                    palI2c->ReadSize,
+                    TIME_MS2I(20));
             }
         }
     }
-    NANOCLR_NOCLEANUP();
+
+    while (eventResult)
+    {
+        if (!isLongRunningOperation)
+        {
+            // this is not a long running operation so nothing to do here
+            break;
+        }
+
+        if (palI2c->WorkingThread->state == CH_STATE_FINAL)
+        {
+            // I2C working thread is now complete
+            break;
+        }
+
+        // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
+        NANOCLR_CHECK_HRESULT(
+            g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_I2cMaster, eventResult));
+    }
+
+    if (isLongRunningOperation)
+    {
+        // pop timeout heap block from stack
+        stack.PopValue();
+    }
+
+    if (eventResult || !isLongRunningOperation)
+    {
+        // event occurred
+        // OR this is NOT a long running operation
+
+        i2cReleaseBus(palI2c->Driver);
+
+        // create the return object (I2cTransferResult)
+        // only at this point we are sure that there will be a return from this thread so it's OK to use the
+        // managed stack
+        CLR_RT_HeapBlock &top = stack.PushValueAndClear();
+        NANOCLR_CHECK_HRESULT(
+            g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+        result = top.Dereference();
+        FAULT_ON_NULL(result);
+
+        if (isLongRunningOperation)
+        {
+            // ChibiOS requirement: need to call chThdWait for I2C working thread in order to have it's memory
+            // released to the heap, otherwise it won't be returned
+            transactionResult = chThdWait(palI2c->WorkingThread);
+        }
+
+        // get the result from the working thread execution
+        if (transactionResult != MSG_OK)
+        {
+            // error in transaction
+            int errors = i2cGetErrors(palI2c->Driver);
+
+            // figure out what was the error and set the status field
+            switch (errors)
+            {
+                case I2C_ACK_FAILURE:
+                    result[I2cTransferResult::FIELD___status].SetInteger(
+                        (CLR_UINT32)I2cTransferStatus_SlaveAddressNotAcknowledged);
+                    break;
+
+                case I2C_TIMEOUT:
+                    result[I2cTransferResult::FIELD___status].SetInteger(
+                        (CLR_UINT32)I2cTransferStatus_ClockStretchTimeout);
+                    break;
+
+                default:
+                    result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_UnknownError);
+            }
+
+            // set the bytes transferred count to 0 because we don't have a way to know how many bytes were
+            // actually sent/received
+            result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(0);
+        }
+        else
+        {
+            // successful transaction
+            // set the result field
+            result[I2cTransferResult::FIELD___status].SetInteger((CLR_UINT32)I2cTransferStatus_FullTransfer);
+
+            // set the bytes transferred field
+            result[I2cTransferResult::FIELD___bytesTransferred].SetInteger(
+                (CLR_UINT32)(palI2c->WriteSize + palI2c->ReadSize));
+        }
+
+        if (palI2c->ReadSize > 0)
+        {
+            // invalidate cache over read buffer to ensure that content from DMA is read
+            // (only required for Cortex-M7)
+            cacheBufferInvalidate(palI2c->ReadBuffer, palI2c->ReadSize);
+        }
+    }
+
+    NANOCLR_CLEANUP();
+
+    if (hr != CLR_E_THREAD_WAITING)
+    {
+        // un-pin the buffers
+        if (writeBuffer != NULL && writeBuffer->IsPinned())
+        {
+            writeBuffer->Unpin();
+        }
+
+        if (readBuffer != NULL && readBuffer->IsPinned())
+        {
+            readBuffer->Unpin();
+        }
+    }
+
+    NANOCLR_CLEANUP_END();
 }

--- a/targets/TI_SimpleLink/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -139,150 +139,166 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::
     NativeTransmit___SystemDeviceI2cI2cTransferResult__SystemSpanByte__SystemSpanByte(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
+
+    uint8_t busIndex;
+    NF_PAL_I2C *palI2c = NULL;
+
+    CLR_RT_HeapBlock hbTimeout;
+    CLR_INT64 *timeout;
+    bool eventResult = true;
+    uint32_t estimatedDurationMiliseconds;
+
+    CLR_RT_HeapBlock *result;
+    CLR_RT_HeapBlock *writeSpanByte;
+    CLR_RT_HeapBlock *readSpanByte;
+    CLR_RT_HeapBlock *connectionSettings;
+    CLR_RT_HeapBlock_Array *writeBuffer = NULL;
+    CLR_RT_HeapBlock_Array *readBuffer = NULL;
+
+    // get a pointer to the managed object instance and check that it's not NULL
+    CLR_RT_HeapBlock *pThis = stack.This();
+    FAULT_ON_NULL(pThis);
+
+    // get pointer to connection settings field
+    connectionSettings = pThis[FIELD___connectionSettings].Dereference();
+
+    // get bus index
+    busIndex = (uint8_t)connectionSettings[I2cConnectionSettings::FIELD___busId].NumericByRef().s4;
+
+    // get the driver for the I2C bus
+    switch (busIndex)
     {
-        uint8_t busIndex;
-        NF_PAL_I2C *palI2c = NULL;
+        case 1:
+            palI2c = &I2C1_PAL;
+            break;
 
-        CLR_RT_HeapBlock hbTimeout;
-        CLR_INT64 *timeout;
-        bool eventResult = true;
-        uint32_t estimatedDurationMiliseconds;
+        default:
+            // the requested I2C bus is not valid
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+            break;
+    }
 
-        CLR_RT_HeapBlock *writeSpanByte;
-        CLR_RT_HeapBlock *readSpanByte;
-        CLR_RT_HeapBlock_Array *writeBuffer = NULL;
-        CLR_RT_HeapBlock_Array *readBuffer = NULL;
-        CLR_RT_HeapBlock *result;
-
-        // get a pointer to the managed object instance and check that it's not NULL
-        CLR_RT_HeapBlock *pThis = stack.This();
-        FAULT_ON_NULL(pThis);
-
-        // get pointer to connection settings field
-        CLR_RT_HeapBlock *connectionSettings = pThis[FIELD___connectionSettings].Dereference();
-
-        // get bus index
-        busIndex = (uint8_t)connectionSettings[I2cConnectionSettings::FIELD___busId].NumericByRef().s4;
-
-        // get the driver for the I2C bus
-        switch (busIndex)
-        {
-            case 1:
-                palI2c = &I2C1_PAL;
-                break;
-
-            default:
-                // the requested I2C bus is not valid
-                NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
-                break;
-        }
-
-        // dereference the write and read SpanByte from the arguments
-        writeSpanByte = stack.Arg1().Dereference();
-        if (writeSpanByte != NULL)
-        {
-            // get buffer
-            writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
-            if (writeBuffer != NULL)
-            {
-                // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
-                palI2c->i2cTransaction.writeCount = writeBuffer->m_numOfElements;
-            }
-        }
-
-        if (writeBuffer == NULL)
-        {
-            // nothing to write, have to zero this
-            palI2c->i2cTransaction.writeCount = 0;
-        }
-
-        readSpanByte = stack.Arg2().Dereference();
-        if (readSpanByte != NULL)
-        {
-            // get buffer
-            readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
-            if (readBuffer != NULL)
-            {
-                // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
-                palI2c->i2cTransaction.readCount = readBuffer->m_numOfElements;
-            }
-        }
-
-        if (readBuffer == NULL)
-        {
-            // nothing to read, have to zero this
-            palI2c->i2cTransaction.readCount = 0;
-        }
-
-        // set a timeout to an infinite timeout
-        // the catch is that the working thread MUST ALWAYS return at some point
-        // !! need to cast to CLR_INT64 otherwise it wont setup a proper timeout infinite
-        hbTimeout.SetInteger((CLR_INT64)-1);
-
-        NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
-
-        // protect the buffers from GC so DMA can find them where they are supposed to be
-        CLR_RT_ProtectFromGC gcWriteBuffer(*writeBuffer);
-        CLR_RT_ProtectFromGC gcReadBuffer(*readBuffer);
-
+    // dereference the write and read SpanByte from the arguments
+    writeSpanByte = stack.Arg1().Dereference();
+    if (writeSpanByte != NULL)
+    {
+        // get buffer
+        writeBuffer = writeSpanByte[SpanByte::FIELD___array].DereferenceArray();
         if (writeBuffer != NULL)
         {
-            palI2c->i2cTransaction.writeBuf = (uint8_t *)writeBuffer->GetFirstElement();
+            // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
+            palI2c->i2cTransaction.writeCount = writeBuffer->m_numOfElements;
         }
+    }
 
+    if (writeBuffer == NULL)
+    {
+        // nothing to write, have to zero this
+        palI2c->i2cTransaction.writeCount = 0;
+    }
+
+    readSpanByte = stack.Arg2().Dereference();
+    if (readSpanByte != NULL)
+    {
+        // get buffer
+        readBuffer = readSpanByte[SpanByte::FIELD___array].DereferenceArray();
         if (readBuffer != NULL)
         {
-            palI2c->i2cTransaction.readBuf = (uint8_t *)readBuffer->GetFirstElement();
+            // get the size of the buffer by reading the number of elements in the CLR_RT_HeapBlock_Array
+            palI2c->i2cTransaction.readCount = readBuffer->m_numOfElements;
         }
-
-        // perform I2C transaction using driver's callback which will set the appropriate event on completion
-        if (stack.m_customState == 1)
-        {
-            I2C_transfer(palI2c->i2c, &palI2c->i2cTransaction);
-
-            // bump custom state
-            stack.m_customState = 2;
-        }
-
-        while (eventResult)
-        {
-            // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
-            NANOCLR_CHECK_HRESULT(
-                g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_I2cMaster, eventResult));
-
-            if (eventResult)
-            {
-                // event occurred
-
-                // create the return object (I2cTransferResult)
-                // only at this point we are sure that there will be a return from this thread so it's OK to use the
-                // managed stack
-                CLR_RT_HeapBlock &top = stack.PushValueAndClear();
-                NANOCLR_CHECK_HRESULT(
-                    g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
-                result = top.Dereference();
-                FAULT_ON_NULL(result);
-
-                // successful transaction
-                // set the result field
-                result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status].SetInteger(
-                    (CLR_UINT32)I2cTransferStatus_FullTransfer);
-
-                // set the bytes transferred field
-                result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___bytesTransferred]
-                    .SetInteger((CLR_UINT32)(palI2c->i2cTransaction.writeCount + palI2c->i2cTransaction.readCount));
-
-                // done here
-                break;
-            }
-            else
-            {
-                NANOCLR_SET_AND_LEAVE(CLR_E_TIMEOUT);
-            }
-        }
-
-        // pop timeout heap block from stack
-        stack.PopValue();
     }
-    NANOCLR_NOCLEANUP();
+
+    if (readBuffer == NULL)
+    {
+        // nothing to read, have to zero this
+        palI2c->i2cTransaction.readCount = 0;
+    }
+
+    // set a timeout to an infinite timeout
+    // the catch is that the working thread MUST ALWAYS return at some point
+    // !! need to cast to CLR_INT64 otherwise it wont setup a proper timeout infinite
+    hbTimeout.SetInteger((CLR_INT64)-1);
+
+    NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
+
+    // pin the buffers so DMA can find them where they are supposed to be
+    if (writeBuffer != NULL)
+    {
+        writeBuffer->Pin();
+        palI2c->i2cTransaction.writeBuf = (uint8_t *)writeBuffer->GetFirstElement();
+    }
+
+    if (readBuffer != NULL)
+    {
+        readBuffer->Pin();
+        palI2c->i2cTransaction.readBuf = (uint8_t *)readBuffer->GetFirstElement();
+    }
+
+    // perform I2C transaction using driver's callback which will set the appropriate event on completion
+    if (stack.m_customState == 1)
+    {
+        I2C_transfer(palI2c->i2c, &palI2c->i2cTransaction);
+
+        // bump custom state
+        stack.m_customState = 2;
+    }
+
+    while (eventResult)
+    {
+        // non-blocking wait allowing other threads to run while we wait for the I2C transaction to complete
+        NANOCLR_CHECK_HRESULT(
+            g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_I2cMaster, eventResult));
+
+        if (eventResult)
+        {
+            // event occurred
+
+            // create the return object (I2cTransferResult)
+            // only at this point we are sure that there will be a return from this thread so it's OK to use the
+            // managed stack
+            CLR_RT_HeapBlock &top = stack.PushValueAndClear();
+            NANOCLR_CHECK_HRESULT(
+                g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_I2cTransferResult));
+            result = top.Dereference();
+            FAULT_ON_NULL(result);
+
+            // successful transaction
+            // set the result field
+            result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___status].SetInteger(
+                (CLR_UINT32)I2cTransferStatus_FullTransfer);
+
+            // set the bytes transferred field
+            result[Library_win_dev_i2c_native_Windows_Devices_I2c_I2cTransferResult::FIELD___bytesTransferred]
+                .SetInteger((CLR_UINT32)(palI2c->i2cTransaction.writeCount + palI2c->i2cTransaction.readCount));
+
+            // done here
+            break;
+        }
+        else
+        {
+            NANOCLR_SET_AND_LEAVE(CLR_E_TIMEOUT);
+        }
+    }
+
+    // pop timeout heap block from stack
+    stack.PopValue();
+
+    NANOCLR_CLEANUP();
+
+    if (hr != CLR_E_THREAD_WAITING)
+    {
+        // un-pin the buffers
+        if (writeBuffer != NULL && writeBuffer->IsPinned())
+        {
+            writeBuffer->Unpin();
+        }
+
+        if (readBuffer != NULL && readBuffer->IsPinned())
+        {
+            readBuffer->Unpin();
+        }
+    }
+
+    NANOCLR_CLEANUP_END();
 }


### PR DESCRIPTION
## Description
- Replaced CLR_RT_ProtectFromGC with pinning buffer HB.
- Pinned buffer HB where missing it.

## Motivation and Context
- Driver and API calls that access data buffers rely on the content remaining stationary. Certain operations pass pointers to heap blocks (usually arrays), which can be moved by the garbage collector (GC) during asynchronous calls. In most cases, this was managed by using `CLR_RT_ProtectFromGC`, which prevents the GC from incorrectly collecting the object. However, it does not prevent the object from being moved during heap relocation. Pinning the heap block (HB) is the correct approach. In a few places, this was not properly accounted for.
- Addresses nanoFramework/Home#1354.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Long rung testing of stress app calling such APIs.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved buffer management and error handling for SPI, I2C, and USB stream operations across multiple device targets.
  - Enhanced resource management with better buffer pinning and cleanup processes.
  - Refined transaction handling for more robust communication protocols.

- **Refactor**
  - Restructured code for improved readability and maintainability.
  - Clarified logic in device communication methods.
  - Added more comprehensive error checking and status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->