### PR TITLE
Recovering lost code getting I2S pin mapping on ESP32

### DIFF
--- a/targets/ESP32/_common/DeviceMapping_common.cpp
+++ b/targets/ESP32/_common/DeviceMapping_common.cpp
@@ -61,6 +61,9 @@ int Esp32_GetMappedDevicePins(Esp32_MapDeviceType deviceType, int busIndex, int 
             case DEV_TYPE_SDMMC:
                 return (int)Esp32_SDMMC_DevicePinMap[busIndex][pinIndex];
 #endif
+            case DEV_TYPE_I2S:
+                return (int)Esp32_I2S_DevicePinMap[busIndex][pinIndex];
+             
             default:
                 break;
         };


### PR DESCRIPTION
## Description

- This code was most likely lost with latest IDF update.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Resolves nanoFramework/Home#1678

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested on ESP32 REV1 Lolin Lite board with I2S/ADC mode

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ESP32 hardware mapping now includes I2S device support, enabling automatic pin mapping for I2S peripherals. This improves compatibility with audio modules and allows configuring I2S buses through the standard device mapping flow. Existing device behaviors and defaults remain unchanged for stable operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->