### PR TITLE
Stack trace is now generated despite debugger state

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Exception.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Exception.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -193,8 +193,7 @@ HRESULT Library_corlib_native_System_Exception::SetStackTrace(CLR_RT_HeapBlock &
 
 #if defined(NANOCLR_TRACE_EXCEPTIONS)
 
-        if (CLR_EE_DBG_IS(NoStackTraceInExceptions) || CLR_EE_DBG_IS_NOT(Enabled) || CLR_EE_IS(Compaction_Pending) ||
-            g_CLR_RT_ExecutionEngine.m_fPerformGarbageCollection)
+        if (CLR_EE_DBG_IS(NoStackTraceInExceptions))
         {
             // stack trace is DISABLED or...
             // no debugger is attached or...
@@ -204,8 +203,11 @@ HRESULT Library_corlib_native_System_Exception::SetStackTrace(CLR_RT_HeapBlock &
             (void)dst;
             (void)array;
 
-            // null the array that would hold the stack trace
-            obj[FIELD___stackTrace].SetObjectReference(NULL);
+            // create an empty array for the stack trace
+            NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance(
+                obj[FIELD___stackTrace],
+                depth,
+                g_CLR_RT_WellKnownTypes.m_UInt8));
         }
         else
         {
@@ -243,10 +245,7 @@ HRESULT Library_corlib_native_System_Exception::SetStackTrace(CLR_RT_HeapBlock &
             if (!g_CLR_RT_ExecutionEngine.m_fShuttingDown)
 #endif
             {
-                if (CLR_EE_DBG_IS_NOT(NoStackTraceInExceptions) && CLR_EE_DBG_IS(Enabled))
-                {
-                    CLR_RT_DUMP::EXCEPTION(*stack, ref);
-                }
+                CLR_RT_DUMP::EXCEPTION(*stack, ref);
             }
         }
 


### PR DESCRIPTION
## Description
- Remove conditions other than no stacktrace in exceptions.
- Replace null stack trace array with empty stack trace array.

## Motivation and Context
- Partially reverts #2783.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved exception handling and stack trace management
	- Simplified error logging mechanism
	- Streamlined stack trace creation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->