### PR TITLE
OOM exception is back to EE and is not disposed anymore

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Exception.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Exception.cpp
@@ -124,9 +124,9 @@ HRESULT Library_corlib_native_System_Exception::CreateInstance(
     if (FAILED(hr = g_CLR_RT_ExecutionEngine.NewObjectFromIndex(ref, cls)))
     {
 #if defined(NANOCLR_APPDOMAINS)
-        ref.SetObjectReference(&g_CLR_RT_ExecutionEngine.GetCurrentAppDomain()->m_outOfMemoryException);
+        ref.SetObjectReference(g_CLR_RT_ExecutionEngine.GetCurrentAppDomain()->m_outOfMemoryException);
 #else
-        ref.SetObjectReference(&g_CLR_RT_ExecutionEngine.m_outOfMemoryException);
+        ref.SetObjectReference(g_CLR_RT_ExecutionEngine.m_outOfMemoryException);
 #endif
 
         hrIn = CLR_E_OUT_OF_MEMORY;

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -91,8 +91,9 @@ HRESULT CLR_RT_ExecutionEngine::ExecutionEngine_Initialize()
                                                     // CLR_RT_Thread*                      m_cctorThread;
                                                     //
 #if !defined(NANOCLR_APPDOMAINS)
-    m_globalLock = NULL; // CLR_RT_HeapBlock*                  m_globalLock;
-#endif                   //
+    m_globalLock = NULL;           // CLR_RT_HeapBlock*                  m_globalLock;
+    m_outOfMemoryException = NULL; // CLR_RT_HeapBlock*                   m_outOfMemoryException;
+#endif
 
     m_currentUICulture = NULL; // CLR_RT_HeapBlock*                   m_currentUICulture;
 
@@ -449,6 +450,7 @@ void CLR_RT_ExecutionEngine::Relocate()
 
 #if !defined(NANOCLR_APPDOMAINS)
     CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_globalLock);
+    CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_outOfMemoryException);
 #endif
 
     CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_currentUICulture);

--- a/src/CLR/Core/GarbageCollector.cpp
+++ b/src/CLR/Core/GarbageCollector.cpp
@@ -409,6 +409,7 @@ void CLR_RT_GarbageCollector::Mark()
 
 #if !defined(NANOCLR_APPDOMAINS)
         CheckSingleBlock_Force(g_CLR_RT_ExecutionEngine.m_globalLock);
+        CheckSingleBlock_Force(g_CLR_RT_ExecutionEngine.m_outOfMemoryException);
 #endif
 
         CheckSingleBlock_Force(g_CLR_RT_ExecutionEngine.m_currentUICulture);
@@ -686,6 +687,7 @@ void CLR_RT_GarbageCollector::AppDomain_Mark()
 
         CheckSingleBlock_Force(appDomain->m_globalLock);
         CheckSingleBlock_Force(appDomain->m_strName);
+        CheckSingleBlock_Force(appDomain->m_outOfMemoryException);
     }
     NANOCLR_FOREACH_NODE_END();
 }

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -2246,6 +2246,7 @@ void CLR_RT_AppDomain::AppDomain_Initialize()
     m_id = g_CLR_RT_ExecutionEngine.m_appDomainIdNext++;
     m_globalLock = NULL;
     m_strName = NULL;
+    m_outOfMemoryException = NULL;
     m_appDomainAssemblyLastAccess = NULL;
 }
 
@@ -2300,12 +2301,17 @@ HRESULT CLR_RT_AppDomain::LoadAssembly(CLR_RT_Assembly *assm)
 
     // Preemptively allocate an out of memory exception.
     // We can never get into a case where an out of memory exception cannot be thrown.
+    if (m_outOfMemoryException == NULL)
+    {
+        _ASSERTE(!strcmp(assm->m_szName, "mscorlib")); // always the first assembly to be loaded
 
-    _ASSERTE(!strcmp(assm->m_szName, "mscorlib")); // always the first assembly to be loaded
+        CLR_RT_HeapBlock exception;
 
-    NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(
-        m_outOfMemoryException,
-        g_CLR_RT_WellKnownTypes.m_OutOfMemoryException));
+        NANOCLR_CHECK_HRESULT(
+            g_CLR_RT_ExecutionEngine.NewObjectFromIndex(exception, g_CLR_RT_WellKnownTypes.m_OutOfMemoryException));
+
+        m_outOfMemoryException = exception.Dereference();
+    }
 
     NANOCLR_CLEANUP();
 
