### PR TITLE
Add MCUboot serial recovery detection for STM32F7 ChibiOS targets

### DIFF
--- a/MCUboot/CMakeLists.txt
+++ b/MCUboot/CMakeLists.txt
@@ -147,6 +147,7 @@ if(${TARGET_SERIES} STREQUAL "STM32F7xx")
         ${CMAKE_SOURCE_DIR}/targets/ChibiOS/_mcuboot/startup_stm32f7.s
         ${CMAKE_SOURCE_DIR}/targets/ChibiOS/_mcuboot/system_stm32f7xx.c
         ${CMAKE_SOURCE_DIR}/targets/ChibiOS/_mcuboot/stm32f7_flash_bare.c
+        ${CMAKE_SOURCE_DIR}/targets/ChibiOS/_mcuboot/mcuboot_serial_port.c
     )
 
     # Include directories shared by all STM32F7xx bootloader targets.
@@ -162,16 +163,20 @@ if(${TARGET_SERIES} STREQUAL "STM32F7xx")
         # 3. MCUboot upstream bootutil public headers.
         ${mcuboot_SOURCE_DIR}/boot/bootutil/include
 
-        # 4. mbedTLS ASN.1 decoder headers.
+        # 4. MCUboot boot_serial include — provides boot_serial.h with the
+        #    boot_uart_funcs type used in boot_serial_start().
+        ${mcuboot_SOURCE_DIR}/boot/boot_serial/include
+
+        # 5. mbedTLS ASN.1 decoder headers.
         ${mcuboot_SOURCE_DIR}/ext/mbedtls-asn1/include
 
-        # 5. Tinycrypt headers.
+        # 6. Tinycrypt headers.
         ${mcuboot_SOURCE_DIR}/ext/tinycrypt/lib/include
 
-        # 6. CMSIS Device F7 headers (stm32f769xx.h, stm32f7xx.h, system_stm32f7xx.h).
+        # 7. CMSIS Device F7 headers (stm32f769xx.h, stm32f7xx.h, system_stm32f7xx.h).
         ${cmsis_device_f7_SOURCE_DIR}/Include
 
-        # 7. CMSIS Core headers (core_cm7.h, cmsis_gcc.h).
+        # 8. CMSIS Core headers (core_cm7.h, cmsis_gcc.h).
         ${cmsis_core_SOURCE_DIR}/Include
     )
 

--- a/MCUboot/include/mcuboot_config/mcuboot_config.h
+++ b/MCUboot/include/mcuboot_config/mcuboot_config.h
@@ -123,7 +123,7 @@
 // Enabled per target via CONFIG_NF_MCUBOOT_SERIAL_RECOVERY=y in Kconfig.
 //
 #if defined(CONFIG_NF_MCUBOOT_SERIAL_RECOVERY)
-#define MCUBOOT_SERIAL 1
+#define MCUBOOT_SERIAL              1
 #define MCUBOOT_SERIAL_DETECT_DELAY 100
 // Disable the LED status pin — avoids os_cputime dependency in boot_serial.c.
 #define BOOT_SERIAL_REPORT_PIN -1

--- a/MCUboot/include/mcuboot_config/mcuboot_config.h
+++ b/MCUboot/include/mcuboot_config/mcuboot_config.h
@@ -124,6 +124,9 @@
 //
 #if defined(CONFIG_NF_MCUBOOT_SERIAL_RECOVERY)
 #define MCUBOOT_SERIAL 1
+#define MCUBOOT_SERIAL_DETECT_DELAY 100
+// Disable the LED status pin — avoids os_cputime dependency in boot_serial.c.
+#define BOOT_SERIAL_REPORT_PIN -1
 #endif
 
 //

