### PR TITLE
Fix MVAR resolution in MethodDef_Instance::ResolveToken

### DIFF
--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -2254,16 +2254,15 @@ bool CLR_RT_MethodDef_Instance::ResolveToken(
 
                                         if (argElem.DataType == DATATYPE_MVAR)
                                         {
-                                            if (caller != nullptr && NANOCLR_INDEX_IS_VALID(caller->arrayElementType) &&
-                                                argElem.GenericParamPosition == 0)
-                                            {
-                                                resolvedArgs[a] = caller->arrayElementType;
-                                            }
-                                            else
+                                            // The MethodSpec carries the explicit IL-encoded generic arguments for this
+                                            // call and is authoritative. It must take precedence over arrayElementType,
+                                            // which is only a runtime-inferred fallback (used for SZArrayHelper-style
+                                            // dispatch) and can be stale when propagated across generic method
+                                            // boundaries.
+                                            if (hasMethodSpec)
                                             {
                                                 CLR_RT_SignatureParser::Element msArgElem{};
-                                                if (hasMethodSpec &&
-                                                    msInst.GetGenericArgument(argElem.GenericParamPosition, msArgElem))
+                                                if (msInst.GetGenericArgument(argElem.GenericParamPosition, msArgElem))
                                                 {
                                                     if (msArgElem.DataType == DATATYPE_VAR &&
                                                         caller->genericType != nullptr &&
@@ -2292,6 +2291,16 @@ bool CLR_RT_MethodDef_Instance::ResolveToken(
                                                 {
                                                     allResolved = false;
                                                 }
+                                            }
+                                            else if (
+                                                caller != nullptr && NANOCLR_INDEX_IS_VALID(caller->arrayElementType) &&
+                                                argElem.GenericParamPosition == 0)
+                                            {
+                                                resolvedArgs[a] = caller->arrayElementType;
+                                            }
+                                            else
+                                            {
+                                                allResolved = false;
                                             }
                                         }
                                         else if (argElem.DataType == DATATYPE_VAR)

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -2273,7 +2273,8 @@ bool CLR_RT_MethodDef_Instance::ResolveToken(
                                                         if (callerTsInst.InitializeFromIndex(*caller->genericType) &&
                                                             callerTsInst.GetGenericParam(
                                                                 msArgElem.GenericParamPosition,
-                                                                paramElem))
+                                                                paramElem) &&
+                                                            NANOCLR_INDEX_IS_VALID(paramElem.Class))
                                                         {
                                                             resolvedArgs[a] = paramElem.Class;
                                                         }
@@ -2282,9 +2283,16 @@ bool CLR_RT_MethodDef_Instance::ResolveToken(
                                                             allResolved = false;
                                                         }
                                                     }
-                                                    else
+                                                    else if (NANOCLR_INDEX_IS_VALID(msArgElem.Class))
                                                     {
                                                         resolvedArgs[a] = msArgElem.Class;
+                                                    }
+                                                    else
+                                                    {
+                                                        // A DATATYPE_VAR without a resolvable caller context, or any
+                                                        // other element that did not yield a concrete type, must fail
+                                                        // resolution rather than bind to an empty Class index.
+                                                        allResolved = false;
                                                     }
                                                 }
                                                 else


### PR DESCRIPTION
-  MVAR (!!0) resolution now checks the MethodSpec first (authoritative IL-encoded generic argument) and only falls back to arrayElementType when no MethodSpec exists.

<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->

## Motivation and Context
- Found in failing unit tests in nanoframework/System.Collections#175. Those two unit tests failing have been there for quite sometime. Recent fixes in the test adapter are now correctly picking up these.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#245].

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
