### PR TITLE
Fix execution of static constructors

### DIFF
--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -4787,7 +4787,20 @@ bool CLR_RT_Assembly::FindNextStaticConstructor(CLR_RT_MethodDef_Index &index)
 
         index.Set(assemblyIndex, i);
 
-        if (md->flags & CLR_RECORD_METHODDEF::MD_StaticConstructor)
+        // turn the index into a MethodDef_Instance
+        CLR_RT_MethodDef_Instance methodDefInst;
+        methodDefInst.InitializeFromIndex(index);
+
+        CLR_RT_TypeDef_Instance typeDefInst;
+        typeDefInst.InitializeFromMethod(methodDefInst);
+
+        // check if this is a static constructor
+        // but skip it if:
+        // - references generic parameters
+        // - it lives on a generic type definition
+        if ((md->flags & CLR_RECORD_METHODDEF::MD_StaticConstructor) &&
+            ((md->flags & CLR_RECORD_METHODDEF::MD_ContainsGenericParameter) == 0) &&
+            typeDefInst.target->genericParamCount == 0)
         {
             return true;
         }


### PR DESCRIPTION
## Description
- These are now skipped if they contain generic parameters or they live in a generic type definition.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running MDP tests.
- Running mscorlib working branch for Span<>
- Tested against nanoframework/CoreLibrary#245
[build with MDP buildId 55899]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