--- a/targets/ChibiOS/ORGPAL_PALTHREE/MCUboot/mcuboot_detect_pin.c
+++ b/targets/ChibiOS/ORGPAL_PALTHREE/MCUboot/mcuboot_detect_pin.c
@@ -1,0 +1,41 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// mcuboot_detect_pin.c — Serial recovery GPIO detection for ORGPAL_PALTHREE
+// (STM32F769ZI, button GPIOK7, external pull-up, active-LOW).
+//
+// boot_serial_detect_pin() mirrors the IsToRemainInBooter() check in
+// targets/ChibiOS/ORGPAL_PALTHREE/nanoBooter/main.c:
+//   palReadPad(GPIOK, GPIOK_BUTTON_BOOT)
+// The same GPIOK7 pin with external pull-up is used; button press = LOW.
+//
+// MCUboot calls this function after MCUBOOT_SERIAL_DETECT_DELAY (100 ms) so
+// no additional debounce delay is needed here.
+//
+// No UART is initialised for the PAL boards: wire protocol uses USB CDC (SDU1)
+// and the USB OTG peripheral occupies PA9/PA10, leaving no accessible USART1
+// pins for serial recovery.
+
+#include "mcuboot_serial_port.h"
+
+#if defined(MCUBOOT_SERIAL)
+
+#include <stm32f7xx.h>
+#include <core_cm7.h>
+
+bool boot_serial_detect_pin(void)
+{
+    // Enable GPIOK clock (matches board.h: input floating, external pull-up).
+    RCC->AHB1ENR |= RCC_AHB1ENR_GPIOKEN;
+    __DSB();
+
+    // Ensure PK7 is in input mode (MODER bits [15:14] = 00).
+    GPIOK->MODER &= ~(3U << (7U * 2U));
+
+    // Active-LOW: return true when button is pressed (line pulled LOW).
+    return (GPIOK->IDR & (1U << 7U)) == 0U;
+}
+
+#endif // MCUBOOT_SERIAL

--- a/targets/ChibiOS/ORGPAL_PALTHREE/MCUboot/mcuboot_flash_map_boot.c
+++ b/targets/ChibiOS/ORGPAL_PALTHREE/MCUboot/mcuboot_flash_map_boot.c
@@ -15,9 +15,10 @@
 #include <string.h>
 #include <assert.h>
 
+#include "mcuboot_config.h"
+
 #include "flash_map_backend/flash_map_backend.h"
 #include "sysflash/sysflash.h"
-#include "mcuboot_config.h"
 
 #include "stm32_f7xx_flash.h"
 #include "stm32f7_flash_bare.h"

