### PR TITLE
Fix dump token for typespec

### DIFF
--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -524,8 +524,14 @@ void CLR_RT_Assembly::DumpToken(CLR_UINT32 token, const CLR_RT_TypeSpec_Index *g
             // back to BuildTypeName for the full concrete name.
             //
 
+            CLR_UINT32 ownerAsm = assemblyIndex;
+            if (genericType != nullptr && NANOCLR_INDEX_IS_VALID(*genericType))
+            {
+                ownerAsm = genericType->Assembly();
+            }
+
             CLR_RT_TypeSpec_Index tsIdx;
-            tsIdx.Set(assemblyIndex, index);
+            tsIdx.Set(ownerAsm, index);
 
             // bind to get the signature blob
             CLR_RT_TypeSpec_Instance tsInst{};


### PR DESCRIPTION
## Description
- Fix access to correct assembly index.

## Motivation and Context
- When executing IL in assembly A, if loading a typespec token from assembly B it has to honour the assembly index in the token and not assume it's in the executing assembly.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running MDP unit tests and sample app with implementation of `Span<T>`.
- Tested against nanoframework/CoreLibrary#245
[build with MDP buildId 56229]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
