### PR TITLE
Fixes in `String.Format()`

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_String.cpp
+++ b/src/CLR/CorLib/corlib_native_System_String.cpp
@@ -1297,7 +1297,7 @@ HRESULT Library_corlib_native_System_String::Format___STATIC__STRING__STRING__SZ
 
     // Get arguments array
     args = stack.Arg1().DereferenceArray();
-    FAULT_ON_NULL(args);
+    FAULT_ON_NULL_ARG(args);
 
     // loop twice: first to calculate length, second to format
     for (int pass = 0; pass < 2; pass++)
@@ -1558,16 +1558,67 @@ HRESULT Library_corlib_native_System_String::Format___STATIC__STRING__STRING__SZ
 
                                         case 'f':
                                         case 'F':
-                                        case 'n':
-                                        case 'N':
-                                            // N format is like F but with thousand separators
-                                            // For now, we just use F format since we don't have NumberFormatInfo
                                             len = Library_corlib_native_System_Number::Format_F(
                                                 argBuffer,
                                                 deref,
                                                 precision,
                                                 negSign,
                                                 decSep);
+                                            break;
+
+                                        case 'n':
+                                        case 'N':
+                                            // N format is like F but with thousands separators
+                                            len = Library_corlib_native_System_Number::Format_F(
+                                                argBuffer,
+                                                deref,
+                                                precision,
+                                                negSign,
+                                                decSep);
+
+                                            if (len > 0)
+                                            {
+                                                // Insert thousands separators into the integer part.
+                                                // Strategy: build result in tempBuffer, then copy back.
+                                                char tempBuffer[FORMAT_RESULT_BUFFER_SIZE] = {0};
+                                                int srcIdx = 0;
+                                                int dstIdx = 0;
+
+                                                argBuffer[len] = '\0';
+
+                                                // Preserve leading negative sign
+                                                if (argBuffer[srcIdx] == '-')
+                                                {
+                                                    tempBuffer[dstIdx++] = argBuffer[srcIdx++];
+                                                }
+
+                                                // Locate end of integer part (decimal point or end of string)
+                                                int intEnd = srcIdx;
+                                                while (intEnd < len && argBuffer[intEnd] != '.')
+                                                {
+                                                    intEnd++;
+                                                }
+
+                                                // Copy integer digits, inserting ',' every 3 digits from the right
+                                                for (int i = srcIdx; i < intEnd; i++)
+                                                {
+                                                    if (i > srcIdx && (intEnd - i) % 3 == 0)
+                                                    {
+                                                        tempBuffer[dstIdx++] = ',';
+                                                    }
+                                                    tempBuffer[dstIdx++] = argBuffer[i];
+                                                }
+
+                                                // Copy decimal part (decimal point and fractional digits)
+                                                while (intEnd < len)
+                                                {
+                                                    tempBuffer[dstIdx++] = argBuffer[intEnd++];
+                                                }
+
+                                                tempBuffer[dstIdx] = '\0';
+                                                memcpy(argBuffer, tempBuffer, dstIdx + 1);
+                                                len = dstIdx;
+                                            }
                                             break;
 
                                         case 'd':


### PR DESCRIPTION
## Description
- Now throws ArgumentNullException, per .NET expected behaviour.
- Fix N/n format specifier missing thousands separators.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#245].

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
