### PR TITLE
Various fixes for generics

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -351,6 +351,7 @@ HRESULT CLR_RT_HeapBlock::SetGenericInstanceObject(const CLR_RT_TypeSpec_Index &
 
     m_data.genericInstance.genericType = genericType;
     m_data.genericInstance.ptr = nullptr;
+    m_id.raw = CLR_RT_HEAPBLOCK_RAW_ID(DATATYPE_GENERICINST, 0, 1);
 
     NANOCLR_NOCLEANUP();
 }

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -3227,6 +3227,7 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
 
                             evalPos[0].SetReflection(method);
                         }
+                        break;
 
                         default:
                             NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -712,7 +712,7 @@ struct CLR_RT_MethodSpec_Index
 
     CLR_INDEX Method() const
     {
-        return (data & 0x7FFF);
+        return (CLR_INDEX)data;
     }
 };
 

--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -1187,6 +1187,7 @@ struct CLR_RT_HeapBlock
     {
         m_id.raw = CLR_RT_HEAPBLOCK_RAW_ID(DATATYPE_GENERICINST, 0, 1);
         m_data.genericInstance.genericType.data = genericType.data;
+        m_data.genericInstance.ptr = nullptr; 
     }
 
     const CLR_RT_TypeSpec_Index &ObjectGenericType() const

--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -1187,7 +1187,7 @@ struct CLR_RT_HeapBlock
     {
         m_id.raw = CLR_RT_HEAPBLOCK_RAW_ID(DATATYPE_GENERICINST, 0, 1);
         m_data.genericInstance.genericType.data = genericType.data;
-        m_data.genericInstance.ptr = nullptr; 
+        m_data.genericInstance.ptr = nullptr;
     }
 
     const CLR_RT_TypeSpec_Index &ObjectGenericType() const


### PR DESCRIPTION
## Description
- Fix handling of generic types and instances in several locations.
- Fix access to MethodSpec_Index.
- Add missing handling of MethodSpec in ldtoken instruction.
- Fix field iteration in NewGenericInstanceObject.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Tested against nanoframework/CoreLibrary#245.
- Tested with MDP test projects.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
