### PR TITLE
I2C dispose fix

### DIFF
--- a/targets/ESP32/_include/targetPAL_I2c.h
+++ b/targets/ESP32/_include/targetPAL_I2c.h
@@ -10,7 +10,7 @@
 #include <esp32_idf.h>
 #include <nanoHAL_v2.h>
 
-extern uint8_t Esp_I2C_Initialised_Flag[I2C_NUM_MAX];
+extern int16_t Esp_I2C_Initialised_Flag[I2C_NUM_MAX];
 
 void Esp32_I2c_UnitializeAll();
 

--- a/targets/ESP32/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
+++ b/targets/ESP32/_nanoCLR/System.Device.I2c/sys_dev_i2c_native_System_Device_I2c_I2cDevice.cpp
@@ -61,6 +61,7 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::NativeInit___VOI
         CLR_RT_HeapBlock *pThis = stack.This();
         FAULT_ON_NULL(pThis);
 
+
         // get a pointer to the managed spi connectionSettings object instance
         pConfig = pThis[FIELD___connectionSettings].Dereference();
 
@@ -92,9 +93,9 @@ HRESULT Library_sys_dev_i2c_native_System_Device_I2c_I2cDevice::NativeInit___VOI
 
             // Ensure driver gets uninitialized during soft reboot
             HAL_AddSoftRebootHandler(Esp32_I2c_UnitializeAll);
-
-            Esp_I2C_Initialised_Flag[bus]++;
         }
+
+        Esp_I2C_Initialised_Flag[bus]++;
     }
     NANOCLR_NOCLEANUP();
 }

--- a/targets/ESP32/_nanoCLR/targetPAL_I2c.cpp
+++ b/targets/ESP32/_nanoCLR/targetPAL_I2c.cpp
@@ -7,7 +7,7 @@
 #include <esp32_idf.h>
 #include <nanoHAL_v2.h>
 
-uint8_t Esp_I2C_Initialised_Flag[I2C_NUM_MAX] = {
+int16_t Esp_I2C_Initialised_Flag[I2C_NUM_MAX] = {
     0
 #if I2C_NUM_MAX > 1
     ,


### PR DESCRIPTION
## Description
When creating and disposing a number of I2CDevice objects the driver was disposed wrongly due to error in code counting open devices.

This fixes the counter logic.

The scan example should be changed to dispose I2CDevice objects otherwise memory is filled with unused objects until GC runs.
Other code should do the same when I2CDevcie is no longer in use.

## Motivation and Context
- Fixes nanoFramework/Home#1601

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested with I2C scan program

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced I2C bus management by updating internal tracking to support a broader range of values.
  - Adjusted the initialization logic to reliably update device activation counts for greater consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->