--- a/targets/ChibiOS/ORGPAL_PALTHREE/MCUboot/mcuboot_target.cmake
+++ b/targets/ChibiOS/ORGPAL_PALTHREE/MCUboot/mcuboot_target.cmake
@@ -15,6 +15,7 @@ nf_setup_mcuboot_target_build(
     EXTRA_SOURCES
         ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ORGPAL_PALTHREE/MCUboot/at25sf641_spi_bare.c
         ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ORGPAL_PALTHREE/MCUboot/mcuboot_flash_map_boot.c
+        ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ORGPAL_PALTHREE/MCUboot/mcuboot_detect_pin.c
 
     EXTRA_INCLUDES
         ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ORGPAL_PALTHREE/MCUboot

--- a/targets/ChibiOS/ORGPAL_PALX/MCUboot/mcuboot_detect_pin.c
+++ b/targets/ChibiOS/ORGPAL_PALX/MCUboot/mcuboot_detect_pin.c
@@ -1,0 +1,41 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// mcuboot_detect_pin.c — Serial recovery GPIO detection for ORGPAL_PALX
+// (STM32F769NI, button GPIOK7, external pull-up, active-LOW).
+//
+// boot_serial_detect_pin() mirrors the IsToRemainInBooter() check in
+// targets/ChibiOS/ORGPAL_PALX/nanoBooter/main.c:
+//   palReadPad(GPIOK, GPIOK_BUTTON_BOOT)
+// The same GPIOK7 pin with external pull-up is used; button press = LOW.
+//
+// MCUboot calls this function after MCUBOOT_SERIAL_DETECT_DELAY (100 ms) so
+// no additional debounce delay is needed here.
+//
+// No UART is initialised for the PAL boards: wire protocol uses USB CDC (SDU1)
+// and the USB OTG peripheral occupies PA9/PA10, leaving no accessible USART1
+// pins for serial recovery.
+
+#include "mcuboot_serial_port.h"
+
+#if defined(MCUBOOT_SERIAL)
+
+#include <stm32f7xx.h>
+#include <core_cm7.h>
+
+bool boot_serial_detect_pin(void)
+{
+    // Enable GPIOK clock (matches board.h: input floating, external pull-up).
+    RCC->AHB1ENR |= RCC_AHB1ENR_GPIOKEN;
+    __DSB();
+
+    // Ensure PK7 is in input mode (MODER bits [15:14] = 00).
+    GPIOK->MODER &= ~(3U << (7U * 2U));
+
+    // Active-LOW: return true when button is pressed (line pulled LOW).
+    return (GPIOK->IDR & (1U << 7U)) == 0U;
+}
+
+#endif // MCUBOOT_SERIAL

--- a/targets/ChibiOS/ORGPAL_PALX/MCUboot/mcuboot_target.cmake
+++ b/targets/ChibiOS/ORGPAL_PALX/MCUboot/mcuboot_target.cmake
@@ -16,6 +16,7 @@ nf_setup_mcuboot_target_build(
     EXTRA_SOURCES
         ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ORGPAL_PALX/MCUboot/w25q512_qspi_bare.c
         ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ORGPAL_PALX/MCUboot/mcuboot_flash_map_boot.c
+        ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ORGPAL_PALX/MCUboot/mcuboot_detect_pin.c
 
     EXTRA_INCLUDES
         ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ORGPAL_PALX/MCUboot

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/CMakePresets.json
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/CMakePresets.json
@@ -16,7 +16,7 @@
             "hidden": false,
             "cacheVariables": {
                 "NF_TARGET_DEFCONFIG": "targets/ChibiOS/ST_STM32F769I_DISCOVERY/defconfig",
-                "NF_MCUBOOT_SLOT_SIZE": "0x190000",
+                "NF_MCUBOOT_SLOT_SIZE": "0xF0000",
                 "NF_MCUBOOT_SIGNING_KEY": "${sourceDir}/MCUboot/keys/dev-signing-key.pem"
             }
         }

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_config.h
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_config.h
@@ -1,0 +1,32 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// MCUboot configuration for ST_STM32F769I_DISCOVERY (STM32F769NI).
+//
+// Primary slots:   internal STM32F769NI flash (FLASHv2 peripheral)
+// Secondary slots: SD card via FatFs (not yet integrated — stubs return -1)
+// Upgrade strategy: MCUBOOT_SWAP_USING_OFFSET
+// IMAGE_NUMBER: 2 (Image 0 = nanoCLR, Image 1 = deployment)
+
+#ifndef MCUBOOT_CONFIG_ST_STM32F769I_DISCOVERY_H
+#define MCUBOOT_CONFIG_ST_STM32F769I_DISCOVERY_H
+
+// STM32F7 FLASHv2: minimum write unit is 4 bytes (FLASH_CR_PSIZE_WORD).
+// MCUboot uses this to align swap-state trailer fields.
+#define MCUBOOT_FLASH_WRITE_ALIGNMENT 4U
+
+// SD card virtual sector size = 4 kB (FAT cluster granularity used for FatFs
+// file-backed secondary slots). FatFs integration is deferred; stub returns -1.
+#define MCUBOOT_EXTERNAL_FLASH_SECTOR_SIZE (4U * 1024U)
+
+// MCUboot image header size in bytes.
+// Must match the --header-size argument passed to imgtool sign.
+#define MCUBOOT_IMAGE_HEADER_SIZE 0x200U
+
+// Maximum number of sectors across any single image slot.
+// Largest slot: Image 1 secondary = 1024 kB / 4 kB virtual sectors = 256.
+#define MCUBOOT_MAX_IMG_SECTORS 256U
+
+#endif // MCUBOOT_CONFIG_ST_STM32F769I_DISCOVERY_H

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_detect_pin.c
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_detect_pin.c
@@ -1,0 +1,54 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// boot_serial_detect_pin() implementation for ST_STM32F769I_DISCOVERY.
+//
+// Detection button: USER button on PA0 (active-HIGH, external pull-down,
+// configured as floating in board.h — mirrors nanoBooter IsToRemainInBooter()).
+// MCUboot delays 100 ms before calling this function (MCUBOOT_SERIAL_DETECT_DELAY),
+// so no manual debounce is needed here.
+//
+// UART: USART1 PA9(TX) / PA10(RX), AF7, 115 200 baud.
+// This matches the wire protocol serial device (SD1) used by nanoCLR.
+// mcuboot_uart_init() overrides the weak no-op in mcuboot_serial_port.c and
+// is called by the shared boot_serial_start() stub before the recovery loop.
+
+#include "mcuboot_serial_port.h"
+
+#if defined(MCUBOOT_SERIAL)
+
+#include <stm32f7xx.h>
+#include <core_cm7.h>
+
+bool boot_serial_detect_pin(void)
+{
+    // Same button as nanoBooter IsToRemainInBooter(): GPIOA0, external pull-down,
+    // floating mode. Button pressed = HIGH (active-HIGH).
+    RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN;
+    __DSB();
+    GPIOA->MODER &= ~(3U << (0U * 2U)); // PA0 as input (floating, matches board.h)
+
+    return (GPIOA->IDR & (1U << 0U)) != 0U; // HIGH = pressed
+}
+
+void mcuboot_uart_init(void)
+{
+    // USART1: PA9 TX / PA10 RX, AF7 (same UART as wire protocol SD1 in nanoCLR).
+    // PCLK2 = 108 MHz → BRR = 108 000 000 / 115 200 ≈ 938.
+    RCC->APB2ENR |= RCC_APB2ENR_USART1EN;
+    RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN;
+    __DSB();
+
+    // PA9 (TX) and PA10 (RX): alternate function mode (MODER bits[1:0] = 10b).
+    GPIOA->MODER = (GPIOA->MODER & ~(0xFU << 18U)) | (0xAU << 18U);
+
+    // PA9 → AFR[1] bits[7:4] = 0x7, PA10 → AFR[1] bits[11:8] = 0x7.
+    GPIOA->AFR[1] = (GPIOA->AFR[1] & ~(0xFFU << 4U)) | (0x77U << 4U);
+
+    USART1->BRR = 938U;
+    USART1->CR1 = USART_CR1_TE | USART_CR1_RE | USART_CR1_UE;
+}
+
+#endif // MCUBOOT_SERIAL

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_flash_layout.h
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_flash_layout.h
@@ -53,9 +53,11 @@
 // clang-format on
 
 // Boundary assertions — evaluated in every translation unit that includes this header.
-static_assert(NF_MCUBOOT_SLOT_IMG0_PRI_OFF + NF_MCUBOOT_SLOT_IMG0_PRI_SIZE <= NF_MCUBOOT_SLOT_IMG1_PRI_OFF,
-              "DISCOVERY: CLR primary overflows into deploy primary");
-static_assert(NF_MCUBOOT_SLOT_IMG0_SEC_OFF + NF_MCUBOOT_SLOT_IMG0_SEC_SIZE <= NF_MCUBOOT_SLOT_IMG1_SEC_OFF,
-              "DISCOVERY: CLR secondary overflows into deploy secondary");
+static_assert(
+    NF_MCUBOOT_SLOT_IMG0_PRI_OFF + NF_MCUBOOT_SLOT_IMG0_PRI_SIZE <= NF_MCUBOOT_SLOT_IMG1_PRI_OFF,
+    "DISCOVERY: CLR primary overflows into deploy primary");
+static_assert(
+    NF_MCUBOOT_SLOT_IMG0_SEC_OFF + NF_MCUBOOT_SLOT_IMG0_SEC_SIZE <= NF_MCUBOOT_SLOT_IMG1_SEC_OFF,
+    "DISCOVERY: CLR secondary overflows into deploy secondary");
 
 #endif // MCUBOOT_FLASH_LAYOUT_ST_STM32F769I_DISCOVERY_H

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_flash_layout.h
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_flash_layout.h
@@ -1,0 +1,61 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// mcuboot_flash_layout.h — Flash slot layout constants for ST_STM32F769I_DISCOVERY.
+//
+// Single source of truth for all MCUboot slot addresses and sizes.
+// Included by both:
+//   - common/mcuboot_flash_map.c      (ChibiOS / nanoCLR context)
+//   - MCUboot/mcuboot_flash_map_boot.c (bare-metal bootloader context)
+//
+// Layout (STM32F769NI 2 MB internal + SD card via FatFs for secondary slots):
+//
+//   FLASH_AREA_BOOTLOADER        (0): 0x08000000  32 kB   internal sector 0
+//   FLASH_AREA_IMAGE_0_PRIMARY   (1): 0x08010000  960 kB  internal sectors 2-7 (bank 1)
+//   FLASH_AREA_IMAGE_0_SECONDARY (2): SD card file /mcuboot/img0_sec.bin  960 kB
+//   FLASH_AREA_IMAGE_1_PRIMARY   (4): 0x08100000  1024 kB internal bank 2
+//   FLASH_AREA_IMAGE_1_SECONDARY (5): SD card file /mcuboot/img1_sec.bin  1024 kB
+//
+// Secondary slots are accessed as FatFs files (virtual sector = 4 kB).
+// FatFs integration is deferred — mcuboot_ext_flash_init() currently returns -1
+// so MCUboot boots the primary slot without attempting an upgrade.
+
+#ifndef MCUBOOT_FLASH_LAYOUT_ST_STM32F769I_DISCOVERY_H
+#define MCUBOOT_FLASH_LAYOUT_ST_STM32F769I_DISCOVERY_H
+
+#include <stdint.h>
+#include <assert.h>
+
+// clang-format off
+
+// MCUboot bootloader slot (sector 0, 32 kB)
+#define NF_MCUBOOT_SLOT_BOOTLOADER_OFF      0x08000000U
+#define NF_MCUBOOT_SLOT_BOOTLOADER_SIZE     (32U * 1024U)
+
+// Image 0 primary — nanoCLR (sectors 2-7, bank 1, 960 kB)
+#define NF_MCUBOOT_SLOT_IMG0_PRI_OFF        0x08010000U
+#define NF_MCUBOOT_SLOT_IMG0_PRI_SIZE       (960U * 1024U)
+
+// Image 0 secondary — CLR upgrade candidate on SD card (virtual, 960 kB)
+#define NF_MCUBOOT_SLOT_IMG0_SEC_OFF        0x000000U
+#define NF_MCUBOOT_SLOT_IMG0_SEC_SIZE       (960U * 1024U)
+
+// Image 1 primary — deployment (bank 2, 1024 kB)
+#define NF_MCUBOOT_SLOT_IMG1_PRI_OFF        0x08100000U
+#define NF_MCUBOOT_SLOT_IMG1_PRI_SIZE       (1024U * 1024U)
+
+// Image 1 secondary — deployment upgrade candidate on SD card (virtual, 1024 kB)
+#define NF_MCUBOOT_SLOT_IMG1_SEC_OFF        0x0F0000U
+#define NF_MCUBOOT_SLOT_IMG1_SEC_SIZE       (1024U * 1024U)
+
+// clang-format on
+
+// Boundary assertions — evaluated in every translation unit that includes this header.
+static_assert(NF_MCUBOOT_SLOT_IMG0_PRI_OFF + NF_MCUBOOT_SLOT_IMG0_PRI_SIZE <= NF_MCUBOOT_SLOT_IMG1_PRI_OFF,
+              "DISCOVERY: CLR primary overflows into deploy primary");
+static_assert(NF_MCUBOOT_SLOT_IMG0_SEC_OFF + NF_MCUBOOT_SLOT_IMG0_SEC_SIZE <= NF_MCUBOOT_SLOT_IMG1_SEC_OFF,
+              "DISCOVERY: CLR secondary overflows into deploy secondary");
+
+#endif // MCUBOOT_FLASH_LAYOUT_ST_STM32F769I_DISCOVERY_H

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_flash_map_boot.c
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_flash_map_boot.c
@@ -3,14 +3,16 @@
 // See LICENSE file in the project root for full license information.
 //
 
-// MCUboot flash_area_* porting layer for the standalone MCUboot bootloader binary
+// MCUboot flash_area_* porting layer for the standalone MCUboot bootloader
+// binary on ST_STM32F769I_DISCOVERY (STM32F769NI).
 //
 // This file is the bootloader-context counterpart to:
-//   targets/ChibiOS/ORGPAL_PALX/common/mcuboot_flash_map.c
+//   targets/ChibiOS/ST_STM32F769I_DISCOVERY/common/mcuboot_flash_map.c
 //
-// Key differences from the nanoCLR version:
-//   - Internal flash ops use stm32f7_flash_bare.c  (no ChibiOS STM32 flash HAL)
-//   - External flash ops use w25q512_qspi_bare.c   (no ChibiOS QSPI / QSPID1)
+// Secondary slots (SD card via FatFs) are stubbed out: mcuboot_ext_flash_init()
+// returns -1, and all external flash operations return an error. MCUboot treats
+// the secondary slots as unavailable and boots the primary slot directly.
+// Full FatFs integration is deferred to a later implementation step.
 
 #include <stdint.h>
 #include <stddef.h>
@@ -24,7 +26,6 @@
 
 #include "stm32_f7xx_flash.h"
 #include "stm32f7_flash_bare.h"
-#include "w25q512_qspi_bare.h"
 #include "mcuboot_flash_layout.h"
 #include "mcuboot_board_iface.h"
 
@@ -44,10 +45,11 @@ static_assert(
     NF_MCUBOOT_SLOT_IMG1_SEC_SIZE / MCUBOOT_EXTERNAL_FLASH_SECTOR_SIZE <= MCUBOOT_MAX_IMG_SECTORS,
     "Deploy secondary sector count exceeds MCUBOOT_MAX_IMG_SECTORS");
 
-// Board interface: initialise W25Q512 via bare-metal QUADSPI.
+// Board interface: SD card FatFs secondary slots — not yet integrated.
+// Returns -1 (non-fatal); MCUboot continues and boots the primary slot.
 int mcuboot_ext_flash_init(void)
 {
-    return w25q512_bare_init() ? 0 : -1;
+    return -1;
 }
 
 int flash_area_open(uint8_t id, const struct flash_area **area_outp)
@@ -77,7 +79,8 @@ int flash_area_read(const struct flash_area *area, uint32_t off, void *dst, uint
     }
     else
     {
-        return w25q512_bare_read((uint8_t *)dst, area->fa_off + off, len) ? 0 : -1;
+        // SD card FatFs not yet integrated.
+        return -1;
     }
 }
 
