### PR TITLE
Replace Random generator with ChibiOS TRNG

### DIFF
--- a/src/PAL/COM/sockets/ssl/MbedTLS/ssl_decode_private_key_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/MbedTLS/ssl_decode_private_key_internal.cpp
@@ -6,37 +6,6 @@
 
 #include "mbedtls.h"
 
-extern void SSL_GetCertDateTime_internal(DATE_TIME_INFO *dt, mbedtls_x509_time *mt);
-
-#if defined(PLATFORM_ESP32)
-int random(void *ctx, unsigned char *buf, size_t len)
-{
-    return mbedtls_ctr_drbg_random(ctx, buf, len);
-}
-#else
-
-#include <hal.h>
-#include <hal_nf_community.h>
-
-int random(void *context, unsigned char *output, size_t output_size)
-{
-    (void)context;
-
-    // start random generator
-    rngStart();
-
-    for (size_t i = 0; i < output_size; i++)
-    {
-        // our generator returns 32bits numbers
-        *output = (uint8_t)rngGenerateRandomNumber();
-
-        output++;
-    }
-
-    return 0;
-}
-#endif
-
 int ssl_decode_private_key_internal(
     const unsigned char *key,
     size_t keyLength,
@@ -52,12 +21,12 @@ int ssl_decode_private_key_internal(
     /////////////////////////////////////////////////////////////////////////////////////////////////
     // developer notes:                                                                            //
     // this call parses certificates in both string and binary formats                             //
-    // when the formart is a string it has to include the terminator otherwise the parse will fail //
+    // when the format is a string it has to include the terminator otherwise the parse will fail //
     /////////////////////////////////////////////////////////////////////////////////////////////////
 #if MBEDTLS_VERSION_MAJOR < 3
     retCode = mbedtls_pk_parse_key(&pkey, key, keyLength, password, passwordLength);
 #else
-    retCode = mbedtls_pk_parse_key(&pkey, key, keyLength, password, passwordLength, random, NULL);
+    retCode = mbedtls_pk_parse_key(&pkey, key, keyLength, password, passwordLength, mbedtls_ctr_drbg_random, NULL);
 #endif
 
     // need to free this here

--- a/targets/ChibiOS/MXCHIP_AZ3166/nanoCLR/halconf_nf.h
+++ b/targets/ChibiOS/MXCHIP_AZ3166/nanoCLR/halconf_nf.h
@@ -12,7 +12,7 @@
 #endif
 
 #if !defined(HAL_NF_USE_STM32_RNG)
-#define HAL_NF_USE_STM32_RNG FALSE
+#define HAL_NF_USE_STM32_RNG TRUE
 #endif
 
 #endif // HALCONF_NF_H

--- a/targets/ChibiOS/MXCHIP_AZ3166/nanoCLR/halconf_nf.h
+++ b/targets/ChibiOS/MXCHIP_AZ3166/nanoCLR/halconf_nf.h
@@ -7,12 +7,12 @@
 #define HALCONF_NF_H
 
 // enables STM32 Flash driver
-#if !defined(HAL_NF_USE_STM32_FLASH) 
-#define HAL_NF_USE_STM32_FLASH         TRUE
+#if !defined(HAL_NF_USE_STM32_FLASH)
+#define HAL_NF_USE_STM32_FLASH TRUE
 #endif
 
 #if !defined(HAL_NF_USE_STM32_RNG)
-#define HAL_NF_USE_STM32_RNG           FALSE
+#define HAL_NF_USE_STM32_RNG FALSE
 #endif
 
 #endif // HALCONF_NF_H

--- a/targets/ChibiOS/MXCHIP_AZ3166/nanoCLR/halconf_nf.h
+++ b/targets/ChibiOS/MXCHIP_AZ3166/nanoCLR/halconf_nf.h
@@ -11,4 +11,8 @@
 #define HAL_NF_USE_STM32_FLASH         TRUE
 #endif
 
+#if !defined(HAL_NF_USE_STM32_RNG)
+#define HAL_NF_USE_STM32_RNG           FALSE
+#endif
+
 #endif // HALCONF_NF_H

--- a/targets/ChibiOS/MXCHIP_AZ3166/nanoCLR/mcuconf.h
+++ b/targets/ChibiOS/MXCHIP_AZ3166/nanoCLR/mcuconf.h
@@ -270,6 +270,11 @@
 #define STM32_ST_USE_TIMER                  5
 
 /*
+ * TRNG driver system settings.
+ */
+#define STM32_TRNG_USE_RNG1                 FALSE
+
+/*
  * UART driver system settings.
  */
 #define STM32_UART_USE_USART1               FALSE

--- a/targets/ChibiOS/ORGPAL_PALTHREE/nanoCLR/halconf.h
+++ b/targets/ChibiOS/ORGPAL_PALTHREE/nanoCLR/halconf.h
@@ -179,7 +179,7 @@
  * @brief   Enables the TRNG subsystem.
  */
 #if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
-#define HAL_USE_TRNG FALSE
+#define HAL_USE_TRNG TRUE
 #endif
 
 /**

--- a/targets/ChibiOS/ORGPAL_PALTHREE/nanoCLR/mcuconf.h
+++ b/targets/ChibiOS/ORGPAL_PALTHREE/nanoCLR/mcuconf.h
@@ -366,7 +366,7 @@
 /*
  * TRNG driver system settings.
  */
-#define STM32_TRNG_USE_RNG1 FALSE
+#define STM32_TRNG_USE_RNG1 TRUE
 
 /*
  * UART driver system settings.

--- a/targets/ChibiOS/ORGPAL_PALX/nanoCLR/halconf.h
+++ b/targets/ChibiOS/ORGPAL_PALX/nanoCLR/halconf.h
@@ -178,7 +178,7 @@
  * @brief   Enables the TRNG subsystem.
  */
 #if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
-#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_TRNG                        TRUE
 #endif
 
 /**

--- a/targets/ChibiOS/ORGPAL_PALX/nanoCLR/mcuconf.h
+++ b/targets/ChibiOS/ORGPAL_PALX/nanoCLR/mcuconf.h
@@ -366,7 +366,7 @@
 /*
  * TRNG driver system settings.
  */
-#define STM32_TRNG_USE_RNG1 FALSE
+#define STM32_TRNG_USE_RNG1 TRUE
 
 /*
  * UART driver system settings.

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/halconf_nf.h
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/halconf_nf.h
@@ -12,7 +12,7 @@
 #endif
 
 #if !defined(HAL_NF_USE_STM32_RNG)
-#define HAL_NF_USE_STM32_RNG TRUE
+#define HAL_NF_USE_STM32_RNG FALSE
 #endif
 
 #endif // HALCONF_NF_H

--- a/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/halconf_nf.h
+++ b/targets/ChibiOS/ST_NUCLEO64_F091RC/nanoCLR/halconf_nf.h
@@ -7,13 +7,12 @@
 #define HALCONF_NF_H
 
 // enables STM32 Flash driver
-#if !defined(HAL_NF_USE_STM32_FLASH) 
-#define HAL_NF_USE_STM32_FLASH         TRUE
+#if !defined(HAL_NF_USE_STM32_FLASH)
+#define HAL_NF_USE_STM32_FLASH TRUE
 #endif
 
 #if !defined(HAL_NF_USE_STM32_RNG)
-#define HAL_NF_USE_STM32_RNG           FALSE
+#define HAL_NF_USE_STM32_RNG TRUE
 #endif
 
 #endif // HALCONF_NF_H
-

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf.h
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf.h
@@ -179,7 +179,7 @@
  * @brief   Enables the TRNG subsystem.
  */
 #if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
-#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_TRNG                        TRUE
 #endif
 
 /**

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf.h
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf.h
@@ -179,7 +179,7 @@
  * @brief   Enables the TRNG subsystem.
  */
 #if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
-#define HAL_USE_TRNG                        TRUE
+#define HAL_USE_TRNG                        FALSE
 #endif
 
 /**

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf_nf.h
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf_nf.h
@@ -20,4 +20,8 @@
 #define HAL_LTDC_MODULE_ENABLED TRUE
 #endif
 
+#if !defined(HAL_NF_USE_STM32_RNG)
+#define HAL_NF_USE_STM32_RNG           TRUE
+#endif
+
 #endif // HALCONF_NF_H

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf_nf.h
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/halconf_nf.h
@@ -21,7 +21,7 @@
 #endif
 
 #if !defined(HAL_NF_USE_STM32_RNG)
-#define HAL_NF_USE_STM32_RNG           TRUE
+#define HAL_NF_USE_STM32_RNG TRUE
 #endif
 
 #endif // HALCONF_NF_H

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/mcuconf.h
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/mcuconf.h
@@ -325,7 +325,7 @@
 /*
  * TRNG driver system settings.
  */
-#define STM32_TRNG_USE_RNG1 TRUE
+#define STM32_TRNG_USE_RNG1                 FALSE
 
 /*
  * UART driver system settings.

--- a/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/mcuconf.h
+++ b/targets/ChibiOS/ST_STM32F429I_DISCOVERY/nanoCLR/mcuconf.h
@@ -323,6 +323,11 @@
 #define STM32_ST_USE_TIMER                  2
 
 /*
+ * TRNG driver system settings.
+ */
+#define STM32_TRNG_USE_RNG1 TRUE
+
+/*
  * UART driver system settings.
  */
 #define STM32_UART_USE_USART1               TRUE

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf.h
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/halconf.h
@@ -180,7 +180,7 @@
  * @brief   Enables the TRNG subsystem.
  */
 #if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
-#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_TRNG                        TRUE
 #endif
 
 /**

--- a/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/mcuconf.h
+++ b/targets/ChibiOS/ST_STM32F769I_DISCOVERY/nanoCLR/mcuconf.h
@@ -372,7 +372,7 @@
 /*
  * TRNG driver system settings.
  */
-#define STM32_TRNG_USE_RNG1 FALSE
+#define STM32_TRNG_USE_RNG1             TRUE
 
 /*
  * UART driver system settings.

--- a/targets/ChibiOS/_nanoCLR/mbedtls_entropy_hardware_pool.c
+++ b/targets/ChibiOS/_nanoCLR/mbedtls_entropy_hardware_pool.c
@@ -12,7 +12,6 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t 
 {
     (void)data;
 
-    
 #if (HAL_NF_USE_STM32_RNG == TRUE)
 
     // start random generator

--- a/targets/ChibiOS/_nanoCLR/mbedtls_entropy_hardware_pool.c
+++ b/targets/ChibiOS/_nanoCLR/mbedtls_entropy_hardware_pool.c
@@ -5,6 +5,7 @@
 
 #include <hal.h>
 #include <hal_nf_community.h>
+#include <mbedtls/entropy.h>
 #include <psa/crypto.h>
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen);
 // Get len bytes of entropy from the hardware RNG.
@@ -35,7 +36,11 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t 
 
     trngStart(&TRNGD1, NULL);
 
-    trngGenerate(&TRNGD1, len, output);
+    if (!trngGenerate(&TRNGD1, len, output))
+    {
+        trngStop(&TRNGD1);
+        return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
+    }
 
     // callers require this to be set
     *olen = len;
@@ -78,13 +83,19 @@ psa_status_t mbedtls_psa_external_get_random(
 
     trngStart(&TRNGD1, NULL);
 
-    trngGenerate(&TRNGD1, output_size, output);
+    if (!trngGenerate(&TRNGD1, output_size, output))
+    {
+        trngStop(&TRNGD1);
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
 
     // callers require this to be set
     *output_length = output_size;
 
     trngStop(&TRNGD1);
 
+#else
+#error "No hardware RNG source configured: enable HAL_NF_USE_STM32_RNG or HAL_USE_TRNG"
 #endif
 
     return PSA_SUCCESS;

--- a/targets/ChibiOS/_nanoCLR/mbedtls_entropy_hardware_pool.c
+++ b/targets/ChibiOS/_nanoCLR/mbedtls_entropy_hardware_pool.c
@@ -7,11 +7,13 @@
 #include <hal_nf_community.h>
 #include <psa/crypto.h>
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen);
-
 // Get len bytes of entropy from the hardware RNG.
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
 {
     (void)data;
+
+    
+#if (HAL_NF_USE_STM32_RNG == TRUE)
 
     // start random generator
     rngStart();
@@ -30,6 +32,19 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t 
     // stop random generator
     rngStop();
 
+#elif (HAL_USE_TRNG == TRUE)
+
+    trngStart(&TRNGD1, NULL);
+
+    trngGenerate(&TRNGD1, len, output);
+
+    // callers require this to be set
+    *olen = len;
+
+    trngStop(&TRNGD1);
+
+#endif
+
     return 0;
 }
 
@@ -40,6 +55,8 @@ psa_status_t mbedtls_psa_external_get_random(
     size_t *output_length)
 {
     (void)context;
+
+#if HAL_NF_USE_STM32_RNG == TRUE
 
     // start random generator
     rngStart();
@@ -54,6 +71,22 @@ psa_status_t mbedtls_psa_external_get_random(
 
     // callers require this to be set
     *output_length = output_size;
+
+    // stop random generator
+    rngStop();
+
+#elif (HAL_USE_TRNG == TRUE)
+
+    trngStart(&TRNGD1, NULL);
+
+    trngGenerate(&TRNGD1, output_size, output);
+
+    // callers require this to be set
+    *output_length = output_size;
+
+    trngStop(&TRNGD1);
+
+#endif
 
     return PSA_SUCCESS;
 }

--- a/targets/ChibiOS/_nanoCLR/targetRandom.cpp
+++ b/targets/ChibiOS/_nanoCLR/targetRandom.cpp
@@ -16,6 +16,8 @@ void CLR_RT_Random::Initialize()
 
     trngStart(&TRNGD1, NULL);
 
+#else
+#error "No hardware RNG source configured: enable HAL_NF_USE_STM32_RNG or HAL_USE_TRNG"
 #endif
 }
 
@@ -31,6 +33,8 @@ void CLR_RT_Random::Initialize(int seed)
 
     trngStart(&TRNGD1, NULL);
 
+#else
+#error "No hardware RNG source configured: enable HAL_NF_USE_STM32_RNG or HAL_USE_TRNG"
 #endif
 }
 
@@ -47,6 +51,8 @@ uint32_t CLR_RT_Random::Next()
 
     return randomValue;
 
+#else
+#error "No hardware RNG source configured: enable HAL_NF_USE_STM32_RNG or HAL_USE_TRNG"
 #endif
 }
 
@@ -64,6 +70,8 @@ double CLR_RT_Random::NextDouble()
     trngGenerate(&TRNGD1, sizeof(randomValue), (uint8_t *)&randomValue);
     return ((double)randomValue) / ((double)0xFFFFFFFF);
 
+#else
+#error "No hardware RNG source configured: enable HAL_NF_USE_STM32_RNG or HAL_USE_TRNG"
 #endif
 }
 
@@ -81,5 +89,7 @@ void CLR_RT_Random::NextBytes(unsigned char *buffer, unsigned int count)
 
     trngGenerate(&TRNGD1, count, buffer);
 
+#else
+#error "No hardware RNG source configured: enable HAL_NF_USE_STM32_RNG or HAL_USE_TRNG"
 #endif
 }

--- a/targets/ChibiOS/_nanoCLR/targetRandom.cpp
+++ b/targets/ChibiOS/_nanoCLR/targetRandom.cpp
@@ -8,33 +8,78 @@
 
 void CLR_RT_Random::Initialize()
 {
+#if (HAL_NF_USE_STM32_RNG == TRUE)
+
     rngStart();
+
+#elif (HAL_USE_TRNG == TRUE)
+
+    trngStart(&TRNGD1, NULL);
+
+#endif
 }
 
-void CLR_RT_Random::Initialize( int seed )
+void CLR_RT_Random::Initialize(int seed)
 {
     (void)seed;
 
+#if (HAL_NF_USE_STM32_RNG == TRUE)
+
     rngStart();
+
+#elif (HAL_USE_TRNG == TRUE)
+
+    trngStart(&TRNGD1, NULL);
+
+#endif
 }
 
 uint32_t CLR_RT_Random::Next()
 {
+#if (HAL_NF_USE_STM32_RNG == TRUE)
+
     return rngGenerateRandomNumber();
+
+#elif (HAL_USE_TRNG == TRUE)
+
+    uint32_t randomValue = 0;
+    trngGenerate(&TRNGD1, sizeof(randomValue), (uint8_t *)&randomValue);
+
+    return randomValue;
+
+#endif
 }
 
 double CLR_RT_Random::NextDouble()
 {
     // the hardware generator returns a value between 0 - 0xFFFFFFFF
+
+#if (HAL_NF_USE_STM32_RNG == TRUE)
+
     return ((double)rngGenerateRandomNumber()) / ((double)0xFFFFFFFF);
+
+#elif (HAL_USE_TRNG == TRUE)
+
+    uint32_t randomValue = 0;
+    trngGenerate(&TRNGD1, sizeof(randomValue), (uint8_t *)&randomValue);
+    return ((double)randomValue) / ((double)0xFFFFFFFF);
+
+#endif
 }
 
-void CLR_RT_Random::NextBytes(unsigned char* buffer, unsigned int count)
+void CLR_RT_Random::NextBytes(unsigned char *buffer, unsigned int count)
 {
+#if (HAL_NF_USE_STM32_RNG == TRUE)
     unsigned int i;
 
-    for(i = 0; i < count; i++)
+    for (i = 0; i < count; i++)
     {
         buffer[i] = (unsigned char)rngGenerateRandomNumber();
     }
+
+#elif (HAL_USE_TRNG == TRUE)
+
+    trngGenerate(&TRNGD1, count, buffer);
+
+#endif
 }

--- a/targets/ChibiOS/_nf-overlay/os/hal/include/hal_nf_community.h
+++ b/targets/ChibiOS/_nf-overlay/os/hal/include/hal_nf_community.h
@@ -47,7 +47,8 @@
 
 // Normal drivers
 // STM32-specific overlay drivers — only include for STM32 targets
-#if defined(STM32F0XX) || defined(STM32F4XX) || defined(STM32F7XX) || defined(STM32H7XX) || defined(STM32L0XX) || defined(STM32L4XX)
+#if defined(STM32F0XX) || defined(STM32F4XX) || defined(STM32F7XX) || defined(STM32H7XX) || defined(STM32L0XX) ||      \
+    defined(STM32L4XX)
 #include "stm32_qspi/hal_stm32_qspi.h"
 #include "stm32_flash/hal_stm32_flash.h"
 #include "stm32_crc/hal_stm32_crc.h"
@@ -57,11 +58,12 @@
 #elif defined(RP2040)
 // RP2040 RNG stubs (ROSC-based) — provided by target_rng.c
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
-  void rngStart(void);
-  void rngStop(void);
-  uint32_t rngGenerateRandomNumber(void);
+    void rngStart(void);
+    void rngStop(void);
+    uint32_t rngGenerateRandomNumber(void);
 #ifdef __cplusplus
 }
 #endif

--- a/targets/ChibiOS/_nf-overlay/os/hal/include/hal_nf_community.h
+++ b/targets/ChibiOS/_nf-overlay/os/hal/include/hal_nf_community.h
@@ -17,8 +17,8 @@
 #endif
 
 #if !defined(HAL_NF_USE_STM32_RNG)
-// the default for this driver is to be included
-#define HAL_NF_USE_STM32_RNG TRUE
+// the default for this driver is NOT to be included
+#define HAL_NF_USE_STM32_RNG FALSE
 #endif
 
 #if !defined(HAL_NF_USE_FSMC)

--- a/targets/ThreadX/ST/ORGPAL_PALTHREE/nanoCLR/halconf.h
+++ b/targets/ThreadX/ST/ORGPAL_PALTHREE/nanoCLR/halconf.h
@@ -178,7 +178,7 @@
  * @brief   Enables the TRNG subsystem.
  */
 #if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
-#define HAL_USE_TRNG FALSE
+#define HAL_USE_TRNG TRUE
 #endif
 
 /**

--- a/targets/ThreadX/ST/ORGPAL_PALTHREE/nanoCLR/mcuconf.h
+++ b/targets/ThreadX/ST/ORGPAL_PALTHREE/nanoCLR/mcuconf.h
@@ -360,7 +360,7 @@
 /*
  * TRNG driver system settings.
  */
-#define STM32_TRNG_USE_RNG1             TRUE
+#define STM32_TRNG_USE_RNG1 TRUE
 
 /*
  * UART driver system settings.

--- a/targets/ThreadX/ST/ORGPAL_PALTHREE/nanoCLR/mcuconf.h
+++ b/targets/ThreadX/ST/ORGPAL_PALTHREE/nanoCLR/mcuconf.h
@@ -360,7 +360,7 @@
 /*
  * TRNG driver system settings.
  */
-#define STM32_TRNG_USE_RNG1 FALSE
+#define STM32_TRNG_USE_RNG1             TRUE
 
 /*
  * UART driver system settings.

--- a/targets/ThreadX/ST/ST_B_L475E_IOT01A/nanoCLR/halconf.h
+++ b/targets/ThreadX/ST/ST_B_L475E_IOT01A/nanoCLR/halconf.h
@@ -178,7 +178,7 @@
  * @brief   Enables the TRNG subsystem.
  */
 #if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
-#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_TRNG                        TRUE
 #endif
 
 /**


### PR DESCRIPTION
## Description
- Enable TRNG for targets supporting it.
- Disable nanoFramework community RNG for targets capable of using TRNG.
- Simplification of ssl_decode_private_key_internal()
  + Now using mbedTLS mbedtls_ctr_drbg_random for random generator.

## Motivation and Context
- Prefering to use official ChibiOS HAL true random generator.
- Keeping nanoFramework RNG implementation for archive.
- Touching the random API forced simplification of `ssl_decode_private_key_internal()`. Turned out that the random implementations there weren't needed anymore. Recent versions of mbedTLS provide `mbedtls_ctr_drbg_random` which is defined at platform level.
 
## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
