### PR TITLE
Fix ST_STM32F429I_DISCOVERY release CLR linker flash regions

### DIFF
--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/common/Device_BlockStorage.c
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/common/Device_BlockStorage.c
@@ -20,8 +20,8 @@ const BlockRange BlockRange2[] = {
 
 // 128kB blocks
 const BlockRange BlockRange3[] = {
-    {BlockRange_BLOCKTYPE_CODE, 0, 0},       // 0x08020000 nanoCLR
-    {BlockRange_BLOCKTYPE_DEPLOYMENT, 1, 6}, // 0x08040000 deployment
+    {BlockRange_BLOCKTYPE_CODE, 0, 3},       // 0x08020000 nanoCLR
+    {BlockRange_BLOCKTYPE_DEPLOYMENT, 4, 6}, // 0x080A0000 deployment
 };
 
 // 16kB blocks

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/common/Device_BlockStorage.c
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/common/Device_BlockStorage.c
@@ -7,10 +7,9 @@
 #include <nanoPAL_BlockStorage.h>
 
 // 16kB blocks
-const BlockRange BlockRange1[] = 
-{
-    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 1 },            // 0x08000000 nanoBooter
-    { BlockRange_BLOCKTYPE_CODE      ,   2, 3 }             // 0x08008000 nanoCLR
+const BlockRange BlockRange1[] = {
+    {BlockRange_BLOCKTYPE_BOOTSTRAP, 0, 1}, // 0x08000000 nanoBooter
+    {BlockRange_BLOCKTYPE_CODE, 2, 3}       // 0x08008000 nanoCLR
 };
 
 // 64kB blocks

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash0     (rx) : org = 0x08008000, len = 2M - 32k - 1792k      /* flash0 size less the space reserved for nanoBooter and application deployment*/
+    flash0     (rx) : org = 0x08008000, len = 2M - 32k - 1408k      /* flash0 size less the space reserved for nanoBooter and application deployment*/
     flash1     (rx) : org = 0x00000000, len = 0
     flash2     (rx) : org = 0x00000000, len = 0
     flash3     (rx) : org = 0x00000000, len = 0
@@ -21,7 +21,7 @@ MEMORY
     flash6     (rx) : org = 0x00000000, len = 0
     flash7     (rx) : org = 0x00000000, len = 0
     config     (rw) : org = 0x00000000, len = 0                     /* space reserved for configuration block */
-    deployment (rx) : org = 0x08040000, len = 1792k                 /* space reserved for application deployment */
+    deployment (rx) : org = 0x080A0000, len = 1408k                 /* space reserved for application deployment */
     ramvt      (wx) : org = 0x00000000, len = 0                     /* initial RAM address is reserved for a copy of the vector table */
     ram0       (wx) : org = 0x20000030, len = 192k-48               /* SRAM1 + SRAM2 + SRAM3 */
     ram1       (wx) : org = 0x20000000, len = 112k                  /* SRAM1 */

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/STM32F429xI_CLR.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash0     (rx) : org = 0x08008000, len = 2M - 32k - 1408k      /* flash0 size less the space reserved for nanoBooter and application deployment*/
+    flash0     (rx) : org = 0x08008000, len = 2M - 32k - 1792k      /* flash0 size less the space reserved for nanoBooter and application deployment*/
     flash1     (rx) : org = 0x00000000, len = 0
     flash2     (rx) : org = 0x00000000, len = 0
     flash3     (rx) : org = 0x00000000, len = 0
@@ -21,7 +21,7 @@ MEMORY
     flash6     (rx) : org = 0x00000000, len = 0
     flash7     (rx) : org = 0x00000000, len = 0
     config     (rw) : org = 0x00000000, len = 0                     /* space reserved for configuration block */
-    deployment (rx) : org = 0x08040000, len = 1664k                 /* space reserved for application deployment */
+    deployment (rx) : org = 0x08040000, len = 1792k                 /* space reserved for application deployment */
     ramvt      (wx) : org = 0x00000000, len = 0                     /* initial RAM address is reserved for a copy of the vector table */
     ram0       (wx) : org = 0x20000030, len = 192k-48               /* SRAM1 + SRAM2 + SRAM3 */
     ram1       (wx) : org = 0x20000000, len = 112k                  /* SRAM1 */


### PR DESCRIPTION
## Description
- The release block storage (`Device_BlockStorage.c`) only allocated 224 kB to the CLR CODE region (region3, block 0 only), but the release binary is ~252 kB. This left the binary with nowhere to fit.
- In addition, the original release linker (before any of these changes) had `flash0` set to 608 kB (the debug value) which masked the block storage error at build time — but the deployment region started at `0x08040000` (only 224 kB after CLR start), meaning the CLR binary would physically overwrite flash sectors the runtime considers "deployment" at run time.
- The correct fix is to align the release layout with the debug layout: extend the CLR CODE region in `BlockRange3` from block 0 only to blocks 0–3 (4×128 kB), moving the deployment boundary from `0x08040000` to `0x080A0000`.

## Motivation and Context
Found during a coherency audit of all ChibiOS target block storage configurations vs. their paired linker files. All other targets were coherent; this was the sole discrepancy.

## How Has This Been Tested?
Both files are linker/block-storage definitions. The fix produces a consistent, non-overlapping memory map:

| Region | Before (broken) | After (fixed) |
|---|---|---|
| nanoBooter | 32 kB @ 0x08000000 | 32 kB @ 0x08000000 |
| CLR code (`flash0`) | 608 kB (linker) / 224 kB (block storage) — **mismatch** | 608 kB — coherent |
| Deployment start | 0x08040000 — **overlaps CLR** | 0x080A0000 — no overlap |
| Deployment size | 1664 kB (linker) / 1792 kB (block storage) — **mismatch** | 1408 kB — coherent |
| Total | 2304 kB > 2 MB — **overflow** | 2048 kB = 2 MB ✓ |

The debug linker (`STM32F429xI_CLR-DEBUG.ld`) and debug block storage (`Device_BlockStorage-DEBUG.c`) are unchanged and were already correct. The fixed release layout is now identical to the debug layout.

## Screenshots

N/A

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).