### PR TITLE
Support array values in custom attribute parser

### DIFF
--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -9754,6 +9754,11 @@ HRESULT CLR_RT_AttributeParser::Next(Value *&res)
 
                 NanoCLRDataType dt = CLR_RT_TypeSystem::MapElementTypeToDataType(elementType);
 
+                if (dt >= DATATYPE_FIRST_INVALID)
+                {
+                    NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
+                }
+
                 dtl = c_CLR_RT_DataTypeLookup[dt];
 
                 if (dtl.m_flags & CLR_RT_DataTypeLookup::c_Numeric)
@@ -9765,6 +9770,10 @@ HRESULT CLR_RT_AttributeParser::Next(Value *&res)
                 else if (dt == DATATYPE_STRING)
                 {
                     NANOCLR_CHECK_HRESULT(ReadString(currentParam));
+                }
+                else if (dt == DATATYPE_SZARRAY)
+                {
+                    NANOCLR_CHECK_HRESULT(ReadArrayValue(currentParam));
                 }
                 else
                 {
@@ -9796,6 +9805,15 @@ HRESULT CLR_RT_AttributeParser::Next(Value *&res)
 
             CLR_RT_HeapBlock *currentParam = &m_lastValue.m_value;
             NANOCLR_CHECK_HRESULT(ReadString(currentParam));
+        }
+        else if (m_res.DataType == DATATYPE_SZARRAY)
+        {
+            // single parameter of array type
+            // OK to skip element type
+            m_blob += sizeof(CLR_UINT8);
+
+            CLR_RT_HeapBlock *currentParam = &m_lastValue.m_value;
+            NANOCLR_CHECK_HRESULT(ReadArrayValue(currentParam));
         }
         else
         {
@@ -9887,6 +9905,11 @@ HRESULT CLR_RT_AttributeParser::Next(Value *&res)
             CLR_RT_HeapBlock *currentParam = &m_lastValue.m_value;
             NANOCLR_CHECK_HRESULT(ReadString(currentParam));
         }
+        else if (m_res.DataType == DATATYPE_SZARRAY)
+        {
+            CLR_RT_HeapBlock *currentParam = &m_lastValue.m_value;
+            NANOCLR_CHECK_HRESULT(ReadArrayValue(currentParam));
+        }
         else
         {
             NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
@@ -9894,6 +9917,71 @@ HRESULT CLR_RT_AttributeParser::Next(Value *&res)
     }
 
     m_lastValue.m_pos = m_currentPos++;
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT CLR_RT_AttributeParser::ReadArrayValue(CLR_RT_HeapBlock *&value)
+{
+    NANOCLR_HEADER();
+
+    CLR_UINT8 elementType;
+    CLR_UINT8 elementCount;
+    const CLR_RT_DataTypeLookup *dtl;
+
+    NANOCLR_READ_UNALIGNED_UINT8(elementType, m_blob);
+    NANOCLR_READ_UNALIGNED_UINT8(elementCount, m_blob);
+
+    NanoCLRDataType dt = CLR_RT_TypeSystem::MapElementTypeToDataType(elementType);
+
+    if (dt >= DATATYPE_FIRST_INVALID)
+    {
+        NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
+    }
+
+    dtl = &c_CLR_RT_DataTypeLookup[dt];
+
+    if (dtl->m_flags & CLR_RT_DataTypeLookup::c_Numeric)
+    {
+        CLR_UINT32 size = dtl->m_sizeInBytes;
+
+        NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstance(*value, elementCount, *dtl->m_cls));
+
+        CLR_UINT8 *arrayData = value->DereferenceArray()->GetFirstElement();
+
+        if (dt == DATATYPE_BOOLEAN)
+        {
+            for (CLR_UINT8 i = 0; i < elementCount; i++)
+            {
+                CLR_UINT8 boolValue;
+                NANOCLR_READ_UNALIGNED_UINT8(boolValue, m_blob);
+
+                arrayData[i] = boolValue ? 1 : 0;
+            }
+        }
+        else
+        {
+            memcpy(arrayData, m_blob, size * elementCount);
+            m_blob += size * elementCount;
+        }
+    }
+    else if (dt == DATATYPE_STRING)
+    {
+        NANOCLR_CHECK_HRESULT(
+            CLR_RT_HeapBlock_Array::CreateInstance(*value, elementCount, g_CLR_RT_WellKnownTypes.String));
+
+        auto *currentElement = (CLR_RT_HeapBlock *)value->DereferenceArray()->GetFirstElement();
+
+        for (CLR_UINT8 i = 0; i < elementCount; i++)
+        {
+            NANOCLR_CHECK_HRESULT(ReadString(currentElement));
+            currentElement++;
+        }
+    }
+    else
+    {
+        NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
+    }
 
     NANOCLR_NOCLEANUP();
 }

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -2478,6 +2478,7 @@ struct CLR_RT_AttributeParser
         const NanoCLRDataType dt,
         const CLR_RT_TypeDef_Index *m_cls,
         const CLR_UINT32 size);
+    HRESULT ReadArrayValue(CLR_RT_HeapBlock *&value);
     HRESULT ReadString(CLR_RT_HeapBlock *&value);
 
   private:


### PR DESCRIPTION
## Description
- Add parsing for SZARRAY custom attribute arguments and validate mapped element types before lookup. This keeps nanoCLR aligned with MDP’s proprietary attribute encoding for DataRow arguments such as byte[].

## Motivation and Context
- Following nanoframework/metadata-processor#236.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#245]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
