### PR TITLE
Fix resolving token for MedthodRef to work with closed generic types

### DIFF
--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -2107,7 +2107,7 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     FETCH_ARG_COMPRESSED_METHODTOKEN(arg, ip);
 
                     CLR_RT_MethodDef_Instance calleeInst{};
-                    if (calleeInst.ResolveToken(arg, assm) == false)
+                    if (calleeInst.ResolveToken(arg, assm, stack->m_call.genericType) == false)
                     {
                         NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                     }
@@ -2345,7 +2345,7 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     FETCH_ARG_COMPRESSED_METHODTOKEN(arg, ip);
 
                     CLR_RT_MethodDef_Instance calleeInst{};
-                    if (calleeInst.ResolveToken(arg, assm) == false)
+                    if (calleeInst.ResolveToken(arg, assm, stack->m_call.genericType) == false)
                     {
                         NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                     }
@@ -3223,7 +3223,7 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                         case TBL_MethodDef:
                         {
                             CLR_RT_MethodDef_Instance method{};
-                            if (method.ResolveToken(arg, assm) == false)
+                            if (method.ResolveToken(arg, assm, stack->m_call.genericType) == false)
                             {
                                 NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                             }
@@ -3247,7 +3247,7 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                         case TBL_MethodSpec:
                         {
                             CLR_RT_MethodDef_Instance method{};
-                            if (!method.ResolveToken(arg, assm))
+                            if (!method.ResolveToken(arg, assm, stack->m_call.genericType))
                             {
                                 NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                             }
@@ -3403,7 +3403,7 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     CHECKSTACK(stack, evalPos);
 
                     CLR_RT_MethodDef_Instance method{};
-                    if (method.ResolveToken(arg, assm) == false)
+                    if (method.ResolveToken(arg, assm, stack->m_call.genericType) == false)
                     {
                         NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                     }
@@ -3421,7 +3421,7 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     FETCH_ARG_COMPRESSED_METHODTOKEN(arg, ip);
 
                     CLR_RT_MethodDef_Instance callee{};
-                    if (callee.ResolveToken(arg, assm) == false)
+                    if (callee.ResolveToken(arg, assm, stack->m_call.genericType) == false)
                     {
                         NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                     }

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -2172,7 +2172,7 @@ struct CLR_RT_MethodDef_Instance : public CLR_RT_MethodDef_Index
     bool InitializeFromIndex(const CLR_RT_MethodDef_Index &index);
     void ClearInstance();
 
-    bool ResolveToken(CLR_UINT32 tk, CLR_RT_Assembly *assm);
+    bool ResolveToken(CLR_UINT32 tk, CLR_RT_Assembly *assm, const CLR_RT_TypeSpec_Index *callerGeneric);
 
     //--//
 


### PR DESCRIPTION
## Description
- Now takes new parameter with the TypeSpec of the caller.
- Add new code to validate if TypeSpec is the same as the caller generic type. If that's the case, it will prefer the closed generic type.
- Update callers as needed.
- Improvements in DumpToken to properly output TypeDef and MethodRef.

## Motivation and Context
- Now uses closed generic instantiations when appropriate, as it was missing context and was always using the open generic type.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running MDP unit tests and sample app.
- Tested against nanoframework/CoreLibrary#245
[build with MDP buildId 55899]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
