### PR TITLE
Fix DateTime and TimeSpan type creation

### DIFF
--- a/src/CLR/CorLib/corlib_native.h
+++ b/src/CLR/CorLib/corlib_native.h
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -467,7 +467,7 @@ struct Library_corlib_native_System_TimeSpan
 
     //--//
 
-    static CLR_INT64 *NewObject(CLR_RT_HeapBlock &ref);
+    static CLR_INT64 *NewObject(CLR_RT_StackFrame &stack);
     static CLR_INT64 *GetValuePtr(CLR_RT_StackFrame &stack);
     static CLR_INT64 *GetValuePtr(CLR_RT_HeapBlock &ref);
 
@@ -496,7 +496,7 @@ struct Library_corlib_native_System_DateTime
 
     //--//
 
-    static CLR_INT64 *NewObject(CLR_RT_HeapBlock &ref);
+    static CLR_INT64 *NewObject(CLR_RT_StackFrame &stack);
     static CLR_INT64 *GetValuePtr(CLR_RT_StackFrame &stack);
     static CLR_INT64 *GetValuePtr(CLR_RT_HeapBlock &ref);
 

--- a/src/CLR/CorLib/corlib_native_System_Convert.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Convert.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation. All rights reserved.
 // Portions Copyright (C) 2002-2019 Free Software Foundation, Inc. All rights reserved.
@@ -533,12 +533,10 @@ HRESULT Library_corlib_native_System_Convert::NativeToDateTime___STATIC__SystemD
     // grab parameter with flag to throw on failure
     bool throwOnFailure = (bool)stack.Arg1().NumericByRefConst().u1;
 
-    CLR_RT_HeapBlock &ref = stack.PushValue();
-
     // check string parameter for null
     FAULT_ON_NULL_ARG(str);
 
-    pRes = Library_corlib_native_System_DateTime::NewObject(ref);
+    pRes = Library_corlib_native_System_DateTime::NewObject(stack);
     FAULT_ON_NULL(pRes);
 
     // try 'u' Universal time with sortable format (yyyy-MM-dd' 'HH:mm:ss)

--- a/src/CLR/CorLib/corlib_native_System_DateTime.cpp
+++ b/src/CLR/CorLib/corlib_native_System_DateTime.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -154,9 +154,7 @@ HRESULT Library_corlib_native_System_DateTime::get_UtcNow___STATIC__SystemDateTi
 
     CLR_INT64 *val;
 
-    CLR_RT_HeapBlock &ref = stack.PushValue();
-
-    val = Library_corlib_native_System_DateTime::NewObject(ref);
+    val = Library_corlib_native_System_DateTime::NewObject(stack);
     FAULT_ON_NULL(val);
 
     // load with full date&time
@@ -171,9 +169,7 @@ HRESULT Library_corlib_native_System_DateTime::get_Today___STATIC__SystemDateTim
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_RT_HeapBlock &ref = stack.PushValue();
-
-    CLR_INT64 *val = NewObject(ref);
+    CLR_INT64 *val = NewObject(stack);
 
     // load with date part only
     // including UTC flag
@@ -184,17 +180,14 @@ HRESULT Library_corlib_native_System_DateTime::get_Today___STATIC__SystemDateTim
 
 //--//
 
-CLR_INT64 *Library_corlib_native_System_DateTime::NewObject(CLR_RT_HeapBlock &ref)
+CLR_INT64 *Library_corlib_native_System_DateTime::NewObject(CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
 
-    CLR_RT_TypeDescriptor dtType;
+    CLR_RT_HeapBlock &ref = stack.PushValue();
 
-    // initialize <DateTime> type descriptor
-    dtType.InitializeFromType(g_CLR_RT_WellKnownTypes.m_DateTime);
-
-    // create an instance of <DateTime>
-    g_CLR_RT_ExecutionEngine.NewObject(ref, dtType.m_handlerCls);
+    ref.SetDataId(CLR_RT_HEAPBLOCK_RAW_ID(DATATYPE_DATETIME, 0, 1));
+    ref.ClearData();
 
     return GetValuePtr(ref);
 }

--- a/src/CLR/CorLib/corlib_native_System_TimeSpan.cpp
+++ b/src/CLR/CorLib/corlib_native_System_TimeSpan.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -178,17 +178,14 @@ HRESULT Library_corlib_native_System_TimeSpan::Equals___STATIC__BOOLEAN__SystemT
 
 //--//
 
-CLR_INT64 *Library_corlib_native_System_TimeSpan::NewObject(CLR_RT_HeapBlock &ref)
+CLR_INT64 *Library_corlib_native_System_TimeSpan::NewObject(CLR_RT_StackFrame &stack)
 {
     NATIVE_PROFILE_CLR_CORE();
 
-    CLR_RT_TypeDescriptor dtType;
+    CLR_RT_HeapBlock &ref = stack.PushValue();
 
-    // initialize <DateTime> type descriptor
-    dtType.InitializeFromType(g_CLR_RT_WellKnownTypes.m_TimeSpan);
-
-    // create an instance of <TimeSpan>
-    g_CLR_RT_ExecutionEngine.NewObject(ref, dtType.m_handlerCls);
+    ref.SetDataId(CLR_RT_HEAPBLOCK_RAW_ID(DATATYPE_TIMESPAN, 0, 1));
+    ref.ClearData();
 
     return GetValuePtr(ref);
 }

