### PR TITLE
Fix SystemState_Query atomic load operating on wrong address

### DIFF
--- a/src/HAL/nanoHAL_SystemEvents.c
+++ b/src/HAL/nanoHAL_SystemEvents.c
@@ -52,5 +52,9 @@ __nfweak void SystemState_Clear(SYSTEM_STATE_type state)
 
 __nfweak bool SystemState_Query(SYSTEM_STATE_type state)
 {
-    return __atomic_load_n(&state, __ATOMIC_RELAXED) ? true : false;
+#if defined(__CM0_CMSIS_VERSION)
+    return (SystemStates[state] > 0) ? true : false;
+#else
+    return (__atomic_load_n(&SystemStates[state], __ATOMIC_RELAXED) > 0) ? true : false;
+#endif
 }


### PR DESCRIPTION
## Description
- SystemState_Query() on non-Cortex-M0/M0+ targets was atomically loading the local state parameter (an enum index) instead of SystemStates[state], effectively checking whether the state enum value itself was non-zero rather than whether the state was active. This silently broke all system state queries on M3/M4/M7 and similar cores.

## Motivation and Context
Fix SystemState_Query atomic load operating on wrong address 
(cherry picked from commit 6f158c9da0b9b354fffcc1b79534322ef7163f42)

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
