### PR TITLE
MCUboot porting layer skeleton (Phase 0 Step 2)

### DIFF
--- a/CMake/Modules/FindMCUboot.cmake
+++ b/CMake/Modules/FindMCUboot.cmake
@@ -1,0 +1,60 @@
+#
+# Copyright (c) .NET Foundation and Contributors
+# See LICENSE file in the project root for full license information.
+#
+
+# FindMCUboot.cmake — FetchContent declaration for MCUboot upstream.
+#
+# This module downloads the MCUboot source tree at configure time using CMake
+# FetchContent.  Only the porting layer header include paths and the nanoFramework
+# port sources are compiled; MCUboot's own bootloader application is built as an
+# independent CMake target (MCUboot/CMakeLists.txt), not as part of nanoCLR.
+#
+# Usage in a target CMakeLists.txt (when NF_FEATURE_USE_MCUBOOT is ON):
+#   find_package(MCUboot REQUIRED)
+#
+# To use a local checkout instead of downloading (e.g. for offline builds or
+# local development), pass FETCHCONTENT_SOURCE_DIR_MCUBOOT at configure time:
+#   cmake -DFETCHCONTENT_SOURCE_DIR_MCUBOOT=/path/to/local/mcuboot ...
+#
+# This follows the existing nf-interpreter FetchContent conventions
+# (see FindChibiOS.cmake, FindNF_LittleFS.cmake, FindFATFS.cmake).
+
+include(FetchContent)
+
+FetchContent_Declare(
+    mcuboot
+    GIT_REPOSITORY https://github.com/mcu-tools/mcuboot.git
+    GIT_TAG        v2.1.0
+    GIT_SHALLOW    ON
+)
+
+FetchContent_GetProperties(mcuboot)
+
+if(NOT mcuboot_POPULATED)
+    FetchContent_MakeAvailable(mcuboot)
+endif()
+
+# MCUboot upstream include paths required by the porting layer.
+# These are the standard MCUboot header locations within the upstream tree.
+list(APPEND MCUboot_INCLUDE_DIRS
+    ${mcuboot_SOURCE_DIR}/boot/bootutil/include
+    ${mcuboot_SOURCE_DIR}/ext/mbedtls-asn1/include
+    ${CMAKE_SOURCE_DIR}/MCUboot/include
+)
+
+# Platform port source files — selected by NF_RTOS / target family.
+# Only one platform port is compiled per target build.
+if(RTOS STREQUAL "CHIBIOS")
+    list(APPEND MCUboot_SOURCES
+        ${CMAKE_SOURCE_DIR}/MCUboot/port/stm32/flash_map_stm32.c
+    )
+elseif(RTOS STREQUAL "ESP32")
+    list(APPEND MCUboot_SOURCES
+        ${CMAKE_SOURCE_DIR}/MCUboot/port/esp32/flash_map_esp32.c
+    )
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(MCUboot DEFAULT_MSG MCUboot_INCLUDE_DIRS)

--- a/Kconfig
+++ b/Kconfig
@@ -14,6 +14,7 @@ config TARGET_SERIES
 source "Kconfig.rtos"
 source "Kconfig.build"
 source "Kconfig.features"
+source "Kconfig.mcuboot"
 source "Kconfig.apis"
 source "Kconfig.graphics"
 source "Kconfig.networking"

--- a/Kconfig.mcuboot
+++ b/Kconfig.mcuboot
@@ -68,4 +68,16 @@ config NF_MCUBOOT_SERIAL_RECOVERY
         (e.g. via a GPIO pin), MCUboot enters a recovery shell that accepts new
         images over UART without requiring network access.
 
+config NF_MCUBOOT_HEADER_SIZE
+    hex "MCUboot image header size (bytes)"
+    depends on NF_FEATURE_HAS_MCUBOOT
+    default 0x200
+    help
+        Size in bytes reserved for the MCUboot image header at the start of
+        each firmware slot. This value must match both the flash layout
+        (reserved header area) and the imgtool sign --header-size argument.
+        0x200 (512 bytes) is the standard value for all current nanoFramework
+        targets. Override only if a specific target's flash layout requires a
+        different alignment.
+
 endmenu # MCUboot

--- a/Kconfig.mcuboot
+++ b/Kconfig.mcuboot
@@ -4,15 +4,17 @@
 #
 
 menu "MCUboot"
-    depends on NF_TARGET_HAS_NANOBOOTER
 
 config NF_FEATURE_HAS_MCUBOOT
     bool "Enable MCUboot bootloader integration"
     default n
+    select NF_TARGET_HAS_NANOBOOTER
     help
-        Enable MCUboot as the nanoFramework bootloader for In-Field Update (IFU).
-        When enabled, the firmware is built with signed MCUboot image headers and
-        the flash area backend is wired to the MCUboot porting layer.
+        Enable MCUboot as the bootloader for this target. MCUboot replaces
+        nanoBooter and provides signed-image verification and In-Field Update
+        (IFU) with rollback support. When enabled, the firmware is built with
+        MCUboot image headers and the flash area backend is wired to the MCUboot
+        porting layer.
 
 choice NF_MCUBOOT_UPGRADE_STRATEGY
     prompt "Upgrade strategy"

--- a/Kconfig.mcuboot
+++ b/Kconfig.mcuboot
@@ -1,0 +1,69 @@
+#
+# Copyright (c) .NET Foundation and Contributors
+# See LICENSE file in the project root for full license information.
+#
+
+menu "MCUboot"
+    depends on NF_TARGET_HAS_NANOBOOTER
+
+config NF_FEATURE_HAS_MCUBOOT
+    bool "Enable MCUboot bootloader integration"
+    default n
+    help
+        Enable MCUboot as the nanoFramework bootloader for In-Field Update (IFU).
+        When enabled, the firmware is built with signed MCUboot image headers and
+        the flash area backend is wired to the MCUboot porting layer.
+
+choice NF_MCUBOOT_UPGRADE_STRATEGY
+    prompt "Upgrade strategy"
+    depends on NF_FEATURE_HAS_MCUBOOT
+    default NF_MCUBOOT_SWAP_USING_MOVE
+    help
+        Selects the MCUboot image upgrade algorithm. Exactly one strategy must
+        be chosen per target. The correct choice depends on whether the secondary
+        slot resides in internal or external flash.
+
+config NF_MCUBOOT_SWAP_USING_OFFSET
+    bool "Swap using offset"
+    help
+        Primary slot is in internal flash; secondary slot is on external storage
+        (QSPI flash, SD card, or USB MSD). MCUboot copies the new image sector
+        by sector from secondary to primary using the offset variant, which does
+        not require a separate scratch partition. Recommended for STM32 targets.
+
+config NF_MCUBOOT_SWAP_USING_MOVE
+    bool "Swap using move"
+    help
+        Both slots reside in internal flash. MCUboot moves sectors without a
+        dedicated scratch partition (slot sizes must be equal and aligned).
+        Recommended for ESP32 targets.
+
+config NF_MCUBOOT_OVERWRITE_ONLY
+    bool "Overwrite only (no rollback)"
+    help
+        The new image overwrites the primary slot directly. No rollback is
+        possible after a successful upgrade. Use only on targets with no
+        secondary storage.
+
+endchoice # NF_MCUBOOT_UPGRADE_STRATEGY
+
+config NF_MCUBOOT_IMAGE_NUMBER
+    int "Number of managed images"
+    depends on NF_FEATURE_HAS_MCUBOOT
+    range 1 2
+    default 2
+    help
+        Number of independently managed MCUboot images.
+        2 (default): Image 0 = nanoCLR firmware, Image 1 = deployment area.
+        Both images can be upgraded and rolled back independently.
+
+config NF_MCUBOOT_SERIAL_RECOVERY
+    bool "Enable serial recovery mode"
+    depends on NF_FEATURE_HAS_MCUBOOT
+    default n
+    help
+        Enable MCUboot serial recovery (mcumgr/UART). When triggered at boot
+        (e.g. via a GPIO pin), MCUboot enters a recovery shell that accepts new
+        images over UART without requiring network access.
+
+endmenu # MCUboot

--- a/MCUboot/CMakeLists.txt
+++ b/MCUboot/CMakeLists.txt
@@ -1,0 +1,54 @@
+#
+# Copyright (c) .NET Foundation and Contributors
+# See LICENSE file in the project root for full license information.
+#
+
+# MCUboot/CMakeLists.txt — Build rules for the MCUboot bootloader integration.
+#
+# MCUboot is built as an INDEPENDENT binary that replaces nanoBooter.
+# It is NOT linked into nanoCLR.  The nanoCLR CMake build produces a signed image
+# (via imgtool post-build step) that MCUboot can validate and boot.
+#
+# This file is only processed when NF_FEATURE_USE_MCUBOOT is ON.
+# It is included from the top-level CMakeLists.txt or target CMakeLists.txt
+# via: if(NF_FEATURE_USE_MCUBOOT) add_subdirectory(MCUboot) endif()
+#
+# MCUboot upstream source is fetched via FindMCUboot.cmake (FetchContent).
+# The nanoFramework porting layer (port/stm32/ or port/esp32/) is compiled
+# together with MCUboot's bootutil library.
+#
+# TODO(ifu-phase1): Wire up the full MCUboot bootloader build here.
+#   Step 1: add_library(mcuboot_port ...) with platform port sources.
+#   Step 2: target_include_directories for MCUboot upstream + nf port headers.
+#   Step 3: add_executable(mcuboot.elf) linking bootutil + mcuboot_port + BSP startup.
+#   Step 4: add post-build objcopy to produce mcuboot.bin / mcuboot.hex.
+#
+# For now this is a skeleton CMakeLists that documents the intended structure.
+
+cmake_minimum_required(VERSION 3.31)
+
+# MCUboot porting layer interface library.
+# Provides the include paths and port sources to any target that links MCUboot.
+add_library(nf_mcuboot_port INTERFACE)
+
+target_include_directories(nf_mcuboot_port INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+# TODO(ifu-phase1): Replace INTERFACE with STATIC and add platform port sources:
+#
+# if(RTOS STREQUAL "CHIBIOS")
+#     target_sources(nf_mcuboot_port PRIVATE
+#         port/stm32/flash_map_stm32.c
+#     )
+#     target_include_directories(nf_mcuboot_port PUBLIC
+#         port/stm32
+#     )
+# elseif(RTOS STREQUAL "ESP32")
+#     target_sources(nf_mcuboot_port PRIVATE
+#         port/esp32/flash_map_esp32.c
+#     )
+#     target_include_directories(nf_mcuboot_port PUBLIC
+#         port/esp32
+#     )
+# endif()

--- a/MCUboot/include/flash_map_backend/flash_map_backend.h
+++ b/MCUboot/include/flash_map_backend/flash_map_backend.h
@@ -1,0 +1,118 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// MCUboot flash area abstraction layer.
+// This header defines the flash_area_* API contract that each platform port must implement.
+// The nanoFramework porting layer implements this API on top of the platform-native flash driver.
+//
+// Reference: MCUboot boot/bootutil/include/bootutil/bootutil.h and
+//            boot/mcu_flash/flash_map_backend/flash_map_backend.h
+
+#ifndef FLASH_MAP_BACKEND_H
+#define FLASH_MAP_BACKEND_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//
+// Flash area descriptor — identifies a named flash region (slot, bootloader, scratch).
+// The platform port populates a static table of these descriptors indexed by fa_id.
+//
+struct flash_area
+{
+    uint8_t fa_id;        // Flash area ID (FLASH_AREA_BOOTLOADER, FLASH_AREA_IMAGE_x_*)
+    uint8_t fa_device_id; // Device ID: FLASH_DEVICE_INTERNAL_FLASH or FLASH_DEVICE_EXTERNAL_FLASH
+    uint16_t pad16;
+    uint32_t fa_off;  // Byte offset of this area within its device
+    uint32_t fa_size; // Size of this area in bytes
+};
+
+//
+// Flash sector descriptor — one erasable sector within a flash area.
+// Used by flash_area_get_sectors() to communicate sector geometry to MCUboot's swap engine.
+//
+struct flash_sector
+{
+    uint32_t fs_off;  // Byte offset of this sector from the start of its flash area
+    uint32_t fs_size; // Size of this sector in bytes
+};
+
+//
+// Open a flash area by ID for subsequent read/write/erase operations.
+// Returns 0 on success, negative errno on failure.
+//
+int flash_area_open(uint8_t id, const struct flash_area **area_outp);
+
+//
+// Close a previously opened flash area.
+// After this call the pointer returned by flash_area_open() must not be used.
+//
+void flash_area_close(const struct flash_area *area);
+
+//
+// Read len bytes from flash area area at byte offset off into buffer dst.
+// Returns 0 on success, negative errno on failure.
+//
+int flash_area_read(const struct flash_area *area, uint32_t off, void *dst, uint32_t len);
+
+//
+// Write len bytes from buffer src to flash area area at byte offset off.
+// The destination region must already be erased.
+// Returns 0 on success, negative errno on failure.
+//
+int flash_area_write(const struct flash_area *area, uint32_t off, const void *src, uint32_t len);
+
+//
+// Erase len bytes of flash area area starting at byte offset off.
+// off and len must be aligned to the device's erase-sector size.
+// Returns 0 on success, negative errno on failure.
+//
+int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len);
+
+//
+// Return the minimum write alignment (in bytes) for the given flash area.
+// MCUboot uses this to align trailer and status fields.
+// Typical values: 1 (NOR flash), 4 (STM32 F4/F7), 8 (STM32 H7), 32 (ESP32 with encryption).
+//
+uint32_t flash_area_align(const struct flash_area *area);
+
+//
+// Return the byte value that erased flash reads as (typically 0xFF for NOR flash).
+//
+uint8_t flash_area_erased_val(const struct flash_area *area);
+
+//
+// Populate sectors[] with the sector geometry of flash area fa_id.
+// On entry *count is the capacity of sectors[].
+// On return *count is the actual number of sectors written.
+// Returns 0 on success, negative errno on failure.
+//
+// This function is required when MCUBOOT_USE_FLASH_AREA_GET_SECTORS is defined.
+//
+int flash_area_get_sectors(int fa_id, uint32_t *count, struct flash_sector *sectors);
+
+//
+// Translate (image_index, slot) to a flash area ID.
+// image_index: 0 = nanoCLR, 1 = deployment (multi-image).
+// slot: 0 = primary, 1 = secondary.
+// Returns the FLASH_AREA_IMAGE_x_* ID for the given combination.
+//
+int flash_area_id_from_multi_image_slot(int image_index, int slot);
+
+//
+// Translate slot index to a flash area ID for single-image configurations.
+// Equivalent to flash_area_id_from_multi_image_slot(0, slot).
+//
+int flash_area_id_from_image_slot(int slot);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FLASH_MAP_BACKEND_H

