### PR TITLE
Rework `DateTime` and `TimeSpan`

### DIFF
--- a/src/CLR/CorLib/corlib_native.cpp
+++ b/src/CLR/CorLib/corlib_native.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // See LICENSE file in the project root for full license information.
 //
@@ -435,8 +435,6 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     Library_corlib_native_System_DateTime::DaysInMonth___STATIC__I4__I4__I4,
     NULL,
-    Library_corlib_native_System_DateTime::get_UtcNow___STATIC__SystemDateTime,
-    Library_corlib_native_System_DateTime::get_Today___STATIC__SystemDateTime,
     NULL,
     NULL,
     NULL,
@@ -449,10 +447,14 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
+    NULL,
+    Library_corlib_native_System_DateTime::GetUtcNowAsTicks___STATIC__I8,
+    Library_corlib_native_System_DateTime::GetTodayAsTicks___STATIC__I8,
     NULL,
     Library_corlib_native_System_Convert::NativeToInt64___STATIC__I8__STRING__BOOLEAN__I8__I8__I4__BOOLEAN__BYREF_BOOLEAN,
     Library_corlib_native_System_Convert::NativeToDouble___STATIC__R8__STRING__BOOLEAN__BYREF_BOOLEAN,
-    Library_corlib_native_System_Convert::NativeToDateTime___STATIC__SystemDateTime__STRING__BOOLEAN__BYREF_BOOLEAN,
+    Library_corlib_native_System_Convert::NativeToDateTime___STATIC__VOID__STRING__BOOLEAN__BYREF_BOOLEAN__BYREF_SystemDateTime,
     NULL,
     NULL,
     NULL,
@@ -671,6 +673,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     Library_corlib_native_System_Reflection_RuntimeMethodInfo::GetCustomAttributesNative___SZARRAY_OBJECT__BOOLEAN,
+    NULL,
     NULL,
     NULL,
     NULL,
@@ -1356,6 +1359,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
     Library_corlib_native_System_Runtime_CompilerServices_RuntimeHelpers::InitializeArray___STATIC__VOID__SystemArray__SystemRuntimeFieldHandle,
     Library_corlib_native_System_Runtime_CompilerServices_RuntimeHelpers::GetObjectValue___STATIC__OBJECT__OBJECT,
     Library_corlib_native_System_Runtime_CompilerServices_RuntimeHelpers::RunClassConstructor___STATIC__VOID__SystemRuntimeTypeHandle,
@@ -1483,11 +1487,11 @@ const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_mscorlib =
 
 #if (NANOCLR_REFLECTION == TRUE)
 
-    0x445C7AF9,
+    0xC5D5F755,
 
 #elif (NANOCLR_REFLECTION == FALSE)
 
-    0xE3A4B52F,
+    0x29A4F740,
 
 #else
 #error "NANOCLR_REFLECTION has to be define either TRUE or FALSE. Check the build options."

--- a/src/CLR/CorLib/corlib_native.h
+++ b/src/CLR/CorLib/corlib_native.h
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -467,7 +467,6 @@ struct Library_corlib_native_System_TimeSpan
 
     //--//
 
-    static CLR_INT64 *NewObject(CLR_RT_HeapBlock &ref);
     static CLR_INT64 *GetValuePtr(CLR_RT_StackFrame &stack);
     static CLR_INT64 *GetValuePtr(CLR_RT_HeapBlock &ref);
 
@@ -491,12 +490,11 @@ struct Library_corlib_native_System_DateTime
     NANOCLR_NATIVE_DECLARE(_ctor___VOID__I4__I4__I4__I4__I4__I4__I4);
     NANOCLR_NATIVE_DECLARE(GetDateTimePart___I4__SystemDateTimeDateTimePart);
     NANOCLR_NATIVE_DECLARE(DaysInMonth___STATIC__I4__I4__I4);
-    NANOCLR_NATIVE_DECLARE(get_UtcNow___STATIC__SystemDateTime);
-    NANOCLR_NATIVE_DECLARE(get_Today___STATIC__SystemDateTime);
+    NANOCLR_NATIVE_DECLARE(GetUtcNowAsTicks___STATIC__I8);
+    NANOCLR_NATIVE_DECLARE(GetTodayAsTicks___STATIC__I8);
 
     //--//
 
