### PR TITLE
Fix loading token of generic parameter

### DIFF
--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -3264,6 +3264,15 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                                 NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                             }
 
+                            // resolve the generic parameter in the context of the caller's generic type, if different
+                            // from the caller's assembly.
+                            CLR_RT_Assembly *resolveAsm = assm;
+                            if (stack->m_call.genericType && NANOCLR_INDEX_IS_VALID(*stack->m_call.genericType))
+                            {
+                                resolveAsm =
+                                    g_CLR_RT_TypeSystem.m_assemblies[stack->m_call.genericType->Assembly() - 1];
+                            }
+
                             if (stack->m_call.genericType != nullptr)
                             {
                                 CLR_UINT32 rawGenericParamRow = CLR_DataFromTk(arg);
@@ -3276,7 +3285,7 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                                     // Method generic parameter (!!T)
 
                                     CLR_RT_MethodSpec_Index msIndex;
-                                    if (!assm->FindMethodSpecFromTypeSpec(
+                                    if (!resolveAsm->FindMethodSpecFromTypeSpec(
                                             stack->m_call.genericType->TypeSpec(),
                                             msIndex))
                                     {
@@ -3318,20 +3327,18 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                                         // closed TypeSpec
                                         const CLR_RT_TypeSpec_Index *callerTypeSpec = stack->m_call.genericType;
                                         CLR_RT_TypeDef_Index resolvedTypeDef;
-                                        NanoCLRDataType resolvedDataType;
+                                        NanoCLRDataType dummyDataType;
 
-                                        HRESULT hr2 = stack->m_call.assembly->FindGenericParamAtTypeSpec(
-                                            callerTypeSpec->TypeSpec(),
-                                            (CLR_UINT32)gpCR.m_target.GenericParam(),
-                                            resolvedTypeDef,
-                                            resolvedDataType);
-
-                                        if (FAILED(hr2))
+                                        if (!resolveAsm->FindGenericParamAtTypeSpec(
+                                                callerTypeSpec->TypeSpec(),
+                                                param.target->number,
+                                                resolvedTypeDef,
+                                                dummyDataType))
                                         {
-                                            NANOCLR_SET_AND_LEAVE(hr2);
+                                            NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                                         }
 
-                                        evalPos[0].SetReflection(resolvedTypeDef);
+                                        NANOCLR_CHECK_HRESULT(evalPos[0].SetReflection(resolvedTypeDef));
                                     }
                                 }
                             }


### PR DESCRIPTION
## Description
- Now resolves the the generic parameter in the context of the caller assembly.
- Fix accessing the generic parameter index when calling the finder helper.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running MDP unit tests and sample app with implementation of `Span<T>`.
- Tested against nanoframework/CoreLibrary#245
[build with MDP buildId 56229]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
