### PR TITLE
Logic fix

### DIFF
--- a/src/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_Directory.cpp
+++ b/src/System.IO.FileSystem/nf_sys_io_filesystem_System_IO_Directory.cpp
@@ -123,13 +123,14 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_Directory::NativeGetChildren___ST
         {
             // skip entries that are not directories when looking for directories
             // skip also directories with hidden and system attribute
-            if (isDirectory &&
-                ((fileData.Attributes & FileAttributes::FileAttributes_Directory) !=
+            if (isDirectory && !(
+                ((fileData.Attributes & FileAttributes::FileAttributes_Directory) ==
                  FileAttributes::FileAttributes_Directory) &&
                 ((fileData.Attributes & FileAttributes::FileAttributes_Hidden) !=
                  FileAttributes::FileAttributes_Hidden) &&
                 ((fileData.Attributes & FileAttributes::FileAttributes_System) !=
                  FileAttributes::FileAttributes_System))
+			   )
             {
                 continue;
             }
@@ -151,7 +152,7 @@ HRESULT Library_nf_sys_io_filesystem_System_IO_Directory::NativeGetChildren___ST
 
                 // check for hidden and system attributes
                 if (((fileData.Attributes & FileAttributes::FileAttributes_Hidden) ==
-                     FileAttributes::FileAttributes_Hidden) &&
+                     FileAttributes::FileAttributes_Hidden) ||
                     ((fileData.Attributes & FileAttributes::FileAttributes_System) ==
                      FileAttributes::FileAttributes_System))
                 {


### PR DESCRIPTION
## Description
Corrected incorrectly inverted logic.

## Motivation and Context

I've stumbles on this while investigating another issue.

The logic on lines 125+ are inverted from lines 60+, but the check for hidden/system attributes was not inverted correctly:

- when looking for directories, the old condition on line 125 was false (and would include in the result although there was no room allocated for it) if the directory entry is a hidden or system file or directory.

- when looking for files, the old condition on line 154 would skip only files that are hidden and system, instead of hidden or system (that is the condition on line 83).

## How Has This Been Tested?

I've checked the code in a custom firmware - it compiles and has the same results for other than the described cases. I haven't tried to create a test with the above cases.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