-    static CLR_INT64 *NewObject(CLR_RT_HeapBlock &ref);
     static CLR_INT64 *GetValuePtr(CLR_RT_StackFrame &stack);
     static CLR_INT64 *GetValuePtr(CLR_RT_HeapBlock &ref);
 
@@ -508,7 +506,7 @@ struct Library_corlib_native_System_Convert
 {
     NANOCLR_NATIVE_DECLARE(NativeToInt64___STATIC__I8__STRING__BOOLEAN__I8__I8__I4__BOOLEAN__BYREF_BOOLEAN);
     NANOCLR_NATIVE_DECLARE(NativeToDouble___STATIC__R8__STRING__BOOLEAN__BYREF_BOOLEAN);
-    NANOCLR_NATIVE_DECLARE(NativeToDateTime___STATIC__SystemDateTime__STRING__BOOLEAN__BYREF_BOOLEAN);
+    NANOCLR_NATIVE_DECLARE(NativeToDateTime___STATIC__VOID__STRING__BOOLEAN__BYREF_BOOLEAN__BYREF_SystemDateTime);
     NANOCLR_NATIVE_DECLARE(ToBase64String___STATIC__STRING__SZARRAY_U1__I4__I4__BOOLEAN);
     NANOCLR_NATIVE_DECLARE(FromBase64String___STATIC__SZARRAY_U1__STRING);
 

--- a/src/CLR/CorLib/corlib_native_System_Convert.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Convert.cpp
@@ -518,12 +518,12 @@ HRESULT Library_corlib_native_System_Convert::NativeToDouble___STATIC__R8__STRIN
     NANOCLR_CLEANUP_END();
 }
 
-HRESULT Library_corlib_native_System_Convert::NativeToDateTime___STATIC__SystemDateTime__STRING__BOOLEAN__BYREF_BOOLEAN(
-    CLR_RT_StackFrame &stack)
+HRESULT Library_corlib_native_System_Convert::
+    NativeToDateTime___STATIC__VOID__STRING__BOOLEAN__BYREF_BOOLEAN__BYREF_SystemDateTime(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
 
-    CLR_INT64 *pRes;
+    CLR_INT64 *pTicks;
 
     char *str = (char *)stack.Arg0().RecoverString();
     char *conversionResult = NULL;
@@ -533,13 +533,8 @@ HRESULT Library_corlib_native_System_Convert::NativeToDateTime___STATIC__SystemD
     // grab parameter with flag to throw on failure
     bool throwOnFailure = (bool)stack.Arg1().NumericByRefConst().u1;
 
-    CLR_RT_HeapBlock &ref = stack.PushValue();
-
     // check string parameter for null
     FAULT_ON_NULL_ARG(str);
-
-    pRes = Library_corlib_native_System_DateTime::NewObject(ref);
-    FAULT_ON_NULL(pRes);
 
     // try 'u' Universal time with sortable format (yyyy-MM-dd' 'HH:mm:ss)
     conversionResult = Nano_strptime(str, "%Y-%m-%d %H:%M:%SZ", &ticks);
@@ -569,7 +564,9 @@ HRESULT Library_corlib_native_System_Convert::NativeToDateTime___STATIC__SystemD
     }
     else
     {
-        *pRes = ticks;
+        // get pointer to DateTime value type in parameter 3
+        pTicks = DateTime::GetValuePtr(stack.Arg3());
+        *pTicks = ticks;
     }
 
     NANOCLR_CLEANUP();

--- a/src/CLR/CorLib/corlib_native_System_DateTime.cpp
+++ b/src/CLR/CorLib/corlib_native_System_DateTime.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -6,6 +6,11 @@
 
 #include "CorLib.h"
 #include <nanoCLR_Interop.h>
+
+/////////////////////////////////////////////////////////////////////////
+// !!! KEEP IN SYNC WITH DateTime._ticksAtOrigin (in managed code) !!! //
+/////////////////////////////////////////////////////////////////////////
+#define TICKS_AT_ORIGIN 504911232000000000
 
 ///////////////////////////////////////////////////////////////////////
 // !!! KEEP IN SYNC WITH DateTime.DateTimePart (in managed code) !!! //