--- a/src/CLR/Core/TypeSystemLookup.cpp
+++ b/src/CLR/Core/TypeSystemLookup.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -82,8 +82,8 @@ const CLR_RT_DataTypeLookup c_CLR_RT_DataTypeLookup[] =
     { DT_NUM | DT_INT | DT_SGN | DT_PRIM             | DT_DIR | DT_OPT | DT_MT,    64, DT_I8, DT_T(I8                  ), DT_CNV(I8       ), DT_CLS(m_Int64            ), DT_NOREL(CLR_RT_HeapBlock                                 ) DT_OPT_NAME(I8                  ) }, // DATATYPE_I8
     { DT_NUM | DT_INT          | DT_PRIM             | DT_DIR | DT_OPT | DT_MT,    64, DT_U8, DT_T(I8                  ), DT_CNV(U8       ), DT_CLS(m_UInt64           ), DT_NOREL(CLR_RT_HeapBlock                                 ) DT_OPT_NAME(U8                  ) }, // DATATYPE_U8
     { DT_NUM |          DT_SGN | DT_PRIM             | DT_DIR | DT_OPT | DT_MT,    64, DT_I8, DT_T(R8                  ), DT_CNV(R8       ), DT_CLS(m_Double           ), DT_NOREL(CLR_RT_HeapBlock                                 ) DT_OPT_NAME(R8                  ) }, // DATATYPE_R8
-    {          DT_INT | DT_SGN | DT_VALUE            | DT_DIR          | DT_MT,    64, DT_BL, DT_T(DATETIME            ), DT_CNV(END      ), DT_CLS(m_DateTime         ), DT_REL  (CLR_RT_HeapBlock              ::Relocate_Cls     ) DT_OPT_NAME(DATETIME            ) }, // DATATYPE_DATETIME
-    {          DT_INT | DT_SGN | DT_VALUE            | DT_DIR          | DT_MT,    64, DT_BL, DT_T(TIMESPAN            ), DT_CNV(END      ), DT_CLS(m_TimeSpan         ), DT_REL  (CLR_RT_HeapBlock              ::Relocate_Cls     ) DT_OPT_NAME(TIMESPAN            ) }, // DATATYPE_TIMESPAN
+    {          DT_INT | DT_SGN | DT_VALUE            | DT_DIR | DT_OPT | DT_MT,    64, DT_BL, DT_T(DATETIME            ), DT_CNV(END      ), DT_CLS(m_DateTime         ), DT_NOREL(CLR_RT_HeapBlock                                 ) DT_OPT_NAME(DATETIME            ) }, // DATATYPE_DATETIME
+    {          DT_INT | DT_SGN | DT_VALUE            | DT_DIR | DT_OPT | DT_MT,    64, DT_BL, DT_T(TIMESPAN            ), DT_CNV(END      ), DT_CLS(m_TimeSpan         ), DT_NOREL(CLR_RT_HeapBlock                                 ) DT_OPT_NAME(TIMESPAN            ) }, // DATATYPE_TIMESPAN
     { DT_REF                   | DT_PRIM             | DT_DIR          | DT_MT, DT_VS, DT_BL, DT_T(STRING              ), DT_CNV(STRING   ), DT_CLS(m_String           ), DT_REL  (CLR_RT_HeapBlock              ::Relocate_String  ) DT_OPT_NAME(STRING              ) }, // DATATYPE_STRING
                                                                                                                                                                                                                                                                    //
     { DT_REF                                         | DT_DIR          | DT_MT, DT_NA, DT_BL, DT_T(OBJECT              ), DT_CNV(OBJECT   ), DT_CLS(m_Object           ), DT_REL  (CLR_RT_HeapBlock              ::Relocate_Obj     ) DT_OPT_NAME(OBJECT              ) }, // DATATYPE_OBJECT


### PR DESCRIPTION
## Description
- Rework data type lookup table to proper flags and no relocation handler.
- Update declaration of NewObject in both classes. Now take a stack pointer instead of a Heap Block.
- Fix Convert.NativeToDateTime().

## Motivation and Context
- `DateTime` and `TimeSpan` are value types and allocated from the stack. The current implementation was wrongly ignoring this and allocating them from the heap which was causing issues with GC.
- Partially reverts #2794 and adds #2784.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated method signatures for `DateTime` and `TimeSpan` object creation to use stack frame references
	- Modified data type handling for `DateTime` and `TimeSpan` with optimization flags
	- Simplified object instantiation process across multiple system components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->