### PR TITLE
Fix assert in GC::Heap_Compact

### DIFF
--- a/src/CLR/Core/GarbageCollector_Compaction.cpp
+++ b/src/CLR/Core/GarbageCollector_Compaction.cpp
@@ -260,8 +260,8 @@ void CLR_RT_GarbageCollector::Heap_Compact()
 
                     _ASSERTE(relocCurrent->m_destination >= (CLR_UINT8 *)freeRegion_hc->m_payloadStart);
                     _ASSERTE(relocCurrent->m_destination < (CLR_UINT8 *)freeRegion_hc->m_payloadEnd);
-                    _ASSERTE(relocCurrent->m_start >= (CLR_UINT8 *)freeRegion_hc->m_payloadStart);
-                    _ASSERTE(relocCurrent->m_start < (CLR_UINT8 *)freeRegion_hc->m_payloadEnd);
+                    _ASSERTE(relocCurrent->m_start >= (CLR_UINT8 *)currentSource_hc->m_payloadStart);
+                    _ASSERTE(relocCurrent->m_start < (CLR_UINT8 *)currentSource_hc->m_payloadEnd);
                     _ASSERTE(moveBytes == (move * sizeof(CLR_RT_HeapBlock)));
 
 #endif


### PR DESCRIPTION
## Description
- Now using the correct HeapCluster to compare.

## Motivation and Context
- Was using wrong struct for comparison.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced memory safety validation during heap compaction process
	- Refined memory boundary checks in garbage collection mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->