@@ -89,7 +92,8 @@ int flash_area_write(const struct flash_area *area, uint32_t off, const void *sr
     }
     else
     {
-        return w25q512_bare_write((const uint8_t *)src, area->fa_off + off, len) ? 0 : -1;
+        // SD card FatFs not yet integrated.
+        return -1;
     }
 }
 
@@ -111,17 +115,8 @@ int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len)
     }
     else
     {
-        uint32_t erase_addr = area->fa_off + off;
-        uint32_t end = erase_addr + len;
-
-        while (erase_addr < end)
-        {
-            if (!w25q512_bare_erase(erase_addr))
-            {
-                return -1;
-            }
-            erase_addr += MCUBOOT_EXTERNAL_FLASH_SECTOR_SIZE;
-        }
+        // SD card FatFs not yet integrated.
+        return -1;
     }
 
     return 0;

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_stm32f769_disco.ld
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_stm32f769_disco.ld
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) .NET Foundation and Contributors
+ * See LICENSE file in the project root for full license information.
+ *
+ * Linker script for the standalone MCUboot bootloader on ST_STM32F769I_DISCOVERY
+ * (STM32F769NI).
+ *
+ * Memory map:
+ *   flash (32 kB) — MCUboot bootloader code + read-only data
+ *   ram   (128 kB) — DTCM-RAM: stack, .data, .bss, heap
+ *                    DTCM is directly connected to the Cortex-M7 core and
+ *                    does not require D-cache management, which simplifies
+ *                    bare-metal operation.
+ *
+ * The bootloader occupies flash sector 0 (32 kB).
+ * It must not overlap the config sector 1 at 0x08008000 or the nanoCLR
+ * primary slot at 0x08010000.
+ *
+ * Stack and heap sizing:
+ *   _Min_Stack_Size = 4 kB  — adequate for MCUboot + ECDSA verification.
+ *   _Min_Heap_Size  = 8 kB  — required by MCUboot's os_heap.h (stdlib malloc).
+ */
+
+MEMORY
+{
+    flash (rx)  : ORIGIN = 0x08000000, LENGTH = 32K
+    ram   (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+_Min_Stack_Size = 0x1000;   /* 4 kB minimum stack   */
+_Min_Heap_Size  = 0x2000;   /* 8 kB minimum heap    */
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    /* Interrupt vector table — must be at the start of flash. */
+    .isr_vector :
+    {
+        . = ALIGN(512);
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } > flash
+
+    /* Code and read-only data. */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)
+        *(.text*)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.eh_frame)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        _etext = .;
+    } > flash
+
+    /* Read-only data. */
+    .rodata :
+    {
+        . = ALIGN(4);
+        *(.rodata)
+        *(.rodata*)
+        . = ALIGN(4);
+    } > flash
+
+    /* ARM exception unwind tables (required for C++ and newlib). */
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > flash
+
+    .ARM :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        __exidx_end = .;
+    } > flash
+
+    /* C++ constructor/destructor lists. */
+    .preinit_array :
+    {
+        PROVIDE_HIDDEN(__preinit_array_start = .);
+        KEEP(*(.preinit_array*))
+        PROVIDE_HIDDEN(__preinit_array_end = .);
+    } > flash
+
+    .init_array :
+    {
+        PROVIDE_HIDDEN(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array*))
+        PROVIDE_HIDDEN(__init_array_end = .);
+    } > flash
+
+    .fini_array :
+    {
+        PROVIDE_HIDDEN(__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array*))
+        PROVIDE_HIDDEN(__fini_array_end = .);
+    } > flash
+
+    /* Initialised data: LMA in flash, VMA in RAM. */
+    /* _sidata is the load address (LMA) used by Reset_Handler. */
+    _sidata = LOADADDR(.data);
+
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data)
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } > ram AT > flash
+
+    /* Zero-initialised data. */
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        __bss_start__ = _sbss;
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+        __bss_end__ = _ebss;
+    } > ram
+
+    /* Heap — grows upward from _end toward the stack. */
+    ._user_heap_stack :
+    {
+        . = ALIGN(8);
+        PROVIDE(end = .);
+        PROVIDE(_end = .);
+        . = . + _Min_Heap_Size;
+        . = . + _Min_Stack_Size;
+        . = ALIGN(8);
+    } > ram
+
+    /* _estack — initial Main Stack Pointer (top of RAM region). */
+    _estack = ORIGIN(ram) + LENGTH(ram);
+
+    /* Discard C++ exception unwind info (not needed in bare-metal bootloader). */
+    /DISCARD/ :
+    {
+        libc.a   (*)
+        libm.a   (*)
+        libgcc.a (*)
+    }
+
+    .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_target.cmake
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_target.cmake
@@ -3,6 +3,31 @@
 # See LICENSE file in the project root for full license information.
 #
 