@@ -147,56 +152,26 @@ HRESULT Library_corlib_native_System_DateTime::DaysInMonth___STATIC__I4__I4__I4(
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT Library_corlib_native_System_DateTime::get_UtcNow___STATIC__SystemDateTime(CLR_RT_StackFrame &stack)
+HRESULT Library_corlib_native_System_DateTime::GetUtcNowAsTicks___STATIC__I8(CLR_RT_StackFrame &stack)
 {
-    NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
 
-    CLR_INT64 *val;
-
-    CLR_RT_HeapBlock &ref = stack.PushValue();
-
-    val = Library_corlib_native_System_DateTime::NewObject(ref);
-    FAULT_ON_NULL(val);
-
-    // load with full date&time
-    // including UTC flag
-    *val = (CLR_INT64)(HAL_Time_CurrentDateTime(false) | s_UTCMask);
-
-    NANOCLR_NOCLEANUP();
-}
-
-HRESULT Library_corlib_native_System_DateTime::get_Today___STATIC__SystemDateTime(CLR_RT_StackFrame &stack)
-{
-    NATIVE_PROFILE_CLR_CORE();
-    NANOCLR_HEADER();
-
-    CLR_RT_HeapBlock &ref = stack.PushValue();
-
-    CLR_INT64 *val = NewObject(ref);
-
-    // load with date part only
-    // including UTC flag
-    *val = (CLR_INT64)(HAL_Time_CurrentDateTime(true) | s_UTCMask);
+    CLR_INT64 value = HAL_Time_CurrentDateTime(false);
+    value += TICKS_AT_ORIGIN;
+    stack.SetResult_I8(value);
 
     NANOCLR_NOCLEANUP_NOLABEL();
 }
 
-//--//
-
-CLR_INT64 *Library_corlib_native_System_DateTime::NewObject(CLR_RT_HeapBlock &ref)
+HRESULT Library_corlib_native_System_DateTime::GetTodayAsTicks___STATIC__I8(CLR_RT_StackFrame &stack)
 {
-    NATIVE_PROFILE_CLR_CORE();
+    NANOCLR_HEADER();
 
-    CLR_RT_TypeDescriptor dtType;
+    CLR_INT64 value = HAL_Time_CurrentDateTime(true);
+    value += TICKS_AT_ORIGIN;
+    stack.SetResult_I8(value);
 
-    // initialize <DateTime> type descriptor
-    dtType.InitializeFromType(g_CLR_RT_WellKnownTypes.m_DateTime);
-
-    // create an instance of <DateTime>
-    g_CLR_RT_ExecutionEngine.NewObject(ref, dtType.m_handlerCls);
-
-    return GetValuePtr(ref);
+    NANOCLR_NOCLEANUP_NOLABEL();
 }
 
 //--//

--- a/src/CLR/CorLib/corlib_native_System_TimeSpan.cpp
+++ b/src/CLR/CorLib/corlib_native_System_TimeSpan.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -177,21 +177,6 @@ HRESULT Library_corlib_native_System_TimeSpan::Equals___STATIC__BOOLEAN__SystemT
 }
 
 //--//
