### PR TITLE
Fix nanoCLR version output

### DIFF
--- a/targets/netcore/nanoFramework.nanoCLR/nanoCLR_native.cpp
+++ b/targets/netcore/nanoFramework.nanoCLR/nanoCLR_native.cpp
@@ -182,7 +182,7 @@ const char *nanoCLR_GetVersion()
 
         const std::string_view str{buffer, result.out};
 
-        std::memcpy(pszVersion, buffer, result.size);
+        std::memcpy(pszVersion, buffer, result.size + 1);
     }
 
     return pszVersion;


### PR DESCRIPTION
## Description
- memcpy is now considering the string terminator.

## Motivation and Context
- Reported version on the virtual device was missing the terminator, thus causing issues when processing the version returned as a "unterminated" string.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Locally with nanoCLR.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