-# ST_STM32F769I_DISCOVERY — MCUboot standalone bootloader build.
-# Placeholder: full board-specific MCUboot integration is planned for a later phase.
-# nf_setup_mcuboot_target_build() is intentionally not called here.
+# ST_STM32F769I_DISCOVERY — STM32F769NI, SD card FatFs secondary slots (stub).
+# Called from MCUboot/CMakeLists.txt via include() after the series-common
+# variables (MCUBOOT_SERIES_COMMON_*) have been set for STM32F7xx.
+# Secondary slots use SD card FatFs files; FatFs integration is deferred —
+# mcuboot_ext_flash_init() returns -1 and MCUboot boots the primary slot.
+
+nf_setup_mcuboot_target_build(
+
+    LINKER_FILE
+        ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_stm32f769_disco.ld
+
+    EXTRA_SOURCES
+        ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_flash_map_boot.c
+        ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot/mcuboot_detect_pin.c
+
+    EXTRA_INCLUDES
+        ${CMAKE_SOURCE_DIR}/targets/ChibiOS/ST_STM32F769I_DISCOVERY/MCUboot
+
+    COMPILE_DEFINITIONS
+        STM32F769xx
+        MCUBOOT_USE_TINYCRYPT=1
+
+    EXTRA_COMPILE_OPTIONS
+        $<$<CONFIG:Release>:-Os>
+        $<$<CONFIG:MinSizeRel>:-Os>
+        $<$<CONFIG:Debug>:-Os -g3>
+        $<$<CONFIG:RelWithDebInfo>:-Os -g>
+)

