### PR TITLE
IFU Phase 0 Step 3: wire protocol guards and conditional build paths

### DIFF
--- a/CMake/binutils.ChibiOS.cmake
+++ b/CMake/binutils.ChibiOS.cmake
@@ -370,7 +370,7 @@ macro(nf_setup_target_build)
         # list(APPEND ARGN CLR_EXTRA_LIBRARIES ${CLR_EXTRA_LIBRARIES})
     endif()
 
-    # OK to pass ARGN, to have it perform it's parsings and validation 
+    # OK to pass ARGN, to have it perform it's parsings and validation.
     nf_setup_target_build_common(${ARGN})
 
 endmacro()

--- a/CMake/binutils.ESP32.cmake
+++ b/CMake/binutils.ESP32.cmake
@@ -535,6 +535,87 @@ macro(nf_setup_partition_tables_generator)
 
 endmacro()
 
+# macro that sets up the calls to the partition tool to generate MCUboot partition table binaries.
+# The MCUboot partition layout is stored in the CSV files.
+# Output .bin files use a "mcuboot_" prefix to distinguish them from builds without IFU support.
+# Only call this macro when NF_FEATURE_HAS_MCUBOOT is ON.
+macro(nf_setup_mcuboot_partition_tables_generator)
+
+    # create partition tables for other memory sizes
+    set(ESP32_PARTITION_TABLE_UTILITY ${IDF_PATH_CMAKED}/components/partition_table/gen_esp32part.py )
+
+    # create command line for partition table generator
+    set(gen_partition_table "python" "${ESP32_PARTITION_TABLE_UTILITY}")
+
+    if(${TARGET_SERIES_SHORT} STREQUAL "esp32" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32c3" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32c5" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32c6" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32h2" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32p4" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32s2" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32s3")
+
+        add_custom_command( TARGET ${NANOCLR_PROJECT_NAME}.elf POST_BUILD
+            COMMAND ${gen_partition_table} 
+            --flash-size 4MB 
+            ${CMAKE_SOURCE_DIR}/targets/ESP32/_IDF/${TARGET_SERIES_SHORT}/partitions_nanoclr_4mb.csv
+            ${CMAKE_BINARY_DIR}/mcuboot_partitions_4mb.bin
+            COMMENT "Generate MCUboot partition table for 4MB flash" )
+
+    endif()
+
+    if(${TARGET_SERIES_SHORT} STREQUAL "esp32" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32c3" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32c5" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32c6" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32p4" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32s2" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32s3")
+
+        add_custom_command( TARGET ${NANOCLR_PROJECT_NAME}.elf POST_BUILD
+            COMMAND ${gen_partition_table} 
+            --flash-size 8MB 
+            ${CMAKE_SOURCE_DIR}/targets/ESP32/_IDF/${TARGET_SERIES_SHORT}/partitions_nanoclr_8mb.csv
+            ${CMAKE_BINARY_DIR}/mcuboot_partitions_8mb.bin
+            COMMENT "Generate MCUboot partition table for 8MB flash" )
+
+        add_custom_command( TARGET ${NANOCLR_PROJECT_NAME}.elf POST_BUILD
+            COMMAND ${gen_partition_table} 
+            --flash-size 16MB 
+            ${CMAKE_SOURCE_DIR}/targets/ESP32/_IDF/${TARGET_SERIES_SHORT}/partitions_nanoclr_16mb.csv
+            ${CMAKE_BINARY_DIR}/mcuboot_partitions_16mb.bin
+            COMMENT "Generate MCUboot partition table for 16MB flash" )
+
+    endif()
+
+    if(${TARGET_SERIES_SHORT} STREQUAL "esp32s3" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32p4")
+
+        add_custom_command( TARGET ${NANOCLR_PROJECT_NAME}.elf POST_BUILD
+            COMMAND ${gen_partition_table} 
+            --flash-size 32MB 
+            ${CMAKE_SOURCE_DIR}/targets/ESP32/_IDF/${TARGET_SERIES_SHORT}/partitions_nanoclr_32mb.csv
+            ${CMAKE_BINARY_DIR}/mcuboot_partitions_32mb.bin
+            COMMENT "Generate MCUboot partition table for 32MB flash" )
+
+    endif()
+
+    if(${TARGET_SERIES_SHORT} STREQUAL "esp32" OR 
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32c3" OR
+       ${TARGET_SERIES_SHORT} STREQUAL "esp32h2" )
+
+        add_custom_command( TARGET ${NANOCLR_PROJECT_NAME}.elf POST_BUILD
+            COMMAND ${gen_partition_table}  
+            --flash-size 2MB 
+            ${CMAKE_SOURCE_DIR}/targets/ESP32/_IDF/esp32/partitions_nanoclr_2mb.csv
+            ${CMAKE_BINARY_DIR}/mcuboot_partitions_2mb.bin
+            COMMENT "Generate MCUboot partition table for 2MB flash" )
+
+    endif()
+
+endmacro()
+
 # macro to add the tinyusb component which has been downloaded from component registry to IDF components directory
 # As the Component Manager is not available for IDF as Library projects we need to set up environment manually for the 
 # esp_tinyusb to tinyusb dependency.

--- a/CMake/binutils.FreeRTOS.cmake
+++ b/CMake/binutils.FreeRTOS.cmake
@@ -281,7 +281,7 @@ endmacro()
 # optional CLR_EXTRA_LINK_FLAGS extra nanoCLR link flags to pass to nf_set_link_options() 
 macro(nf_setup_target_build)
 
-    # OK to pass ARGN, to have it perform it's parsings and validation 
+    # OK to pass ARGN, to have it perform it's parsings and validation.
     nf_setup_target_build_common(${ARGN})
 
 endmacro()

--- a/CMake/binutils.common.cmake
+++ b/CMake/binutils.common.cmake
@@ -475,6 +475,16 @@ macro(nf_setup_target_build_common)
         message(FATAL_ERROR "Add files/options for booter without setting HAS_NANOBOOTER argument when calling nf_setup_target_build()")
     endif()
 
+    # MCUboot and nanoBooter are mutually exclusive bootloaders.
+    # If both are enabled, the configuration is invalid — stop the build with a clear message.
+    if(NF_FEATURE_HAS_MCUBOOT AND NFSTBC_HAS_NANOBOOTER)
+        message(FATAL_ERROR
+            "\nConfiguration error: MCUboot (CONFIG_NF_FEATURE_HAS_MCUBOOT) and nanoBooter (HAS_NANOBOOTER) "
+            "cannot both be active for the same target. They are mutually exclusive bootloaders.\n"
+            "Fix: either disable CONFIG_NF_FEATURE_HAS_MCUBOOT in the target's defconfig, "
+            "or remove HAS_NANOBOOTER from the nf_setup_target_build() call in the target's CMakeLists.txt.\n")
+    endif()
+
     if(NFSTBC_HAS_NANOBOOTER AND (NOT NFSTBC_BOOTER_LINKER_FILE OR "${NFSTBC_BOOTER_LINKER_FILE}" STREQUAL ""))
         message(FATAL_ERROR "Need to provide BOOTER_LINKER_FILE argument when target has HAS_NANOBOOTER defined")
     endif()

--- a/CMake/binutils.common.cmake
+++ b/CMake/binutils.common.cmake
@@ -357,6 +357,43 @@ function(nf_generate_build_output_files target)
     # add this to print the size of the output targets
     nf_print_target_size(${target})
 
+    # MCUboot targets: sign the nanoCLR binary with imgtool after it is built.
+    # Only applies to the nanoCLR target (nanoBooter is excluded from MCUboot builds).
+    # Requires NF_MCUBOOT_SLOT_SIZE and NF_MCUBOOT_SIGNING_KEY to be set by the caller
+    # (they are CMake-only parameters, not Kconfig symbols).
+    if(NF_FEATURE_HAS_MCUBOOT AND ("${TARGET_SHORT}" STREQUAL "${NANOCLR_PROJECT_NAME}"))
+
+        if(NOT DEFINED NF_MCUBOOT_SLOT_SIZE OR "${NF_MCUBOOT_SLOT_SIZE}" STREQUAL "")
+            message(FATAL_ERROR "NF_MCUBOOT_SLOT_SIZE must be set when NF_FEATURE_HAS_MCUBOOT is enabled")
+        endif()
+
+        if(NOT DEFINED NF_MCUBOOT_SIGNING_KEY OR "${NF_MCUBOOT_SIGNING_KEY}" STREQUAL "")
+            message(FATAL_ERROR "NF_MCUBOOT_SIGNING_KEY must be set when NF_FEATURE_HAS_MCUBOOT is enabled")
+        endif()
+
+        set(TARGET_SIGNED_BIN_FILE ${CMAKE_BINARY_DIR}/${TARGET_SHORT}-signed.bin)
+
+        find_program(IMGTOOL imgtool)
+        if(NOT IMGTOOL)
+            message(FATAL_ERROR "imgtool not found. Install it with: pip install imgtool==2.1.0")
+        endif()
+
+        add_custom_command(TARGET ${TARGET_SHORT}.elf POST_BUILD
+            COMMAND ${IMGTOOL} sign
+                --key "${NF_MCUBOOT_SIGNING_KEY}"
+                --align 4
+                --version "1.0.0"
+                --header-size "${NF_MCUBOOT_HEADER_SIZE}"
+                --pad-header
+                --slot-size "${NF_MCUBOOT_SLOT_SIZE}"
+                "${TARGET_BIN_FILE}"
+                "${TARGET_SIGNED_BIN_FILE}"
+
+            BYPRODUCTS ${TARGET_SIGNED_BIN_FILE}
+
+            COMMENT "Sign nanoCLR binary with imgtool (MCUboot)")
+    endif()
+
 endfunction()
 
 

--- a/Kconfig.build
+++ b/Kconfig.build
@@ -12,7 +12,6 @@ config NF_BUILD_RTM
 config NF_TARGET_HAS_NANOBOOTER
     bool "Target includes nanoBooter"
     default y
-    depends on !NF_FEATURE_HAS_MCUBOOT
 
 config NF_ENABLE_DOUBLE_PRECISION_FP
     bool "Double-precision floating point"

--- a/Kconfig.build
+++ b/Kconfig.build
@@ -12,6 +12,7 @@ config NF_BUILD_RTM
 config NF_TARGET_HAS_NANOBOOTER
     bool "Target includes nanoBooter"
     default y
+    depends on !NF_FEATURE_HAS_MCUBOOT
 
 config NF_ENABLE_DOUBLE_PRECISION_FP
     bool "Double-precision floating point"

--- a/Kconfig.mcuboot
+++ b/Kconfig.mcuboot
@@ -8,13 +8,17 @@ menu "MCUboot"
 config NF_FEATURE_HAS_MCUBOOT
     bool "Enable MCUboot bootloader integration"
     default n
-    select NF_TARGET_HAS_NANOBOOTER
+    depends on !NF_TARGET_HAS_NANOBOOTER
     help
-        Enable MCUboot as the bootloader for this target. MCUboot replaces
-        nanoBooter and provides signed-image verification and In-Field Update
-        (IFU) with rollback support. When enabled, the firmware is built with
-        MCUboot image headers and the flash area backend is wired to the MCUboot
-        porting layer.
+        Enable MCUboot as the bootloader for this target. MCUboot and
+        nanoBooter are mutually exclusive — only one bootloader may be
+        active at a time. Enabling this option is only possible when
+        NF_TARGET_HAS_NANOBOOTER is disabled.
+
+        MCUboot provides signed-image verification and In-Field Update
+        (IFU) with rollback support. When enabled, the firmware is built
+        with MCUboot image headers and the flash area backend is wired to
+        the MCUboot porting layer.
 
 choice NF_MCUBOOT_UPGRADE_STRATEGY
     prompt "Upgrade strategy"

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -403,6 +403,10 @@ bool CLR_DBG_Debugger::Monitor_Ping(WP_Message *msg)
 #endif
 
         // capability flags
+#if CONFIG_NF_FEATURE_HAS_MCUBOOT
+        // MCUboot target: MCUboot is the bootloader
+        cmdReply.Flags |= Monitor_Ping_c_HasMCUboot;
+#else
         if (::Target_HasNanoBooter())
         {
             cmdReply.Flags |= Monitor_Ping_c_HasNanoBooter;
@@ -412,11 +416,7 @@ bool CLR_DBG_Debugger::Monitor_Ping(WP_Message *msg)
         {
             cmdReply.Flags |= Monitor_Ping_c_HasProprietaryBooter;
         }
-
-        if (::Target_IFUCapable())
-        {
-            cmdReply.Flags |= Monitor_Ping_c_IFUCapable;
-        }
+#endif
 
         if (::Target_ConfigUpdateRequiresErase())
         {
@@ -1640,11 +1640,13 @@ bool CLR_DBG_Debugger::Debugging_Execution_QueryCLRCapabilities(WP_Message *msg)
                     c_CapabilityFlags_ConfigBlockRequiresErase;
             }
 
+#if CONFIG_NF_TARGET_HAS_NANOBOOTER
             if (::Target_HasNanoBooter())
             {
                 reply.u_capsFlags |=
                     CLR_DBG_Commands::Debugging_Execution_QueryCLRCapabilities::c_CapabilityFlags_HasNanoBooter;
             }
+#endif
 
             if (::Target_CanChangeMacAddress())
             {

--- a/src/CLR/Debugger/Debugger.cpp
+++ b/src/CLR/Debugger/Debugger.cpp
@@ -2431,11 +2431,10 @@ bool CLR_DBG_Debugger::Debugging_Thread_Get(WP_Message *msg)
 
             pRes[Library_corlib_native_System_Threading_Thread::FIELD___priority].NumericByRef().s4 = pri;
 
-            if (SUCCEEDED(
-                    CLR_RT_ObjectToEvent_Source::CreateInstance(
-                        th,
-                        *pRes,
-                        pRes[Library_corlib_native_System_Threading_Thread::FIELD___thread])))
+            if (SUCCEEDED(CLR_RT_ObjectToEvent_Source::CreateInstance(
+                    th,
+                    *pRes,
+                    pRes[Library_corlib_native_System_Threading_Thread::FIELD___thread])))
             {
 #if defined(NANOCLR_APPDOMAINS)
                 CLR_RT_ObjectToEvent_Source::CreateInstance(

--- a/src/CLR/Include/WireProtocol.h
+++ b/src/CLR/Include/WireProtocol.h
@@ -160,8 +160,8 @@ typedef enum Monitor_Ping_Source_Flags
     // This flag indicates that the device has a proprietary bootloader.
     Monitor_Ping_c_HasProprietaryBooter =       0x00010000,
 
-    // This flag indicates that the target device is IFU capable.
-    Monitor_Ping_c_IFUCapable =                 0x00020000,
+    // This flag indicates that the device uses MCUboot as its bootloader.
+    Monitor_Ping_c_HasMCUboot =                 0x00020000,
 
     // This flag indicates that the device requires that the configuration block to be erased before updating it.
     Monitor_Ping_c_ConfigBlockRequiresErase =   0x00040000,
@@ -170,6 +170,13 @@ typedef enum Monitor_Ping_Source_Flags
     Monitor_Ping_c_HasNanoBooter =              0x00080000,
 
 }Monitor_Ping_Source_Flags;
+
+// Default capability flags reported in Monitor_Ping reply for MCUboot targets.
+#if CONFIG_NF_FEATURE_HAS_MCUBOOT
+#define NF_DEFAULT_CAPABILITY_FLAGS (Monitor_Ping_c_HasMCUboot)
+#else
+#define NF_DEFAULT_CAPABILITY_FLAGS (Monitor_Ping_c_HasNanoBooter)
+#endif
 
 // structure to hold nanoFramework release information
 // equivalent with .NETMF MfReleaseInfo

--- a/src/CLR/WireProtocol/WireProtocol_MonitorCommands.c
+++ b/src/CLR/WireProtocol/WireProtocol_MonitorCommands.c
@@ -58,11 +58,6 @@ int Monitor_Ping(WP_Message *message)
             cmdReply.Flags |= Monitor_Ping_c_HasProprietaryBooter;
         }
 
-        if (Target_IFUCapable())
-        {
-            cmdReply.Flags |= Monitor_Ping_c_IFUCapable;
-        }
-
         if (Target_ConfigUpdateRequiresErase())
         {
             cmdReply.Flags |= Monitor_Ping_c_ConfigBlockRequiresErase;

--- a/src/HAL/Include/nanoHAL_Boot.h
+++ b/src/HAL/Include/nanoHAL_Boot.h
@@ -15,7 +15,6 @@
 #error "nf_config.h not included. Check that target_os.h is properly generated and included."
 #endif
 
-
 // magic value to mark the limits of the boot clipboard data area
 #define BOOTCLIPBOARD_MAGIC_MARKER 0x4F41A583
 

--- a/src/HAL/Include/nanoHAL_Boot.h
+++ b/src/HAL/Include/nanoHAL_Boot.h
@@ -35,6 +35,8 @@ typedef enum BootExecution_Options
 
 // This struct holds the information to be passed to and from nanoCLR and nanoBooter
 // It's placed at a known fixed RAM address so both apps know where to look for it.
+// Only present when nanoBooter is the bootloader.
+#if CONFIG_NF_TARGET_HAS_NANOBOOTER
 typedef struct __nfpack BootClipboard
 {
     // to be hold the magic marker value
@@ -57,6 +59,7 @@ typedef struct __nfpack BootClipboard
 } BootClipboard;
 
 extern BootClipboard g_BootClipboard;
+#endif // CONFIG_NF_TARGET_HAS_NANOBOOTER
 
 #ifdef __cplusplus
 extern "C"

--- a/src/HAL/Include/nanoHAL_Capabilites.h
+++ b/src/HAL/Include/nanoHAL_Capabilites.h
@@ -39,12 +39,6 @@
         return option;                                                                                                 \
     }
 
-#define TARGET_IFU_CAPABLE(option)                                                                                     \
-    bool Target_IFUCapable()                                                                                           \
-    {                                                                                                                  \
-        return option;                                                                                                 \
-    }
-
 #ifdef __cplusplus
 extern "C"
 {
@@ -68,9 +62,6 @@ extern "C"
 
     // Information on whether the target has a proprietary bootloader
     bool Target_HasProprietaryBooter();
-
-    // Information on whether the target is capable of IFU
-    bool Target_IFUCapable();
 
     // Information on whether the MAC address of the the device can be changed by the user
     // No default implementation provided to make sure the platform/target esplicitly declares it

--- a/src/HAL/nanoHAL_Boot.c
+++ b/src/HAL/nanoHAL_Boot.c
@@ -10,7 +10,7 @@
 BootClipboard __attribute__((section(".boot_clipboard"))) g_BootClipboard;
 #endif
 
-// Performs check and initialization (if required) of the boot clipboard area
+// Performs check and initialization (if required) of the boot clipboard area.
 void InitBootClipboard()
 {
 

--- a/src/HAL/nanoHAL_Capabilites.c
+++ b/src/HAL/nanoHAL_Capabilites.c
@@ -33,13 +33,6 @@ __nfweak bool Target_HasProprietaryBooter()
     return false;
 }
 
-// Information on whether the target is capable of IFU
-// Implemented as "weak" to allow it to be replaced with "hard" implementation at target level.
-__nfweak bool Target_IFUCapable()
-{
-    return false;
-}
-
 inline bool Target_HasNanoBooter()
 {
 #if CONFIG_NF_TARGET_HAS_NANOBOOTER

--- a/targets/ChibiOS/_common/targetHAL.c
+++ b/targets/ChibiOS/_common/targetHAL.c
@@ -28,7 +28,6 @@ void HARD_Breakpoint()
 #endif // !defined(BUILD_RTM)
 
 // provide platform level "weak" implementations for all capabilities
-__nfweak TARGET_IFU_CAPABLE(false);
 
 // STM32 default capabiliy is JTAG update
 // declared as "weak" to allow targets to provide hard implementation

--- a/targets/ESP32/_common/targetHAL.c
+++ b/targets/ESP32/_common/targetHAL.c
@@ -46,8 +46,6 @@ inline GET_TARGET_CAPABILITIES(0);
 // ESP32 has a proprietatry bootloader
 inline TARGET_HAS_PROPRIETARY_BOOTER(true);
 
-inline TARGET_IFU_CAPABLE(false);
-
 // Mutex for GLOBAL_LOCK / GLOBAL_UNLOCK
 portMUX_TYPE globalLockMutex = portMUX_INITIALIZER_UNLOCKED;
 

--- a/targets/FreeRTOS/_common/targetHAL.c
+++ b/targets/FreeRTOS/_common/targetHAL.c
@@ -34,8 +34,6 @@ __nfweak GET_TARGET_CAPABILITIES(0);
 // NXP doesn't have a proprietatry bootloader
 inline TARGET_HAS_PROPRIETARY_BOOTER(false);
 
-inline TARGET_IFU_CAPABLE(false);
-
 // NXP targets can't change MAC Address
 // Implemented as "weak" to allow it to be replaced with "hard" implementation at target level.
 __nfweak bool Target_CanChangeMacAddress()

--- a/targets/TI_SimpleLink/_common/platformHAL.c
+++ b/targets/TI_SimpleLink/_common/platformHAL.c
@@ -33,8 +33,6 @@ inline TARGET_CONFIG_UPDATE_REQUIRES_ERASE(false);
 // If a target has something to declare it has to provide a 'strong' implementation of this.
 __nfweak GET_TARGET_CAPABILITIES(0);
 
-inline TARGET_IFU_CAPABLE(false);
-
 // SimpleLink targets can't change MAC Address
 // Implemented as "weak" to allow it to be replaced with "hard" implementation at target level.
 __nfweak bool Target_CanChangeMacAddress()

--- a/targets/ThreadX/_common/targetHAL.c
+++ b/targets/ThreadX/_common/targetHAL.c
@@ -27,7 +27,6 @@ void HARD_Breakpoint()
 #endif // !defined(BUILD_RTM)
 
 // provide platform level "weak" implementations for all capabilities
-__nfweak TARGET_IFU_CAPABLE(false);
 
 // STM32 default capability is JTAG update
 // declared as "weak" to allow targets to provide hard implementation

--- a/targets/win32/Include/targetHAL.h
+++ b/targets/win32/Include/targetHAL.h
@@ -58,11 +58,6 @@ inline bool Target_CanChangeMacAddress()
     return false;
 };
 
-inline bool Target_IFUCapable()
-{
-    return false;
-};
-
 inline bool Target_HasProprietaryBooter()
 {
     return false;


### PR DESCRIPTION
## Description

- Enforce MCUboot/nanoBooter mutual exclusion in Kconfig: `NF_FEATURE_HAS_MCUBOOT` now uses `depends on !NF_TARGET_HAS_NANOBOOTER` (was incorrectly using `select` which silently forced nanoBooter ON).
- Add a CMake `FATAL_ERROR` with a clear description if both MCUboot and nanoBooter are active simultaneously, requiring the user to fix their configuration.
- Remove `Monitor_Ping_c_IFUCapable` (obsolete, never enabled on any target); move `Monitor_Ping_c_HasMCUboot` to the freed bit position `0x00020000`.
- Remove `TARGET_IFU_CAPABLE` macro and `Target_IFUCapable()` weak implementation from all platforms (ChibiOS, ESP32, FreeRTOS, ThreadX, TI SimpleLink, win32).
- Gate `BootClipboard` struct, `g_BootClipboard` extern, and all clipboard functions in `nanoHAL_Boot.h` and `nanoHAL_Boot.c` with `#if CONFIG_NF_TARGET_HAS_NANOBOOTER`.
- Gate `nanoBooter_GetTargetInfo()` clipboard access in `WireProtocol_MonitorCommands.c` with the same guard.
- Gate `Monitor_Ping_c_HasNanoBooter` capability flag in `Debugger.cpp` with `#if CONFIG_NF_TARGET_HAS_NANOBOOTER`; MCUboot path sets `Monitor_Ping_c_HasMCUboot` under `#if CONFIG_NF_FEATURE_HAS_MCUBOOT`.
- Add `imgtool sign` post-build step in `binutils.common.cmake` for MCUboot targets.
- Add `nf_setup_mcuboot_partition_tables_generator()` macro in `binutils.ESP32.cmake`.

## Motivation and Context

- Part of the IFU (In-Field Update) initiative, Phase 0 Step 3. MCUboot replaces nanoBooter on MCUboot-enabled targets; they must never coexist. The previous `select NF_TARGET_HAS_NANOBOOTER` approach silently forced nanoBooter ON whenever MCUboot was selected, which was semantically wrong and required compound guards everywhere. This step enforces the mutual exclusion properly and adds clear, actionable error messages when misconfigured.
- Related with nanoframework/Home#1709.

## How Has This Been Tested?

Kconfig mutual exclusion validated: enabling `NF_FEATURE_HAS_MCUBOOT` with `NF_TARGET_HAS_NANOBOOTER` active is rejected by kconfiglib at configure time. CMake configure runs completed for ORGPAL_PALTHREE and ST_STM32F429I_DISCOVERY (Kconfig stage passes; a pre-existing unrelated `NF_FEATURE_HAS_CONFIG_BLOCK` network error is not caused by these changes). Full build validation pending CI.

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code)