### PR TITLE
Fix CEE_NEWOBJ for generic types

### DIFF
--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -3330,7 +3330,6 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                                         // closed TypeSpec
                                         const CLR_RT_TypeSpec_Index *callerTypeSpec = stack->m_call.genericType;
                                         CLR_RT_TypeDef_Index resolvedTypeDef;
-
                                         NanoCLRDataType dummyDataType;
 
                                         if (!resolveAsm->FindGenericParamAtTypeSpec(

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -2378,7 +2378,10 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     CLR_RT_HeapBlock *top;
                     CLR_INT32 changes;
 
-                    cls.InitializeFromMethod(calleeInst); // This is the class to create!
+                    if (!calleeInst.GetDeclaringType(cls))
+                    {
+                        NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
+                    }
 
                     evalPos++;
 


### PR DESCRIPTION
## Description
- Class is now created from callee instance.

## Motivation and Context
- Need to be use the closed-generic type when creating a new object, not the open definition. `GetDeclaringType()` is aware of the `genericType` field inside the `CLR_RT_MethodDef_Instance`.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running MDP unit tests and sample app with implementation of `Span<T>`.
- Tested against nanoframework/CoreLibrary#245
[build with MDP buildId 56229]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