--- a/targets/ChibiOS/_mcuboot/mcuboot_serial_port.c
+++ b/targets/ChibiOS/_mcuboot/mcuboot_serial_port.c
@@ -1,0 +1,38 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// mcuboot_serial_port.c — Shared serial recovery stub for the bare-metal
+// MCUboot bootloader (STM32 ChibiOS targets).
+//
+// boot_serial_start() is a PLACEHOLDER. When MCUBOOT_SERIAL=1 and the boot
+// button is held at power-on, MCUboot calls boot_serial_detect_pin() (board-
+// specific) and then boot_serial_start(). This stub satisfies the linker while
+// the full SMP serial stack is deferred to a later implementation step.
+
+#include "mcuboot_serial_port.h"
+
+#if defined(MCUBOOT_SERIAL)
+
+#include <cmsis_compiler.h>
+
+void boot_serial_start(const struct boot_uart_funcs *f)
+{
+    (void)f;
+    mcuboot_uart_init();
+    // PLACEHOLDER — full SMP serial recovery not yet implemented.
+    // Hardware reset required to recover from this state.
+    while (1)
+    {
+        __NOP();
+    }
+}
+
+// Weak default no-op — overridden by boards that require hardware UART
+// initialisation before entering the recovery loop (e.g. ST_STM32F769I_DISCOVERY).
+__attribute__((weak)) void mcuboot_uart_init(void)
+{
+}
+
+#endif // MCUBOOT_SERIAL

