### PR TITLE
Fix parsing array in CLR_RT_TypeDescriptor::InitializeFromSignatureToken

### DIFF
--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -793,6 +793,18 @@ bool CLR_RT_HeapBlock::TypeDescriptorsMatch(
     const CLR_RT_TypeDescriptor &expectedType,
     const CLR_RT_TypeDescriptor &actualType)
 {
+#if defined(NANOCLR_TRACE_GENERICS)
+    if (s_CLR_RT_fTrace_GenericFields >= c_CLR_RT_Trace_Info)
+    {
+        CLR_Debug::Printf(
+            "[DIAG] TypeDescriptorsMatch expected DT=%d hCls=%08X hGT=%08X lvl=%d  actual DT=%d hCls=%08X hGT=%08X lvl=%d\r\n",
+            (int)expectedType.GetDataType(), (unsigned)expectedType.m_handlerCls.data,
+            (unsigned)expectedType.m_handlerGenericType.data, (int)expectedType.m_reflex.levels,
+            (int)actualType.GetDataType(), (unsigned)actualType.m_handlerCls.data,
+            (unsigned)actualType.m_handlerGenericType.data, (int)actualType.m_reflex.levels);
+    }
+#endif
+
     // Figure out logical DataTypes, promoting ACTUAL CLASS ---> GENERICINST
     NanoCLRDataType expectedDataType = expectedType.GetDataType();
     NanoCLRDataType actualDataType = actualType.GetDataType();
@@ -867,10 +879,31 @@ bool CLR_RT_HeapBlock::TypeDescriptorsMatch(
 
         case DATATYPE_SZARRAY:
         {
-            // compare outer dims (always 1) then element types
-            CLR_RT_TypeDescriptor expectedElementType, actualElementType;
-            expectedElementType.GetElementType(expectedElementType);
-            actualElementType.GetElementType(actualElementType);
+            // derive element-type descriptors from the ARRAY descriptors
+            CLR_RT_TypeDescriptor expectedElementType;
+            CLR_RT_TypeDescriptor actualElementType;
+            CLR_RT_TypeDescriptor eCopy = expectedType;
+            CLR_RT_TypeDescriptor aCopy = actualType;
+
+            bool eOk = eCopy.GetElementType(expectedElementType);
+            bool aOk = aCopy.GetElementType(actualElementType);
+
+#if defined(NANOCLR_TRACE_GENERICS)
+            if (s_CLR_RT_fTrace_GenericFields >= c_CLR_RT_Trace_Info)
+            {
+                CLR_Debug::Printf(
+                    "[DIAG] TDM SZARRAY eOk=%d eCls=%08X eDT=%d aOk=%d aCls=%08X aDT=%d\r\n",
+                    (int)eOk, (unsigned)expectedElementType.m_handlerCls.data,
+                    (int)expectedElementType.GetDataType(),
+                    (int)aOk, (unsigned)actualElementType.m_handlerCls.data,
+                    (int)actualElementType.GetDataType());
+            }
+#endif
+            if (!eOk || !aOk)
+            {
+                return false;
+            }
+
             return TypeDescriptorsMatch(expectedElementType, actualElementType);
         }
 

--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -797,11 +797,16 @@ bool CLR_RT_HeapBlock::TypeDescriptorsMatch(
     if (s_CLR_RT_fTrace_GenericFields >= c_CLR_RT_Trace_Info)
     {
         CLR_Debug::Printf(
-            "[DIAG] TypeDescriptorsMatch expected DT=%d hCls=%08X hGT=%08X lvl=%d  actual DT=%d hCls=%08X hGT=%08X lvl=%d\r\n",
-            (int)expectedType.GetDataType(), (unsigned)expectedType.m_handlerCls.data,
-            (unsigned)expectedType.m_handlerGenericType.data, (int)expectedType.m_reflex.levels,
-            (int)actualType.GetDataType(), (unsigned)actualType.m_handlerCls.data,
-            (unsigned)actualType.m_handlerGenericType.data, (int)actualType.m_reflex.levels);
+            "[DIAG] TypeDescriptorsMatch expected DT=%d hCls=%08X hGT=%08X lvl=%d  actual DT=%d hCls=%08X hGT=%08X "
+            "lvl=%d\r\n",
+            (int)expectedType.GetDataType(),
+            (unsigned)expectedType.m_handlerCls.data,
+            (unsigned)expectedType.m_handlerGenericType.data,
+            (int)expectedType.m_reflex.levels,
+            (int)actualType.GetDataType(),
+            (unsigned)actualType.m_handlerCls.data,
+            (unsigned)actualType.m_handlerGenericType.data,
+            (int)actualType.m_reflex.levels);
     }
 #endif
 
@@ -893,9 +898,11 @@ bool CLR_RT_HeapBlock::TypeDescriptorsMatch(
             {
                 CLR_Debug::Printf(
                     "[DIAG] TDM SZARRAY eOk=%d eCls=%08X eDT=%d aOk=%d aCls=%08X aDT=%d\r\n",
-                    (int)eOk, (unsigned)expectedElementType.m_handlerCls.data,
+                    (int)eOk,
+                    (unsigned)expectedElementType.m_handlerCls.data,
                     (int)expectedElementType.GetDataType(),
-                    (int)aOk, (unsigned)actualElementType.m_handlerCls.data,
+                    (int)aOk,
+                    (unsigned)actualElementType.m_handlerCls.data,
                     (int)actualElementType.GetDataType());
             }
 #endif

--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -885,8 +885,8 @@ bool CLR_RT_HeapBlock::TypeDescriptorsMatch(
         case DATATYPE_SZARRAY:
         {
             // derive element-type descriptors from the ARRAY descriptors
-            CLR_RT_TypeDescriptor expectedElementType;
-            CLR_RT_TypeDescriptor actualElementType;
+            CLR_RT_TypeDescriptor expectedElementType{};
+            CLR_RT_TypeDescriptor actualElementType{};
             CLR_RT_TypeDescriptor eCopy = expectedType;
             CLR_RT_TypeDescriptor aCopy = actualType;
 
@@ -899,11 +899,11 @@ bool CLR_RT_HeapBlock::TypeDescriptorsMatch(
                 CLR_Debug::Printf(
                     "[DIAG] TDM SZARRAY eOk=%d eCls=%08X eDT=%d aOk=%d aCls=%08X aDT=%d\r\n",
                     (int)eOk,
-                    (unsigned)expectedElementType.m_handlerCls.data,
-                    (int)expectedElementType.GetDataType(),
+                    eOk ? (unsigned)expectedElementType.m_handlerCls.data : 0u,
+                    eOk ? (int)expectedElementType.GetDataType() : -1,
                     (int)aOk,
-                    (unsigned)actualElementType.m_handlerCls.data,
-                    (int)actualElementType.GetDataType());
+                    aOk ? (unsigned)actualElementType.m_handlerCls.data : 0u,
+                    aOk ? (int)actualElementType.GetDataType() : -1);
             }
 #endif
             if (!eOk || !aOk)

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -3613,6 +3613,19 @@ bool CLR_RT_ExecutionEngine::IsInstanceOf(
     CLR_RT_TypeDef_Instance &instTarget = descTarget.m_handlerCls;
     bool fArray = false;
 
+#if defined(NANOCLR_TRACE_GENERICS)
+    if (s_CLR_RT_fTrace_GenericFields >= c_CLR_RT_Trace_Info)
+    {
+        CLR_Debug::Printf(
+            "[DIAG] IsInstanceOf desc DT=%d hCls=%08X hGT=%08X lvl=%d  target DT=%d hCls=%08X hGT=%08X lvl=%d isInst=%d\r\n",
+            (int)desc.GetDataType(), (unsigned)desc.m_handlerCls.data,
+            (unsigned)desc.m_handlerGenericType.data, (int)desc.m_reflex.levels,
+            (int)descTarget.GetDataType(), (unsigned)descTarget.m_handlerCls.data,
+            (unsigned)descTarget.m_handlerGenericType.data, (int)descTarget.m_reflex.levels,
+            (int)isInstInstruction);
+    }
+#endif
+
     // Closed generic instances keep their type information in 'm_handlerGenericType' and have 'm_handlerCls'
     // cleared (so GetDataType() reports DATATYPE_GENERICINST). The comparison logic below dereferences
     // 'inst.target' / 'instTarget.target', which would be null for those descriptors. Better delegate to the

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -3617,11 +3617,16 @@ bool CLR_RT_ExecutionEngine::IsInstanceOf(
     if (s_CLR_RT_fTrace_GenericFields >= c_CLR_RT_Trace_Info)
     {
         CLR_Debug::Printf(
-            "[DIAG] IsInstanceOf desc DT=%d hCls=%08X hGT=%08X lvl=%d  target DT=%d hCls=%08X hGT=%08X lvl=%d isInst=%d\r\n",
-            (int)desc.GetDataType(), (unsigned)desc.m_handlerCls.data,
-            (unsigned)desc.m_handlerGenericType.data, (int)desc.m_reflex.levels,
-            (int)descTarget.GetDataType(), (unsigned)descTarget.m_handlerCls.data,
-            (unsigned)descTarget.m_handlerGenericType.data, (int)descTarget.m_reflex.levels,
+            "[DIAG] IsInstanceOf desc DT=%d hCls=%08X hGT=%08X lvl=%d  target DT=%d hCls=%08X hGT=%08X lvl=%d "
+            "isInst=%d\r\n",
+            (int)desc.GetDataType(),
+            (unsigned)desc.m_handlerCls.data,
+            (unsigned)desc.m_handlerGenericType.data,
+            (int)desc.m_reflex.levels,
+            (int)descTarget.GetDataType(),
+            (unsigned)descTarget.m_handlerCls.data,
+            (unsigned)descTarget.m_handlerGenericType.data,
+            (int)descTarget.m_reflex.levels,
             (int)isInstInstruction);
     }
 #endif

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -478,6 +478,8 @@ HRESULT CLR_RT_SignatureParser::Advance(Element &res)
     res.Levels = 0;
     res.GenericParamPosition = 0xFFFF;
     res.Class.Clear();
+    res.IsGenericInst = 0;
+    res.GenParamCount = 0;
 
     switch (Type)
     {

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -700,7 +700,20 @@ HRESULT CLR_RT_SignatureParser::Advance(Element &res)
             break;
     }
 
-    NANOCLR_NOCLEANUP();
+    NANOCLR_CLEANUP();
+#if defined(NANOCLR_TRACE_GENERICS)
+    if (s_CLR_RT_fTrace_GenericFields >= c_CLR_RT_Trace_Info)
+    {
+        CLR_Debug::Printf(
+            "[DIAG] SigParser::Advance hr=%08X Type=%d DataType=%02X Levels=%d IsByRef=%d "
+            "IsGenericInst=%d GenParamCount=%d GenParamPos=%04X Class.data=%08X\r\n",
+            (unsigned)hr, (int)Type, (unsigned)res.DataType,
+            (int)res.Levels, (int)res.IsByRef, (int)res.IsGenericInst,
+            (int)res.GenParamCount, (unsigned)res.GenericParamPosition,
+            (unsigned)res.Class.data);
+    }
+#endif
+    NANOCLR_CLEANUP_END();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -3040,6 +3053,18 @@ HRESULT CLR_RT_TypeDescriptor::InitializeFromSignatureToken(
 {
     NANOCLR_HEADER();
 
+#if defined(NANOCLR_TRACE_GENERICS)
+    if (s_CLR_RT_fTrace_GenericFields >= c_CLR_RT_Trace_Info)
+    {
+        CLR_Debug::Printf(
+            "[DIAG] InitFromSigToken assm=%s token=%08X callerHasGenType=%d callerHasElemType=%d\r\n",
+            assm ? assm->name : "(null)",
+            (unsigned)token,
+            (int)(caller && caller->genericType && NANOCLR_INDEX_IS_VALID(*caller->genericType)),
+            (int)(caller && NANOCLR_INDEX_IS_VALID(caller->arrayElementType)));
+    }
+#endif
+
     // Peel the compressed token to find out which table and index we're in
     NanoCLRTable dataTable = CLR_TypeFromTk(token);
     CLR_UINT32 idx = CLR_DataFromTk(token);
@@ -3189,7 +3214,22 @@ HRESULT CLR_RT_TypeDescriptor::InitializeFromSignatureToken(
             else
             {
                 // e.g. SZARRAY, VALUETYPE, CLASS
-                this->InitializeFromSignatureParser(parser);
+                // The parser has already been advanced above;
+                // use the parsed elem directly rather than re-advancing an exhausted parser.
+                if (NANOCLR_INDEX_IS_VALID(elem.Class))
+                {
+                    NANOCLR_CHECK_HRESULT(InitializeFromType(elem.Class));
+                }
+                else
+                {
+                    NANOCLR_CHECK_HRESULT(InitializeFromDataType(elem.DataType));
+                }
+
+                if (elem.Levels > 0)
+                {
+                    m_reflex.levels = elem.Levels;
+                    ConvertToArray();
+                }
             }
 
             if ((elem.DataType == DATATYPE_VAR || elem.DataType == DATATYPE_MVAR) && elem.Levels > 0)
@@ -3204,7 +3244,18 @@ HRESULT CLR_RT_TypeDescriptor::InitializeFromSignatureToken(
             NANOCLR_SET_AND_LEAVE(CLR_E_NOTIMPL);
     }
 
-    NANOCLR_NOCLEANUP();
+    NANOCLR_CLEANUP();
+#if defined(NANOCLR_TRACE_GENERICS)
+    if (s_CLR_RT_fTrace_GenericFields >= c_CLR_RT_Trace_Info)
+    {
+        CLR_Debug::Printf(
+            "[DIAG] InitFromSigToken EXIT hr=%08X DT=%d hCls=%08X hGT=%08X levels=%d\r\n",
+            (unsigned)hr,
+            (int)GetDataType(), (unsigned)m_handlerCls.data,
+            (unsigned)m_handlerGenericType.data, (int)m_reflex.levels);
+    }
+#endif
+    NANOCLR_CLEANUP_END();
 }
 
 HRESULT CLR_RT_TypeDescriptor::InitializeFromObject(const CLR_RT_HeapBlock &ref)

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -707,9 +707,14 @@ HRESULT CLR_RT_SignatureParser::Advance(Element &res)
         CLR_Debug::Printf(
             "[DIAG] SigParser::Advance hr=%08X Type=%d DataType=%02X Levels=%d IsByRef=%d "
             "IsGenericInst=%d GenParamCount=%d GenParamPos=%04X Class.data=%08X\r\n",
-            (unsigned)hr, (int)Type, (unsigned)res.DataType,
-            (int)res.Levels, (int)res.IsByRef, (int)res.IsGenericInst,
-            (int)res.GenParamCount, (unsigned)res.GenericParamPosition,
+            (unsigned)hr,
+            (int)Type,
+            (unsigned)res.DataType,
+            (int)res.Levels,
+            (int)res.IsByRef,
+            (int)res.IsGenericInst,
+            (int)res.GenParamCount,
+            (unsigned)res.GenericParamPosition,
             (unsigned)res.Class.data);
     }
 #endif
@@ -3251,8 +3256,10 @@ HRESULT CLR_RT_TypeDescriptor::InitializeFromSignatureToken(
         CLR_Debug::Printf(
             "[DIAG] InitFromSigToken EXIT hr=%08X DT=%d hCls=%08X hGT=%08X levels=%d\r\n",
             (unsigned)hr,
-            (int)GetDataType(), (unsigned)m_handlerCls.data,
-            (unsigned)m_handlerGenericType.data, (int)m_reflex.levels);
+            (int)GetDataType(),
+            (unsigned)m_handlerCls.data,
+            (unsigned)m_handlerGenericType.data,
+            (int)m_reflex.levels);
     }
 #endif
     NANOCLR_CLEANUP_END();


### PR DESCRIPTION
## Description
- Instead of re-parsing the exhausted parser, the else branch now directly uses the already-parsed elem.
- Add several aditional DIAG outputs for generics trace.

## Motivation and Context
- Found in failing unit tests at Json library.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#245].

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
