### PR TITLE
Fix support generic struct arrays with generic TypeSpecs

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapBlock_Array.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Array.cpp
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -144,7 +144,18 @@ HRESULT CLR_RT_HeapBlock_Array::CreateInstance(
         CLR_RT_ReflectionDef_Index reflex{};
         reflex.kind = REFLECTION_TYPE;
         reflex.levels = tsInst.levels;
-        reflex.data.type = tsInst.cachedElementType;
+
+        // For generic instantiation TypeSpecs (e.g. Pair<TKey,TValue>), genericTypeDef holds
+        // the open generic typedef (e.g. Pair<,>).  cachedElementType is only set for
+        // non-generic TypeSpecs resolved via VAR/MVAR, so prefer genericTypeDef when valid.
+        if (NANOCLR_INDEX_IS_VALID(tsInst.genericTypeDef))
+        {
+            reflex.data.type = tsInst.genericTypeDef;
+        }
+        else
+        {
+            reflex.data.type = tsInst.cachedElementType;
+        }
 
         NANOCLR_CHECK_HRESULT(ref.SetReflection(reflex));
     }

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -2117,13 +2117,18 @@ HRESULT CLR_RT_ExecutionEngine::InitializeReference(
         {
             if (genericInstance == nullptr || !NANOCLR_INDEX_IS_VALID(*genericInstance))
             {
-                NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
+                // VAR cannot be resolved without a closed generic context (e.g. when
+                // pre-allocating array element structs for an open generic type).
+                // Treat as an object reference (null) so field initialization proceeds.
+                dt = DATATYPE_OBJECT;
             }
+            else
+            {
+                NANOCLR_CHECK_HRESULT(
+                    ResolveGenericTypeParameter(*genericInstance, res.GenericParamPosition, realTypeDef, dt));
 
-            NANOCLR_CHECK_HRESULT(
-                ResolveGenericTypeParameter(*genericInstance, res.GenericParamPosition, realTypeDef, dt));
-
-            goto process_datatype;
+                goto process_datatype;
+            }
         }
         else if (dt == DATATYPE_MVAR)
         {

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -2083,7 +2083,8 @@ static HRESULT ResolveGenericTypeParameter(
 HRESULT CLR_RT_ExecutionEngine::InitializeReference(
     CLR_RT_HeapBlock &ref,
     CLR_RT_SignatureParser &parser,
-    const CLR_RT_TypeSpec_Instance *genericInstance)
+    const CLR_RT_TypeSpec_Instance *genericInstance,
+    bool allowUnresolvedVarFallback)
 {
     NATIVE_PROFILE_CLR_CORE();
     //
@@ -2117,10 +2118,18 @@ HRESULT CLR_RT_ExecutionEngine::InitializeReference(
         {
             if (genericInstance == nullptr || !NANOCLR_INDEX_IS_VALID(*genericInstance))
             {
-                // VAR cannot be resolved without a closed generic context (e.g. when
-                // pre-allocating array element structs for an open generic type).
-                // Treat as an object reference (null) so field initialization proceeds.
-                dt = DATATYPE_OBJECT;
+                if (allowUnresolvedVarFallback)
+                {
+                    // VAR cannot be resolved without a closed generic context (e.g. when
+                    // pre-allocating array element structs for an open generic type).
+                    // Treat as an object reference (null) so field initialization proceeds;
+                    // subsequent stfld instructions will overwrite with the correct type.
+                    dt = DATATYPE_OBJECT;
+                }
+                else
+                {
+                    NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
+                }
             }
             else
             {
@@ -2206,7 +2215,8 @@ HRESULT CLR_RT_ExecutionEngine::InitializeReference(
     CLR_RT_HeapBlock &ref,
     const CLR_RECORD_FIELDDEF *target,
     CLR_RT_Assembly *assm,
-    const CLR_RT_TypeSpec_Instance *genericInstance)
+    const CLR_RT_TypeSpec_Instance *genericInstance,
+    bool allowUnresolvedVarFallback)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
@@ -2214,7 +2224,7 @@ HRESULT CLR_RT_ExecutionEngine::InitializeReference(
     CLR_RT_SignatureParser parser{};
     parser.Initialize_FieldDef(assm, target);
 
-    NANOCLR_SET_AND_LEAVE(InitializeReference(ref, parser, genericInstance));
+    NANOCLR_SET_AND_LEAVE(InitializeReference(ref, parser, genericInstance, allowUnresolvedVarFallback));
 
     NANOCLR_NOCLEANUP();
 }
@@ -2640,7 +2650,7 @@ HRESULT CLR_RT_ExecutionEngine::NewObject(
                         const char *fieldName = assm->GetString(target->name);
 #endif
 
-                        NANOCLR_CHECK_HRESULT(InitializeReference(*obj, target, assm, genericInstance));
+                        NANOCLR_CHECK_HRESULT(InitializeReference(*obj, target, assm, genericInstance, true));
                     }
                 }
 

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1279,11 +1279,12 @@ bool CLR_RT_TypeDef_Instance::ResolveToken(
                                 return false;
                             }
 
-                            if ((elem.DataType == DATATYPE_CLASS || elem.DataType == DATATYPE_VALUETYPE) && NANOCLR_INDEX_IS_VALID(elem.Class))
+                            if ((elem.DataType == DATATYPE_CLASS || elem.DataType == DATATYPE_VALUETYPE) &&
+                                NANOCLR_INDEX_IS_VALID(elem.Class))
                             {
-                                data     = elem.Class.data;
+                                data = elem.Class.data;
                                 assembly = g_CLR_RT_TypeSystem.m_assemblies[elem.Class.Assembly() - 1];
-                                target   = assembly->GetTypeDef(elem.Class.Type());
+                                target = assembly->GetTypeDef(elem.Class.Type());
 #if defined(NANOCLR_INSTANCE_NAMES)
                                 name = assembly->GetString(target->name);
 #endif

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -1269,38 +1269,28 @@ bool CLR_RT_TypeDef_Instance::ResolveToken(
                     {
                         if (elem.DataType == DATATYPE_GENERICINST)
                         {
+                            // Advance past the open generic type token.
+                            // After this call elem.Class holds the open generic typedef (e.g. Pair<,>).
+                            // The parser has already consumed the arg-count byte inside Advance,
+                            // so there is no further element to skip.  Return the typedef directly
+                            // for NEWARR / STELEM / ISINST / CASTCLASS with a GENERICINST token.
                             if (FAILED(parser.Advance(elem)))
                             {
                                 return false;
                             }
 
-                            if (elem.DataType == DATATYPE_CLASS || elem.DataType == DATATYPE_VALUETYPE)
+                            if ((elem.DataType == DATATYPE_CLASS || elem.DataType == DATATYPE_VALUETYPE) && NANOCLR_INDEX_IS_VALID(elem.Class))
                             {
-                                // consume the CLASS/VALUETYPE marker
-                                if (FAILED(parser.Advance(elem)))
-                                {
-                                    return false;
-                                }
-                                // consume the generic‐definition token itself
-                                if (FAILED(parser.Advance(elem)))
-                                {
-                                    return false;
-                                }
-                                // consume the count of generic arguments
-                                if (FAILED(parser.Advance(elem)))
-                                {
-                                    return false;
-                                }
+                                data     = elem.Class.data;
+                                assembly = g_CLR_RT_TypeSystem.m_assemblies[elem.Class.Assembly() - 1];
+                                target   = assembly->GetTypeDef(elem.Class.Type());
+#if defined(NANOCLR_INSTANCE_NAMES)
+                                name = assembly->GetString(target->name);
+#endif
+                                return true;
                             }
 
-                            // walk forward until a VAR (type‐generic) or MVAR (method‐generic) is hit
-                            while (elem.DataType != DATATYPE_VAR && elem.DataType != DATATYPE_MVAR)
-                            {
-                                if (FAILED(parser.Advance(elem)))
-                                {
-                                    return false;
-                                }
-                            }
+                            return false;
                         }
 
                         genericPosition = elem.GenericParamPosition;

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -4222,12 +4222,14 @@ struct CLR_RT_ExecutionEngine
     HRESULT InitializeReference(
         CLR_RT_HeapBlock &ref,
         CLR_RT_SignatureParser &parser,
-        const CLR_RT_TypeSpec_Instance *genericInstance = nullptr);
+        const CLR_RT_TypeSpec_Instance *genericInstance = nullptr,
+        bool allowUnresolvedVarFallback = false);
     HRESULT InitializeReference(
         CLR_RT_HeapBlock &ref,
         const CLR_RECORD_FIELDDEF *target,
         CLR_RT_Assembly *assm,
-        const CLR_RT_TypeSpec_Instance *genericInstance = nullptr);
+        const CLR_RT_TypeSpec_Instance *genericInstance = nullptr,
+        bool allowUnresolvedVarFallback = false);
 
     HRESULT InitializeLocals(CLR_RT_HeapBlock *locals, const CLR_RT_MethodDef_Instance &methodDefInstance);
 


### PR DESCRIPTION
## Description
- ResolveToken for a TypeDef instance now resolves generic TypeSpec tokens to their open generic TypeDef, enabling newarr, ldelem.any and stelem.any to succeed on generic struct element types.
- InitializeReference now properly handles a VAR field without generic instance context, falling back to Object instead of faiing, mirroring the existing MVAR behaviour.
- Narrow VAR fallback to array pre-allocation path only.
  + Add allowUnresolvedVarFallback parameter to InitializeReference.
  + Now using this when resolving VAR.
  + Update callers, noticably NewObject as this is the only path reached from ClearElements → NewObjectFromIndex during open-generic array pre-allocation.

## Motivation and Context
- newarr `Pair<TKey,TValue>` inside a generic method emits a generic TypeSpec token. The runtime had no handling for this token class in ResolveToken, causing CLR_E_WRONG_TYPE for newarr, ldelem.any and stelem.any on generic struct arrays.
Even after resolving the element type, pre-allocating struct slots in the new array calls InitializeReference on each field. For open generic structs the field types are unresolved VAR parameters; without a closed generic context at array-creation time the call unconditionally returned CLR_E_FAIL. Fields are written correctly by subsequent stfld instructions, so initialising them as objects (which are null) is safe.
- Edge case surfaced when adding new test code in MDP nanoframework/metadata-processor#232.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#245].

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