--- a/targets/ChibiOS/_mcuboot/mcuboot_serial_port.h
+++ b/targets/ChibiOS/_mcuboot/mcuboot_serial_port.h
@@ -1,0 +1,45 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// mcuboot_serial_port.h — Serial recovery port declarations for the bare-metal
+// MCUboot bootloader (STM32 ChibiOS targets).
+//
+// boot_serial_start() is a placeholder — the full SMP serial recovery stack
+// (boot_serial.c, zcbor, base64, crc16) is not yet included in the build.
+// When the button is detected, the bootloader enters an infinite loop and
+// requires a hardware reset to recover.
+//
+// boot_serial_detect_pin() is board-specific and lives in each board's
+// MCUboot/mcuboot_detect_pin.c translation unit.
+
+#ifndef MCUBOOT_SERIAL_PORT_H
+#define MCUBOOT_SERIAL_PORT_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if defined(MCUBOOT_SERIAL)
+#include "boot_serial/boot_serial.h"
+
+    // Placeholder implementation of boot_serial_start().
+    // Satisfies the linker when MCUBOOT_SERIAL=1 without pulling in the full
+    // SMP serial stack. Loops forever; hardware reset is required to exit.
+    void boot_serial_start(const struct boot_uart_funcs *f);
+
+    // Optional board-specific UART initialisation, called by boot_serial_start()
+    // before entering the recovery loop. The default (weak) implementation is a
+    // no-op; boards that require a hardware UART (e.g. ST_STM32F769I_DISCOVERY)
+    // override this in their mcuboot_detect_pin.c.
+    void mcuboot_uart_init(void);
+
+#endif // MCUBOOT_SERIAL
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MCUBOOT_SERIAL_PORT_H

