### PR TITLE
Fix buffer overflow in enc28j60_lwip_xmit()

### DIFF
--- a/src/DeviceInterfaces/Network/Enc28j60/enc28j60_lwip.cpp
+++ b/src/DeviceInterfaces/Network/Enc28j60/enc28j60_lwip.cpp
@@ -606,6 +606,13 @@ err_t enc28j60_lwip_xmit(struct netif *pNetIF, struct pbuf *pPBuf)
 
     while (pPBuf)
     {
+        if ((idx + pPBuf->len) > (length + 2))
+        {
+            GLOBAL_UNLOCK();
+            pbuf_free(pTmp);
+            return ERR_BUF;
+        }
+
         memcpy(&pTx[idx], pPBuf->payload, pPBuf->len);
 
         idx += pPBuf->len;


### PR DESCRIPTION
## Description
- Committing to main branch from #3353.

## Motivation and Context
(cherry picked from commit a4c77c7eb9208dcf9213f0adfe1a0175691003a0)

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
