### PR TITLE
Fix Konfig defaults for ethernet builds

### DIFF
--- a/targets/ESP32/Kconfig.ethernet
+++ b/targets/ESP32/Kconfig.ethernet
@@ -14,7 +14,7 @@ if ESP32_ETHERNET_SUPPORT
 
 choice ESP32_ETHERNET_INTERFACE_CHOICE
     prompt "Ethernet PHY interface"
-    default ESP32_ETHERNET_PHY_IP101
+    default ESP32_ETHERNET_PHY_LAN8720
 
 config ESP32_ETHERNET_PHY_IP101
     bool "IP101"
@@ -36,7 +36,7 @@ config ESP32_ETHERNET_INTERFACE
 config ESP32_ETHERNET_PHY_ADDR
     int "Ethernet PHY address"
     range 0 31
-    default 1
+    default 0
 
 config ESP32_ETHERNET_MDC_GPIO
     int "MDC GPIO pin"


### PR DESCRIPTION
## Description
The default values for ESP32_ETHERNET_INTERFACE and ESP32_ETHERNET_PHY_ADDR were different to the previous cmakepreset build causing the ethernet controller to not be configured correctly

Adjusted default back to original

## Motivation and Context
Reported as issue on discord
https://discord.com/channels/478725473862549535/481782754674212867/1505026912592855090


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally with original Olimex Poe-ISo board.
This is not same board as reported olimex board but hopefully it will resolve that board as well.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
