### PR TITLE
Improvements in profiler

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapCluster.cpp
+++ b/src/CLR/Core/CLR_RT_HeapCluster.cpp
@@ -243,7 +243,13 @@ void CLR_RT_HeapCluster::RecoverFromGC()
             } while (next < end && next->IsAlive() == false);
 
 #if defined(NANOCLR_PROFILE_NEW_ALLOCATIONS)
-            g_CLR_PRF_Profiler.TrackObjectDeletion(ptr);
+
+            // don't report free blocks, as they are not being deleted, rather grouped
+            if (ptr->DataType() != DATATYPE_FREEBLOCK)
+            {
+                g_CLR_PRF_Profiler.TrackObjectDeletion(ptr);
+            }
+
 #endif
             ptr->SetDataId(CLR_RT_HEAPBLOCK_RAW_ID(DATATYPE_FREEBLOCK, CLR_RT_HeapBlock::HB_Pinned, lenTot));
 

--- a/src/CLR/Core/Cache.cpp
+++ b/src/CLR/Core/Cache.cpp
@@ -447,10 +447,6 @@ void CLR_RT_EventCache::Append_Node(CLR_RT_HeapBlock *node)
     ptr->Debug_ClearBlock(SENTINEL_NODE_APPENDED);
 
     lst.m_blocks.LinkAtBack(ptr);
-
-#if defined(NANOCLR_PROFILE_NEW_ALLOCATIONS)
-    g_CLR_PRF_Profiler.TrackObjectCreation(node);
-#endif
 }
 
 CLR_RT_HeapBlock *CLR_RT_EventCache::Extract_Node_Slow(CLR_UINT32 dataType, CLR_UINT32 flags, CLR_UINT32 blocks)

--- a/src/CLR/Core/GarbageCollector.cpp
+++ b/src/CLR/Core/GarbageCollector.cpp
@@ -137,6 +137,10 @@ void CLR_RT_AssertEarlyCollection::CheckAll(CLR_RT_HeapBlock *ptr)
 CLR_UINT32 CLR_RT_GarbageCollector::ExecuteGarbageCollection()
 {
     NATIVE_PROFILE_CLR_CORE();
+
+    // bump the number of garbage collections
+    m_numberOfGarbageCollections++;
+
 #if defined(NANOCLR_PROFILE_NEW_ALLOCATIONS)
     g_CLR_PRF_Profiler.RecordGarbageCollectionBegin();
 #endif
@@ -147,9 +151,6 @@ CLR_UINT32 CLR_RT_GarbageCollector::ExecuteGarbageCollection()
     int ellapsedTimeMilliSec = 0;
 
 #endif
-
-    // bump the number of garbage collections
-    m_numberOfGarbageCollections++;
 
 #if defined(NANOCLR_GC_VERBOSE)
     if (s_CLR_RT_fTrace_GC >= c_CLR_RT_Trace_Info)

--- a/src/CLR/Core/GarbageCollector_Compaction.cpp
+++ b/src/CLR/Core/GarbageCollector_Compaction.cpp
@@ -10,12 +10,13 @@
 CLR_UINT32 CLR_RT_GarbageCollector::ExecuteCompaction()
 {
     NATIVE_PROFILE_CLR_CORE();
-#if defined(NANOCLR_PROFILE_NEW_ALLOCATIONS)
-    g_CLR_PRF_Profiler.RecordHeapCompactionBegin();
-#endif
 
     // bump the number of heap compactions
     m_numberOfCompactions++;
+
+#if defined(NANOCLR_PROFILE_NEW_ALLOCATIONS)
+    g_CLR_PRF_Profiler.RecordHeapCompactionBegin();
+#endif
 
 #if defined(NANOCLR_TRACE_MEMORY_STATS)
 

--- a/targets/netcore/nanoFramework.nanoCLR.Host/NanoClrHostBuilder.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.Host/NanoClrHostBuilder.cs
@@ -163,7 +163,7 @@ namespace nanoFramework.nanoCLR.Host
 
         private nanoCLRHostBuilder SetProfilerMessageCallback(Action<string> profilerMessage)
         {
-            _preInitConfigureSteps.Add(() => Interop.nanoCLR.nanoCLR_SetProfilerMessageCallback((msg) => profilerMessage(msg)));
+            _configureSteps.Add(() => Interop.nanoCLR.nanoCLR_SetProfilerMessageCallback((msg) => profilerMessage(msg)));
 
             return this;
         }

--- a/targets/netcore/nanoFramework.nanoCLR.Host/Profiler/ProfilerPackets.cs
+++ b/targets/netcore/nanoFramework.nanoCLR.Host/Profiler/ProfilerPackets.cs
@@ -69,7 +69,9 @@ namespace nanoFramework.Tools.NanoProfiler
                 case Packets.Commands.c_Profiling_HeapCompact_End:
                     return new Packets.HeapCompactionEndPacket(stream);
                 default:
-                    throw new ApplicationException("Unable to decode packet.");
+                    // throw new ApplicationException("Unable to decode packet.");
+                    // TODO: don't care about this for now
+                    return null;
             }
         }
     }


### PR DESCRIPTION
## Description
- Adjust order of calls to record heap compaction.
- Adjust placement of GC collection run counter.
- Deleting a free blocks is not tracked anymore.
- Creating objects in event cache is not tracked anymore.
- Fix data types being excluded from several profiler handlers.
- Fix several calls to pack and write for 64 platforms.
- Fix computation of last time stamp in profiler init.
- Fix counter being output in heap compaction end handler.
- Setting profiler message callback is now added to the config steps.
- Packet processor doesn't throw exception anymore with unknown packet type.

## Motivation and Context
- Fixes wrong config of nanoCLR host.
- Fixes and improves several bugs in profiler in what concerns object creation, deletion and message correctness.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Reorganized internal processes for memory management and diagnostic event tracking.
	- Adjusted configuration flow to optimize callback initialization timing.
- **Bug Fixes**
	- Corrected messaging to reflect accurate memory compaction metrics.
	- Enhanced error handling for unknown diagnostic packets.
- **Style**
	- Standardized numeric literal formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->