--- a/MCUboot/include/flash_map_backend/flash_map_backend.h
+++ b/MCUboot/include/flash_map_backend/flash_map_backend.h
@@ -17,99 +17,100 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-//
-// Flash area descriptor — identifies a named flash region (slot, bootloader, scratch).
-// The platform port populates a static table of these descriptors indexed by fa_id.
-//
-struct flash_area
-{
-    uint8_t fa_id;        // Flash area ID (FLASH_AREA_BOOTLOADER, FLASH_AREA_IMAGE_x_*)
-    uint8_t fa_device_id; // Device ID: FLASH_DEVICE_INTERNAL_FLASH or FLASH_DEVICE_EXTERNAL_FLASH
-    uint16_t pad16;
-    uint32_t fa_off;  // Byte offset of this area within its device
-    uint32_t fa_size; // Size of this area in bytes
-};
+    //
+    // Flash area descriptor — identifies a named flash region (slot, bootloader, scratch).
+    // The platform port populates a static table of these descriptors indexed by fa_id.
+    //
+    struct flash_area
+    {
+        uint8_t fa_id;        // Flash area ID (FLASH_AREA_BOOTLOADER, FLASH_AREA_IMAGE_x_*)
+        uint8_t fa_device_id; // Device ID: FLASH_DEVICE_INTERNAL_FLASH or FLASH_DEVICE_EXTERNAL_FLASH
+        uint16_t pad16;
+        uint32_t fa_off;  // Byte offset of this area within its device
+        uint32_t fa_size; // Size of this area in bytes
+    };
 
-//
-// Flash sector descriptor — one erasable sector within a flash area.
-// Used by flash_area_get_sectors() to communicate sector geometry to MCUboot's swap engine.
-//
-struct flash_sector
-{
-    uint32_t fs_off;  // Byte offset of this sector from the start of its flash area
-    uint32_t fs_size; // Size of this sector in bytes
-};
+    //
+    // Flash sector descriptor — one erasable sector within a flash area.
+    // Used by flash_area_get_sectors() to communicate sector geometry to MCUboot's swap engine.
+    //
+    struct flash_sector
+    {
+        uint32_t fs_off;  // Byte offset of this sector from the start of its flash area
+        uint32_t fs_size; // Size of this sector in bytes
+    };
 
-//
-// Open a flash area by ID for subsequent read/write/erase operations.
-// Returns 0 on success, negative errno on failure.
-//
-int flash_area_open(uint8_t id, const struct flash_area **area_outp);
+    //
+    // Open a flash area by ID for subsequent read/write/erase operations.
+    // Returns 0 on success, negative errno on failure.
+    //
+    int flash_area_open(uint8_t id, const struct flash_area **area_outp);
 
-//
-// Close a previously opened flash area.
-// After this call the pointer returned by flash_area_open() must not be used.
-//
-void flash_area_close(const struct flash_area *area);
+    //
+    // Close a previously opened flash area.
+    // After this call the pointer returned by flash_area_open() must not be used.
+    //
+    void flash_area_close(const struct flash_area *area);
 
-//
-// Read len bytes from flash area area at byte offset off into buffer dst.
-// Returns 0 on success, negative errno on failure.
-//
-int flash_area_read(const struct flash_area *area, uint32_t off, void *dst, uint32_t len);
+    //
+    // Read len bytes from flash area area at byte offset off into buffer dst.
+    // Returns 0 on success, negative errno on failure.
+    //
+    int flash_area_read(const struct flash_area *area, uint32_t off, void *dst, uint32_t len);
 
-//
-// Write len bytes from buffer src to flash area area at byte offset off.
-// The destination region must already be erased.
-// Returns 0 on success, negative errno on failure.
-//
-int flash_area_write(const struct flash_area *area, uint32_t off, const void *src, uint32_t len);
+    //
+    // Write len bytes from buffer src to flash area area at byte offset off.
+    // The destination region must already be erased.
+    // Returns 0 on success, negative errno on failure.
+    //
+    int flash_area_write(const struct flash_area *area, uint32_t off, const void *src, uint32_t len);
 
-//
-// Erase len bytes of flash area area starting at byte offset off.
-// off and len must be aligned to the device's erase-sector size.
-// Returns 0 on success, negative errno on failure.
-//
-int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len);
+    //
+    // Erase len bytes of flash area area starting at byte offset off.
+    // off and len must be aligned to the device's erase-sector size.
+    // Returns 0 on success, negative errno on failure.
+    //
+    int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len);
 
-//
-// Return the minimum write alignment (in bytes) for the given flash area.
-// MCUboot uses this to align trailer and status fields.
-// Typical values: 1 (NOR flash), 4 (STM32 F4/F7), 8 (STM32 H7), 32 (ESP32 with encryption).
-//
-uint32_t flash_area_align(const struct flash_area *area);
+    //
+    // Return the minimum write alignment (in bytes) for the given flash area.
+    // MCUboot uses this to align trailer and status fields.
+    // Typical values: 1 (NOR flash), 4 (STM32 F4/F7), 8 (STM32 H7), 32 (ESP32 with encryption).
+    //
+    uint32_t flash_area_align(const struct flash_area *area);
 
-//
-// Return the byte value that erased flash reads as (typically 0xFF for NOR flash).
-//
-uint8_t flash_area_erased_val(const struct flash_area *area);
+    //
+    // Return the byte value that erased flash reads as (typically 0xFF for NOR flash).
+    //
+    uint8_t flash_area_erased_val(const struct flash_area *area);
 
-//
-// Populate sectors[] with the sector geometry of flash area fa_id.
-// On entry *count is the capacity of sectors[].
-// On return *count is the actual number of sectors written.
-// Returns 0 on success, negative errno on failure.
-//
-// This function is required when MCUBOOT_USE_FLASH_AREA_GET_SECTORS is defined.
-//
-int flash_area_get_sectors(int fa_id, uint32_t *count, struct flash_sector *sectors);
+    //
+    // Populate sectors[] with the sector geometry of flash area fa_id.
+    // On entry *count is the capacity of sectors[].
+    // On return *count is the actual number of sectors written.
+    // Returns 0 on success, negative errno on failure.
+    //
+    // This function is required when MCUBOOT_USE_FLASH_AREA_GET_SECTORS is defined.
+    //
+    int flash_area_get_sectors(int fa_id, uint32_t *count, struct flash_sector *sectors);
 
-//
-// Translate (image_index, slot) to a flash area ID.
-// image_index: 0 = nanoCLR, 1 = deployment (multi-image).
-// slot: 0 = primary, 1 = secondary.
-// Returns the FLASH_AREA_IMAGE_x_* ID for the given combination.
-//
-int flash_area_id_from_multi_image_slot(int image_index, int slot);
+    //
+    // Translate (image_index, slot) to a flash area ID.
+    // image_index: 0 = nanoCLR, 1 = deployment (multi-image).
+    // slot: 0 = primary, 1 = secondary.
+    // Returns the FLASH_AREA_IMAGE_x_* ID for the given combination.
+    //
+    int flash_area_id_from_multi_image_slot(int image_index, int slot);
 
-//
-// Translate slot index to a flash area ID for single-image configurations.
-// Equivalent to flash_area_id_from_multi_image_slot(0, slot).
-//
-int flash_area_id_from_image_slot(int slot);
+    //
+    // Translate slot index to a flash area ID for single-image configurations.
+    // Equivalent to flash_area_id_from_multi_image_slot(0, slot).
+    //
+    int flash_area_id_from_image_slot(int slot);
 
 #ifdef __cplusplus
 }

--- a/MCUboot/include/mcuboot_config/mcuboot_config.h
+++ b/MCUboot/include/mcuboot_config/mcuboot_config.h
@@ -21,6 +21,7 @@
 //   CONFIG_NF_MCUBOOT_OVERWRITE_ONLY      (fallback: no rollback)
 //   CONFIG_NF_MCUBOOT_IMAGE_NUMBER        (defaults to 2)
 //   CONFIG_NF_MCUBOOT_SERIAL_RECOVERY     (optional UART recovery)
+//   CONFIG_NF_MCUBOOT_HEADER_SIZE         (image header size in bytes, defaults to 0x200)
 
 #ifndef __MCUBOOT_CONFIG_H__
 #define __MCUBOOT_CONFIG_H__
@@ -121,6 +122,17 @@
 //
 #if defined(CONFIG_NF_MCUBOOT_SERIAL_RECOVERY)
 #define MCUBOOT_SERIAL 1
