### PR TITLE
Fix generic interface method dispatch for multi-argument types

### DIFF
--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -9086,6 +9086,21 @@ bool CLR_RT_TypeSystem::FindVirtualMethodDef(
 // method uses generic type parameter T (VAR N) while the concrete implementation uses
 // a closed generic instance (e.g. KeyValuePair<TKey,TValue>).  The inner sub-elements
 // of the GENERICINST are drained from the parser so Available() stays consistent.
+static bool DrainGenericInstSubtree(CLR_RT_SignatureParser &parser, int targetAvail)
+{
+    while (parser.Available() > targetAvail)
+    {
+        CLR_RT_SignatureParser::Element drained{};
+
+        if (FAILED(parser.Advance(drained)))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 static bool MatchSignatureForVirtualDispatch(CLR_RT_SignatureParser &parserLeft, CLR_RT_SignatureParser &parserRight)
 {
     if (parserLeft.Type != parserRight.Type)
@@ -9119,30 +9134,23 @@ static bool MatchSignatureForVirtualDispatch(CLR_RT_SignatureParser &parserLeft,
         if (resLeft.DataType == DATATYPE_VAR && resRight.DataType == DATATYPE_GENERICINST)
         {
             int targetAvail = iAvailLeft - 1;
-            while (parserRight.Available() > targetAvail)
+            if (!DrainGenericInstSubtree(parserRight, targetAvail))
             {
-                CLR_RT_SignatureParser::Element drained{};
-
-                if (FAILED(parserRight.Advance(drained)))
-                {
-                    return false;
-                }
+                return false;
             }
+
             continue;
         }
 
         if (resLeft.DataType == DATATYPE_GENERICINST && resRight.DataType == DATATYPE_VAR)
         {
             int targetAvail = iAvailRight - 1;
-            while (parserLeft.Available() > targetAvail)
-            {
-                CLR_RT_SignatureParser::Element drained{};
 
-                if (FAILED(parserLeft.Advance(drained)))
-                {
-                    return false;
-                }
+            if (!DrainGenericInstSubtree(parserLeft, targetAvail))
+            {
+                return false;
             }
+
             continue;
         }
 

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -9114,29 +9114,34 @@ static bool MatchSignatureForVirtualDispatch(CLR_RT_SignatureParser &parserLeft,
         // Relaxed VAR <-> GENERICINST matching for interface virtual dispatch:
         // the interface method may use a type parameter (VAR N) while the concrete
         // implementation uses the expanded generic type (GENERICINST ...).  Drain the
-        // GENERICINST inner elements so the parser position stays consistent.
+        // whole GENERICINST sub-tree on the expanded side so the parser position stays
+        // consistent.
         if (resLeft.DataType == DATATYPE_VAR && resRight.DataType == DATATYPE_GENERICINST)
         {
-            CLR_RT_SignatureParser::Element inner{};
-            if (FAILED(parserRight.Advance(inner)))
-                return false; // type element (CLASS/VALUETYPE + TypeRef)
-            for (int i = 0; i < inner.GenParamCount; i++)
+            int targetAvail = iAvailLeft - 1;
+            while (parserRight.Available() > targetAvail)
             {
-                if (FAILED(parserRight.Advance(inner)))
+                CLR_RT_SignatureParser::Element drained{};
+
+                if (FAILED(parserRight.Advance(drained)))
+                {
                     return false;
+                }
             }
             continue;
         }
 
         if (resLeft.DataType == DATATYPE_GENERICINST && resRight.DataType == DATATYPE_VAR)
         {
-            CLR_RT_SignatureParser::Element inner{};
-            if (FAILED(parserLeft.Advance(inner)))
-                return false;
-            for (int i = 0; i < inner.GenParamCount; i++)
+            int targetAvail = iAvailRight - 1;
+            while (parserLeft.Available() > targetAvail)
             {
-                if (FAILED(parserLeft.Advance(inner)))
+                CLR_RT_SignatureParser::Element drained{};
+
+                if (FAILED(parserLeft.Advance(drained)))
+                {
                     return false;
+                }
             }
             continue;
         }


### PR DESCRIPTION
## Description
- Loop variable reuse destroyed GenParamCount; KeyValuePair<TKey,TValue> only drained first arg, desynchronized parsers

## Motivation and Context
- Fixes explicit interface impl resolution for Dictionary<TKey,TValue> (Remove, Contains, GetEnumerator)
- Generic VAR↔GENERICINST signature matching was dropping arguments when draining nested generic instances
- Drain sub-tree by converging Available() instead of counting arguments by hand
- Surfaced from Sys.Collections unit tests failing.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#245].

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
