### PR TITLE
Fixing WirelessAP config retrieve and deployment in Wire Protocol

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -1130,6 +1130,7 @@ bool CLR_DBG_Debugger::Monitor_QueryConfiguration(WP_Message *message)
 
     HAL_Configuration_NetworkInterface *configNetworkInterface;
     HAL_Configuration_Wireless80211 *configWireless80211NetworkInterface;
+    HAL_Configuration_WirelessAP *configWirelessAPNetworkInterface;
     HAL_Configuration_X509CaRootBundle *x509Certificate;
     HAL_Configuration_X509DeviceCertificate *x509DeviceCertificate;
 
@@ -1270,7 +1271,31 @@ bool CLR_DBG_Debugger::Monitor_QueryConfiguration(WP_Message *message)
             break;
 
         case DeviceConfigurationOption_WirelessNetworkAP:
-            // TODO missing implementation for now
+
+            configWirelessAPNetworkInterface =
+                (HAL_Configuration_WirelessAP *)platform_malloc(sizeof(HAL_Configuration_WirelessAP));
+
+            // check allocation
+            if (configWirelessAPNetworkInterface != NULL)
+            {
+                memset(configWirelessAPNetworkInterface, 0, sizeof(HAL_Configuration_WirelessAP));
+
+                if (ConfigurationManager_GetConfigurationBlock(
+                        configWirelessAPNetworkInterface,
+                        (DeviceConfigurationOption)cmd->Configuration,
+                        cmd->BlockIndex) == true)
+                {
+                    size = sizeof(HAL_Configuration_WirelessAP);
+
+                    WP_ReplyToCommand(message, true, false, (uint8_t *)configWirelessAPNetworkInterface, size);
+                }
+
+                platform_free(configWirelessAPNetworkInterface);
+
+                // done here
+                return true;
+            }
+
             break;
 
         default:
@@ -1301,6 +1326,7 @@ bool CLR_DBG_Debugger::Monitor_UpdateConfiguration(WP_Message *message)
     {
         case DeviceConfigurationOption_Network:
         case DeviceConfigurationOption_Wireless80211Network:
+        case DeviceConfigurationOption_WirelessNetworkAP:
         case DeviceConfigurationOption_X509CaRootBundle:
         case DeviceConfigurationOption_X509DeviceCertificates:
         case DeviceConfigurationOption_All:


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Fixing AP config retrieve and deployment in Wire Protocol

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixing AP config retrieve and deployment in Wire Protocol
- Addresses nanoframework/Home#1593.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a real ESP32S3 device

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring wireless access point settings in the debugger
  - Introduced new configuration management for wireless network interfaces

- **Improvements**
  - Enhanced debugger functionality to handle wireless network configuration queries and updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->