### PR TITLE
Add UART versions of main S3 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ We also have a [Community Targets](https://github.com/nanoframework/nf-Community
 |:---|---|---|
 | ESP32_S3 | Display & Quad spiram support | [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_S3/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_S3/latest/) |
 | ESP32_S3_BLE | Display, BLE, Quad spiram support | [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_S3_BLE/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_S3_BLE/latest/) |
+| ESP32_S3_BLE_UART | Display, BLE, Quad spiram support, connection via UART| [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_S3_BLE_UART/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_S3_BLE_UART/latest/) |
 | ESP32_S3_ALL |  Display, BLE, Octal spiram support | [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_S3_ALL/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_S3_ALL/latest/) |
+| ESP32_S3_ALL_UART |  Display, BLE, Octal spiram support, connection via UART | [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_S3_ALL_UART/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_S3_ALL_UART/latest/) |
 
 ### ESP32 risc-v boards
 | Target |  Note | Version |

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -49,6 +49,8 @@
 | ESP32_S3 | [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_S3/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_S3/latest/) |
 | ESP32_S3_BLE | [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_S3_BLE/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_S3_BLE/latest/) |
 | ESP32_S3_ALL | [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_S3_ALL/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_S3_ALL/latest/) |
+| ESP32_S3_BLE_UART | [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_S3_BLE_UART/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_S3_BLE_UART/latest/) |
+| ESP32_S3_ALL_UART | [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_S3_ALL_UART/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_S3_ALL_UART/latest/) |
 
 ### M5Stack
 

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -532,6 +532,24 @@ jobs:
           PackageName: ESP32_S3_BLE
           CMakePreset: ESP32_S3_BLE
 
+        ESP32_S3_BLE_UART:
+          TargetBoard: ESP32_S3
+          TargetSeries: "esp32s3"
+          BuildOptions:
+          IDF_Target: esp32s3
+          TargetName: ESP32_S3_BLE_UART
+          PackageName: ESP32_S3_BLE_UART
+          CMakePreset: ESP32_S3_BLE_UART
+
+        ESP32_S3_ALL_UART:
+          TargetBoard: ESP32_S3
+          TargetSeries: "esp32s3"
+          BuildOptions:
+          IDF_Target: esp32s3
+          TargetName: ESP32_S3_ALL_UART
+          PackageName: ESP32_S3_ALL_UART
+          CMakePreset: ESP32_S3_ALL_UART
+
         ESP32_WESP32:
           TargetSeries: "esp32"
           TargetBoard: ESP32

--- a/targets/ESP32/CMakePresets.json
+++ b/targets/ESP32/CMakePresets.json
@@ -375,6 +375,32 @@
             }
         },
         {
+            "name": "ESP32_S3_BLE_UART",
+            "inherits": [
+                "xtensa-esp32s3-preset",
+                "user-tools-repos",
+                "user-prefs"
+            ],
+            "hidden": false,
+            "cacheVariables": {
+                "TARGET_NAME": "${presetName}",
+                "SDK_CONFIG_FILE": "sdkconfig.default_ble.esp32s3",
+                "NF_BUILD_RTM": "OFF",
+                "NF_FEATURE_DEBUGGER": "ON",
+                "NF_FEATURE_RTC": "ON",
+                "NF_FEATURE_HAS_SDCARD": "ON",
+                "API_nanoFramework.Device.OneWire": "ON",
+                "API_nanoFramework.Device.Bluetooth": "ON",
+                "API_System.Device.I2c.Slave": "ON",
+                "API_nanoFramework.Graphics": "ON",
+                "GRAPHICS_DISPLAY": "Generic_SPI.cpp",
+                "TOUCHPANEL_DEVICE": "XPT2046.cpp",
+                "GRAPHICS_DISPLAY_INTERFACE": "Spi_To_Display.cpp",
+                "TOUCHPANEL_INTERFACE": "Spi_To_TouchPanel.cpp",
+                "ESP32_SPIRAM_FOR_IDF_ALLOCATION": "1024 * 1024"
+            }
+        },
+        {
             "name": "ESP32_S3_ALL",
             "inherits": [
                 "xtensa-esp32s3-preset",
@@ -390,6 +416,32 @@
                 "NF_FEATURE_RTC": "ON",
                 "NF_FEATURE_HAS_SDCARD": "ON",
                 "ESP32_USB_CDC": "ON",
+                "API_nanoFramework.Device.OneWire": "ON",
+                "API_nanoFramework.Device.Bluetooth": "ON",
+                "API_System.Device.I2c.Slave": "ON",
+                "API_nanoFramework.Graphics": "ON",
+                "GRAPHICS_DISPLAY": "Generic_SPI.cpp",
+                "TOUCHPANEL_DEVICE": "XPT2046.cpp",
+                "GRAPHICS_DISPLAY_INTERFACE": "Spi_To_Display.cpp",
+                "TOUCHPANEL_INTERFACE": "Spi_To_TouchPanel.cpp",
+                "ESP32_SPIRAM_FOR_IDF_ALLOCATION": "1024 * 1024"
+            }
+        },
+        {
+            "name": "ESP32_S3_ALL_UART",
+            "inherits": [
+                "xtensa-esp32s3-preset",
+                "user-tools-repos",
+                "user-prefs"
+            ],
+            "hidden": false,
+            "cacheVariables": {
+                "TARGET_NAME": "${presetName}",
+                "SDK_CONFIG_FILE": "sdkconfig.default_octal_ble.esp32s3",
+                "NF_BUILD_RTM": "OFF",
+                "NF_FEATURE_DEBUGGER": "ON",
+                "NF_FEATURE_RTC": "ON",
+                "NF_FEATURE_HAS_SDCARD": "ON",
                 "API_nanoFramework.Device.OneWire": "ON",
                 "API_nanoFramework.Device.Bluetooth": "ON",
                 "API_System.Device.I2c.Slave": "ON",
@@ -952,9 +1004,21 @@
         },
         {
             "inherits": "base-user",
+            "name": "ESP32_S3_BLE_UART",
+            "displayName": "ESP32_S3_BLE_UART",
+            "configurePreset": "ESP32_S3_BLE_UART"
+        },
+        {
+            "inherits": "base-user",
             "name": "ESP32_S3_ALL",
             "displayName": "ESP32_S3_ALL",
             "configurePreset": "ESP32_S3_ALL"
+        },
+        {
+            "inherits": "base-user",
+            "name": "ESP32_S3_ALL_UART",
+            "displayName": "ESP32_S3_ALL_UART",
+            "configurePreset": "ESP32_S3_ALL_UART"
         },
         {
             "inherits": "base-user",


### PR DESCRIPTION
## Description
There are a number of new S3 development boards that only have a connection via a USB to serial chip.  The current firmware is configured to work via the native USB connection which will not work for these boards.

This PR adds the following new targets:

ESP32_S3_BLE_UART
ESP32_S3_ALL_UART

Readme.md and Readme.zh_cn.md updated with new targets.

azure nightly updated to include new builds.

## Motivation and Context
Discussed on discord

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Build tested locally but unable to test run as no S3 test board available with UART connection
Will be tested by users

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for two new ESP32_S3 board variants with UART connectivity: "ESP32_S3_BLE_UART" and "ESP32_S3_ALL_UART".
- **Documentation**
  - Updated both English and Chinese README files to include the new board variants, along with version badges and links.
- **Chores**
  - Enhanced build configuration to support the new ESP32_S3 UART board variants in automated pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->