### PR TITLE
Fix IsInstanceOf for closed instances

### DIFF
--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -3613,6 +3613,15 @@ bool CLR_RT_ExecutionEngine::IsInstanceOf(
     CLR_RT_TypeDef_Instance &instTarget = descTarget.m_handlerCls;
     bool fArray = false;
 
+    // Closed generic instances keep their type information in 'm_handlerGenericType' and have 'm_handlerCls'
+    // cleared (so GetDataType() reports DATATYPE_GENERICINST). The comparison logic below dereferences
+    // 'inst.target' / 'instTarget.target', which would be null for those descriptors. Better delegate to the
+    // generic-aware TypeDescriptorsMatch helper to avoid dereferencing a null handler.
+    if (desc.GetDataType() == DATATYPE_GENERICINST || descTarget.GetDataType() == DATATYPE_GENERICINST)
+    {
+        return CLR_RT_HeapBlock::TypeDescriptorsMatch(descTarget, desc);
+    }
+
     while (desc.m_reflex.levels > 0 && descTarget.m_reflex.levels > 0)
     {
         desc.GetElementType(desc);


### PR DESCRIPTION
## Description
- Now defaulting to TypeDescriptorsMatch helper to avoid dereferencing a null handler.

## Motivation and Context
- Fixes failing unit tests nanoframework/nanoFramework.Json#455
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#245].

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
