### PR TITLE
Add missing UNLOCK from early returns in ENC28J60

### DIFF
--- a/src/DeviceInterfaces/Network/Enc28j60/enc28j60_lwip.cpp
+++ b/src/DeviceInterfaces/Network/Enc28j60/enc28j60_lwip.cpp
@@ -242,6 +242,7 @@ void enc28j60_lwip_interrupt(struct netif *pNetIF)
 
     if (!pNetIF)
     {
+        GLOBAL_UNLOCK();
         return;
     }
 
@@ -399,6 +400,7 @@ int enc28j60_lwip_recv(struct netif *pNetIF)
         {
             enc28j60_handle_recv_error(pNetIF, spiHandle);
             packetsLeft = 0;
+            GLOBAL_UNLOCK();
             break;
         }
         else
@@ -488,6 +490,7 @@ int enc28j60_lwip_recv(struct netif *pNetIF)
 
         if ((++numPacketsProcessed > CFG_MAX_PACKETS_PROCESSED) && packetsLeft)
         {
+            GLOBAL_UNLOCK();
             break;
         }
 
@@ -524,6 +527,7 @@ err_t enc28j60_lwip_xmit(struct netif *pNetIF, struct pbuf *pPBuf)
 
     if (!pNetIF)
     {
+        GLOBAL_UNLOCK();
         return ERR_ARG;
     }
 
@@ -593,7 +597,10 @@ err_t enc28j60_lwip_xmit(struct netif *pNetIF, struct pbuf *pPBuf)
     // irq.Acquire();
 
     if (!pTmp)
+    {
+        GLOBAL_UNLOCK();
         return ERR_MEM;
+    }
 
     pTx = (uint8_t *)pTmp->payload;
 


### PR DESCRIPTION
## Description
- Now all early exit paths call GLOBAL_UNLOCK().

## Motivation and Context
- These were unbalanced with the GLOBAL_LOCK on early exit causing a global lock.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
