### PR TITLE
Various fixes for generics support

### DIFF
--- a/src/CLR/Core/CLR_RT_StackFrame.cpp
+++ b/src/CLR/Core/CLR_RT_StackFrame.cpp
@@ -336,6 +336,7 @@ bool CLR_RT_StackFrame::PushInline(
     {
         m_inlineFrame->m_frame.m_localAllocs[i] = m_localAllocs[i];
     }
+    m_inlineFrame->m_frame.m_genericTypeSpecStorage = m_genericTypeSpecStorage;
 
     // increment the evalPos pointer so that we don't corrupt the real stack
     evalPos++;
@@ -436,6 +437,12 @@ void CLR_RT_StackFrame::RestoreFromInlineStack()
     for (CLR_INT32 i = 0; i < c_Max_Localloc_Count; i++)
     {
         m_localAllocs[i] = m_inlineFrame->m_frame.m_localAllocs[i];
+    }
+    m_genericTypeSpecStorage = m_inlineFrame->m_frame.m_genericTypeSpecStorage;
+    // If the restored m_call.genericType pointed into m_genericTypeSpecStorage, fix the pointer.
+    if (m_call.genericType == &m_inlineFrame->m_frame.m_genericTypeSpecStorage)
+    {
+        m_call.genericType = &m_genericTypeSpecStorage;
     }
 }
 

