### PR TITLE
Add workaround for building ESP32 with Nimble in debug

### DIFF
--- a/CMake/binutils.ESP32.cmake
+++ b/CMake/binutils.ESP32.cmake
@@ -870,6 +870,18 @@ macro(nf_add_idf_as_library)
         message(STATUS "Using default XTAL frequency")
     endif()
 
+    # Workaround for MODLOG_N implicit-declaration error with GCC 15+ in NimBLE debug builds.
+    # NimBLE defines log-level names as integers (DEBUG=1, INFO=2, ...). When these are used as
+    # the level argument to MODLOG_DFLT(), they expand to their numeric values before the ## paste
+    # in modlog.h, producing e.g. MODLOG_1 which is not defined. GCC 15 turns that implicit-
+    # function-declaration into a hard error. The compat header provides silent no-op fallbacks.
+    if(HAL_USE_BLE_OPTION AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
+        idf_build_set_property(COMPILE_OPTIONS
+            "-include${CMAKE_SOURCE_DIR}/targets/ESP32/_include/nimble_modlog_compat.h"
+            APPEND
+        )
+    endif()
+
     # create IDF static libraries
     idf_build_process(${TARGET_SERIES_SHORT}
         COMPONENTS 

--- a/targets/ESP32/_include/nimble_modlog_compat.h
+++ b/targets/ESP32/_include/nimble_modlog_compat.h
@@ -1,0 +1,49 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+// Compatibility shim for NimBLE modlog numeric-level macros with GCC 15+.
+//
+// NimBLE defines log-level constants as integers (e.g. DEBUG=1, INFO=2, ...).
+// When MODLOG_DFLT(DEBUG, ...) expands, DEBUG is resolved to 1 before the
+// ## token-paste in modlog.h fires, producing MODLOG_1 which is not defined
+// in the ESP-IDF NimBLE port's modlog.h. GCC 15 promotes that implicit-
+// function-declaration from a warning to an error. The definitions below
+// provide silent no-op fallbacks for every numeric variant that modlog.h
+// leaves undefined, without modifying any ESP-IDF source files.
+
+#ifndef NIMBLE_MODLOG_COMPAT_H
+#define NIMBLE_MODLOG_COMPAT_H
+
+#ifndef MODLOG_1
+// NOLINTBEGIN
+#define MODLOG_1(ml_mod_, ...) ((void)0)
+// NOLINTEND
+#endif
+
+#ifndef MODLOG_2
+// NOLINTBEGIN
+#define MODLOG_2(ml_mod_, ...) ((void)0)
+// NOLINTEND
+#endif
+
+#ifndef MODLOG_3
+// NOLINTBEGIN
+#define MODLOG_3(ml_mod_, ...) ((void)0)
+// NOLINTEND
+#endif
+
+#ifndef MODLOG_4
+// NOLINTBEGIN
+#define MODLOG_4(ml_mod_, ...) ((void)0)
+// NOLINTEND
+#endif
+
+#ifndef MODLOG_5
+// NOLINTBEGIN
+#define MODLOG_5(ml_mod_, ...) ((void)0)
+// NOLINTEND
+#endif
+
+#endif // NIMBLE_MODLOG_COMPAT_H


### PR DESCRIPTION
## Description
- Implement workaround to fix MODLOG_1 error.

## Motivation and Context
- Fix infamous MODLOG_1 error when using Nimble component in ESP32 and building in debug.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
