### PR TITLE
Fix load and store field IL instructions for value types in stack

### DIFF
--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -2568,8 +2568,41 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
 
                     CLR_RT_HeapBlock *obj = &evalPos[0];
                     NanoCLRDataType dt = obj->DataType();
+   
+                    // If it's a byref, it must be a struct instance on the stack/heap
+                    bool instanceIsByRef =
+                        (obj->DataType() == DATATYPE_BYREF) || (obj->DataType() == DATATYPE_ARRAY_BYREF);
 
-                    NANOCLR_CHECK_HRESULT(CLR_RT_TypeDescriptor::ExtractObjectAndDataType(obj, dt));
+                    if (instanceIsByRef)
+                    {
+                        // extra check for DATATYPE_DATETIME and DATATYPE_TIMESPAN (special cases)
+                        if (obj->Dereference()->DataType() == DATATYPE_DATETIME ||
+                            obj->Dereference()->DataType() == DATATYPE_TIMESPAN)
+                        {
+                            NANOCLR_CHECK_HRESULT(CLR_RT_TypeDescriptor::ExtractObjectAndDataType(obj, dt));
+                        }
+                        else
+                        {
+                            // we already have a pointer to the raw struct
+                            dt = DATATYPE_VALUETYPE;
+
+                            obj = obj->Dereference();
+                            FAULT_ON_NULL(obj);
+                        }
+                    }
+                    else
+                    {
+                        // ordinary object/array
+                        FAULT_ON_NULL(obj);
+                        NANOCLR_CHECK_HRESULT(CLR_RT_TypeDescriptor::ExtractObjectAndDataType(obj, dt));
+                    }
+
+                    //if ((dt == DATATYPE_OBJECT || dt == DATATYPE_BYREF) && obj->Dereference() == NULL)
+                    //{
+                    //    NANOCLR_SET_AND_LEAVE(CLR_E_NULL_REFERENCE); 
+                    //}
+
+                    //NANOCLR_CHECK_HRESULT(CLR_RT_TypeDescriptor::ExtractObjectAndDataType(obj, dt));
 
                     switch (dt)
                     {
@@ -2665,9 +2698,35 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     }
 
                     CLR_RT_HeapBlock *obj = &evalPos[1];
-                    NanoCLRDataType dt = obj->DataType();
+                    NanoCLRDataType dt;
 
-                    NANOCLR_CHECK_HRESULT(CLR_RT_TypeDescriptor::ExtractObjectAndDataType(obj, dt));
+                    // If it's a byref, it must be a struct instance on the stack/heap
+                    bool instanceIsByRef =
+                        (obj->DataType() == DATATYPE_BYREF) || (obj->DataType() == DATATYPE_ARRAY_BYREF);
+
+                    if (instanceIsByRef)
+                    {
+                        // extra check for DATATYPE_DATETIME and DATATYPE_TIMESPAN (special cases)
+                        if (obj->Dereference()->DataType() == DATATYPE_DATETIME ||
+                            obj->Dereference()->DataType() == DATATYPE_TIMESPAN)
+                        {
+                            NANOCLR_CHECK_HRESULT(CLR_RT_TypeDescriptor::ExtractObjectAndDataType(obj, dt));
+                        }
+                        else
+                        {
+                            // we already have a pointer to the raw struct
+                            dt = DATATYPE_VALUETYPE;
+
+                            // follow the byref so obj really points at the struct
+                            obj = obj->Dereference();
+                        }
+                    }
+                    else
+                    {
+                        // ordinary object/array
+                        FAULT_ON_NULL(obj);
+                        NANOCLR_CHECK_HRESULT(CLR_RT_TypeDescriptor::ExtractObjectAndDataType(obj, dt));
+                    }
 
                     switch (dt)
                     {


### PR DESCRIPTION
## Description
- Now dealing properly with value types for structs assigned from stack and not from heap.
- Fixes in store and load field.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running MDP unit tests and sample app with implementation of `Span<T>`.
- Tested against nanoframework/CoreLibrary#245
[build with MDP buildId 56229]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