+#endif
+
+//
+// Image header size — must match the flash layout reserved header area and
+// the imgtool sign --header-size argument.
+// Configured via CONFIG_NF_MCUBOOT_HEADER_SIZE in Kconfig (default 0x200 = 512 bytes).
+//
+#if defined(CONFIG_NF_MCUBOOT_HEADER_SIZE)
+#define MCUBOOT_HEADER_SIZE CONFIG_NF_MCUBOOT_HEADER_SIZE
+#else
+#define MCUBOOT_HEADER_SIZE 0x200
 #endif
 
 //

--- a/MCUboot/include/mcuboot_config/mcuboot_config.h
+++ b/MCUboot/include/mcuboot_config/mcuboot_config.h
@@ -1,0 +1,130 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// MCUboot compile-time configuration for nanoFramework.
+//
+// This header is the single authoritative compile-time configuration for the MCUboot
+// bootloader integration in nanoFramework.  It is included by all MCUboot source files
+// via the include path MCUboot/include/mcuboot_config/.
+//
+// Per-platform overrides (alignment, sector size, etc.) are applied by including the
+// platform-specific header AFTER this file:
+//   - MCUboot/port/stm32/mcuboot_stm32_config.h
+//   - MCUboot/port/esp32/mcuboot_esp32_config.h
+//
+// Upgrade strategy is selected at CMake configure time via one of:
+//   -DNF_MCUBOOT_SWAP_USING_OFFSET=ON   (STM32: primary internal, secondary external)
+//   -DNF_MCUBOOT_SWAP_USING_MOVE=ON     (ESP32: both slots in internal flash)
+//   -DNF_MCUBOOT_OVERWRITE_ONLY=ON      (fallback: no rollback)
+//
+// IMAGE_NUMBER and SERIAL_RECOVERY are similarly controlled via CMake.
+
+#ifndef __MCUBOOT_CONFIG_H__
+#define __MCUBOOT_CONFIG_H__
+
+//
+// Signature algorithm — ECDSA P-256 (secp256r1).
+// Chosen for small key/signature size and fast Cortex-M verification.
+// The public key is compiled into the MCUboot binary; signing uses imgtool.
+//
+#define MCUBOOT_SIGN_EC256
+
+//
+// Upgrade strategy — exactly one of the following is defined at CMake configure time.
+//
+// NF_MCUBOOT_SWAP_USING_OFFSET: STM32 primary platform.
+//   Primary slot: internal STM32 flash (nanoCLR code area).
+//   Secondary slot: external (Q)SPI flash, SD card, or USB MSD.
+//   MCUboot copies the new image from secondary to primary in-place, sector by sector,
+//   using the "offset" variant that does not require a separate scratch area.
+//
+// NF_MCUBOOT_SWAP_USING_MOVE: ESP32.
+//   Both slots reside in internal SPI flash.
+//   MCUboot moves sectors without a dedicated scratch area (requires aligned slot sizes).
+//
+// NF_MCUBOOT_OVERWRITE_ONLY: fallback for targets with no secondary NVM.
+//   No rollback support — new image overwrites primary slot directly.
+//
+#if defined(NF_MCUBOOT_SWAP_USING_OFFSET)
+#define MCUBOOT_SWAP_USING_OFFSET 1
+#elif defined(NF_MCUBOOT_SWAP_USING_MOVE)
+#define MCUBOOT_SWAP_USING_MOVE 1
+#elif defined(NF_MCUBOOT_OVERWRITE_ONLY)
+#define MCUBOOT_OVERWRITE_ONLY
+#endif
+
+//
+// Primary slot validation policy — build-type gated.
+//
+// Debug builds (NF_BUILD_RTM not defined):
+//   MCUBOOT_VALIDATE_PRIMARY_SLOT is NOT defined.
+//   Wire Protocol writes raw .NET assemblies directly to Image 1 primary slot
+//   (deploy_0) without MCUboot image headers.  MCUboot must not validate Image 1
+//   primary on every boot or it would reject Wire-Protocol-written content.
+//   MCUboot only validates Image 1 at OTA upgrade time (when deploy_1 contains
+//   a staged, signed OTA package).
+//
+// RTM builds (NF_BUILD_RTM defined):
+//   MCUBOOT_VALIDATE_PRIMARY_SLOT is defined — every boot validates the signature
+//   of the primary slot image.  Wire Protocol is disabled in RTM firmware, so
+//   direct writes to deploy_0 never occur.
+//
+#if defined(NF_BUILD_RTM)
+#define MCUBOOT_VALIDATE_PRIMARY_SLOT
+#endif
+
+//
+// Flash abstraction — use the flash_area_get_sectors() API for sector enumeration.
+// DEV_WITH_ERASE: flash device requires explicit erase before write.
+//
+#define MCUBOOT_USE_FLASH_AREA_GET_SECTORS
+#define MCUBOOT_DEV_WITH_ERASE
+
+//
+// Maximum number of erasable sectors that MCUboot will track per image slot.
+// Must be >= (slot_size / min_sector_size).
+// 512 is sufficient for all current nanoFramework targets:
+//   - STM32F76xx 128kB sectors: 960kB / 128kB = 7.5 → 8 sectors
+//   - ESP32 4kB sectors: 1664kB / 4kB = 416 sectors  (< 512 ✓)
+//
+#define MCUBOOT_MAX_IMG_SECTORS 512
+
+//
+// Multi-image configuration.
+// IMAGE_NUMBER = 2 for ALL nanoFramework targets (STM32 and ESP32).
+//   Image 0 — nanoCLR firmware  (primary = clr_0, secondary = clr_1)
+//   Image 1 — deployment area   (primary = deploy_0, secondary = deploy_1)
+// Both images are independently managed and can be upgraded/rolled back independently.
+//
+#if defined(NF_MCUBOOT_IMAGE_NUMBER)
+#define MCUBOOT_IMAGE_NUMBER NF_MCUBOOT_IMAGE_NUMBER
+#else
+#define MCUBOOT_IMAGE_NUMBER 2
+#endif
+
+//
+// Dependency checking — automatically enabled for multi-image configurations.
+// Enforces deploy→CLR version compatibility via IMAGE_TLV_DEPENDENCY TLV in signed images.
+//
+#if (MCUBOOT_IMAGE_NUMBER > 1)
+#define MCUBOOT_DEPENDENCY_CHECK 1
+#endif
+
+//
+// Serial recovery — optional bootloader recovery mode over UART.
+// Enabled per target via -DNF_MCUBOOT_SERIAL_RECOVERY=ON at CMake configure time.
+//
+#if defined(NF_MCUBOOT_SERIAL_RECOVERY)
+#define MCUBOOT_SERIAL 1
+#endif
+
+//
+// Logging — enable MCUboot's internal log output.
+// The platform port must provide MCUBOOT_LOG_MODULE_DECLARE / MCUBOOT_LOG_ERR etc.
+// wrappers redirecting to the nanoFramework trace infrastructure.
+//
+#define MCUBOOT_HAVE_LOGGING 1
+
+#endif // __MCUBOOT_CONFIG_H__

--- a/MCUboot/include/mcuboot_config/mcuboot_config.h
+++ b/MCUboot/include/mcuboot_config/mcuboot_config.h
@@ -14,15 +14,18 @@
 //   - MCUboot/port/stm32/mcuboot_stm32_config.h
 //   - MCUboot/port/esp32/mcuboot_esp32_config.h
 //
-// Upgrade strategy is selected at CMake configure time via one of:
-//   -DNF_MCUBOOT_SWAP_USING_OFFSET=ON   (STM32: primary internal, secondary external)
-//   -DNF_MCUBOOT_SWAP_USING_MOVE=ON     (ESP32: both slots in internal flash)
-//   -DNF_MCUBOOT_OVERWRITE_ONLY=ON      (fallback: no rollback)
-//
-// IMAGE_NUMBER and SERIAL_RECOVERY are similarly controlled via CMake.
+// Upgrade strategy and other options are selected via Kconfig (nf_config.h).
+// The relevant symbols are:
+//   CONFIG_NF_MCUBOOT_SWAP_USING_OFFSET   (STM32: primary internal, secondary external)
+//   CONFIG_NF_MCUBOOT_SWAP_USING_MOVE     (ESP32: both slots in internal flash)
+//   CONFIG_NF_MCUBOOT_OVERWRITE_ONLY      (fallback: no rollback)
+//   CONFIG_NF_MCUBOOT_IMAGE_NUMBER        (defaults to 2)
+//   CONFIG_NF_MCUBOOT_SERIAL_RECOVERY     (optional UART recovery)
 
 #ifndef __MCUBOOT_CONFIG_H__
 #define __MCUBOOT_CONFIG_H__
+
+#include "nf_config.h"
 
 //
 // Signature algorithm — ECDSA P-256 (secp256r1).
@@ -32,33 +35,33 @@
 #define MCUBOOT_SIGN_EC256
 
 //
-// Upgrade strategy — exactly one of the following is defined at CMake configure time.
+// Upgrade strategy — exactly one of the following is set via Kconfig.
 //
-// NF_MCUBOOT_SWAP_USING_OFFSET: STM32 primary platform.
+// CONFIG_NF_MCUBOOT_SWAP_USING_OFFSET: STM32 primary platform.
 //   Primary slot: internal STM32 flash (nanoCLR code area).
 //   Secondary slot: external (Q)SPI flash, SD card, or USB MSD.
 //   MCUboot copies the new image from secondary to primary in-place, sector by sector,
 //   using the "offset" variant that does not require a separate scratch area.
 //
-// NF_MCUBOOT_SWAP_USING_MOVE: ESP32.
+// CONFIG_NF_MCUBOOT_SWAP_USING_MOVE: ESP32.
 //   Both slots reside in internal SPI flash.
 //   MCUboot moves sectors without a dedicated scratch area (requires aligned slot sizes).
 //
-// NF_MCUBOOT_OVERWRITE_ONLY: fallback for targets with no secondary NVM.
+// CONFIG_NF_MCUBOOT_OVERWRITE_ONLY: fallback for targets with no secondary NVM.
 //   No rollback support — new image overwrites primary slot directly.
 //
-#if defined(NF_MCUBOOT_SWAP_USING_OFFSET)
+#if defined(CONFIG_NF_MCUBOOT_SWAP_USING_OFFSET)
 #define MCUBOOT_SWAP_USING_OFFSET 1
-#elif defined(NF_MCUBOOT_SWAP_USING_MOVE)
+#elif defined(CONFIG_NF_MCUBOOT_SWAP_USING_MOVE)
 #define MCUBOOT_SWAP_USING_MOVE 1
-#elif defined(NF_MCUBOOT_OVERWRITE_ONLY)
+#elif defined(CONFIG_NF_MCUBOOT_OVERWRITE_ONLY)
 #define MCUBOOT_OVERWRITE_ONLY
 #endif
 
 //
 // Primary slot validation policy — build-type gated.
 //
-// Debug builds (NF_BUILD_RTM not defined):
+// Debug builds (CONFIG_NF_BUILD_RTM not set):
 //   MCUBOOT_VALIDATE_PRIMARY_SLOT is NOT defined.
 //   Wire Protocol writes raw .NET assemblies directly to Image 1 primary slot
 //   (deploy_0) without MCUboot image headers.  MCUboot must not validate Image 1
@@ -66,12 +69,12 @@
 //   MCUboot only validates Image 1 at OTA upgrade time (when deploy_1 contains
 //   a staged, signed OTA package).
 //
