### PR TITLE
Fix handling of TypeSpec token for arrays

### DIFF
--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -452,7 +452,7 @@ void CLR_RT_Assembly::DumpToken(CLR_UINT32 token, const CLR_RT_TypeSpec_Index *g
                 // Build the closed‐generic owner name
                 char rgType[256], *sz = rgType;
                 size_t cb = sizeof(rgType);
-                g_CLR_RT_TypeSystem.BuildTypeName(*genericType, sz, cb);
+                g_CLR_RT_TypeSystem.BuildTypeName(*genericType, sz, cb, 0);
 
                 // Append the field name
                 CLR_SafeSprintf(sz, cb, "::%s", GetString(fr->name));
@@ -554,7 +554,7 @@ void CLR_RT_Assembly::DumpToken(CLR_UINT32 token, const CLR_RT_TypeSpec_Index *g
                 char bufCorrupt[256];
                 char *pCorrupt = bufCorrupt;
                 size_t cbCorrupt = sizeof(bufCorrupt);
-                g_CLR_RT_TypeSystem.BuildTypeName(tsIdx, pCorrupt, cbCorrupt);
+                g_CLR_RT_TypeSystem.BuildTypeName(tsIdx, pCorrupt, cbCorrupt, elem.Levels);
                 CLR_Debug::Printf("%s", bufCorrupt);
                 break;
             }
@@ -596,8 +596,7 @@ void CLR_RT_Assembly::DumpToken(CLR_UINT32 token, const CLR_RT_TypeSpec_Index *g
                 }
                 break;
             }
-
-            if (elem.DataType == DATATYPE_SZARRAY)
+            else if (elem.DataType == DATATYPE_SZARRAY)
             {
                 // advance to see what’s inside the array
                 if (FAILED(parser.Advance(elem)))
@@ -648,18 +647,18 @@ void CLR_RT_Assembly::DumpToken(CLR_UINT32 token, const CLR_RT_TypeSpec_Index *g
                     char bufArr[256];
                     char *pArr = bufArr;
                     size_t cbArr = sizeof(bufArr);
-                    g_CLR_RT_TypeSystem.BuildTypeName(tsIdx, pArr, cbArr);
+                    g_CLR_RT_TypeSystem.BuildTypeName(tsIdx, pArr, cbArr, elem.Levels);
                     CLR_Debug::Printf("%s", bufArr);
                     break;
                 }
             }
 
             // now all the rest: just print the full type name
-            char bufGeneric[256];
-            char *pGeneric = bufGeneric;
-            size_t cbGeneric = sizeof(bufGeneric);
-            g_CLR_RT_TypeSystem.BuildTypeName(tsIdx, pGeneric, cbGeneric);
-            CLR_Debug::Printf("%s", bufGeneric);
+            char bufTypeName[256];
+            char *pTypeName = bufTypeName;
+            size_t cbType = sizeof(bufTypeName);
+            g_CLR_RT_TypeSystem.BuildTypeName(tsIdx, pTypeName, cbType, elem.Levels);
+            CLR_Debug::Printf("%s", bufTypeName);
             break;
         }
 

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -2000,7 +2000,7 @@ struct CLR_RT_TypeSystem // EVENT HEAP - NO RELOCATION -
         const CLR_RECORD_RESOURCE *&res,
         CLR_UINT32 &size);
 
-    HRESULT BuildTypeName(const CLR_RT_TypeSpec_Index &typeIndex, char *&szBuffer, size_t &iBuffer);
+    HRESULT BuildTypeName(const CLR_RT_TypeSpec_Index &typeIndex, char *&szBuffer, size_t &iBuffer, CLR_UINT32 levels);
     HRESULT BuildTypeName(
         const CLR_RT_TypeDef_Index &cls,
         char *&szBuffer,


### PR DESCRIPTION
## Description
- Now properly handling TypeSpecs for array types by dealing with Levels in CLR_RT_Assembly::DumpToken
- Rename variables for clarity and consistency.
- CLR_RT_TypeSystem::BuildTypeName now takes levels parameter to properly deal with TypeSpec arrays.
- Fix wrong ouptut of generic notation.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running MDP unit tests and sample app with implementation of `Span<T>`.
- Tested against nanoframework/CoreLibrary#245
[build with MDP buildId 56369]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Type names now accurately display array nesting levels, with brackets (e.g., `[]`) indicating array dimensions.

* **Bug Fixes**
  * Improved display of type names to correctly represent generic parameters and array or pointer levels in diagnostic outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->