-
-CLR_INT64 *Library_corlib_native_System_TimeSpan::NewObject(CLR_RT_HeapBlock &ref)
-{
-    NATIVE_PROFILE_CLR_CORE();
-
-    CLR_RT_TypeDescriptor dtType;
-
-    // initialize <DateTime> type descriptor
-    dtType.InitializeFromType(g_CLR_RT_WellKnownTypes.m_TimeSpan);
-
-    // create an instance of <TimeSpan>
-    g_CLR_RT_ExecutionEngine.NewObject(ref, dtType.m_handlerCls);
-
-    return GetValuePtr(ref);
-}
 
 CLR_INT64 *Library_corlib_native_System_TimeSpan::GetValuePtr(CLR_RT_StackFrame &stack)
 {

--- a/src/CLR/Core/TypeSystemLookup.cpp
+++ b/src/CLR/Core/TypeSystemLookup.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -82,8 +82,8 @@ const CLR_RT_DataTypeLookup c_CLR_RT_DataTypeLookup[] =
     { DT_NUM | DT_INT | DT_SGN | DT_PRIM             | DT_DIR | DT_OPT | DT_MT,    64, DT_I8, DT_T(I8                  ), DT_CNV(I8       ), DT_CLS(m_Int64            ), DT_NOREL(CLR_RT_HeapBlock                                 ) DT_OPT_NAME(I8                  ) }, // DATATYPE_I8
     { DT_NUM | DT_INT          | DT_PRIM             | DT_DIR | DT_OPT | DT_MT,    64, DT_U8, DT_T(I8                  ), DT_CNV(U8       ), DT_CLS(m_UInt64           ), DT_NOREL(CLR_RT_HeapBlock                                 ) DT_OPT_NAME(U8                  ) }, // DATATYPE_U8
     { DT_NUM |          DT_SGN | DT_PRIM             | DT_DIR | DT_OPT | DT_MT,    64, DT_I8, DT_T(R8                  ), DT_CNV(R8       ), DT_CLS(m_Double           ), DT_NOREL(CLR_RT_HeapBlock                                 ) DT_OPT_NAME(R8                  ) }, // DATATYPE_R8
-    {          DT_INT | DT_SGN | DT_VALUE            | DT_DIR          | DT_MT,    64, DT_BL, DT_T(DATETIME            ), DT_CNV(END      ), DT_CLS(m_DateTime         ), DT_REL  (CLR_RT_HeapBlock              ::Relocate_Cls     ) DT_OPT_NAME(DATETIME            ) }, // DATATYPE_DATETIME
-    {          DT_INT | DT_SGN | DT_VALUE            | DT_DIR          | DT_MT,    64, DT_BL, DT_T(TIMESPAN            ), DT_CNV(END      ), DT_CLS(m_TimeSpan         ), DT_REL  (CLR_RT_HeapBlock              ::Relocate_Cls     ) DT_OPT_NAME(TIMESPAN            ) }, // DATATYPE_TIMESPAN
+    {          DT_INT | DT_SGN | DT_VALUE            | DT_DIR | DT_OPT | DT_MT,    64, DT_BL, DT_T(DATETIME            ), DT_CNV(END      ), DT_CLS(m_DateTime         ), DT_REL  (CLR_RT_HeapBlock              ::Relocate_Cls     ) DT_OPT_NAME(DATETIME            ) }, // DATATYPE_DATETIME
+    {          DT_INT | DT_SGN | DT_VALUE            | DT_DIR | DT_OPT | DT_MT,    64, DT_BL, DT_T(TIMESPAN            ), DT_CNV(END      ), DT_CLS(m_TimeSpan         ), DT_REL  (CLR_RT_HeapBlock              ::Relocate_Cls     ) DT_OPT_NAME(TIMESPAN            ) }, // DATATYPE_TIMESPAN
     { DT_REF                   | DT_PRIM             | DT_DIR          | DT_MT, DT_VS, DT_BL, DT_T(STRING              ), DT_CNV(STRING   ), DT_CLS(m_String           ), DT_REL  (CLR_RT_HeapBlock              ::Relocate_String  ) DT_OPT_NAME(STRING              ) }, // DATATYPE_STRING
                                                                                                                                                                                                                                                                    //
     { DT_REF                                         | DT_DIR          | DT_MT, DT_NA, DT_BL, DT_T(OBJECT              ), DT_CNV(OBJECT   ), DT_CLS(m_Object           ), DT_REL  (CLR_RT_HeapBlock              ::Relocate_Obj     ) DT_OPT_NAME(OBJECT              ) }, // DATATYPE_OBJECT


### PR DESCRIPTION
## Description
- These types are now back to being optimized types and handled as value types.
- Remove NewObject from both classes as the creation of these value types in the stack is not trivial.
- Add implementation for new native helpers in DateTime.
- Update declaration of native handler for DateTime convert. And code accordingly.
- Update declarations of mscorlib.

## Motivation and Context
- `DateTime` and `TimeSpan``are value types and allocation for them should be done in the stack. Plus, they used to be "optimized" types in nanoFramework type system. With the current API it's not trivial to create "new" objects of these types, therefore it's better to rely on the execution engine to properly allocate memory for them. This PR partially reverts #2794 and adds #2784.
- Because of the above and not being viable to create a new `DateTime` object, it was necessary to rework the `DateTime` convert native handler.
- Following: nanoframework/CoreLibrary#221 and nanoframework/CoreLibrary#222.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running mscorlib unit tests locally with virtual device and real devices.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [x] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated DateTime and TimeSpan handling to use ticks-based methods.
  - Modified GetUtcNow and GetToday to return tick values directly.

- **Bug Fixes**
  - Improved date and time conversion methods.
  - Optimized internal representation of DateTime and TimeSpan types.

- **Refactor**
  - Restructured native DateTime and TimeSpan method implementations.
  - Updated method signatures for better performance and clarity.
  - Removed unnecessary object creation methods for DateTime and TimeSpan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->