### PR TITLE
Fix GUID generation

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Guid.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Guid.cpp
@@ -3,32 +3,33 @@
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
 //
+
 #include "CorLib.h"
 
-//
-//  Generate a new GUID
-//
-//  Based on the version 4 GUID (random)
-//  http://guid.one/guid/make
-
-
-HRESULT Library_corlib_native_System_Guid::GenerateNewGuid___STATIC__SZARRAY_U1( CLR_RT_StackFrame& stack )
+HRESULT Library_corlib_native_System_Guid::GenerateNewGuid___STATIC__SZARRAY_U1(CLR_RT_StackFrame &stack)
 {
     NANOCLR_HEADER();
 
-    CLR_RT_Random       rand;
-    CLR_UINT8*          buf;
-    CLR_RT_HeapBlock&   top = stack.PushValueAndClear();
- 
+    CLR_RT_Random rand;
+    CLR_UINT8 *buf;
+    CLR_RT_HeapBlock &top = stack.PushValueAndClear();
+
     // Create a array of 16 bytes on top of stack to return
-    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance( top, 16, g_CLR_RT_WellKnownTypes.m_UInt8 ));
+    NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance(top, 16, g_CLR_RT_WellKnownTypes.UInt8));
     buf = top.DereferenceArray()->GetFirstElement();
 
     rand.Initialize();
-    rand.NextBytes(buf, 16);           // fill with random numbers
 
-    buf[7] =  (buf[7] & 0x0f) | 0x40;  // Set verion
-    buf[9] =  (buf[7] & 0x3f) | 0x80;  // Set variant
-    
+    // Generate 16 random bytes for the GUID
+    rand.NextBytes(buf, 16);
+
+    // Set the version (version 4, bits 12-15 of time_hi_and_version)
+    // In a standard layout, the version nibble is in byte index 6 (0-based).
+    buf[6] = (buf[6] & 0x0F) | 0x40;
+
+    // Set the variant (the two most significant bits of clock_seq_hi_and_reserved must be 10)
+    // In a standard layout, the variant byte is at index 8.
+    buf[8] = (buf[8] & 0x3F) | 0x80;
+
     NANOCLR_NOCLEANUP();
 }


### PR DESCRIPTION
## Description
- Replace with implementation following RFC 4122.

## Motivation and Context
- Following code analysis from coderabbitai.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
