### PR TITLE
Fix: SPI IO mapping for ESP32-S3 not be assigned

### DIFF
--- a/targets/ESP32/_common/ESP32_S3_DeviceMapping.cpp
+++ b/targets/ESP32/_common/ESP32_S3_DeviceMapping.cpp
@@ -11,7 +11,11 @@
 //  2 devices
 //  Map pins  mosi, miso, clock
 //
-int8_t Esp32_SPI_DevicePinMap[MAX_SPI_DEVICES][Esp32SpiPin_Max] = {{-1, -1, -1}, {-1, -1, -1}};
+int8_t Esp32_SPI_DevicePinMap[MAX_SPI_DEVICES][Esp32SpiPin_Max] ={
+    // SPI1
+    {GPIO_NUM_11, GPIO_NUM_13, GPIO_NUM_12},
+    // SPI2 - no pins assigned
+    {-1, -1, -1}};
 
 //  Serial
 //  2 devices COM1,COM2 ( UART_NUM_0, UART_NUM_1 )


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
On Esp32-S3, when the following code runs, an ArgumentException will be triggered because the SPI IO Ports are not assigned in ESP32_S3_DeviceMapping.cpp
```
SpiConnectionSettings settings = new SpiConnectionSettings(1, 10);
SpiDevice spiDevice = SpiDevice.Create(settings);
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Change the SPI1 ports mapping from {-1, -1, -1} to {GPIO_NUM_11, GPIO_NUM_13, GPIO_NUM_12}

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default GPIO pin assignments have been set for the first SPI device (SPI1), enabling immediate use with predefined pins.
* **Chores**
  * The second SPI device (SPI2) remains unassigned, maintaining flexibility for custom configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->