### PR TITLE
Fixes with aligment digits in `String.Format()`

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_String.cpp
+++ b/src/CLR/CorLib/corlib_native_System_String.cpp
@@ -1361,10 +1361,17 @@ HRESULT Library_corlib_native_System_String::Format___STATIC__STRING__STRING__SZ
                         p++;
                     }
 
+                    bool hasAlignmentDigits = false;
                     while (*p >= '0' && *p <= '9')
                     {
                         alignment = alignment * 10 + (*p - '0');
+                        hasAlignmentDigits = true;
                         p++;
+                    }
+
+                    if (!hasAlignmentDigits)
+                    {
+                        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
                     }
 
                     if (negative)
@@ -1387,6 +1394,11 @@ HRESULT Library_corlib_native_System_String::Format___STATIC__STRING__STRING__SZ
                     }
 
                     formatSpec[formatSpecLen] = '\0';
+
+                    if (formatSpecLen == 0)
+                    {
+                        NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_PARAMETER);
+                    }
                 }
 
                 if (*p != '}')


### PR DESCRIPTION
## Description
- Now properly dealing with alignment digits.

## Motivation and Context
- Follow-up on #3246 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#269]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