@@ -2399,6 +2405,7 @@ void CLR_RT_AppDomain::Relocate()
     NATIVE_PROFILE_CLR_CORE();
     CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_globalLock);
     CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_strName);
+    CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_outOfMemoryException);
 }
 
 HRESULT CLR_RT_AppDomain::VerifyTypeIsLoaded(const CLR_RT_TypeDef_Index &idx)
@@ -4112,9 +4119,16 @@ HRESULT CLR_RT_TypeSystem::PrepareForExecution()
 
     // Preemptively create an out of memory exception.
     // We can never get into a case where an out of memory exception cannot be thrown.
-    NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(
-        g_CLR_RT_ExecutionEngine.m_outOfMemoryException,
-        g_CLR_RT_WellKnownTypes.m_OutOfMemoryException));
+
+    if (g_CLR_RT_ExecutionEngine.m_outOfMemoryException == NULL)
+    {
+        CLR_RT_HeapBlock exception;
+
+        NANOCLR_CHECK_HRESULT(
+            g_CLR_RT_ExecutionEngine.NewObjectFromIndex(exception, g_CLR_RT_WellKnownTypes.m_OutOfMemoryException));
+
+        g_CLR_RT_ExecutionEngine.m_outOfMemoryException = exception.Dereference();
+    }
 #endif
 
     // Load Runtime.Events to setup EventSink for other assemblies using it

--- a/src/CLR/Diagnostics/Profiler.cpp
+++ b/src/CLR/Diagnostics/Profiler.cpp
@@ -473,6 +473,7 @@ void CLR_PRF_Profiler::DumpObject(CLR_RT_HeapBlock *ptr)
                 DumpListOfReferences(appDomain->m_appDomainAssemblies);
                 DumpSingleReference(appDomain->m_globalLock);
                 DumpSingleReference(appDomain->m_strName);
+                DumpSingleReference(appDomain->m_outOfMemoryException);
                 break;
             }
 

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -1437,7 +1437,7 @@ struct CLR_RT_AppDomain : public CLR_RT_ObjectToEvent_Destination // EVENT HEAP 
     CLR_RT_DblLinkedList m_appDomainAssemblies;
     CLR_RT_HeapBlock *m_globalLock;                          // OBJECT HEAP - DO RELOCATION -
     CLR_RT_HeapBlock_String *m_strName;                      // OBJECT HEAP - DO RELOCATION -
-    CLR_RT_HeapBlock m_outOfMemoryException;                 // NO RELOCATION -
+    CLR_RT_HeapBlock *m_outOfMemoryException;                // OBJECT HEAP - DO RELOCATION -
     CLR_RT_AppDomainAssembly *m_appDomainAssemblyLastAccess; // EVENT HEAP  - NO RELOCATION -
     bool m_fCanBeUnloaded;
 
@@ -3657,8 +3657,8 @@ struct CLR_RT_ExecutionEngine
     CLR_RT_Thread *m_cctorThread;             // EVENT HEAP - NO RELOCATION -
 
 #if !defined(NANOCLR_APPDOMAINS)
-    CLR_RT_HeapBlock *m_globalLock;          // OBJECT HEAP - DO RELOCATION -
-    CLR_RT_HeapBlock m_outOfMemoryException; // NO RELOCATION -
+    CLR_RT_HeapBlock *m_globalLock;           // OBJECT HEAP - DO RELOCATION -
+    CLR_RT_HeapBlock *m_outOfMemoryException; // OBJECT HEAP - DO RELOCATION -
 #endif
 
     CLR_RT_HeapBlock *m_currentUICulture; // OBJECT HEAP - DO RELOCATION -


### PR DESCRIPTION
## Description
- This is pre-emptively created when preparing execution so it's always possible to throw this exception.
- Add handlers for heap relocation.
- Add forced mark for OOM in GC mark stage.
- Add entry for AppDomain OOM in profiler.

## Motivation and Context
- OOM has to be allocated from object heap and has to be relocatable.
- Attempt to fix bad behaviour of OOM was done in #2970, which wasn't a definitive fix. The missing bit was the call forced check on GC mark stage.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Long running app stressing the GC and checking with the profiler that the OOM is not disposed and gets relocated.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