-// RTM builds (NF_BUILD_RTM defined):
+// RTM builds (CONFIG_NF_BUILD_RTM=y):
 //   MCUBOOT_VALIDATE_PRIMARY_SLOT is defined — every boot validates the signature
 //   of the primary slot image.  Wire Protocol is disabled in RTM firmware, so
 //   direct writes to deploy_0 never occur.
 //
-#if defined(NF_BUILD_RTM)
+#if defined(CONFIG_NF_BUILD_RTM)
 #define MCUBOOT_VALIDATE_PRIMARY_SLOT
 #endif
 
@@ -98,8 +101,8 @@
 //   Image 1 — deployment area   (primary = deploy_0, secondary = deploy_1)
 // Both images are independently managed and can be upgraded/rolled back independently.
 //
-#if defined(NF_MCUBOOT_IMAGE_NUMBER)
-#define MCUBOOT_IMAGE_NUMBER NF_MCUBOOT_IMAGE_NUMBER
+#if defined(CONFIG_NF_MCUBOOT_IMAGE_NUMBER)
+#define MCUBOOT_IMAGE_NUMBER CONFIG_NF_MCUBOOT_IMAGE_NUMBER
 #else
 #define MCUBOOT_IMAGE_NUMBER 2
 #endif
@@ -114,9 +117,9 @@
 
 //
 // Serial recovery — optional bootloader recovery mode over UART.
-// Enabled per target via -DNF_MCUBOOT_SERIAL_RECOVERY=ON at CMake configure time.
+// Enabled per target via CONFIG_NF_MCUBOOT_SERIAL_RECOVERY=y in Kconfig.
 //
-#if defined(NF_MCUBOOT_SERIAL_RECOVERY)
+#if defined(CONFIG_NF_MCUBOOT_SERIAL_RECOVERY)
 #define MCUBOOT_SERIAL 1
 #endif
 

--- a/MCUboot/include/os/os_heap.h
+++ b/MCUboot/include/os/os_heap.h
@@ -15,18 +15,19 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-static inline void *os_malloc(size_t size)
-{
-    return malloc(size);
-}
+    static inline void *os_malloc(size_t size)
+    {
+        return malloc(size);
+    }
 
-static inline void os_free(void *mem)
-{
-    free(mem);
-}
+    static inline void os_free(void *mem)
+    {
+        free(mem);
+    }
 
 #ifdef __cplusplus
 }

