### PR TITLE
Fix handler for ldtoken with generic parameter

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -294,31 +294,6 @@ HRESULT CLR_RT_HeapBlock::SetReflection(const CLR_RT_MethodDef_Index &md)
     NANOCLR_NOCLEANUP();
 }
 
-HRESULT CLR_RT_HeapBlock::SetReflection(const CLR_RT_GenericParam_Index &gp)
-{
-    NATIVE_PROFILE_CLR_CORE();
-    NANOCLR_HEADER();
-
-    CLR_RT_GenericParam_Instance genericParam;
-    CLR_RT_TypeDef_Index typeDef;
-
-    if (genericParam.InitializeFromIndex(gp) == false)
-    {
-        NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
-    }
-
-    // grab the type definition from the generic param
-    typeDef = genericParam.CrossReference().classTypeDef;
-
-    m_id.raw = CLR_RT_HEAPBLOCK_RAW_ID(DATATYPE_REFLECTION, 0, 1);
-    m_data.reflection.levels = 0;
-    m_data.reflection.kind = REFLECTION_TYPE;
-    // set the type definition in the reflection block
-    m_data.reflection.data.type.Set(typeDef.Assembly(), typeDef.Type());
-
-    NANOCLR_NOCLEANUP();
-}
-
 HRESULT CLR_RT_HeapBlock::SetObjectCls(const CLR_RT_TypeDef_Index &cls)
 {
     NATIVE_PROFILE_CLR_CORE();

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -3240,7 +3240,30 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                                 NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                             }
 
-                            evalPos[0].SetReflection(param);
+                            if (stack->m_call.genericType != nullptr)
+                            {
+                                // For a method in a generic type, caller->genericType points to the TypeSpec of the
+                                // closed type
+                                CLR_UINT32 closedTypeSpecRow = stack->m_call.genericType->TypeSpec();
+
+                                CLR_RT_TypeDef_Index resolvedTypeDef;
+                                NanoCLRDataType resolvedDataType;
+
+                                CLR_UINT32 index = CLR_DataFromTk(arg);
+
+                                assm->FindGenericParamAtTypeSpec(
+                                    closedTypeSpecRow,
+                                    index,
+                                    resolvedTypeDef,
+                                    resolvedDataType);
+
+                                evalPos[0].SetReflection(resolvedTypeDef);
+                            }
+                            else
+                            {
+                                // No caller context??
+                                NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
+                            }
                         }
                         break;
 

--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -1351,7 +1351,6 @@ struct CLR_RT_HeapBlock
     HRESULT SetReflection(const CLR_RT_TypeDef_Index &cls);
     HRESULT SetReflection(const CLR_RT_FieldDef_Index &fd);
     HRESULT SetReflection(const CLR_RT_MethodDef_Index &md);
-    HRESULT SetReflection(const CLR_RT_GenericParam_Index &gp);
 
     HRESULT InitializeArrayReference(CLR_RT_HeapBlock &ref, int index);
     void InitializeArrayReferenceDirect(CLR_RT_HeapBlock_Array &array, int index);


### PR DESCRIPTION
## Description
- Now resolves the generic parameter to its closed type and set reflection with it.
- Remove unnecessary SetReflection from generic parameter.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running MDP unit tests and sample app.
- Tested against nanoframework/CoreLibrary#245
[build with MDP buildId 55899]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