--- a/src/CLR/Core/CLR_RT_StackFrame.cpp
+++ b/src/CLR/Core/CLR_RT_StackFrame.cpp
@@ -95,6 +95,7 @@ HRESULT CLR_RT_StackFrame::Push(CLR_RT_Thread *th, const CLR_RT_MethodDef_Instan
                                       // CLR_UINT32                m_flags;
                                       //
         stack->m_call = *callInstPtr; // CLR_RT_MethodDef_Instance m_call;
+        stack->m_call.Normalize(*callInstPtr);
                                       //
                                       // CLR_RT_MethodHandler      m_nativeMethod;
                                       // CLR_PMETADATA             m_IPstart;          // ANY   HEAP - DO RELOCATION -
@@ -329,6 +330,7 @@ bool CLR_RT_StackFrame::PushInline(
     m_inlineFrame->m_frame.m_locals = m_locals;
     m_inlineFrame->m_frame.m_args = m_arguments;
     m_inlineFrame->m_frame.m_call = m_call;
+    m_inlineFrame->m_frame.m_call.Normalize(m_call);
     m_inlineFrame->m_frame.m_evalStack = m_evalStack;
     m_inlineFrame->m_frame.m_evalPos = pThis;
     m_inlineFrame->m_frame.m_localAllocCount = m_localAllocCount;
@@ -346,6 +348,7 @@ bool CLR_RT_StackFrame::PushInline(
     m_arguments = pThis;
     m_locals = &m_evalStackEnd[-md->localsCount];
     m_call = calleeInst;
+    m_call.Normalize(calleeInst);
     m_evalStackEnd = m_locals;
     m_evalStack = evalPos;
     m_evalStackPos = evalPos + 1;
@@ -429,6 +432,7 @@ void CLR_RT_StackFrame::RestoreFromInlineStack()
     m_locals = m_inlineFrame->m_frame.m_locals;
     m_evalStackEnd += m_call.target->localsCount;
     m_call = m_inlineFrame->m_frame.m_call;
+    m_call.Normalize(m_inlineFrame->m_frame.m_call);
     m_IP = m_inlineFrame->m_frame.m_IP;
     m_IPstart = m_inlineFrame->m_frame.m_IPStart;
     m_evalStack = m_inlineFrame->m_frame.m_evalStack;
@@ -451,6 +455,7 @@ void CLR_RT_StackFrame::RestoreStack(CLR_RT_InlineFrame &frame)
     m_arguments = frame.m_args;
     m_locals = frame.m_locals;
     m_call = frame.m_call;
+    m_call.Normalize(frame.m_call);
     m_IP = frame.m_IP;
     m_IPstart = frame.m_IPStart;
     m_evalStack = frame.m_evalStack;
@@ -468,6 +473,7 @@ void CLR_RT_StackFrame::SaveStack(CLR_RT_InlineFrame &frame)
     frame.m_args = m_arguments;
     frame.m_locals = m_locals;
     frame.m_call = m_call;
+    frame.m_call.Normalize(m_call);
     frame.m_IP = m_IP;
     frame.m_IPStart = m_IPstart;
     frame.m_evalPos = m_evalStackPos;

--- a/src/CLR/Core/CLR_RT_StackFrame.cpp
+++ b/src/CLR/Core/CLR_RT_StackFrame.cpp
@@ -96,11 +96,11 @@ HRESULT CLR_RT_StackFrame::Push(CLR_RT_Thread *th, const CLR_RT_MethodDef_Instan
                                       //
         stack->m_call = *callInstPtr; // CLR_RT_MethodDef_Instance m_call;
         stack->m_call.Normalize(*callInstPtr);
-                                      //
-                                      // CLR_RT_MethodHandler      m_nativeMethod;
-                                      // CLR_PMETADATA             m_IPstart;          // ANY   HEAP - DO RELOCATION -
-                                      // CLR_PMETADATA             m_IP;               // ANY   HEAP - DO RELOCATION -
-                                      //
+        //
+        // CLR_RT_MethodHandler      m_nativeMethod;
+        // CLR_PMETADATA             m_IPstart;          // ANY   HEAP - DO RELOCATION -
+        // CLR_PMETADATA             m_IP;               // ANY   HEAP - DO RELOCATION -
+        //
         stack->m_locals =
             stack->m_extension; // CLR_RT_HeapBlock*         m_locals;           // EVENT HEAP - NO RELOCATION -
         stack->m_evalStack =

--- a/src/CLR/Core/CLR_RT_StackFrame.cpp
+++ b/src/CLR/Core/CLR_RT_StackFrame.cpp
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -339,6 +339,12 @@ bool CLR_RT_StackFrame::PushInline(
         m_inlineFrame->m_frame.m_localAllocs[i] = m_localAllocs[i];
     }
     m_inlineFrame->m_frame.m_genericTypeSpecStorage = m_genericTypeSpecStorage;
+    // Normalize: if the saved m_call.genericType was pointing at the live frame's storage,
+    // redirect it to the copy inside the inline frame so the saved context is self-contained.
+    if (m_call.genericType == &m_genericTypeSpecStorage)
+    {
+        m_inlineFrame->m_frame.m_call.genericType = &m_inlineFrame->m_frame.m_genericTypeSpecStorage;
+    }
 
     // increment the evalPos pointer so that we don't corrupt the real stack
     evalPos++;
@@ -466,6 +472,12 @@ void CLR_RT_StackFrame::RestoreStack(CLR_RT_InlineFrame &frame)
     {
         m_localAllocs[i] = frame.m_localAllocs[i];
     }
+    m_genericTypeSpecStorage = frame.m_genericTypeSpecStorage;
+    // Normalize: if the restored m_call.genericType pointed at the saved frame storage, fix it up.
+    if (m_call.genericType == &frame.m_genericTypeSpecStorage)
+    {
+        m_call.genericType = &m_genericTypeSpecStorage;
+    }
 }
 
 void CLR_RT_StackFrame::SaveStack(CLR_RT_InlineFrame &frame)
@@ -482,6 +494,12 @@ void CLR_RT_StackFrame::SaveStack(CLR_RT_InlineFrame &frame)
     for (CLR_INT32 i = 0; i < c_Max_Localloc_Count; i++)
     {
         frame.m_localAllocs[i] = m_localAllocs[i];
+    }
+    frame.m_genericTypeSpecStorage = m_genericTypeSpecStorage;
+    // Normalize: redirect saved genericType pointer to the frame's own storage copy.
+    if (m_call.genericType == &m_genericTypeSpecStorage)
+    {
+        frame.m_call.genericType = &frame.m_genericTypeSpecStorage;
     }
 }
 #endif

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -2127,9 +2127,9 @@ HRESULT CLR_RT_ExecutionEngine::InitializeReference(
         }
         else if (dt == DATATYPE_MVAR)
         {
-            _ASSERTE(true);
-
-            goto process_datatype;
+            // MVAR cannot be resolved without method-spec context in InitializeReference.
+            // Treat as an object reference (null) so local initialization can proceed.
+            dt = DATATYPE_OBJECT;
         }
         else if (dt == DATATYPE_GENERICINST)
         {

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -2552,8 +2552,9 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                                 // Fall back to caller's context even if TypeDef doesn't match.
                                 inlineCtx = effectiveCallerGeneric;
                             }
-                            else if (stack->m_inlineFrame->m_frame.m_call.genericType &&
-                                     NANOCLR_INDEX_IS_VALID(*stack->m_inlineFrame->m_frame.m_call.genericType))
+                            else if (
+                                stack->m_inlineFrame->m_frame.m_call.genericType &&
+                                NANOCLR_INDEX_IS_VALID(*stack->m_inlineFrame->m_frame.m_call.genericType))
                             {
                                 inlineCtx = stack->m_inlineFrame->m_frame.m_call.genericType;
                             }
@@ -2568,7 +2569,7 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                                 stack->m_call.genericType = nullptr;
                             }
 
-// Inherit caller's methodSpec when callee's genericType is open
+                            // Inherit caller's methodSpec when callee's genericType is open
                             if (!NANOCLR_INDEX_IS_VALID(stack->m_call.methodSpec) &&
                                 stack->m_call.genericType != nullptr &&
                                 NANOCLR_INDEX_IS_VALID(*stack->m_call.genericType) &&
@@ -2989,14 +2990,12 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                         // If the constructor operates on an open generic type (MVAR-based) and has no
                         // MethodSpec of its own, inherit the caller's MethodSpec so that MVAR resolution
                         // succeeds inside the callee (e.g. for ldsfld s_emptyArray on List<!!0>).
-                        if (!NANOCLR_INDEX_IS_VALID(calleeInst.methodSpec) &&
-                            calleeInst.genericType != nullptr &&
+                        if (!NANOCLR_INDEX_IS_VALID(calleeInst.methodSpec) && calleeInst.genericType != nullptr &&
                             NANOCLR_INDEX_IS_VALID(*calleeInst.genericType) &&
                             NANOCLR_INDEX_IS_VALID(stack->m_call.methodSpec))
                         {
                             CLR_RT_TypeSpec_Instance tsCheck;
-                            if (tsCheck.InitializeFromIndex(*calleeInst.genericType) &&
-                                !tsCheck.IsClosedGenericType())
+                            if (tsCheck.InitializeFromIndex(*calleeInst.genericType) && !tsCheck.IsClosedGenericType())
                             {
                                 calleeInst.methodSpec = stack->m_call.methodSpec;
                             }

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -2505,6 +2505,82 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
 #ifndef NANOCLR_NO_IL_INLINE
                         if (stack->PushInline(ip, assm, evalPos, calleeInst, pThis))
                         {
+                            // PushInline switches stack->m_call to the callee but does NOT apply the
+                            // generic context or methodSpec inheritance.  Mirror the same logic used
+                            // by the regular Push path below.
+                            //
+                            // Determine the callee's declaring TypeDef so we only honor
+                            // effectiveCallerGeneric when it actually refers to the same generic
+                            // type as the callee's owner. Otherwise (e.g. a generic method calling
+                            // List<!!0>::GetEnumerator) the caller's genericType is unrelated and
+                            // would clobber the closed TypeSpec that ResolveToken already produced.
+                            CLR_UINT32 calleeOwnerTypeDefDataInline = 0;
+                            {
+                                CLR_RT_TypeDef_Instance calleeDeclTypeInline{};
+                                if (calleeInst.GetDeclaringType(calleeDeclTypeInline))
+                                {
+                                    calleeOwnerTypeDefDataInline = calleeDeclTypeInline.data;
+                                }
+                            }
+
+                            auto matchesCalleeOwner = [&](const CLR_RT_TypeSpec_Index *tsIdx) -> bool {
+                                if (calleeOwnerTypeDefDataInline == 0)
+                                    return true; // unknown owner: don't filter
+                                if (!tsIdx || !NANOCLR_INDEX_IS_VALID(*tsIdx))
+                                    return false;
+                                CLR_RT_TypeSpec_Instance tsInst{};
+                                if (!tsInst.InitializeFromIndex(*tsIdx))
+                                    return false;
+                                return NANOCLR_INDEX_IS_VALID(tsInst.genericTypeDef) &&
+                                       tsInst.genericTypeDef.data == calleeOwnerTypeDefDataInline;
+                            };
+
+                            const CLR_RT_TypeSpec_Index *inlineCtx = nullptr;
+
+                            if (effectiveCallerGeneric && NANOCLR_INDEX_IS_VALID(*effectiveCallerGeneric) &&
+                                matchesCalleeOwner(effectiveCallerGeneric))
+                            {
+                                inlineCtx = effectiveCallerGeneric;
+                            }
+                            else if (calleeInst.genericType && NANOCLR_INDEX_IS_VALID(*calleeInst.genericType))
+                            {
+                                inlineCtx = calleeInst.genericType;
+                            }
+                            else if (effectiveCallerGeneric && NANOCLR_INDEX_IS_VALID(*effectiveCallerGeneric))
+                            {
+                                // Fall back to caller's context even if TypeDef doesn't match.
+                                inlineCtx = effectiveCallerGeneric;
+                            }
+                            else if (stack->m_inlineFrame->m_frame.m_call.genericType &&
+                                     NANOCLR_INDEX_IS_VALID(*stack->m_inlineFrame->m_frame.m_call.genericType))
+                            {
+                                inlineCtx = stack->m_inlineFrame->m_frame.m_call.genericType;
+                            }
+
+                            if (inlineCtx)
+                            {
+                                stack->m_genericTypeSpecStorage = *inlineCtx;
+                                stack->m_call.genericType = &stack->m_genericTypeSpecStorage;
+                            }
+                            else
+                            {
+                                stack->m_call.genericType = nullptr;
+                            }
+
+// Inherit caller's methodSpec when callee's genericType is open
+                            if (!NANOCLR_INDEX_IS_VALID(stack->m_call.methodSpec) &&
+                                stack->m_call.genericType != nullptr &&
+                                NANOCLR_INDEX_IS_VALID(*stack->m_call.genericType) &&
+                                NANOCLR_INDEX_IS_VALID(stack->m_inlineFrame->m_frame.m_call.methodSpec))
+                            {
+                                CLR_RT_TypeSpec_Instance tsCheck;
+                                if (tsCheck.InitializeFromIndex(*stack->m_call.genericType) &&
+                                    !tsCheck.IsClosedGenericType())
+                                {
+                                    stack->m_call.methodSpec = stack->m_inlineFrame->m_frame.m_call.methodSpec;
+                                }
+                            }
+
                             fDirty = true;
                             break;
                         }
@@ -2514,24 +2590,64 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
 
                         NANOCLR_CHECK_HRESULT(CLR_RT_StackFrame::Push(th, calleeInst, -1));
 
-                        // Set up the new stack frame's generic context
-                        // Priority order:
-                        // 1. effectiveCallerGeneric (extracted from TypeSpec search for interface calls) - HIGHEST
-                        // PRIORITY
-                        //    This is the concrete closed generic type (e.g., List<int>) not the interface (e.g.,
-                        //    IEnumerable<T>)
-                        // 2. calleeInst.genericType (from MethodRef TypeSpec or virtual dispatch)
-                        // 3. stack->m_call.genericType (inherited from caller)
+                        // Set up the new stack frame's generic context.
+                        //
+                        // Priority:
+                        //   1. effectiveCallerGeneric ONLY when it refers to the same generic
+                        //      TypeDef as the callee's declaring type. This covers interface
+                        //      callvirt cases (e.g. List<int> calling IEnumerable<T>::GetEnumerator)
+                        //      where we already extracted the concrete closed TypeSpec.
+                        //   2. calleeInst.genericType - already refined by ResolveToken's MVAR
+                        //      resolution against the caller's MethodSpec, so it is the closed
+                        //      TypeSpec when one exists.
+                        //   3. effectiveCallerGeneric as a fallback (TypeDef mismatch case).
+                        //   4. stack->m_call.genericType inherited from caller.
                         CLR_RT_StackFrame *newStack = th->CurrentFrame();
                         const CLR_RT_TypeSpec_Index *effectiveGenericContext = nullptr;
 
-                        if (effectiveCallerGeneric && NANOCLR_INDEX_IS_VALID(*effectiveCallerGeneric))
+                        CLR_UINT32 calleeOwnerTypeDefData = 0;
+                        {
+                            CLR_RT_TypeDef_Instance calleeDeclType{};
+                            if (calleeInst.GetDeclaringType(calleeDeclType))
+                            {
+                                calleeOwnerTypeDefData = calleeDeclType.data;
+                            }
+                        }
+
+                        auto refersToCalleeOwner = [&](const CLR_RT_TypeSpec_Index *tsIdx) -> bool {
+                            if (calleeOwnerTypeDefData == 0)
+                            {
+                                // unknown owner: don't filter
+                                return true;
+                            }
+
+                            if (!tsIdx || !NANOCLR_INDEX_IS_VALID(*tsIdx))
+                            {
+                                return false;
+                            }
+
+                            CLR_RT_TypeSpec_Instance tsInst{};
+                            if (!tsInst.InitializeFromIndex(*tsIdx))
+                            {
+                                return false;
+                            }
+
+                            return NANOCLR_INDEX_IS_VALID(tsInst.genericTypeDef) &&
+                                   tsInst.genericTypeDef.data == calleeOwnerTypeDefData;
+                        };
+
+                        if (effectiveCallerGeneric && NANOCLR_INDEX_IS_VALID(*effectiveCallerGeneric) &&
+                            refersToCalleeOwner(effectiveCallerGeneric))
                         {
                             effectiveGenericContext = effectiveCallerGeneric;
                         }
                         else if (calleeInst.genericType && NANOCLR_INDEX_IS_VALID(*calleeInst.genericType))
                         {
                             effectiveGenericContext = calleeInst.genericType;
+                        }
+                        else if (effectiveCallerGeneric && NANOCLR_INDEX_IS_VALID(*effectiveCallerGeneric))
+                        {
+                            effectiveGenericContext = effectiveCallerGeneric;
                         }
                         else if (stack->m_call.genericType && NANOCLR_INDEX_IS_VALID(*stack->m_call.genericType))
                         {
@@ -2549,6 +2665,21 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                         {
                             // Ensure genericType doesn't point to garbage
                             newStack->m_call.genericType = nullptr;
+                        }
+
+                        // If the callee operates on an open generic type (MVAR-based) and has no MethodSpec,
+                        // inherit the caller's MethodSpec for MVAR resolution (e.g. static/instance field access).
+                        if (!NANOCLR_INDEX_IS_VALID(newStack->m_call.methodSpec) &&
+                            newStack->m_call.genericType != nullptr &&
+                            NANOCLR_INDEX_IS_VALID(*newStack->m_call.genericType) &&
+                            NANOCLR_INDEX_IS_VALID(stack->m_call.methodSpec))
+                        {
+                            CLR_RT_TypeSpec_Instance tsCheck;
+                            if (tsCheck.InitializeFromIndex(*newStack->m_call.genericType) &&
+                                !tsCheck.IsClosedGenericType())
+                            {
+                                newStack->m_call.methodSpec = stack->m_call.methodSpec;
+                            }
                         }
                     }
 

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -2480,23 +2480,26 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                         // When constrained. T precedes callvirt and T is a reference type, the managed
                         // pointer on the stack (from ldloca) must be dereferenced to the actual object
                         // reference. For value types the BYREF is kept — the callee receives it as 'this'.
-                        if (constrainedTypeToken != 0 && pThis[0].DataType() == DATATYPE_BYREF)
+                        if (constrainedTypeToken != 0)
                         {
-                            CLR_RT_TypeDef_Instance constrainedType{};
-                            if (constrainedType.ResolveToken(constrainedTypeToken, assm, &stack->m_call))
+                            if (op == CEE_CALLVIRT && pThis[0].DataType() == DATATYPE_BYREF)
                             {
-                                bool isValueType =
-                                    ((constrainedType.target->flags & CLR_RECORD_TYPEDEF::TD_Semantics_Mask) ==
-                                     CLR_RECORD_TYPEDEF::TD_Semantics_ValueType) ||
-                                    ((constrainedType.target->flags & CLR_RECORD_TYPEDEF::TD_Semantics_Mask) ==
-                                     CLR_RECORD_TYPEDEF::TD_Semantics_Enum);
-
-                                if (!isValueType)
+                                CLR_RT_TypeDef_Instance constrainedType{};
+                                if (constrainedType.ResolveToken(constrainedTypeToken, assm, &stack->m_call))
                                 {
-                                    CLR_RT_HeapBlock *derefThis = pThis[0].Dereference();
-                                    if (derefThis != nullptr)
+                                    bool isValueType =
+                                        ((constrainedType.target->flags & CLR_RECORD_TYPEDEF::TD_Semantics_Mask) ==
+                                         CLR_RECORD_TYPEDEF::TD_Semantics_ValueType) ||
+                                        ((constrainedType.target->flags & CLR_RECORD_TYPEDEF::TD_Semantics_Mask) ==
+                                         CLR_RECORD_TYPEDEF::TD_Semantics_Enum);
+
+                                    if (!isValueType)
                                     {
-                                        pThis[0].Assign(*derefThis);
+                                        CLR_RT_HeapBlock *derefThis = pThis[0].Dereference();
+                                        if (derefThis != nullptr)
+                                        {
+                                            pThis[0].Assign(*derefThis);
+                                        }
                                     }
                                 }
                             }

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -2985,6 +2985,22 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                             }
                         }
 
+                        // If the constructor operates on an open generic type (MVAR-based) and has no
+                        // MethodSpec of its own, inherit the caller's MethodSpec so that MVAR resolution
+                        // succeeds inside the callee (e.g. for ldsfld s_emptyArray on List<!!0>).
+                        if (!NANOCLR_INDEX_IS_VALID(calleeInst.methodSpec) &&
+                            calleeInst.genericType != nullptr &&
+                            NANOCLR_INDEX_IS_VALID(*calleeInst.genericType) &&
+                            NANOCLR_INDEX_IS_VALID(stack->m_call.methodSpec))
+                        {
+                            CLR_RT_TypeSpec_Instance tsCheck;
+                            if (tsCheck.InitializeFromIndex(*calleeInst.genericType) &&
+                                !tsCheck.IsClosedGenericType())
+                            {
+                                calleeInst.methodSpec = stack->m_call.methodSpec;
+                            }
+                        }
+
                         if (FAILED(hr = CLR_RT_StackFrame::Push(th, calleeInst, -1)))
                         {
                             if (hr == CLR_E_NOT_SUPPORTED)

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -2415,8 +2415,9 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                                         }
 
                                         // Initialize the dispatched method, preserving the generic context from
-                                        // calleeInst The genericType was set by ResolveToken from the MethodRef's owner
-                                        // TypeSpec
+                                        // calleeInst. The genericType was set by ResolveToken from the MethodRef's
+                                        // owner TypeSpec. InitializeFromIndex stores the TypeSpec in stable member
+                                        // storage (m_typeSpecStorage), so genericType remains valid after the call.
                                         if (calleeInst.genericType && NANOCLR_INDEX_IS_VALID(*calleeInst.genericType))
                                         {
                                             if (calleeInst.InitializeFromIndex(

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -1046,6 +1046,8 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
     CLR_PMETADATA ip;
     bool fCondition;
     bool fDirty = false;
+    // set by CEE_CONSTRAINED prefix, consumed by CEE_CALLVIRT
+    CLR_UINT32 constrainedTypeToken = 0;
 
 #if defined(NANOCLR_OPCODE_STACKCHANGES)
     // Track stack depth for validation
@@ -2471,6 +2473,33 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                             NANOCLR_INDEX_IS_VALID(propagatedArrayElementType))
                         {
                             calleeInst.arrayElementType = propagatedArrayElementType;
+                        }
+
+                        // ECMA-335 §III.2.1 constrained. prefix semantics:
+                        // When constrained. T precedes callvirt and T is a reference type, the managed
+                        // pointer on the stack (from ldloca) must be dereferenced to the actual object
+                        // reference. For value types the BYREF is kept — the callee receives it as 'this'.
+                        if (constrainedTypeToken != 0 && pThis[0].DataType() == DATATYPE_BYREF)
+                        {
+                            CLR_RT_TypeDef_Instance constrainedType{};
+                            if (constrainedType.ResolveToken(constrainedTypeToken, assm, &stack->m_call))
+                            {
+                                bool isValueType =
+                                    ((constrainedType.target->flags & CLR_RECORD_TYPEDEF::TD_Semantics_Mask) ==
+                                     CLR_RECORD_TYPEDEF::TD_Semantics_ValueType) ||
+                                    ((constrainedType.target->flags & CLR_RECORD_TYPEDEF::TD_Semantics_Mask) ==
+                                     CLR_RECORD_TYPEDEF::TD_Semantics_Enum);
+
+                                if (!isValueType)
+                                {
+                                    CLR_RT_HeapBlock *derefThis = pThis[0].Dereference();
+                                    if (derefThis != nullptr)
+                                    {
+                                        pThis[0].Assign(*derefThis);
+                                    }
+                                }
+                            }
+                            constrainedTypeToken = 0;
                         }
 
 #ifndef NANOCLR_NO_IL_INLINE
@@ -4279,7 +4308,8 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                 {
                     FETCH_ARG_COMPRESSED_TYPETOKEN(arg, ip);
 
-                    // nop
+                    // Store the constrained type token; CEE_CALLVIRT will consume it.
+                    constrainedTypeToken = arg;
                     break;
                 }
 

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -8004,11 +8004,23 @@ HRESULT CLR_RT_TypeSystem::BuildTypeName(
                     if (paramElement.DataType == DATATYPE_VAR)
                     {
                         // VAR inside a MethodSpec arg -- resolve against the declaring type's closed TypeSpec
+                        const CLR_RT_TypeSpec_Index *effectiveContext = nullptr;
                         CLR_RT_TypeSpec_Instance contextTs;
                         CLR_RT_SignatureParser::Element argElement;
 
-                        if (contextMethodDef->genericType != nullptr &&
-                            contextTs.InitializeFromIndex(*contextMethodDef->genericType) &&
+                        if (contextTypeSpec != nullptr && NANOCLR_INDEX_IS_VALID(*contextTypeSpec))
+                        {
+                            effectiveContext = contextTypeSpec;
+                        }
+                        else if (
+                            contextMethodDef->genericType != nullptr &&
+                            NANOCLR_INDEX_IS_VALID(*contextMethodDef->genericType))
+                        {
+                            effectiveContext = contextMethodDef->genericType;
+                        }
+
+                        if (effectiveContext != nullptr &&
+                            contextTs.InitializeFromIndex(*effectiveContext) &&
                             contextTs.GetGenericParam(paramElement.GenericParamPosition, argElement))
                         {
                             paramTypeDef = argElement.Class;

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1356,7 +1356,9 @@ bool CLR_RT_TypeDef_Instance::ResolveToken(
                                     return false;
                                 }
                             }
-                            else if (NANOCLR_INDEX_IS_VALID(caller->arrayElementType) && genericPosition == 0)
+                            else if (
+                                caller != nullptr && NANOCLR_INDEX_IS_VALID(caller->arrayElementType) &&
+                                genericPosition == 0)
                             {
                                 // Fallback to arrayElementType: covers SZArrayHelper scenarios and
                                 // the nested-VAR case where the context TypeSpec is still open.
@@ -8305,8 +8307,25 @@ HRESULT CLR_RT_TypeSystem::BuildMethodName(
                         CLR_RT_TypeSpec_Instance contextTs;
                         CLR_RT_SignatureParser::Element paramElement;
 
+                        // Compute effective generic context: prefer the explicit genericType parameter,
+                        // fall back to the method instance own genericType to avoid null dereference.
+                        CLR_RT_TypeSpec_Index effectiveGenericIndex;
+                        if (genericType != nullptr && NANOCLR_INDEX_IS_VALID(*genericType))
+                        {
+                            effectiveGenericIndex = *genericType;
+                        }
+                        else if (mdInst.genericType != nullptr && NANOCLR_INDEX_IS_VALID(*mdInst.genericType))
+                        {
+                            effectiveGenericIndex = *mdInst.genericType;
+                        }
+                        else
+                        {
+                            CLR_SafeSprintf(szBuffer, iBuffer, "!%d", elem.GenericParamPosition);
+                            continue;
+                        }
+
                         // try to resolve from method context
-                        if (!contextTs.InitializeFromIndex(*genericType))
+                        if (!contextTs.InitializeFromIndex(effectiveGenericIndex))
                         {
                             NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
                         }

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1316,7 +1316,8 @@ bool CLR_RT_TypeDef_Instance::ResolveToken(
                             {
                                 effectiveContext = contextTypeSpec;
                             }
-                            else if (caller != nullptr && NANOCLR_INDEX_IS_VALID(*caller->genericType))
+                            else if (caller != nullptr && caller->genericType != nullptr &&
+                                     NANOCLR_INDEX_IS_VALID(*caller->genericType))
                             {
                                 effectiveContext = caller->genericType;
                             }

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -2971,21 +2971,44 @@ HRESULT CLR_RT_TypeDescriptor::InitializeFromSignatureToken(
                     if (msInst.InitializeFromIndex(caller->methodSpec))
                     {
                         CLR_RT_SignatureParser::Element msElem;
-                        if (msInst.GetGenericArgument(elem.GenericParamPosition, msElem) &&
-                            NANOCLR_INDEX_IS_VALID(msElem.Class))
+                        if (msInst.GetGenericArgument(elem.GenericParamPosition, msElem))
                         {
-                            this->InitializeFromTypeDef(msElem.Class);
-                            break;
+                            if (NANOCLR_INDEX_IS_VALID(msElem.Class))
+                            {
+                                // Concrete type argument: use it directly.
+                                this->InitializeFromTypeDef(msElem.Class);
+                                break;
+                            }
+                            else if (msElem.DataType == DATATYPE_VAR && caller->genericType != nullptr &&
+                                     NANOCLR_INDEX_IS_VALID(*caller->genericType))
+                            {
+                                // !!U -> !T: the MethodSpec maps a method-generic to a type-generic;
+                                // resolve the type-generic slot from the caller's closed TypeSpec.
+                                CLR_RT_TypeSpec_Instance callerTypeSpec;
+                                if (callerTypeSpec.InitializeFromIndex(*caller->genericType))
+                                {
+                                    CLR_RT_SignatureParser::Element paramElement;
+                                    if (callerTypeSpec.GetGenericParam(msElem.GenericParamPosition, paramElement) &&
+                                        NANOCLR_INDEX_IS_VALID(paramElement.Class))
+                                    {
+                                        this->InitializeFromTypeDef(paramElement.Class);
+                                        break;
+                                    }
+                                }
+                            }
                         }
                     }
                 }
 
-                // Fallback: use the GenericParam table (gives the declared constraint, e.g. object).
+                // Fallback: use the GenericParam table on the caller's assembly (gives the declared
+                // constraint, e.g. object).  Use caller->assembly rather than assm so that cross-assembly
+                // calls look up the GenericParam table in the assembly that actually declares the method,
+                // avoiding picking up the wrong table from a different assembly.
                 if (caller != nullptr)
                 {
                     CLR_RT_GenericParam_Index gp;
-                    assm->FindGenericParamAtMethodDef(*caller, elem.GenericParamPosition, gp);
-                    auto &info = assm->crossReferenceGenericParam[gp.GenericParam()];
+                    caller->assembly->FindGenericParamAtMethodDef(*caller, elem.GenericParamPosition, gp);
+                    auto &info = caller->assembly->crossReferenceGenericParam[gp.GenericParam()];
                     this->InitializeFromTypeDef(info.classTypeDef);
                 }
                 else

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1373,13 +1373,12 @@ bool CLR_RT_TypeDef_Instance::ResolveToken(
                         {
                         resolve_generic_argument:
 
-                            // Use the caller bound genericType (Stack<Int32>, etc.)
-                            if (caller == nullptr || NANOCLR_INDEX_IS_INVALID(*caller->genericType))
+                            if (caller == nullptr)
                             {
                                 return false;
                             }
 
-                            // resolve from methodspec context
+                            // resolve from methodspec context (MVAR = method-level generic parameter)
                             if (NANOCLR_INDEX_IS_VALID(caller->methodSpec))
                             {
                                 CLR_RT_MethodSpec_Instance methodSpecInstance;
@@ -2964,11 +2963,35 @@ HRESULT CLR_RT_TypeDescriptor::InitializeFromSignatureToken(
             }
             else if (elem.DataType == DATATYPE_MVAR)
             {
-                // !!U: method-generic
-                CLR_RT_GenericParam_Index gp;
-                assm->FindGenericParamAtMethodDef(*caller, elem.GenericParamPosition, gp);
-                auto &info = assm->crossReferenceGenericParam[gp.GenericParam()];
-                this->InitializeFromTypeDef(info.classTypeDef);
+                // !!U: method-generic parameter — resolve from the caller's MethodSpec if available,
+                // which gives the concrete closed type (e.g. String for BuildListAndCount<String>).
+                if (caller != nullptr && NANOCLR_INDEX_IS_VALID(caller->methodSpec))
+                {
+                    CLR_RT_MethodSpec_Instance msInst;
+                    if (msInst.InitializeFromIndex(caller->methodSpec))
+                    {
+                        CLR_RT_SignatureParser::Element msElem;
+                        if (msInst.GetGenericArgument(elem.GenericParamPosition, msElem) &&
+                            NANOCLR_INDEX_IS_VALID(msElem.Class))
+                        {
+                            this->InitializeFromTypeDef(msElem.Class);
+                            break;
+                        }
+                    }
+                }
+
+                // Fallback: use the GenericParam table (gives the declared constraint, e.g. object).
+                if (caller != nullptr)
+                {
+                    CLR_RT_GenericParam_Index gp;
+                    assm->FindGenericParamAtMethodDef(*caller, elem.GenericParamPosition, gp);
+                    auto &info = assm->crossReferenceGenericParam[gp.GenericParam()];
+                    this->InitializeFromTypeDef(info.classTypeDef);
+                }
+                else
+                {
+                    NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
+                }
             }
             else if (elem.DataType == DATATYPE_GENERICINST)
             {

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1316,8 +1316,9 @@ bool CLR_RT_TypeDef_Instance::ResolveToken(
                             {
                                 effectiveContext = contextTypeSpec;
                             }
-                            else if (caller != nullptr && caller->genericType != nullptr &&
-                                     NANOCLR_INDEX_IS_VALID(*caller->genericType))
+                            else if (
+                                caller != nullptr && caller->genericType != nullptr &&
+                                NANOCLR_INDEX_IS_VALID(*caller->genericType))
                             {
                                 effectiveContext = caller->genericType;
                             }
@@ -8019,8 +8020,7 @@ HRESULT CLR_RT_TypeSystem::BuildTypeName(
                             effectiveContext = contextMethodDef->genericType;
                         }
 
-                        if (effectiveContext != nullptr &&
-                            contextTs.InitializeFromIndex(*effectiveContext) &&
+                        if (effectiveContext != nullptr && contextTs.InitializeFromIndex(*effectiveContext) &&
                             contextTs.GetGenericParam(paramElement.GenericParamPosition, argElement))
                         {
                             paramTypeDef = argElement.Class;

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1350,12 +1350,6 @@ bool CLR_RT_TypeDef_Instance::ResolveToken(
 
                                     goto resolve_generic_argument;
                                 }
-                                else if (paramElement.DataType == DATATYPE_VAR)
-                                {
-                                    // nested VAR not implemented
-                                    ASSERT(false);
-                                    return false;
-                                }
                                 else
                                 {
                                     return false;

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -7940,8 +7940,7 @@ HRESULT CLR_RT_TypeSystem::BuildTypeName(
             // method generic parameter -- try to resolve via MethodSpec; fall back to !!N only on failure
             bool mvarResolved = false;
 
-            if (contextMethodDef != nullptr &&
-                NANOCLR_INDEX_IS_VALID(*contextMethodDef) &&
+            if (contextMethodDef != nullptr && NANOCLR_INDEX_IS_VALID(*contextMethodDef) &&
                 NANOCLR_INDEX_IS_VALID(contextMethodDef->methodSpec))
             {
                 CLR_RT_MethodSpec_Instance methodSpec{};

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -8223,8 +8223,9 @@ HRESULT CLR_RT_TypeSystem::BuildMethodName(
         // Append the method name
         CLR_SafeSprintf(szBuffer, iBuffer, "::%s", mdInst.assembly->GetString(mdInst.target->name));
 
-        // If this method has generic parameters (methodSpec is valid), append them
-        if (NANOCLR_INDEX_IS_VALID(mdInst.methodSpec))
+        // If this method itself is generic (has its own generic parameters) and has a methodSpec, append them.
+        // Do NOT append when methodSpec was merely inherited from the caller for MVAR resolution (e.g. .ctor).
+        if (NANOCLR_INDEX_IS_VALID(mdInst.methodSpec) && mdInst.target->genericParamCount > 0)
         {
             CLR_RT_MethodSpec_Instance msInst{};
             if (msInst.InitializeFromIndex(mdInst.methodSpec))

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -2979,8 +2979,9 @@ HRESULT CLR_RT_TypeDescriptor::InitializeFromSignatureToken(
                                 this->InitializeFromTypeDef(msElem.Class);
                                 break;
                             }
-                            else if (msElem.DataType == DATATYPE_VAR && caller->genericType != nullptr &&
-                                     NANOCLR_INDEX_IS_VALID(*caller->genericType))
+                            else if (
+                                msElem.DataType == DATATYPE_VAR && caller->genericType != nullptr &&
+                                NANOCLR_INDEX_IS_VALID(*caller->genericType))
                             {
                                 // !!U -> !T: the MethodSpec maps a method-generic to a type-generic;
                                 // resolve the type-generic slot from the caller's closed TypeSpec.

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1996,8 +1996,10 @@ bool CLR_RT_MethodDef_Instance::InitializeFromIndex(
         return false;
     }
 
-    // remember the TypeSpec so this is available when needed
-    genericType = &typeSpec;
+    // Store the TypeSpec in stable member storage so that genericType doesn't point
+    // to the caller's stack (the 'typeSpec' parameter would be freed after return).
+    m_typeSpecStorage = typeSpec;
+    genericType = &m_typeSpecStorage;
 
     return true;
 }
@@ -2007,6 +2009,7 @@ void CLR_RT_MethodDef_Instance::ClearInstance()
     NATIVE_PROFILE_CLR_CORE();
     CLR_RT_MethodDef_Index::Clear();
     methodSpec.Clear();
+    m_typeSpecStorage.Clear();
 
     assembly = nullptr;
     target = nullptr;

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -7935,61 +7935,46 @@ HRESULT CLR_RT_TypeSystem::BuildTypeName(
         }
         else if (element.DataType == DATATYPE_MVAR)
         {
-            // method generic parameter
-            if (contextMethodDef != nullptr && NANOCLR_INDEX_IS_VALID(*contextMethodDef))
+            // method generic parameter -- try to resolve via MethodSpec; fall back to !!N only on failure
+            bool mvarResolved = false;
+
+            if (contextMethodDef != nullptr &&
+                NANOCLR_INDEX_IS_VALID(*contextMethodDef) &&
+                NANOCLR_INDEX_IS_VALID(contextMethodDef->methodSpec))
             {
-                if (NANOCLR_INDEX_IS_VALID(contextMethodDef->methodSpec))
+                CLR_RT_MethodSpec_Instance methodSpec{};
+                CLR_RT_SignatureParser::Element paramElement;
+                methodSpec.InitializeFromIndex(contextMethodDef->methodSpec);
+
+                if (methodSpec.GetGenericArgument(element.GenericParamPosition, paramElement))
                 {
-                    CLR_RT_MethodSpec_Instance methodSpec{};
-                    CLR_RT_SignatureParser::Element paramElement;
-                    CLR_RT_TypeDef_Index paramTypeDef;
-                    methodSpec.InitializeFromIndex(contextMethodDef->methodSpec);
-
-                    if (!methodSpec.GetGenericArgument(element.GenericParamPosition, paramElement))
-                    {
-                        NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
-                    }
-
-                    paramTypeDef = paramElement.Class;
+                    CLR_RT_TypeDef_Index paramTypeDef = paramElement.Class;
 
                     if (paramElement.DataType == DATATYPE_VAR)
                     {
-                        // Build the type name for this generic argument
-                        // Use the method's declaring type as context for VAR resolution
-
+                        // VAR inside a MethodSpec arg -- resolve against the declaring type's closed TypeSpec
                         CLR_RT_TypeSpec_Instance contextTs;
                         CLR_RT_SignatureParser::Element argElement;
 
-                        // try to resolve from method context
-                        if (!contextTs.InitializeFromIndex(*contextMethodDef->genericType))
-                        {
-                            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
-                        }
-
-                        if (contextTs.GetGenericParam(paramElement.GenericParamPosition, argElement))
+                        if (contextMethodDef->genericType != nullptr &&
+                            contextTs.InitializeFromIndex(*contextMethodDef->genericType) &&
+                            contextTs.GetGenericParam(paramElement.GenericParamPosition, argElement))
                         {
                             paramTypeDef = argElement.Class;
-
-                            goto output_type;
-                        }
-                        else
-                        {
-                            // Couldn't resolve
-                            char encodedParam[7];
-                            snprintf(encodedParam, ARRAYSIZE(encodedParam), "!%d", argElement.GenericParamPosition);
-                            NANOCLR_CHECK_HRESULT(QueueStringToBuffer(szBuffer, iBuffer, encodedParam));
                         }
                     }
-                    else
+
+                    if (paramTypeDef.data != 0)
                     {
-                    output_type:
                         NANOCLR_CHECK_HRESULT(BuildTypeName(paramTypeDef, szBuffer, iBuffer));
+                        mvarResolved = true;
                     }
                 }
             }
-            else
+
+            if (!mvarResolved)
             {
-                // couldn't be resolved, print encoded form (!!N)
+                // resolution failed (no MethodSpec, GetGenericArgument returned false, etc.) -- print !!N
                 char encodedParam[7];
                 snprintf(encodedParam, ARRAYSIZE(encodedParam), "!!%d", element.GenericParamPosition);
                 NANOCLR_CHECK_HRESULT(QueueStringToBuffer(szBuffer, iBuffer, encodedParam));

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1334,7 +1334,8 @@ bool CLR_RT_TypeDef_Instance::ResolveToken(
                             CLR_RT_SignatureParser::Element paramElement;
 
                             // Try to map using the generic context (e.g. !T→Int32)
-                            if (callerTypeSpec.GetGenericParam(genericPosition, paramElement))
+                            if (callerTypeSpec.GetGenericParam(genericPosition, paramElement) &&
+                                paramElement.DataType != DATATYPE_VAR)
                             {
                                 // Successfully resolved from generic context
                                 if (NANOCLR_INDEX_IS_VALID(paramElement.Class))
@@ -1357,7 +1358,8 @@ bool CLR_RT_TypeDef_Instance::ResolveToken(
                             }
                             else if (NANOCLR_INDEX_IS_VALID(caller->arrayElementType) && genericPosition == 0)
                             {
-                                // Fallback to arrayElementType for SZArrayHelper scenarios
+                                // Fallback to arrayElementType: covers SZArrayHelper scenarios and
+                                // the nested-VAR case where the context TypeSpec is still open.
                                 data = caller->arrayElementType.data;
                                 assembly = g_CLR_RT_TypeSystem.m_assemblies[caller->arrayElementType.Assembly() - 1];
                                 target = assembly->GetTypeDef(caller->arrayElementType.Type());

--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -972,6 +972,19 @@ void CLR_RT_Assembly::DumpOpcode(CLR_RT_StackFrame *stack, CLR_PMETADATA ip)
     if (s_CLR_RT_fTrace_Instructions >= c_CLR_RT_Trace_Verbose)
     {
         inst = stack->m_call;
+
+        // When the current frame has an open generic type (contains MVAR) but no MethodSpec,
+        // inherit the caller frame's MethodSpec so BuildTypeName can resolve the MVAR to its
+        // concrete type (e.g. List<MVAR_0> + caller MethodSpec<String> -> List<String>).
+        if (!NANOCLR_INDEX_IS_VALID(inst.methodSpec) && inst.genericType != nullptr &&
+            NANOCLR_INDEX_IS_VALID(*inst.genericType))
+        {
+            CLR_RT_StackFrame *caller = stack->Caller();
+            if (caller != nullptr && NANOCLR_INDEX_IS_VALID(caller->m_call.methodSpec))
+            {
+                inst.methodSpec = caller->m_call.methodSpec;
+            }
+        }
     }
     else
     {
@@ -1012,10 +1025,40 @@ void CLR_RT_Assembly::DumpOpcodeDirect(
         if (op == CEE_CALL || op == CEE_CALLVIRT)
         {
             CLR_RT_MethodDef_Instance mdInst{};
-            if (NANOCLR_INDEX_IS_VALID(call) && mdInst.ResolveToken(token, call.assembly, call.genericType))
+            // Resolve the call token using the caller's assembly and generic context.
+            // Pass null for genericType on the first attempt (avoids mismatching an open TypeSpec
+            // against a non-generic declaring type such as System.Object::.ctor).
+            if (NANOCLR_INDEX_IS_VALID(call) && mdInst.ResolveToken(token, call.assembly, nullptr, &call))
             {
+                // If the first resolve found that the method's declaring type is generic (open TypeSpec),
+                // retry with call.genericType to get the closed form for display (e.g. List<String>::Add).
+                // Do NOT retry for non-generic declaring types (e.g. Object::.ctor) where genericType is null.
+                if (mdInst.genericType != nullptr && NANOCLR_INDEX_IS_VALID(*mdInst.genericType) &&
+                    call.genericType != nullptr && NANOCLR_INDEX_IS_VALID(*call.genericType))
+                {
+                    CLR_RT_MethodDef_Instance mdInstWithGeneric{};
+                    if (mdInstWithGeneric.ResolveToken(token, call.assembly, call.genericType, &call))
+                    {
+                        mdInst = mdInstWithGeneric;
+                    }
+                }
+
+                // If the resolved method's genericType is still open (has MVAR) but the calling frame
+                // has an inherited methodSpec, propagate it so BuildMethodName can close the MVAR args.
+                if (!NANOCLR_INDEX_IS_VALID(mdInst.methodSpec) &&
+                    mdInst.genericType != nullptr &&
+                    NANOCLR_INDEX_IS_VALID(*mdInst.genericType) &&
+                    NANOCLR_INDEX_IS_VALID(call.methodSpec))
+                {
+                    CLR_RT_TypeSpec_Instance tsCheck;
+                    if (tsCheck.InitializeFromIndex(*mdInst.genericType) && !tsCheck.IsClosedGenericType())
+                    {
+                        mdInst.methodSpec = call.methodSpec;
+                    }
+                }
+
                 // mdInst now holds the target MethodDef (or MethodSpec) plus any genericType.
-                CLR_RT_DUMP::METHOD(mdInst, call.genericType);
+                CLR_RT_DUMP::METHOD(mdInst, mdInst.genericType);
             }
             else
             {

--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -1045,10 +1045,8 @@ void CLR_RT_Assembly::DumpOpcodeDirect(
 
                 // If the resolved method's genericType is still open (has MVAR) but the calling frame
                 // has an inherited methodSpec, propagate it so BuildMethodName can close the MVAR args.
-                if (!NANOCLR_INDEX_IS_VALID(mdInst.methodSpec) &&
-                    mdInst.genericType != nullptr &&
-                    NANOCLR_INDEX_IS_VALID(*mdInst.genericType) &&
-                    NANOCLR_INDEX_IS_VALID(call.methodSpec))
+                if (!NANOCLR_INDEX_IS_VALID(mdInst.methodSpec) && mdInst.genericType != nullptr &&
+                    NANOCLR_INDEX_IS_VALID(*mdInst.genericType) && NANOCLR_INDEX_IS_VALID(call.methodSpec))
                 {
                     CLR_RT_TypeSpec_Instance tsCheck;
                     if (tsCheck.InitializeFromIndex(*mdInst.genericType) && !tsCheck.IsClosedGenericType())

--- a/src/CLR/Diagnostics/Info.cpp
+++ b/src/CLR/Diagnostics/Info.cpp
@@ -649,8 +649,8 @@ void CLR_RT_Assembly::DumpToken(
                         }
                         else if (paramElement.DataType == DATATYPE_VAR)
                         {
-                            // nested VAR not implemented
-                            ASSERT(false);
+                            // Nested VAR: the contextTypeSpec is itself open (unresolved VAR).
+                            // Fall through to print "!n" as a literal below.
                         }
                     }
                 }

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -2290,6 +2290,21 @@ struct CLR_RT_MethodDef_Instance : public CLR_RT_MethodDef_Index
 
     //--//
 
+    // After any plain by-value copy of a CLR_RT_MethodDef_Instance, call
+    // Normalize(src) to re-anchor the self-referential genericType pointer.
+    // InitializeFromIndex (typeSpec overload) sets genericType = &m_typeSpecStorage;
+    // a plain copy leaves genericType pointing at the source's m_typeSpecStorage,
+    // which dangles when the source goes out of scope.  Call Normalize(src)
+    // immediately after every  dst = src  where src may have had
+    // genericType == &src.m_typeSpecStorage.
+    inline void Normalize(const CLR_RT_MethodDef_Instance &src)
+    {
+        if (src.genericType == &src.m_typeSpecStorage)
+        {
+            genericType = &m_typeSpecStorage;
+        }
+    }
+
     bool InitializeFromIndex(const CLR_RT_MethodDef_Index &index);
     bool InitializeFromIndex(
         const CLR_RT_MethodDef_Index &index,

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -2277,6 +2277,10 @@ struct CLR_RT_MethodDef_Instance : public CLR_RT_MethodDef_Index
     const CLR_RT_TypeSpec_Index *genericType;
     CLR_RT_MethodSpec_Index methodSpec;
 
+    // Stable storage for the TypeSpec when set by InitializeFromIndex(md, typeSpec, caller).
+    // Prevents genericType from pointing to a caller's stack-local parameter.
+    CLR_RT_TypeSpec_Index m_typeSpecStorage;
+
     // For SZArrayHelper rebind: stores the array element TypeDef when dispatching from arrays
     CLR_RT_TypeDef_Index arrayElementType;
 
@@ -2558,6 +2562,7 @@ struct CLR_RT_InlineFrame
     CLR_PMETADATA m_IPStart;
     CLR_UINT8 m_localAllocCount;
     uintptr_t m_localAllocs[MAX_LOCALALLOC_COUNT];
+    CLR_RT_TypeSpec_Index m_genericTypeSpecStorage;
 };
 
 struct CLR_RT_InlineBuffer


### PR DESCRIPTION
## Description
- Fix dumping opcodes: now properly resolves types in calls.
- Fix initializing field from local vars when variable is MVAR: setting to OBJECT which will provide a null object ref.
- Fix output and processing of VAR type when resolving a token.
- InlineFrame now stores generic TypeSpec: required to prevent generic type from pointing to a caller's stack-local parameter.
- Implement CEE_CONSTRAINED opcode.
- Fix BuildTypeName for MVAR processing.
- Fix BuildMethodName to deal with MVAR resolution.
- Fix resolving token for TypeDef Instance for VAR and SZArrayHelper.
- Fix PushInline for call and callvirt.
- Fix newobj to properly resolve MVAR constructors.
- Fix resolving token for TypeDef instance when dealing with MVAR.

## Motivation and Context
- Fixed issues surfaced when running new unit tests in System.Collections.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running nanoframework/System.Collections#165.
- [tested against nanoframework/CoreLibrary#269]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
