### PR TITLE
Fix signature parser usage

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Type.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Type.cpp
@@ -145,7 +145,7 @@ HRESULT Library_corlib_native_System_Type::GetGenericArguments___SZARRAY_SystemT
         NANOCLR_CHECK_HRESULT(parser.Advance(elem));
 
         // get the number of generic parameters
-        count = parser.GenParamCount;
+        count = elem.GenParamCount;
 
         // allocate an array to hold the generic arguments
         NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance(top, count, g_CLR_RT_WellKnownTypes.TypeStatic));
@@ -432,14 +432,14 @@ HRESULT Library_corlib_native_System_Type::get_IsGenericTypeDefinition___BOOLEAN
         parser.Advance(element);
 
         // check if it has generic parameters
-        if (parser.GenParamCount == 0)
+        if (element.GenParamCount == 0)
         {
             isTypeDefinition = false;
         }
         else
         {
             // keep reading the generic parameters
-            for (int i = 0; i < parser.GenParamCount; i++)
+            for (int i = 0; i < element.GenParamCount; i++)
             {
                 if (SUCCEEDED(parser.Advance(element)))
                 {

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -2074,7 +2074,7 @@ HRESULT CLR_RT_ExecutionEngine::InitializeLocals(
                     varParser.Advance(varElement);
 
                     // consume parameters
-                    for (int paramIndex = 0; paramIndex < varParser.GenParamCount; paramIndex++)
+                    for (int paramIndex = 0; paramIndex < varElement.GenParamCount; paramIndex++)
                     {
                         NANOCLR_CHECK_HRESULT(varParser.Advance(varElement));
                     }
@@ -2100,7 +2100,7 @@ HRESULT CLR_RT_ExecutionEngine::InitializeLocals(
                             (const CLR_RT_TypeSpec_Index &)methodDefInstance.genericType->data);
 
                         typeSpec.assembly->FindGenericParamAtTypeSpec(
-                            methodDefInstance.genericType->TypeSpec(),
+                            methodDefInstance.genericType->data,
                             genericParamPosition,
                             cls,
                             dt);
@@ -2108,7 +2108,7 @@ HRESULT CLR_RT_ExecutionEngine::InitializeLocals(
                     else
                     {
                         assembly->FindGenericParamAtTypeSpec(
-                            methodDefInstance.genericType->TypeSpec(),
+                            methodDefInstance.genericType->data,
                             genericParamPosition,
                             cls,
                             dt);


### PR DESCRIPTION
## Description
- Replaced wrong check of generics parameter count in parser when it should be in element.

## Motivation and Context
- Regression introduced in #3213.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Tested against nanoframework/CoreLibrary#252.
[build with MDP buildId 57148]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