--- a/targets/ChibiOS/_mcuboot/nf_config.h
+++ b/targets/ChibiOS/_mcuboot/nf_config.h
@@ -30,4 +30,9 @@
 // In the bootloader context this allows boot even when primary slot signature
 // validation is skipped (debug/development builds).
 
+// Serial recovery mode: detect BUTTON_BOOT pin and enter recovery if pressed.
+// Enables MCUBOOT_SERIAL=1 in mcuboot_config.h. boot_serial_start() is currently
+// a stub — full SMP serial stack is deferred to a later step.
+#define CONFIG_NF_MCUBOOT_SERIAL_RECOVERY 1
+
 #endif // NF_CONFIG_MCUBOOT_STUB_H


### PR DESCRIPTION
## Description

- Implements `boot_serial_detect_pin()` for ORGPAL_PALTHREE, ORGPAL_PALX, and ST_STM32F769I_DISCOVERY, enabling MCUboot serial recovery mode detection on power-on button press.
- Adds shared `boot_serial_start()` infinite-loop stub and a weak `mcuboot_uart_init()` no-op, overridable per board; ST_STM32F769I_DISCOVERY overrides it to initialise USART1.
- Enables `MCUBOOT_SERIAL=1` and `MCUBOOT_SERIAL_DETECT_DELAY=100` in the central MCUboot config.
- Adds full MCUboot bootloader scaffold for ST_STM32F769I_DISCOVERY (flash map, linker script, board config, detect pin).
- Fixes `MCUBOOT_MAX_IMG_SECTORS` redefinition warning by ensuring board-specific `mcuboot_config.h` is included before `sysflash/sysflash.h` in all flash map boot files.

## Motivation and Context

Part of Phase 1 of the nanoFramework IFU (In-Field Update) implementation using MCUboot. Serial recovery mode allows the bootloader to be rescued via UART/USB when the primary image is corrupted.
- Related with nanoframework/Home#1709.

## How Has This Been Tested?

Built locally for ORGPAL_PALTHREE, ORGPAL_PALX, and ST_STM32F769I_DISCOVERY. All three targets build cleanly without warnings.

## Types of changes

- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).