### PR TITLE
Normalize implementation of calls to AccessMemory

### DIFF
--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -998,12 +998,12 @@ bool CLR_DBG_Debugger::Monitor_WriteMemory(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands_Monitor_WriteMemory *cmd = (CLR_DBG_Commands_Monitor_WriteMemory *)msg->m_payload;
-    CLR_DBG_Commands_Monitor_WriteMemory_Reply cmdReply;
+    auto *cmd = (CLR_DBG_Commands_Monitor_WriteMemory *)msg->m_payload;
+    CLR_DBG_Commands_Monitor_WriteMemory_Reply errorCode = AccessMemoryErrorCode_NoError;
 
-    g_CLR_DBG_Debugger->AccessMemory(cmd->address, cmd->length, cmd->data, AccessMemory_Write, &cmdReply);
+    g_CLR_DBG_Debugger->AccessMemory(cmd->address, cmd->length, cmd->data, AccessMemory_Write, &errorCode);
 
-    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
+    WP_ReplyToCommand(msg, errorCode == AccessMemoryErrorCode_NoError, false, &errorCode, sizeof(errorCode));
 
     return true;
 }
@@ -1012,14 +1012,13 @@ bool CLR_DBG_Debugger::Monitor_CheckMemory(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands_Monitor_CheckMemory *cmd = (CLR_DBG_Commands_Monitor_CheckMemory *)msg->m_payload;
-    CLR_DBG_Commands_Monitor_CheckMemory_Reply cmdReply;
-    uint32_t errorCode;
+    auto *cmd = (CLR_DBG_Commands_Monitor_CheckMemory *)msg->m_payload;
+    CLR_DBG_Commands_Monitor_CheckMemory_Reply errorCode = AccessMemoryErrorCode_NoError;
 
     g_CLR_DBG_Debugger
-        ->AccessMemory(cmd->address, cmd->length, (unsigned char *)&cmdReply, AccessMemory_Check, &errorCode);
+        ->AccessMemory(cmd->address, cmd->length, (unsigned char *)&errorCode, AccessMemory_Check, &errorCode);
 
-    WP_ReplyToCommand(msg, errorCode == AccessMemoryErrorCode_NoError, false, &cmdReply, sizeof(cmdReply));
+    WP_ReplyToCommand(msg, errorCode == AccessMemoryErrorCode_NoError, false, &errorCode, sizeof(errorCode));
 
     return true;
 }
@@ -1028,12 +1027,12 @@ bool CLR_DBG_Debugger::Monitor_EraseMemory(WP_Message *msg)
 {
     NATIVE_PROFILE_CLR_DEBUGGER();
 
-    CLR_DBG_Commands_Monitor_EraseMemory *cmd = (CLR_DBG_Commands_Monitor_EraseMemory *)msg->m_payload;
-    CLR_DBG_Commands_Monitor_EraseMemory_Reply cmdReply;
+    auto *cmd = (CLR_DBG_Commands_Monitor_EraseMemory *)msg->m_payload;
+    CLR_DBG_Commands_Monitor_EraseMemory_Reply errorCode = AccessMemoryErrorCode_NoError;
 
-    g_CLR_DBG_Debugger->AccessMemory(cmd->address, cmd->length, NULL, AccessMemory_Erase, &cmdReply);
+    g_CLR_DBG_Debugger->AccessMemory(cmd->address, cmd->length, nullptr, AccessMemory_Erase, &errorCode);
 
-    WP_ReplyToCommand(msg, true, false, &cmdReply, sizeof(cmdReply));
+    WP_ReplyToCommand(msg, errorCode == AccessMemoryErrorCode_NoError, false, &errorCode, sizeof(errorCode));
 
     return true;
 }


### PR DESCRIPTION
## Description
- Now using a common pattern and properly checking error code and setting success parameter in call to WP_ReplyToCommand.

## Motivation and Context
- Following heads up from coderabbitai analysis.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
