### PR TITLE
HeapBlock Convert now honours unsigned parameter

### DIFF
--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -1293,6 +1293,29 @@ struct CLR_RT_HeapBlock
         //
         // For V1, we don't throw on overflow.
         //
+        // For conv.r.un, the source must be treated as unsigned regardless of its
+        // declared DataType (which is always a signed type on the eval stack).
+        // Remap to the unsigned equivalent so Convert_Internal selects scaleIn = -1.
+        if (fUnsigned)
+        {
+            switch (DataType())
+            {
+                case DATATYPE_I1:
+                    ChangeDataType(DATATYPE_U1);
+                    break;
+                case DATATYPE_I2:
+                    ChangeDataType(DATATYPE_U2);
+                    break;
+                case DATATYPE_I4:
+                    ChangeDataType(DATATYPE_U4);
+                    break;
+                case DATATYPE_I8:
+                    ChangeDataType(DATATYPE_U8);
+                    break;
+                default:
+                    break;
+            }
+        }
         return Convert_Internal(et);
     }
 


### PR DESCRIPTION
## Description

## Motivation and Context
- Closes nanoFramework/Home#1735.
- Implemented in develop branch with #3350.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- New unit tests added in mscorlib.
- [tested against nanoframework/CoreLibrary#273].

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
