### PR TITLE
Fix FieldInfo.FieldType returning System.Array for array-typed fields

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_Reflection_RuntimeFieldInfo.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Reflection_RuntimeFieldInfo.cpp
@@ -69,7 +69,7 @@ HRESULT Library_corlib_native_System_Reflection_RuntimeFieldInfo::get_FieldType_
 
         NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.NewObjectFromIndex(top, g_CLR_RT_WellKnownTypes.m_TypeStatic));
         hbObj = top.Dereference();
-        hbObj->SetReflection(desc.m_handlerCls);
+        hbObj->SetReflection(desc.m_reflex);
     }
 
     NANOCLR_NOCLEANUP();


### PR DESCRIPTION
## Description

- Fix `FieldInfo.FieldType` incorrectly returning `System.Array` for array-typed fields (e.g. `byte[]`, `int[]`).
- This also fixes `FieldType.GetElementType()` returning `null` for those fields, making reflection-based deserialization impossible.

## Motivation and Context

- Fixes nanoFramework/Home#1624

## How Has This Been Tested?
- [tested against nanoframework/CoreLibrary#268]

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