--- a/MCUboot/include/os/os_heap.h
+++ b/MCUboot/include/os/os_heap.h
@@ -1,0 +1,35 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// Minimal OS heap shim for MCUboot.
+// MCUboot's boot_status and image verification routines call os_malloc / os_free
+// when MCUBOOT_USE_FLASH_AREA_GET_SECTORS is defined.  This shim redirects those
+// calls to the standard C library heap, which is available in both ChibiOS (via
+// newlib) and ESP-IDF runtime environments.
+
+#ifndef OS_HEAP_H
+#define OS_HEAP_H
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void *os_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+static inline void os_free(void *mem)
+{
+    free(mem);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OS_HEAP_H

--- a/MCUboot/include/sysflash/sysflash.h
+++ b/MCUboot/include/sysflash/sysflash.h
@@ -42,7 +42,8 @@
 #define FLASH_AREA_IMAGE_SCRATCH     3 // Scratch area (swap-using-scratch strategy only; unused by nanoFramework)
 
 #if (MCUBOOT_IMAGE_NUMBER == 2)
-#define FLASH_AREA_IMAGE_1_PRIMARY   4 // Deployment primary slot   (deploy_0; Wire Protocol writes here directly in debug)
+#define FLASH_AREA_IMAGE_1_PRIMARY                                                                                     \
+    4 // Deployment primary slot   (deploy_0; Wire Protocol writes here directly in debug)
 #define FLASH_AREA_IMAGE_1_SECONDARY 5 // Deployment secondary slot (deploy_1; OTA staging area)
 #endif
 
@@ -53,20 +54,17 @@
 //
 #if (MCUBOOT_IMAGE_NUMBER == 1)
 
-#define FLASH_AREA_IMAGE_PRIMARY(x)                                                                                    \
-    (((x) == 0) ? FLASH_AREA_IMAGE_0_PRIMARY : FLASH_SLOT_DOES_NOT_EXIST)
+#define FLASH_AREA_IMAGE_PRIMARY(x) (((x) == 0) ? FLASH_AREA_IMAGE_0_PRIMARY : FLASH_SLOT_DOES_NOT_EXIST)
 
-#define FLASH_AREA_IMAGE_SECONDARY(x)                                                                                  \
-    (((x) == 0) ? FLASH_AREA_IMAGE_0_SECONDARY : FLASH_SLOT_DOES_NOT_EXIST)
+#define FLASH_AREA_IMAGE_SECONDARY(x) (((x) == 0) ? FLASH_AREA_IMAGE_0_SECONDARY : FLASH_SLOT_DOES_NOT_EXIST)
 
 #elif (MCUBOOT_IMAGE_NUMBER == 2)
 
 #define FLASH_AREA_IMAGE_PRIMARY(x)                                                                                    \
-    (((x) == 0) ? FLASH_AREA_IMAGE_0_PRIMARY                                                                          \
-                : (((x) == 1) ? FLASH_AREA_IMAGE_1_PRIMARY : FLASH_SLOT_DOES_NOT_EXIST))
+    (((x) == 0) ? FLASH_AREA_IMAGE_0_PRIMARY : (((x) == 1) ? FLASH_AREA_IMAGE_1_PRIMARY : FLASH_SLOT_DOES_NOT_EXIST))
 
 #define FLASH_AREA_IMAGE_SECONDARY(x)                                                                                  \
-    (((x) == 0) ? FLASH_AREA_IMAGE_0_SECONDARY                                                                        \
+    (((x) == 0) ? FLASH_AREA_IMAGE_0_SECONDARY                                                                         \
                 : (((x) == 1) ? FLASH_AREA_IMAGE_1_SECONDARY : FLASH_SLOT_DOES_NOT_EXIST))
 
 #endif

--- a/MCUboot/include/sysflash/sysflash.h
+++ b/MCUboot/include/sysflash/sysflash.h
@@ -1,0 +1,74 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// Flash slot ID definitions for the nanoFramework MCUboot integration.
+//
+// These constants identify the named flash areas that MCUboot manages.
+// The platform port (flash_map_stm32.c / flash_map_esp32.c) maintains a static
+// table of struct flash_area descriptors indexed by these IDs.
+//
+// IMAGE_NUMBER = 2 for ALL nanoFramework targets:
+//   Image 0 = nanoCLR firmware  (IDs 1, 2)
+//   Image 1 = deployment area   (IDs 4, 5)
+//
+// FLASH_DEVICE_EXTERNAL_FLASH is used by the STM32 port for the secondary (update)
+// slots that reside on (Q)SPI flash, SD card, or USB MSD.
+
+#ifndef __SYSFLASH_H__
+#define __SYSFLASH_H__
+
+#include <mcuboot_config/mcuboot_config.h>
+
+//
+// Device identifiers — stored in flash_area.fa_device_id.
+//
+#define FLASH_DEVICE_INTERNAL_FLASH 0 // On-chip flash (primary slot for all targets)
+#define FLASH_DEVICE_EXTERNAL_FLASH 1 // Off-chip storage: (Q)SPI flash, SD card, USB MSD (STM32 secondary slots)
+
+//
+// Sentinel value returned when FLASH_AREA_IMAGE_PRIMARY/SECONDARY macros receive
+// an out-of-range image index.
+//
+#define FLASH_SLOT_DOES_NOT_EXIST 255
+
+//
+// Flash area IDs.
+//
+#define FLASH_AREA_BOOTLOADER        0 // MCUboot bootloader itself (read-only after flash)
+#define FLASH_AREA_IMAGE_0_PRIMARY   1 // nanoCLR primary slot   (internal flash, active CLR image)
+#define FLASH_AREA_IMAGE_0_SECONDARY 2 // nanoCLR secondary slot (external storage on STM32; internal on ESP32)
+#define FLASH_AREA_IMAGE_SCRATCH     3 // Scratch area (swap-using-scratch strategy only; unused by nanoFramework)
+
+#if (MCUBOOT_IMAGE_NUMBER == 2)
+#define FLASH_AREA_IMAGE_1_PRIMARY   4 // Deployment primary slot   (deploy_0; Wire Protocol writes here directly in debug)
+#define FLASH_AREA_IMAGE_1_SECONDARY 5 // Deployment secondary slot (deploy_1; OTA staging area)
+#endif
+
+//
+// Convenience macros that map (image_index, slot) to a flash area ID.
+// image_index: 0 = nanoCLR, 1 = deployment
+// slot:        0 = primary, 1 = secondary
+//
+#if (MCUBOOT_IMAGE_NUMBER == 1)
+
+#define FLASH_AREA_IMAGE_PRIMARY(x)                                                                                    \
+    (((x) == 0) ? FLASH_AREA_IMAGE_0_PRIMARY : FLASH_SLOT_DOES_NOT_EXIST)
+
+#define FLASH_AREA_IMAGE_SECONDARY(x)                                                                                  \
+    (((x) == 0) ? FLASH_AREA_IMAGE_0_SECONDARY : FLASH_SLOT_DOES_NOT_EXIST)
+
+#elif (MCUBOOT_IMAGE_NUMBER == 2)
+
+#define FLASH_AREA_IMAGE_PRIMARY(x)                                                                                    \
+    (((x) == 0) ? FLASH_AREA_IMAGE_0_PRIMARY                                                                          \
+                : (((x) == 1) ? FLASH_AREA_IMAGE_1_PRIMARY : FLASH_SLOT_DOES_NOT_EXIST))
+
+#define FLASH_AREA_IMAGE_SECONDARY(x)                                                                                  \
+    (((x) == 0) ? FLASH_AREA_IMAGE_0_SECONDARY                                                                        \
+                : (((x) == 1) ? FLASH_AREA_IMAGE_1_SECONDARY : FLASH_SLOT_DOES_NOT_EXIST))
+
+#endif
+
+#endif // __SYSFLASH_H__

--- a/MCUboot/keys/README.md
+++ b/MCUboot/keys/README.md
@@ -1,0 +1,118 @@
+# MCUboot Key Management
+
+This directory contains signing keys for the nanoFramework MCUboot integration.
+
+> ⚠️ **The development key in this directory (`dev-signing-key.pem`) is committed to
+> the public repository and is NOT SECURE.  It must never be used for production
+> firmware releases.**
+
+---
+
+## Key Files
+
+| File | Purpose | Committed? |
+|------|---------|-----------|
+| `dev-signing-key.pem` | ECDSA P-256 private key — development/CI builds only | Yes (intentional) |
+| `root-ec256.pem` | ECDSA P-256 public key — embedded in the MCUboot binary | Yes |
+| `prod-signing-key.pem` | Production private key — **must never be committed** | **No** |
+
+---
+
+## Generating a New Key Pair
+
+Use `imgtool` from the MCUboot project (install via `pip install imgtool`):
+
+```bash
+# Generate a new ECDSA P-256 key pair
+imgtool keygen --key dev-signing-key.pem --type ecdsa-p256
+
+# Extract the public key as a C source file for embedding in MCUboot
+imgtool getpub --key dev-signing-key.pem --lang c > signing_pub_key.c
+```
+
+The `signing_pub_key.c` output contains:
+
+```c
+const unsigned char ecdsa_pub_key[] = { /* ... */ };
+const unsigned int ecdsa_pub_key_len = /* ... */;
+```
+
+This file is compiled into the MCUboot bootloader binary.  Once MCUboot is flashed,
+the public key is **immutable** — only firmware signed with the corresponding private key
+will be accepted.
+
+---
+
+## Signing a Firmware Image
+
+After building nanoCLR, sign the binary with `imgtool`:
+
+```bash
+imgtool sign \
+    --key dev-signing-key.pem \
+    --align 4 \
+    --version 1.0.0.0 \
+    --header-size 0x200 \
+    --pad-header \
+    --slot-size <slot_size_bytes> \
+    nanoCLR.bin \
+    nanoCLR-signed.bin
+```
+
+For ESP32 targets, use `--header-size 0x20` and `--align 32` (if flash encryption is enabled).
+
+Verify a signed image:
+
+```bash
+imgtool verify --key root-ec256.pem nanoCLR-signed.bin
+```
+
+---
+
+## Key Distribution Policy
+
+| Key type | Storage | Who holds it | Build usage |
+|---------|---------|-------------|------------|
+| Development key (`dev-signing-key.pem`) | This repo | All developers, CI | Debug and CI firmware builds |
+| Production key | Azure Key Vault / HSM | Release CI pipeline only | Official nanoFramework firmware releases |
+| Public key (`root-ec256.pem`) | This repo, compiled into MCUboot | All developers, CI | Embedded in every MCUboot binary |
+
+---
+
+## Key Rotation
+
+When a production key needs to be rotated:
+
+1. Generate a new key pair with `imgtool keygen`.
+2. Rebuild MCUboot with the new public key embedded.
+3. Flash the new MCUboot binary to all devices **before** distributing firmware signed with the new key.
+4. All devices must be updated to the new MCUboot before old-key firmware stops working.
+5. Revoke the old key from the key vault.
+
+> ⚠️ Key rotation requires a device firmware update campaign.  Plan carefully.
+
+---
+
+## imgtool Quick Reference
+
+```bash
+# Install imgtool
+pip install imgtool
+
+# Generate key
+imgtool keygen --key <keyfile.pem> --type ecdsa-p256
+
+# Extract public key (C source)
+imgtool getpub --key <keyfile.pem> --lang c
+
+# Sign image
+imgtool sign --key <keyfile.pem> --align <n> --version <x.y.z.b> \
+             --header-size <hdr> --pad-header --slot-size <size> \
+             <input.bin> <output-signed.bin>
+
+# Verify signed image
+imgtool verify --key <pubkey.pem> <signed.bin>
+
+# Show image header/TLV info
+imgtool imginfo <signed.bin>
+```

--- a/MCUboot/port/esp32/bootloader.conf
+++ b/MCUboot/port/esp32/bootloader.conf
@@ -1,0 +1,43 @@
+# MCUboot bootloader configuration for nanoFramework ESP32 targets.
+# Used with the MCUboot Espressif port (boot/espressif/).
+#
+# Reference: https://github.com/mcu-tools/mcuboot/blob/main/boot/espressif/README.md
+#
+# Slot addresses and sizes below match the 4 MB MCUboot partition table:
+#   targets/ESP32/_IDF/esp32/partitions_nanoclr_4mb.csv
+# For other flash sizes, regenerate from the corresponding partitions_nanoclr_NNmb.csv.
+#
+# IMAGE_NUMBER=2: nanoCLR (image 0) + deployment (image 1) managed independently.
+
+# Bootloader binary size budget — must fit in the bootloader partition.
+# The MCUboot Espressif port binary is typically 180-220 kB.
+# ESP32 classic bootloader partition = 0xF000 bytes = 60 kB (default IDF).
+# MCUboot replaces the IDF second-stage bootloader; it is flashed at 0x1000.
+# nanoFramework uses a dedicated 64 kB bootloader partition.
+CONFIG_ESP_BOOTLOADER_SIZE=0x10000
+
+# Signature algorithm: ECDSA P-256 (consistent with mcuboot_config.h)
+CONFIG_ESP_SIGN_EC256=y
+
+# Multi-image: nanoCLR + deployment
+CONFIG_ESP_IMAGE_NUMBER=2
+
+# Primary slot — nanoCLR image 0 (clr_0), 4 MB partition table
+# Address: 0x20000 (immediately after partition table at 0x10000 + 0x1000 gap)
+# Size: 1664 kB = 0x1A0000
+# TODO(ifu-phase2): Update addresses to match the target flash size variant.
+CONFIG_ESP_APPLICATION_PRIMARY_START_ADDRESS=0x20000
+CONFIG_ESP_APPLICATION_SIZE=0x1A0000
+
+# Secondary slot — nanoCLR image 0 (clr_1), 4 MB partition table
+# Address: 0x1C0000
+# Size: 1664 kB = 0x1A0000
+CONFIG_ESP_APPLICATION_SECONDARY_START_ADDRESS=0x1C0000
+
+# Serial recovery — optional UART recovery mode
+CONFIG_ESP_MCUBOOT_SERIAL=y
+
+# Primary slot validation on every boot (RTM behaviour).
+# In development, this may be disabled to allow Wire Protocol direct writes.
+# TODO(ifu-phase2): Gate on NF_BUILD_RTM via IDF Kconfig integration.
+CONFIG_ESP_MCUBOOT_VALIDATE_PRIMARY_SLOT=y

--- a/MCUboot/port/esp32/flash_map_esp32.c
+++ b/MCUboot/port/esp32/flash_map_esp32.c
@@ -55,7 +55,7 @@
 //
 typedef struct
 {
-    struct flash_area base;                    // Must be first — returned as const struct flash_area *
+    struct flash_area base;               // Must be first — returned as const struct flash_area *
     const esp_partition_t *esp_partition; // Resolved by flash_area_open(); NULL until opened
 } nf_esp32_flash_area_t;
 

--- a/MCUboot/port/esp32/flash_map_esp32.c
+++ b/MCUboot/port/esp32/flash_map_esp32.c
@@ -1,0 +1,225 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// ESP32-specific MCUboot flash area implementation (porting layer stub).
+//
+// This file implements the flash_area_* API from flash_map_backend.h on top of
+// the ESP-IDF partition API for all nanoFramework ESP32 variants:
+//   esp32, esp32s2, esp32s3, esp32c3, esp32c5, esp32c6, esp32h2, esp32p4
+//
+// Both slots (primary and secondary) reside in internal SPI flash.
+// Upgrade strategy: MCUBOOT_SWAP_USING_MOVE (set in mcuboot_esp32_config.h).
+//
+// The partition labels used here correspond to the nanoFramework MCUboot partition
+// CSV files at targets/ESP32/_IDF/<variant>/partitions_nanoclr_*.csv:
+//   "clr_0"     → FLASH_AREA_IMAGE_0_PRIMARY   (nanoCLR primary)
+//   "clr_1"     → FLASH_AREA_IMAGE_0_SECONDARY (nanoCLR secondary)
+//   "deploy_0"  → FLASH_AREA_IMAGE_1_PRIMARY   (deployment primary)
+//   "deploy_1"  → FLASH_AREA_IMAGE_1_SECONDARY (deployment secondary)
+//   "mcuboot"   → FLASH_AREA_BOOTLOADER        (not in CSV; located at 0x1000/0x0)
+//
+// Write alignment:
+//   Standard: 4 bytes.
+//   With flash encryption enabled: 32 bytes.
+//   This stub returns 4 bytes; flash encryption support requires a runtime check.
+//
+// All functions are stubs that return success.  Each contains a TODO comment
+// identifying the exact ESP-IDF API call to substitute in Phase 2.
+//
+// Phase 2 implementation tasks are tagged: // TODO(ifu-phase2): <description>
+
+#include <stdint.h>
+#include <stddef.h>
+
+// ESP-IDF partition API
+// TODO(ifu-phase2): Verify include path is correct for the ESP-IDF version in use (v5.5.4).
+#include "esp_partition.h"
+
+#include "flash_map_backend/flash_map_backend.h"
+#include "sysflash/sysflash.h"
+
+//
+// Partition label strings — must match exactly the partition names in the CSV files.
+// These are used to locate the esp_partition_t via esp_partition_find_first().
+//
+#define NF_ESP32_PARTITION_CLR_0    "clr_0"
+#define NF_ESP32_PARTITION_CLR_1    "clr_1"
+#define NF_ESP32_PARTITION_DEPLOY_0 "deploy_0"
+#define NF_ESP32_PARTITION_DEPLOY_1 "deploy_1"
+
+//
+// Extended flash area descriptor that carries the ESP-IDF partition pointer.
+// This allows flash_area_read/write/erase to call the esp_partition_* API directly.
+//
+typedef struct
+{
+    struct flash_area base;                    // Must be first — returned as const struct flash_area *
+    const esp_partition_t *esp_partition; // Resolved by flash_area_open(); NULL until opened
+} nf_esp32_flash_area_t;
+
+//
+// Static flash area table for ESP32 targets.
+// Offsets and sizes are populated at open time from the esp_partition_t resolved by label.
+// TODO(ifu-phase2): Populate fa_off and fa_size at boot from partition table (esp_partition_find_first).
+//
+static nf_esp32_flash_area_t s_esp32_flash_areas[] = {
+    // clang-format off
+    { .base = { .fa_id = FLASH_AREA_BOOTLOADER,        .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH, .fa_off = 0, .fa_size = 0 }, .esp_partition = NULL },
+    { .base = { .fa_id = FLASH_AREA_IMAGE_0_PRIMARY,   .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH, .fa_off = 0, .fa_size = 0 }, .esp_partition = NULL },
+    { .base = { .fa_id = FLASH_AREA_IMAGE_0_SECONDARY, .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH, .fa_off = 0, .fa_size = 0 }, .esp_partition = NULL },
+    { .base = { .fa_id = FLASH_AREA_IMAGE_1_PRIMARY,   .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH, .fa_off = 0, .fa_size = 0 }, .esp_partition = NULL },
+    { .base = { .fa_id = FLASH_AREA_IMAGE_1_SECONDARY, .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH, .fa_off = 0, .fa_size = 0 }, .esp_partition = NULL },
+    // clang-format on
+};
+
+#define FLASH_AREA_TABLE_COUNT (sizeof(s_esp32_flash_areas) / sizeof(s_esp32_flash_areas[0]))
+
+//
+// Map flash area ID to the partition label string used in the partition CSV.
+//
+static const char *s_partition_label_for_id(uint8_t id)
+{
+    switch (id)
+    {
+        case FLASH_AREA_IMAGE_0_PRIMARY:
+            return NF_ESP32_PARTITION_CLR_0;
+        case FLASH_AREA_IMAGE_0_SECONDARY:
+            return NF_ESP32_PARTITION_CLR_1;
+        case FLASH_AREA_IMAGE_1_PRIMARY:
+            return NF_ESP32_PARTITION_DEPLOY_0;
+        case FLASH_AREA_IMAGE_1_SECONDARY:
+            return NF_ESP32_PARTITION_DEPLOY_1;
+        default:
+            return NULL;
+    }
+}
+
+int flash_area_open(uint8_t id, const struct flash_area **area_outp)
+{
+    for (uint32_t i = 0; i < FLASH_AREA_TABLE_COUNT; i++)
+    {
+        if (s_esp32_flash_areas[i].base.fa_id == id)
+        {
+            // TODO(ifu-phase2): Resolve the esp_partition_t and populate fa_off / fa_size.
+            //   const char *label = s_partition_label_for_id(id);
+            //   if (label != NULL) {
+            //       s_esp32_flash_areas[i].esp_partition =
+            //           esp_partition_find_first(ESP_PARTITION_TYPE_APP,
+            //                                   ESP_PARTITION_SUBTYPE_ANY, label);
+            //       if (s_esp32_flash_areas[i].esp_partition != NULL) {
+            //           s_esp32_flash_areas[i].base.fa_off  = s_esp32_flash_areas[i].esp_partition->address;
+            //           s_esp32_flash_areas[i].base.fa_size = s_esp32_flash_areas[i].esp_partition->size;
+            //       }
+            //   }
+            *area_outp = &s_esp32_flash_areas[i].base;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+void flash_area_close(const struct flash_area *area)
+{
+    (void)area;
+    // No resource to release — esp_partition_t is a const pointer into ROM partition table.
+}
+
+int flash_area_read(const struct flash_area *area, uint32_t off, void *dst, uint32_t len)
+{
+    (void)area;
+    (void)off;
+    (void)dst;
+    (void)len;
+
+    // TODO(ifu-phase2): Call esp_partition_read(esp_area->esp_partition, off, dst, len).
+    //   esp_partition_read handles internal cache coherency and SPI flash locking.
+    //   Return (ret == ESP_OK) ? 0 : -1;
+
+    return 0; // Stub: success
+}
+
+int flash_area_write(const struct flash_area *area, uint32_t off, const void *src, uint32_t len)
+{
+    (void)area;
+    (void)off;
+    (void)src;
+    (void)len;
+
+    // TODO(ifu-phase2): Call esp_partition_write(esp_area->esp_partition, off, src, len).
+    //   Note: if flash encryption is enabled, alignment must be 32 bytes.
+    //   Return (ret == ESP_OK) ? 0 : -1;
+
+    return 0; // Stub: success
+}
+
+int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len)
+{
+    (void)area;
+    (void)off;
+    (void)len;
+
+    // TODO(ifu-phase2): Call esp_partition_erase_range(esp_area->esp_partition, off, len).
+    //   ESP32 internal flash erase granularity is 4 kB (one "sector" in ESP-IDF terms).
+    //   off and len must be 4 kB aligned.
+    //   Return (ret == ESP_OK) ? 0 : -1;
+
+    return 0; // Stub: success
+}
+
+uint32_t flash_area_align(const struct flash_area *area)
+{
+    (void)area;
+    // Standard ESP32 SPI flash write alignment is 4 bytes.
+    // TODO(ifu-phase2): Return 32 if flash encryption is enabled (check esp_flash_encryption_enabled()).
+    return 4;
+}
+
+uint8_t flash_area_erased_val(const struct flash_area *area)
+{
+    (void)area;
+    // ESP32 SPI flash (NOR) reads as 0xFF after erase.
+    return 0xFF;
+}
+
+int flash_area_get_sectors(int fa_id, uint32_t *count, struct flash_sector *sectors)
+{
+    (void)fa_id;
+    (void)count;
+    (void)sectors;
+
+    // TODO(ifu-phase2): Populate sectors[] with uniform 4 kB sectors for the ESP32 internal flash.
+    //   ESP32 SPI flash uses uniform 4096-byte erase sectors regardless of variant.
+    //
+    //   uint32_t area_size   = /* fa_size for fa_id, from resolved esp_partition->size */;
+    //   uint32_t sector_size = 4096U;
+    //   uint32_t n           = area_size / sector_size;
+    //   for (uint32_t i = 0; i < n && i < *count; i++) {
+    //       sectors[i].fs_off  = i * sector_size;
+    //       sectors[i].fs_size = sector_size;
+    //   }
+    //   *count = n;
+    //   return 0;
+
+    *count = 0;
+    return 0; // Stub: success
+}
+
+int flash_area_id_from_multi_image_slot(int image_index, int slot)
+{
+    if (image_index == 0)
+    {
+        return (slot == 0) ? FLASH_AREA_IMAGE_0_PRIMARY : FLASH_AREA_IMAGE_0_SECONDARY;
+    }
+    else if (image_index == 1)
+    {
+        return (slot == 0) ? FLASH_AREA_IMAGE_1_PRIMARY : FLASH_AREA_IMAGE_1_SECONDARY;
+    }
+    return -1;
+}
+
+int flash_area_id_from_image_slot(int slot)
+{
+    return flash_area_id_from_multi_image_slot(0, slot);
+}

--- a/MCUboot/port/esp32/mcuboot_esp32_config.h
+++ b/MCUboot/port/esp32/mcuboot_esp32_config.h
@@ -1,0 +1,32 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// ESP32-specific MCUboot configuration overrides for nanoFramework.
+//
+// This header is included AFTER mcuboot_config.h to apply ESP32-specific
+// configuration values that differ from the generic defaults.
+//
+// Upgrade strategy: MCUBOOT_SWAP_USING_MOVE
+//   Both slots reside in internal SPI flash.
+//   No dedicated scratch area is required — MCUboot moves sectors within the
+//   flash address space during a swap.
+//
+// Write alignment: 4 bytes standard; 32 bytes when flash encryption is enabled.
+
+#ifndef MCUBOOT_ESP32_CONFIG_H
+#define MCUBOOT_ESP32_CONFIG_H
+
+// Internal SPI flash sector size for all ESP32 variants.
+// ESP-IDF erases in units of 4 kB regardless of the physical flash chip.
+// MCUboot uses this for sector enumeration in flash_area_get_sectors().
+#define MCUBOOT_ESP32_FLASH_SECTOR_SIZE (4 * 1024U)
+
+// MCUboot image header size in bytes for ESP32 Espressif port.
+// Must match the --header-size argument passed to imgtool sign.
+// 0x20 is the standard value for the Espressif MCUboot port.
+// TODO(ifu-phase2): Confirm with MCUboot Espressif port boot/espressif/include/esp_mcuboot_image.h.
+#define MCUBOOT_IMAGE_HEADER_SIZE 0x20
+
+#endif // MCUBOOT_ESP32_CONFIG_H

--- a/MCUboot/port/stm32/flash_map_stm32.c
+++ b/MCUboot/port/stm32/flash_map_stm32.c
@@ -1,0 +1,220 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// STM32-specific MCUboot flash area implementation (porting layer stub).
+//
+// This file implements the flash_area_* API from flash_map_backend.h on top of
+// the STM32 HAL flash driver already present in nanoFramework.
+//
+// PRIMARY SLOT (nanoCLR / deployment primary):
+//   Uses the STM32 internal flash driver.  The existing Wire Protocol commands
+//   call stm32FlashWrite() / stm32FlashErase() directly; this stub wraps the
+//   same driver calls for the MCUboot path.
+//   Reference: targets/ChibiOS/<BOARD>/common/WireProtocol_MonitorCommands.c
+//
+// SECONDARY SLOT (nanoCLR / deployment secondary — OTA staging):
+//   Uses external storage.  Three options are available per board:
+//     - ORGPAL_PALTHREE / ORGPAL_PALX: (Q)SPI flash via hal_lfs_read/prog/erase
+//     - ST_STM32F769I_DISCOVERY:       SD card via FatFs (virtual-sector abstraction)
+//   Selection is driven by compile-time defines set from the board's CMakeLists.
+//
+// Alignment notes (per-SoC, from STM32 reference manuals):
+//   STM32F76xx: write granularity = 4 bytes (byte/halfword/word/doubleword supported)
+//   STM32F429:  write granularity = 1/2/4 bytes (sector-dependent)
+//
+// All functions are stubs that return success.  Each contains a TODO comment
+// identifying the exact driver call to substitute in Phase 1.
+//
+// Phase 1 implementation tasks are tagged: // TODO(ifu-phase1): <description>
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "flash_map_backend/flash_map_backend.h"
+#include "sysflash/sysflash.h"
+
+//
+// Static flash area table for STM32 targets.
+// Addresses and sizes are placeholders; they are overridden per board by the
+// board-specific mcuboot_stm32_config.h which is included by the CMake build.
+//
+// Layout (example: ORGPAL_PALTHREE / ST_STM32F769I_DISCOVERY, IMAGE_NUMBER=2):
+//   FLASH_AREA_BOOTLOADER        (0): 0x08000000, 32 kB  (MCUboot replaces nanoBooter)
+//   FLASH_AREA_IMAGE_0_PRIMARY   (1): 0x08008000, 960 kB (nanoCLR primary, internal)
+//   FLASH_AREA_IMAGE_0_SECONDARY (2): external,   960 kB (nanoCLR secondary, ext. storage)
+//   FLASH_AREA_IMAGE_1_PRIMARY   (4): 0x080F8000, 1024 kB (deploy_0 primary, internal)
+//   FLASH_AREA_IMAGE_1_SECONDARY (5): external,   1024 kB (deploy_1 secondary, ext. storage)
+//
+// TODO(ifu-phase1): Populate exact addresses from board linker script / MCUboot-flash-layout.md.
+//
+static const struct flash_area s_stm32_flash_areas[] = {
+    // clang-format off
+    { .fa_id = FLASH_AREA_BOOTLOADER,        .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH, .fa_off = 0x00000000, .fa_size = 0 },
+    { .fa_id = FLASH_AREA_IMAGE_0_PRIMARY,   .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH, .fa_off = 0x00000000, .fa_size = 0 },
+    { .fa_id = FLASH_AREA_IMAGE_0_SECONDARY, .fa_device_id = FLASH_DEVICE_EXTERNAL_FLASH, .fa_off = 0x00000000, .fa_size = 0 },
+    { .fa_id = FLASH_AREA_IMAGE_1_PRIMARY,   .fa_device_id = FLASH_DEVICE_INTERNAL_FLASH, .fa_off = 0x00000000, .fa_size = 0 },
+    { .fa_id = FLASH_AREA_IMAGE_1_SECONDARY, .fa_device_id = FLASH_DEVICE_EXTERNAL_FLASH, .fa_off = 0x00000000, .fa_size = 0 },
+    // clang-format on
+};
+
+#define FLASH_AREA_TABLE_COUNT (sizeof(s_stm32_flash_areas) / sizeof(s_stm32_flash_areas[0]))
+
+int flash_area_open(uint8_t id, const struct flash_area **area_outp)
+{
+    for (uint32_t i = 0; i < FLASH_AREA_TABLE_COUNT; i++)
+    {
+        if (s_stm32_flash_areas[i].fa_id == id)
+        {
+            *area_outp = &s_stm32_flash_areas[i];
+            return 0;
+        }
+    }
+    return -1;
+}
+
+void flash_area_close(const struct flash_area *area)
+{
+    (void)area;
+    // No resource to release for memory-mapped internal flash.
+    // TODO(ifu-phase1): If using FatFs SD card for external slot, close the file handle here.
+}
+
+int flash_area_read(const struct flash_area *area, uint32_t off, void *dst, uint32_t len)
+{
+    (void)area;
+    (void)off;
+    (void)dst;
+    (void)len;
+
+    if (area->fa_device_id == FLASH_DEVICE_INTERNAL_FLASH)
+    {
+        // TODO(ifu-phase1): Replace with memcpy from (area->fa_off + off) for memory-mapped internal flash.
+        //   Internal STM32 flash is memory-mapped and readable via direct pointer dereference.
+        //   Example: memcpy(dst, (void *)(area->fa_off + off), len);
+    }
+    else
+    {
+        // TODO(ifu-phase1): ORGPAL_PALTHREE/PALX: call hal_lfs_read_0() / hal_lfs_read_1().
+        //   F769I: call f_read() via FatFs virtual-sector abstraction for the SD card slot file.
+    }
+
+    return 0; // Stub: success
+}
+
+int flash_area_write(const struct flash_area *area, uint32_t off, const void *src, uint32_t len)
+{
+    (void)area;
+    (void)off;
+    (void)src;
+    (void)len;
+
+    if (area->fa_device_id == FLASH_DEVICE_INTERNAL_FLASH)
+    {
+        // TODO(ifu-phase1): Call stm32FlashWrite(area->fa_off + off, src, len).
+        //   stm32FlashWrite() wraps the STM32 HAL FLASH_Program_* calls with unlock/lock.
+        //   Reference: targets/ChibiOS/<BOARD>/common/WireProtocol_MonitorCommands.c
+    }
+    else
+    {
+        // TODO(ifu-phase1): ORGPAL_PALTHREE/PALX: call hal_lfs_prog_0() / hal_lfs_prog_1().
+        //   F769I: call f_write() via FatFs for the SD card slot file.
+    }
+
+    return 0; // Stub: success
+}
+
+int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len)
+{
+    (void)area;
+    (void)off;
+    (void)len;
+
+    if (area->fa_device_id == FLASH_DEVICE_INTERNAL_FLASH)
+    {
+        // TODO(ifu-phase1): Call stm32FlashErase(area->fa_off + off, len).
+        //   Must align erase requests to sector boundaries per flash_area_get_sectors().
+        //   Reference: targets/ChibiOS/<BOARD>/common/WireProtocol_MonitorCommands.c
+    }
+    else
+    {
+        // TODO(ifu-phase1): ORGPAL_PALTHREE/PALX: call hal_lfs_erase_0() / hal_lfs_erase_1().
+        //   F769I: erase range via FatFs (overwrite with 0xFF blocks) for the SD card file.
+    }
+
+    return 0; // Stub: success
+}
+
+uint32_t flash_area_align(const struct flash_area *area)
+{
+    if (area->fa_device_id == FLASH_DEVICE_INTERNAL_FLASH)
+    {
+        // TODO(ifu-phase1): Return SoC-specific write granularity.
+        //   STM32F76xx: 4 (word-aligned writes via FLASH_CR_PSIZE_WORD)
+        //   STM32F429:  4 (same; F429 also supports byte/halfword but word is safest)
+        return 4;
+    }
+    else
+    {
+        // TODO(ifu-phase1): Return write granularity for the external storage device.
+        //   AT25SF641 SPI flash (PALTHREE): 1 byte minimum page-program granularity.
+        //   W25Q128 QSPI flash (PALX): 1 byte minimum page-program granularity.
+        //   SD card FatFs (F769I): 512 bytes (block size); implement virtual-sector shim.
+        return 1;
+    }
+}
+
+uint8_t flash_area_erased_val(const struct flash_area *area)
+{
+    (void)area;
+    // NOR flash (both internal STM32 and all external SPI/QSPI devices used by nanoFramework)
+    // reads as 0xFF after erase.
+    return 0xFF;
+}
+
+int flash_area_get_sectors(int fa_id, uint32_t *count, struct flash_sector *sectors)
+{
+    (void)fa_id;
+    (void)count;
+    (void)sectors;
+
+    // TODO(ifu-phase1): Populate sectors[] with the actual erase sector geometry.
+    //   Internal STM32F76xx: non-uniform sectors (16k/16k/16k/16k/64k/128k*11).
+    //     The CLR primary slot (0x08008000, 960kB) spans: partial 64kB sector + eleven 128kB sectors.
+    //   External AT25SF641 (PALTHREE): uniform 64kB erase blocks → 960kB/64kB = 15 blocks.
+    //   External W25Q128 (PALX): uniform 64kB erase blocks → slot-size/64kB blocks.
+    //   SD card (F769I): implement 4kB virtual sectors over FatFs file I/O.
+    //
+    // Example skeleton for uniform sectors:
+    //   uint32_t sector_size = MCUBOOT_EXTERNAL_FLASH_SECTOR_SIZE;
+    //   uint32_t area_size   = /* fa_size for fa_id */;
+    //   uint32_t n           = area_size / sector_size;
+    //   for (uint32_t i = 0; i < n && i < *count; i++) {
+    //       sectors[i].fs_off  = i * sector_size;
+    //       sectors[i].fs_size = sector_size;
+    //   }
+    //   *count = n;
+    //   return 0;
+
+    *count = 0;
+    return 0; // Stub: success
+}
+
+int flash_area_id_from_multi_image_slot(int image_index, int slot)
+{
+    if (image_index == 0)
+    {
+        return (slot == 0) ? FLASH_AREA_IMAGE_0_PRIMARY : FLASH_AREA_IMAGE_0_SECONDARY;
+    }
+    else if (image_index == 1)
+    {
+        return (slot == 0) ? FLASH_AREA_IMAGE_1_PRIMARY : FLASH_AREA_IMAGE_1_SECONDARY;
+    }
+    return -1;
+}
+
+int flash_area_id_from_image_slot(int slot)
+{
+    return flash_area_id_from_multi_image_slot(0, slot);
+}

--- a/MCUboot/port/stm32/mcuboot_stm32_config.h
+++ b/MCUboot/port/stm32/mcuboot_stm32_config.h
@@ -1,0 +1,32 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// STM32-specific MCUboot configuration overrides for nanoFramework.
+//
+// This header is included AFTER mcuboot_config.h to apply STM32-specific
+// configuration values that differ from the generic defaults.
+//
+// Upgrade strategy: MCUBOOT_SWAP_USING_OFFSET
+//   Primary slot:   internal STM32 flash
+//   Secondary slot: external (Q)SPI flash (PALTHREE/PALX) or SD card FatFs (F769I)
+//
+// Write alignment: STM32F76xx = 4 bytes (FLASH_CR_PSIZE_WORD)
+//                  STM32F429  = 4 bytes (word writes are safest across all sectors)
+
+#ifndef MCUBOOT_STM32_CONFIG_H
+#define MCUBOOT_STM32_CONFIG_H
+
+// External flash sector size used for secondary-slot sector enumeration.
+// AT25SF641 (PALTHREE SPI1) and W25Q128 (PALX QSPI): 64 kB erase blocks.
+// Override per board if smaller sub-sector erase (4 kB) is preferred.
+// TODO(ifu-phase1): Confirm with board-specific flash datasheet before use.
+#define MCUBOOT_EXTERNAL_FLASH_SECTOR_SIZE (64 * 1024U)
+
+// MCUboot image header size in bytes.
+// Standard value for STM32 Cortex-M targets using ARM Embedded GCC.
+// Must match the --header-size argument passed to imgtool sign.
+#define MCUBOOT_IMAGE_HEADER_SIZE 0x200
+
+#endif // MCUBOOT_STM32_CONFIG_H

--- a/MCUboot/version.json
+++ b/MCUboot/version.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.0",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$"
+  ],
+  "pathFilters": [
+    "MCUboot/",
+    "targets/**/mcuboot/"
+  ]
+}

--- a/targets/ESP32/_IDF/esp32/partitions_nanoclr_16mb.csv
+++ b/targets/ESP32/_IDF/esp32/partitions_nanoclr_16mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x420000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x428000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~5.9MB each
-deploy_0,   data, 0x84,     0x42E000, 0x5E9000,  # ~5.9MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0xA17000, 0x5E9000,  # ~5.9MB Image 1 secondary (MCUboot staging)
+# ~5.9MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x42E000, 0x5E9000
+# ~5.9MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0xA17000, 0x5E9000
 ##########################################
 # total size has to be 0x1000000 or less #
 ##########################################

--- a/targets/ESP32/_IDF/esp32/partitions_nanoclr_2mb.csv
+++ b/targets/ESP32/_IDF/esp32/partitions_nanoclr_2mb.csv
@@ -16,8 +16,10 @@ secondary, app,  ota_1,    0xD0000,  0xC0000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,    data, littlefs, 0x190000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  212k each
-deploy_0,  data, 0x84,     0x196000, 0x35000,  # 212k Image 1 primary (active deployment)
-deploy_1,  data, 0x84,     0x1CB000, 0x35000,  # 212k Image 1 secondary (MCUboot staging)
+# 212k Image 1 primary (active deployment)
+deploy_0,  data, 0x84,     0x196000, 0x35000
+# 212k Image 1 secondary (MCUboot staging)
+deploy_1,  data, 0x84,     0x1CB000, 0x35000
 #################################
 # total size has to be 0x200000 #
 #################################

--- a/targets/ESP32/_IDF/esp32/partitions_nanoclr_4mb.csv
+++ b/targets/ESP32/_IDF/esp32/partitions_nanoclr_4mb.csv
@@ -16,8 +16,10 @@ secondary, app,  ota_1,    0x1B0000, 0x190000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,    data, littlefs, 0x340000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  372k each
-deploy_0,  data, 0x84,     0x346000, 0x5D000,  # 372k Image 1 primary (active deployment)
-deploy_1,  data, 0x84,     0x3A3000, 0x5D000,  # 372k Image 1 secondary (MCUboot staging)
+# deploy_0: 372k Image 1 primary (active deployment)
+deploy_0,  data, 0x84,     0x346000, 0x5D000,
+# deploy_1: 372k Image 1 secondary (MCUboot staging)
+deploy_1,  data, 0x84,     0x3A3000, 0x5D000,
 #################################
 # total size has to be 0x400000 #
 #################################

--- a/targets/ESP32/_IDF/esp32/partitions_nanoclr_8mb.csv
+++ b/targets/ESP32/_IDF/esp32/partitions_nanoclr_8mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x420000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x428000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~1.9MB each
-deploy_0,   data, 0x84,     0x42E000, 0x1E9000,  # ~1.9MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x617000, 0x1E9000,  # ~1.9MB Image 1 secondary (MCUboot staging)
+# ~1.9MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x42E000, 0x1E9000
+# ~1.9MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x617000, 0x1E9000
 ##########################################
 # total size has to be 0x800000 or less  #
 ##########################################

--- a/targets/ESP32/_IDF/esp32c3/partitions_nanoclr_16mb.csv
+++ b/targets/ESP32/_IDF/esp32c3/partitions_nanoclr_16mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x360000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x368000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~6.2MB each
-deploy_0,   data, 0x84,     0x36E000, 0x649000,  # ~6.2MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x9B7000, 0x649000,  # ~6.2MB Image 1 secondary (MCUboot staging)
+# ~6.2MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x36E000, 0x649000
+# ~6.2MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x9B7000, 0x649000
 ##########################################
 # total size has to be 0x1000000 or less #
 ##########################################

--- a/targets/ESP32/_IDF/esp32c3/partitions_nanoclr_4mb.csv
+++ b/targets/ESP32/_IDF/esp32c3/partitions_nanoclr_4mb.csv
@@ -17,8 +17,10 @@ secondary,  app,  ota_1,    0x1C0000, 0x1A0000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x360000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  308k each
-deploy_0,   data, 0x84,     0x366000, 0x4D000,  # 308k Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x3B3000, 0x4D000,  # 308k Image 1 secondary (MCUboot staging)
+# 308k Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x366000, 0x4D000
+# 308k Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x3B3000, 0x4D000
 #################################
 # total size has to be 0x400000 #
 #################################

--- a/targets/ESP32/_IDF/esp32c3/partitions_nanoclr_8mb.csv
+++ b/targets/ESP32/_IDF/esp32c3/partitions_nanoclr_8mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x360000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x368000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~2.3MB each
-deploy_0,   data, 0x84,     0x36E000, 0x249000,  # ~2.3MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x5B7000, 0x249000,  # ~2.3MB Image 1 secondary (MCUboot staging)
+# ~2.3MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x36E000, 0x249000
+# ~2.3MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x5B7000, 0x249000
 ##########################################
 # total size has to be 0x800000 or less  #
 ##########################################

--- a/targets/ESP32/_IDF/esp32c5/partitions_nanoclr_16mb.csv
+++ b/targets/ESP32/_IDF/esp32c5/partitions_nanoclr_16mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x4A0000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x4A8000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~5.7MB each
-deploy_0,   data, 0x84,     0x4AE000, 0x5A9000,  # ~5.7MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0xA57000, 0x5A9000,  # ~5.7MB Image 1 secondary (MCUboot staging)
+# ~5.7MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x4AE000, 0x5A9000
+# ~5.7MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0xA57000, 0x5A9000
 ##########################################
 # total size has to be 0x1000000 or less #
 ##########################################

--- a/targets/ESP32/_IDF/esp32c5/partitions_nanoclr_8mb.csv
+++ b/targets/ESP32/_IDF/esp32c5/partitions_nanoclr_8mb.csv
@@ -19,8 +19,10 @@ swap_status,data, 0x85,     0x4A0000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x4A8000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~1.7MB each
-deploy_0,   data, 0x84,     0x4AE000, 0x1A9000,  # ~1.7MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x657000, 0x1A9000,  # ~1.7MB Image 1 secondary (MCUboot staging)
+# ~1.7MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x4AE000, 0x1A9000
+# ~1.7MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x657000, 0x1A9000
 ##########################################
 # total size has to be 0x800000 or less  #
 ##########################################

--- a/targets/ESP32/_IDF/esp32c6/partitions_nanoclr_16mb.csv
+++ b/targets/ESP32/_IDF/esp32c6/partitions_nanoclr_16mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x4A0000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x4A8000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~5.7MB each
-deploy_0,   data, 0x84,     0x4AE000, 0x5A9000,  # ~5.7MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0xA57000, 0x5A9000,  # ~5.7MB Image 1 secondary (MCUboot staging)
+# ~5.7MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x4AE000, 0x5A9000
+# ~5.7MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0xA57000, 0x5A9000
 ##########################################
 # total size has to be 0x1000000 or less #
 ##########################################

--- a/targets/ESP32/_IDF/esp32c6/partitions_nanoclr_8mb.csv
+++ b/targets/ESP32/_IDF/esp32c6/partitions_nanoclr_8mb.csv
@@ -19,8 +19,10 @@ swap_status,data, 0x85,     0x4A0000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x4A8000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~1.7MB each
-deploy_0,   data, 0x84,     0x4AE000, 0x1A9000,  # ~1.7MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x657000, 0x1A9000,  # ~1.7MB Image 1 secondary (MCUboot staging)
+# ~1.7MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x4AE000, 0x1A9000
+# ~1.7MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x657000, 0x1A9000
 ##########################################
 # total size has to be 0x800000 or less  #
 ##########################################

--- a/targets/ESP32/_IDF/esp32h2/partitions_nanoclr_4mb.csv
+++ b/targets/ESP32/_IDF/esp32h2/partitions_nanoclr_4mb.csv
@@ -18,8 +18,10 @@ secondary,  app,  ota_1,    0x1D0000, 0x1B0000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x380000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  244k each
-deploy_0,   data, 0x84,     0x386000, 0x3D000,  # 244k Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x3C3000, 0x3D000,  # 244k Image 1 secondary (MCUboot staging)
+# 244k Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x386000, 0x3D000
+# 244k Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x3C3000, 0x3D000
 #################################
 # total size has to be 0x400000 #
 #################################

--- a/targets/ESP32/_IDF/esp32p4/partitions_nanoclr_16mb.csv
+++ b/targets/ESP32/_IDF/esp32p4/partitions_nanoclr_16mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x360000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x368000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~6.2MB each
-deploy_0,   data, 0x84,     0x36E000, 0x649000,  # ~6.2MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x9B7000, 0x649000,  # ~6.2MB Image 1 secondary (MCUboot staging)
+# ~6.2MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x36E000, 0x649000
+# ~6.2MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x9B7000, 0x649000
 ##########################################
 # total size has to be 0x1000000 or less #
 ##########################################

--- a/targets/ESP32/_IDF/esp32p4/partitions_nanoclr_32mb.csv
+++ b/targets/ESP32/_IDF/esp32p4/partitions_nanoclr_32mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x360000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x368000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~14.3MB each
-deploy_0,   data, 0x84,     0x36E000, 0xE49000,  # ~14.3MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x11B7000, 0xE49000, # ~14.3MB Image 1 secondary (MCUboot staging)
+# ~14.3MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x36E000, 0xE49000
+# ~14.3MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x11B7000, 0xE49000
 ##########################################
 # total size has to be 0x2000000 or less #
 ##########################################

--- a/targets/ESP32/_IDF/esp32p4/partitions_nanoclr_4mb.csv
+++ b/targets/ESP32/_IDF/esp32p4/partitions_nanoclr_4mb.csv
@@ -16,8 +16,10 @@ secondary,  app,  ota_1,    0x1C0000, 0x1A0000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x360000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  308k each
-deploy_0,   data, 0x84,     0x366000, 0x4D000,  # 308k Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x3B3000, 0x4D000,  # 308k Image 1 secondary (MCUboot staging)
+# 308k Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x366000, 0x4D000
+# 308k Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x3B3000, 0x4D000
 #################################
 # total size has to be 0x400000 #
 #################################

--- a/targets/ESP32/_IDF/esp32p4/partitions_nanoclr_8mb.csv
+++ b/targets/ESP32/_IDF/esp32p4/partitions_nanoclr_8mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x360000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x368000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~2.3MB each
-deploy_0,   data, 0x84,     0x36E000, 0x249000,  # ~2.3MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x5B7000, 0x249000,  # ~2.3MB Image 1 secondary (MCUboot staging)
+# ~2.3MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x36E000, 0x249000
+# ~2.3MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x5B7000, 0x249000
 ##########################################
 # total size has to be 0x800000 or less  #
 ##########################################

--- a/targets/ESP32/_IDF/esp32s2/partitions_nanoclr_16mb.csv
+++ b/targets/ESP32/_IDF/esp32s2/partitions_nanoclr_16mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x360000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x368000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~6.2MB each
-deploy_0,   data, 0x84,     0x36E000, 0x649000,  # ~6.2MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x9B7000, 0x649000,  # ~6.2MB Image 1 secondary (MCUboot staging)
+# ~6.2MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x36E000, 0x649000
+# ~6.2MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x9B7000, 0x649000
 ##########################################
 # total size has to be 0x1000000 or less #
 ##########################################

--- a/targets/ESP32/_IDF/esp32s2/partitions_nanoclr_4mb.csv
+++ b/targets/ESP32/_IDF/esp32s2/partitions_nanoclr_4mb.csv
@@ -16,8 +16,10 @@ secondary,  app,  ota_1,    0x1C0000, 0x1A0000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x360000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  308k each
-deploy_0,   data, 0x84,     0x366000, 0x4D000,  # 308k Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x3B3000, 0x4D000,  # 308k Image 1 secondary (MCUboot staging)
+# 308k Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x366000, 0x4D000
+# 308k Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x3B3000, 0x4D000
 #################################
 # total size has to be 0x400000 #
 #################################

--- a/targets/ESP32/_IDF/esp32s2/partitions_nanoclr_8mb.csv
+++ b/targets/ESP32/_IDF/esp32s2/partitions_nanoclr_8mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x360000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x368000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~2.3MB each
-deploy_0,   data, 0x84,     0x36E000, 0x249000,  # ~2.3MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x5B7000, 0x249000,  # ~2.3MB Image 1 secondary (MCUboot staging)
+# ~2.3MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x36E000, 0x249000
+# ~2.3MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x5B7000, 0x249000
 ##########################################
 # total size has to be 0x800000 or less  #
 ##########################################

--- a/targets/ESP32/_IDF/esp32s3/partitions_nanoclr_16mb.csv
+++ b/targets/ESP32/_IDF/esp32s3/partitions_nanoclr_16mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x360000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x368000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~6.2MB each
-deploy_0,   data, 0x84,     0x36E000, 0x649000,  # ~6.2MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x9B7000, 0x649000,  # ~6.2MB Image 1 secondary (MCUboot staging)
+# ~6.2MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x36E000, 0x649000
+# ~6.2MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x9B7000, 0x649000
 ##########################################
 # total size has to be 0x1000000 or less #
 ##########################################

--- a/targets/ESP32/_IDF/esp32s3/partitions_nanoclr_32mb.csv
+++ b/targets/ESP32/_IDF/esp32s3/partitions_nanoclr_32mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x360000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x368000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~14.3MB each
-deploy_0,   data, 0x84,     0x36E000, 0xE49000,  # ~14.3MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x11B7000, 0xE49000, # ~14.3MB Image 1 secondary (MCUboot staging)
+# ~14.3MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x36E000, 0xE49000
+# ~14.3MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x11B7000, 0xE49000
 ##########################################
 # total size has to be 0x2000000 or less #
 ##########################################

--- a/targets/ESP32/_IDF/esp32s3/partitions_nanoclr_4mb.csv
+++ b/targets/ESP32/_IDF/esp32s3/partitions_nanoclr_4mb.csv
@@ -16,8 +16,10 @@ secondary,  app,  ota_1,    0x1C0000, 0x1A0000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x360000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  308k each
-deploy_0,   data, 0x84,     0x366000, 0x4D000,  # 308k Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x3B3000, 0x4D000,  # 308k Image 1 secondary (MCUboot staging)
+# 308k Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x366000, 0x4D000
+# 308k Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x3B3000, 0x4D000
 #################################
 # total size has to be 0x400000 #
 #################################

--- a/targets/ESP32/_IDF/esp32s3/partitions_nanoclr_8mb.csv
+++ b/targets/ESP32/_IDF/esp32s3/partitions_nanoclr_8mb.csv
@@ -18,8 +18,10 @@ swap_status,data, 0x85,     0x360000, 0x8000,
 # Config data for Network, Wireless, certificates, user data  24k
 config,     data, littlefs, 0x368000, 0x6000,
 # Deployment area for Managed code — Image 1 primary+secondary (IMAGE_NUMBER=2)  ~2.3MB each
-deploy_0,   data, 0x84,     0x36E000, 0x249000,  # ~2.3MB Image 1 primary (active deployment)
-deploy_1,   data, 0x84,     0x5B7000, 0x249000,  # ~2.3MB Image 1 secondary (MCUboot staging)
+# ~2.3MB Image 1 primary (active deployment)
+deploy_0,   data, 0x84,     0x36E000, 0x249000
+# ~2.3MB Image 1 secondary (MCUboot staging)
+deploy_1,   data, 0x84,     0x5B7000, 0x249000
 ##########################################
 # total size has to be 0x800000 or less  #
 ##########################################


### PR DESCRIPTION
## Description

- Add MCUboot porting layer skeleton under `MCUboot/` — directory structure, header contracts (`flash_map_backend.h`, `mcuboot_config.h`, `sysflash.h`, `os_heap.h`), platform stubs for STM32 and ESP32, key management README, and FetchContent setup.
- Add `Kconfig.mcuboot` with all MCUboot configuration symbols (`NF_FEATURE_HAS_MCUBOOT`, upgrade strategy choice, image number, header size, serial recovery). Sourced from root `Kconfig`.
- Fix ESP32 partition CSV files: move inline comments off data rows (gen_esp32part.py rejects them).

## Motivation and Context
- Phase 0 Step 2 of the IFU initiative. Establishes the MCUboot integration foundation so Phase 1 (functional flash driver implementation) has a clean base to build on. All existing targets are unaffected — MCUboot is opt-in via `CONFIG_NF_FEATURE_HAS_MCUBOOT=y` in a board defconfig.
- Related with nanoframework/Home#1709.

## How Has This Been Tested?

CMake configure + build verified for ORGPAL_PALTHREE (STM32/ChibiOS) and ESP_WROVER_KIT (ESP32) with no regressions. Kconfig validated with kconfiglib.

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).