### PR TITLE
Improvements in SslNative::InitHelper

### DIFF
--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -2874,6 +2874,7 @@ static const TypeIndexLookup c_TypeIndexLookup[] = {
     TIL("System.Resources", "ResourceManager", m_ResourceManager),
 
     TIL("System.Net.Sockets", "SocketException", m_SocketException),
+    TIL("System.Security.Cryptography", "CryptographicException", m_CryptographicException),
 
     TIL("System.Device.I2c", "I2cTransferResult", m_I2cTransferResult),
 

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -2796,7 +2796,10 @@ struct TypeIndexLookup
 };
 
 static const TypeIndexLookup c_TypeIndexLookup[] = {
-#define TIL(ns, nm, fld) {ns, nm, &g_CLR_RT_WellKnownTypes.fld}
+#define TIL(ns, nm, fld)                                                                                               \
+    {                                                                                                                  \
+        ns, nm, &g_CLR_RT_WellKnownTypes.fld                                                                           \
+    }
     TIL("System", "Boolean", m_Boolean),
     TIL("System", "Char", m_Char),
     TIL("System", "SByte", m_Int8),
@@ -2893,7 +2896,10 @@ struct MethodIndexLookup
 };
 
 static const MethodIndexLookup c_MethodIndexLookup[] = {
-#define MIL(nm, type, method) {nm, &g_CLR_RT_WellKnownTypes.type, &g_CLR_RT_WellKnownMethods.method}
+#define MIL(nm, type, method)                                                                                          \
+    {                                                                                                                  \
+        nm, &g_CLR_RT_WellKnownTypes.type, &g_CLR_RT_WellKnownMethods.method                                           \
+    }
 
     MIL("GetObjectFromId", m_ResourceManager, m_ResourceManager_GetObjectFromId),
     MIL("GetObjectChunkFromId", m_ResourceManager, m_ResourceManager_GetObjectChunkFromId),

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -1576,6 +1576,7 @@ struct CLR_RT_WellKnownTypes
     CLR_RT_TypeDef_Index m_ResourceManager;
 
     CLR_RT_TypeDef_Index m_SocketException;
+    CLR_RT_TypeDef_Index m_CryptographicException;
 
     CLR_RT_TypeDef_Index m_I2cTransferResult;
     CLR_RT_TypeDef_Index m_I2cTransferResult_old;

--- a/src/DeviceInterfaces/System.Net/sys_net_native.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native.cpp
@@ -340,15 +340,18 @@ static const CLR_RT_MethodHandler method_lookup[] =
     NULL,
     NULL,
     NULL,
+    NULL,
+    NULL,
+    NULL,
     Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate2::DecodePrivateKeyNative___STATIC__VOID__SZARRAY_U1__STRING,
 };
 
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_System_Net =
 {
     "System.Net",
-    0x6DFA71D6,
+    0x8EFB9944,
     method_lookup,
-    { 100, 2, 0, 12 }
+    { 100, 2, 0, 14 }
 };
 
 // clang-format on

--- a/src/DeviceInterfaces/System.Net/sys_net_native.h
+++ b/src/DeviceInterfaces/System.Net/sys_net_native.h
@@ -123,6 +123,21 @@
 //     SslProtocols_Tls13 = 12288,
 // } SslProtocols;
 
+// MOVED TO src\PAL\Include\nanoPAL_Sockets.h for convenience
+// typedef enum __nfpack SslError
+// {
+//     SslError_None = 0,
+//     SslError_NoFreeContext = 1,
+//     SslError_OutOfMemory = 2,
+//     SslError_DrbgSeedFailed = 3,
+//     SslError_ConfigDefaultsFailed = 4,
+//     SslError_UnsupportedProtocolVersion = 5,
+//     SslError_PrivateKeyParseFailed = 6,
+//     SslError_CertificateParseFailed = 7,
+//     SslError_OwnCertConfigFailed = 8,
+//     SslError_SetupFailed = 9,
+// } SslError;
+
 struct Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface
 {
     static const int FIELD___interfaceIndex = 1;
@@ -162,19 +177,21 @@ struct Library_sys_net_native_nanoFramework_Networking_NetworkHelper
     static const int FIELD_STATIC___helperException = 4;
     static const int FIELD_STATIC___workingNetworkInterface = 5;
     static const int FIELD_STATIC___ipConfiguration = 6;
-    static const int FIELD_STATIC___helperInstanciated = 7;
+    static const int FIELD_STATIC___workerThread = 7;
+    static const int FIELD_STATIC___stopRequested = 8;
+    static const int FIELD_STATIC___helperInstanciated = 9;
 
     //--//
 };
 
 struct Library_sys_net_native_System_Net_IPAddress
 {
-    static const int FIELD_STATIC__Any = 8;
-    static const int FIELD_STATIC__Loopback = 9;
-    static const int FIELD_STATIC__Broadcast = 10;
-    static const int FIELD_STATIC__None = 11;
-    static const int FIELD_STATIC__IPv6Any = 12;
-    static const int FIELD_STATIC__IPv6Loopback = 13;
+    static const int FIELD_STATIC__Any = 10;
+    static const int FIELD_STATIC__Loopback = 11;
+    static const int FIELD_STATIC__Broadcast = 12;
+    static const int FIELD_STATIC__None = 13;
+    static const int FIELD_STATIC__IPv6Any = 14;
+    static const int FIELD_STATIC__IPv6Loopback = 15;
 
     static const int FIELD__Address = 1;
     static const int FIELD___family = 2;
@@ -227,9 +244,9 @@ struct Library_sys_net_native_System_Net_NetworkInformation_NetworkAvailabilityE
 
 struct Library_sys_net_native_System_Net_NetworkInformation_NetworkChange
 {
-    static const int FIELD_STATIC__NetworkAddressChanged = 14;
-    static const int FIELD_STATIC__NetworkAvailabilityChanged = 15;
-    static const int FIELD_STATIC__NetworkAPStationChanged = 16;
+    static const int FIELD_STATIC__NetworkAddressChanged = 16;
+    static const int FIELD_STATIC__NetworkAvailabilityChanged = 17;
+    static const int FIELD_STATIC__NetworkAPStationChanged = 18;
 
     //--//
 };
@@ -323,6 +340,7 @@ struct Library_sys_net_native_System_Net_Security_SslNative
     static HRESULT InitHelper(CLR_RT_StackFrame &stack, bool isServer);
     static HRESULT ThrowOnError(CLR_RT_StackFrame &stack, int err);
     static void ThrowError(CLR_RT_StackFrame &stack, int errorCode);
+    static HRESULT ThrowCryptographicError(CLR_RT_StackFrame &stack, int errorCode);
 };
 
 struct Library_sys_net_native_System_Net_Sockets_Socket
@@ -408,7 +426,6 @@ struct Library_sys_net_native_System_Net_Sockets_NativeSocket
     static HRESULT BindConnectHelper(CLR_RT_StackFrame &stack, bool fBind);
     static HRESULT ThrowOnError(CLR_RT_StackFrame &stack, CLR_INT32 err);
     static void ThrowError(CLR_RT_StackFrame &stack, CLR_INT32 errorCode);
-
     static CLR_INT32 Helper__SelectSocket(CLR_INT32 socket, CLR_INT32 mode);
 
     /* WARNING!!!
@@ -432,6 +449,13 @@ struct Library_sys_net_native_System_Net_Sockets_NetworkStream
 };
 
 struct Library_sys_net_native_System_Net_Sockets_SocketException
+{
+    static const int FIELD___errorCode = 5;
+
+    //--//
+};
+
+struct Library_sys_net_native_System_Security_Cryptography_CryptographicException
 {
     static const int FIELD___errorCode = 5;
 

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
@@ -9,7 +9,7 @@
 // remap types to ease code readability
 typedef Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate X509Certificate;
 typedef Library_sys_net_native_System_Security_Cryptography_X509Certificates_X509Certificate2 X509Certificate2;
-
+typedef Library_sys_net_native_System_Security_Cryptography_CryptographicException CryptographicException;
 //--//
 
 void Time_GetDateTime(DATE_TIME_INFO *dt)
@@ -422,6 +422,7 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
     CLR_RT_HeapBlock_Array *arrCert = NULL;
     CLR_RT_HeapBlock_Array *privateKey = NULL;
     CLR_UINT8 *sslCert = NULL;
+    SslError sslError;
     volatile int result;
     uint8_t *pk = NULL;
     const char *pkPassword = NULL;
@@ -466,40 +467,56 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
 
     if (isServer)
     {
-        result =
-            (SSL_ServerInit(
-                 sslMode,
-                 sslVerify,
-                 (const char *)sslCert,
-                 sslCert == NULL ? 0 : arrCert->m_numOfElements,
-                 pk,
-                 pk == NULL ? 0 : privateKey->m_numOfElements,
-                 pkPassword,
-                 pkPasswordLength,
-                 sslContext,
-                 useDeviceCertificate)
-                 ? 0
-                 : -1);
+        sslError = SSL_ServerInit(
+            sslMode,
+            sslVerify,
+            (const char *)sslCert,
+            sslCert == NULL ? 0 : arrCert->m_numOfElements,
+            pk,
+            pk == NULL ? 0 : privateKey->m_numOfElements,
+            pkPassword,
+            pkPasswordLength,
+            sslContext,
+            useDeviceCertificate);
     }
     else
     {
-        result =
-            (SSL_ClientInit(
-                 sslMode,
-                 sslVerify,
-                 (const char *)sslCert,
-                 sslCert == NULL ? 0 : arrCert->m_numOfElements,
-                 pk,
-                 pk == NULL ? 0 : privateKey->m_numOfElements,
-                 pkPassword,
-                 pkPasswordLength,
-                 sslContext,
-                 useDeviceCertificate)
-                 ? 0
-                 : -1);
+        sslError = SSL_ClientInit(
+            sslMode,
+            sslVerify,
+            (const char *)sslCert,
+            sslCert == NULL ? 0 : arrCert->m_numOfElements,
+            pk,
+            pk == NULL ? 0 : privateKey->m_numOfElements,
+            pkPassword,
+            pkPasswordLength,
+            sslContext,
+            useDeviceCertificate);
     }
 
-    NANOCLR_CHECK_HRESULT(ThrowOnError(stack, result));
+    switch (sslError)
+    {
+        case SslError_None:
+            break;
+
+        case SslError_OutOfMemory:
+            NANOCLR_SET_AND_LEAVE(CLR_E_OUT_OF_MEMORY);
+            break;
+
+        case SslError_NoFreeContext:
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_OPERATION);
+            break;
+
+        case SslError_UnsupportedProtocolVersion:
+        case SslError_CertificateParseFailed:
+        case SslError_PrivateKeyParseFailed:
+        case SslError_OwnCertConfigFailed:
+        case SslError_DrbgSeedFailed:
+        case SslError_ConfigDefaultsFailed:
+        case SslError_SetupFailed:
+            NANOCLR_CHECK_HRESULT(ThrowCryptographicError(stack, (int)sslError));
+            break;
+    }
 
     if (caCert != NULL)
     {
@@ -571,6 +588,33 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::ThrowOnError(CLR_R
         ThrowError(stack, res);
 
         NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
+    }
+
+    NANOCLR_NOCLEANUP();
+}
+
+HRESULT Library_sys_net_native_System_Net_Security_SslNative::ThrowCryptographicError(
+    CLR_RT_StackFrame &stack,
+    int errorCode)
+{
+    NATIVE_PROFILE_CLR_NETWORK();
+    NANOCLR_HEADER();
+
+    CLR_RT_HeapBlock &res = stack.m_owningThread->m_currentException;
+
+    if ((Library_corlib_native_System_Exception::CreateInstance(
+            res,
+            g_CLR_RT_WellKnownTypes.m_CryptographicException,
+            CLR_E_FAIL,
+            &stack)) == S_OK)
+    {
+        res.Dereference()[CryptographicException::FIELD___errorCode].SetInteger(errorCode);
+
+        NANOCLR_SET_AND_LEAVE(CLR_E_PROCESS_EXCEPTION);
+    }
+    else
+    {
+        NANOCLR_SET_AND_LEAVE(CLR_E_UNKNOWN_TYPE);
     }
 
     NANOCLR_NOCLEANUP();

--- a/src/PAL/COM/sockets/Sockets_debugger.cpp
+++ b/src/PAL/COM/sockets/Sockets_debugger.cpp
@@ -457,7 +457,7 @@ bool Sockets_LWIP_Driver::UpgradeToSsl(
                 NULL,
                 0,
                 g_DebuggerPort_SslCtx_Handle,
-                false))
+                false) == SslError_None)
         {
             int32_t ret;
 

--- a/src/PAL/COM/sockets/ssl/MbedTLS/ssl_generic_init_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/MbedTLS/ssl_generic_init_internal.cpp
@@ -9,7 +9,7 @@
 #include <mbedtls.h>
 #include <mbedtls/debug.h>
 
-bool ssl_generic_init_internal(
+SslError ssl_generic_init_internal(
     int sslMode,
     int sslVerify,
     const char *certificate,
@@ -32,6 +32,8 @@ bool ssl_generic_init_internal(
     int endpoint = 0;
     int ret = 0;
 
+    SslError error = SslError_OutOfMemory;
+
     HAL_Configuration_X509CaRootBundle *certStore = NULL;
     HAL_Configuration_X509DeviceCertificate *deviceCert = NULL;
 
@@ -49,7 +51,7 @@ bool ssl_generic_init_internal(
 
     if (sslContexIndex == -1)
     {
-        return FALSE;
+        return SslError_NoFreeContext;
     }
 
     // create and init MbedTLS nanoFramework context
@@ -140,7 +142,7 @@ bool ssl_generic_init_internal(
     // TODO: review if we can add some instance-unique data to the custom argument below
     if (mbedtls_ctr_drbg_seed(context->ctr_drbg, mbedtls_entropy_func, context->entropy, NULL, 0) != 0)
     {
-        // ctr_drbg_seed_failed
+        error = SslError_DrbgSeedFailed;
         goto error;
     }
 
@@ -150,7 +152,7 @@ bool ssl_generic_init_internal(
             MBEDTLS_SSL_TRANSPORT_STREAM,
             MBEDTLS_SSL_PRESET_DEFAULT) != 0)
     {
-        // ssl_config_defaults_failed
+        error = SslError_ConfigDefaultsFailed;
         goto error;
     }
 
@@ -255,7 +257,7 @@ bool ssl_generic_init_internal(
                     context->ctr_drbg) < 0)
 #endif
             {
-                // private key parse failed
+                error = SslError_PrivateKeyParseFailed;
                 goto error;
             }
         }
@@ -272,13 +274,13 @@ bool ssl_generic_init_internal(
 
         if (mbedtls_x509_crt_parse(context->own_cert, (const unsigned char *)certificate, certLength))
         {
-            // failed parsing own certificate failed
+            error = SslError_CertificateParseFailed;
             goto error;
         }
 
         if (mbedtls_ssl_conf_own_cert(context->conf, context->own_cert, context->pk))
         {
-            // configuring own certificate failed
+            error = SslError_OwnCertConfigFailed;
             goto error;
         }
 
@@ -319,7 +321,7 @@ bool ssl_generic_init_internal(
     ret = mbedtls_ssl_setup(context->ssl, context->conf);
     if (ret != 0)
     {
-        // ssl_setup_failed
+        error = SslError_SetupFailed;
         goto error;
     }
 
@@ -330,7 +332,7 @@ bool ssl_generic_init_internal(
 
     contextHandle = sslContexIndex;
 
-    return true;
+    return SslError_None;
 
 error:
 
@@ -407,5 +409,5 @@ error:
         platform_free(deviceCert);
     }
 
-    return false;
+    return error;
 }

--- a/src/PAL/COM/sockets/ssl/ssl.cpp
+++ b/src/PAL/COM/sockets/ssl/ssl.cpp
@@ -40,7 +40,7 @@ bool SSL_Uninitialize()
     return true;
 }
 
-static bool SSL_GenericInit(
+static SslError SSL_GenericInit(
     int sslMode,
     int sslVerify,
     const char *certificate,
@@ -96,7 +96,7 @@ int SSL_DecodePrivateKey(const unsigned char *key, size_t keyLength, const unsig
     return ssl_decode_private_key_internal(key, keyLength, pwd, pwdLength);
 }
 
-bool SSL_ServerInit(
+SslError SSL_ServerInit(
     int sslMode,
     int sslVerify,
     const char *certificate,
@@ -124,7 +124,7 @@ bool SSL_ServerInit(
         true);
 }
 
-bool SSL_ClientInit(
+SslError SSL_ClientInit(
     int sslMode,
     int sslVerify,
     const char *certificate,

--- a/src/PAL/COM/sockets/ssl/ssl_functions.h
+++ b/src/PAL/COM/sockets/ssl/ssl_functions.h
@@ -48,7 +48,7 @@ int ssl_write_internal(int socket, const char *data, size_t size);
 int ssl_close_socket_internal(int sd);
 int ssl_available_internal(int sd);
 bool ssl_exit_context_internal(int contextHandle);
-bool ssl_generic_init_internal(
+SslError ssl_generic_init_internal(
     int sslMode,
     int sslVerify,
     const char *certificate,

--- a/src/PAL/COM/sockets/ssl/ssl_stubs.cpp
+++ b/src/PAL/COM/sockets/ssl/ssl_stubs.cpp
@@ -21,7 +21,7 @@ __nfweak bool SSL_Uninitialize()
     return TRUE;
 }
 
-__nfweak SSL_Error SSL_ServerInit(
+__nfweak SslError SSL_ServerInit(
     int sslMode,
     int sslVerify,
     const char *certificate,
@@ -49,7 +49,7 @@ __nfweak SSL_Error SSL_ServerInit(
     return SslError_None;
 }
 
-__nfweak SSL_Error SSL_ClientInit(
+__nfweak SslError SSL_ClientInit(
     int sslMode,
     int sslVerify,
     const char *certificate,

--- a/src/PAL/COM/sockets/ssl/ssl_stubs.cpp
+++ b/src/PAL/COM/sockets/ssl/ssl_stubs.cpp
@@ -5,6 +5,7 @@
 //
 
 #include "nanoHAL.h"
+#include <ssl_functions.h>
 
 //--//
 
@@ -20,7 +21,7 @@ __nfweak bool SSL_Uninitialize()
     return TRUE;
 }
 
-__nfweak bool SSL_ServerInit(
+__nfweak SSL_Error SSL_ServerInit(
     int sslMode,
     int sslVerify,
     const char *certificate,
@@ -45,10 +46,10 @@ __nfweak bool SSL_ServerInit(
 
     NATIVE_PROFILE_PAL_COM();
 
-    return TRUE;
+    return SslError_None;
 }
 
-__nfweak bool SSL_ClientInit(
+__nfweak SSL_Error SSL_ClientInit(
     int sslMode,
     int sslVerify,
     const char *certificate,
@@ -73,7 +74,7 @@ __nfweak bool SSL_ClientInit(
 
     NATIVE_PROFILE_PAL_COM();
 
-    return TRUE;
+    return SslError_None;
 }
 
 __nfweak bool SSL_AddCertificateAuthority(int contextHandle, const char *certificate, int certLength)

--- a/src/PAL/Include/nanoPAL_Sockets.h
+++ b/src/PAL/Include/nanoPAL_Sockets.h
@@ -680,9 +680,23 @@ typedef void (*SSL_DATE_TIME_FUNC)(DATE_TIME_INFO *pdt);
 
 #define SSL_RESULT__WOULD_BLOCK -2
 
+enum SslError
+{
+    SslError_None = 0,
+    SslError_NoFreeContext = 1,
+    SslError_OutOfMemory = 2,
+    SslError_DrbgSeedFailed = 3,
+    SslError_ConfigDefaultsFailed = 4,
+    SslError_UnsupportedProtocolVersion = 5,
+    SslError_PrivateKeyParseFailed = 6,
+    SslError_CertificateParseFailed = 7,
+    SslError_OwnCertConfigFailed = 8,
+    SslError_SetupFailed = 9,
+};
+
 bool SSL_Initialize();
 bool SSL_Uninitialize();
-bool SSL_ServerInit(
+SslError SSL_ServerInit(
     int sslMode,
     int sslVerify,
     const char *certificate,
@@ -694,7 +708,7 @@ bool SSL_ServerInit(
     int &sslContextHandle,
     bool useDeviceCertificate);
 
-bool SSL_ClientInit(
+SslError SSL_ClientInit(
     int sslMode,
     int sslVerify,
     const char *certificate,

--- a/targets/TI_SimpleLink/_common/ssl_simplelink.cpp
+++ b/targets/TI_SimpleLink/_common/ssl_simplelink.cpp
@@ -69,7 +69,7 @@ bool ssl_initialize_internal()
     return true;
 }
 
-SSL_Error ssl_generic_init_internal(
+SslError ssl_generic_init_internal(
     int sslMode,
     int sslVerify,
     const char *certificate,

--- a/targets/TI_SimpleLink/_common/ssl_simplelink.cpp
+++ b/targets/TI_SimpleLink/_common/ssl_simplelink.cpp
@@ -69,7 +69,7 @@ bool ssl_initialize_internal()
     return true;
 }
 
-bool ssl_generic_init_internal(
+SSL_Error ssl_generic_init_internal(
     int sslMode,
     int sslVerify,
     const char *certificate,
@@ -110,7 +110,7 @@ bool ssl_generic_init_internal(
     }
 
     if (sslContexIndex == -1)
-        return false;
+        return SslError_NoFreeContext;
 
     // create and init nanoFramework Simple Link context
     // this needs to be freed in ssl_exit_context_internal
@@ -220,7 +220,7 @@ bool ssl_generic_init_internal(
 
     contextHandle = sslContexIndex;
 
-    return true;
+    return SslError_None;
 
 error:
 
@@ -235,7 +235,7 @@ error:
         SlNetSock_secAttribDelete(context->SecurityAttributes);
     }
 
-    return false;
+    return SslError_OutOfMemory;
 }
 
 bool ssl_exit_context_internal(int contextHandle)

--- a/targets/ThreadX/ST/_common/drivers/wifi/inventek/ssl_ISM43362.cpp
+++ b/targets/ThreadX/ST/_common/drivers/wifi/inventek/ssl_ISM43362.cpp
@@ -67,7 +67,7 @@ bool ssl_initialize_internal()
     return true;
 }
 
-SSL_Error ssl_generic_init_internal(
+SslError ssl_generic_init_internal(
     int sslMode,
     int sslVerify,
     const char *certificate,

--- a/targets/ThreadX/ST/_common/drivers/wifi/inventek/ssl_ISM43362.cpp
+++ b/targets/ThreadX/ST/_common/drivers/wifi/inventek/ssl_ISM43362.cpp
@@ -67,7 +67,7 @@ bool ssl_initialize_internal()
     return true;
 }
 
-bool ssl_generic_init_internal(
+SSL_Error ssl_generic_init_internal(
     int sslMode,
     int sslVerify,
     const char *certificate,
@@ -106,7 +106,7 @@ bool ssl_generic_init_internal(
 
     if (sslContexIndex == -1)
     {
-        return false;
+        return SslError_NoFreeContext;
     }
 
     // create and init context
@@ -128,7 +128,7 @@ bool ssl_generic_init_internal(
 
     contextHandle = sslContexIndex;
 
-    return true;
+    return SslError_None;
 
 error:
 
@@ -138,7 +138,7 @@ error:
         platform_free(context);
     }
 
-    return false;
+    return SslError_OutOfMemory;
 }
 
 bool ssl_exit_context_internal(int contextHandle)
@@ -187,7 +187,7 @@ int ssl_connect_internal(int sd, const char *szTargetHost, int contextHandle)
     context->SocketIndex = sd;
 
     // at this point the socket must have been connected
-    
+
     //////////////////////////////////////////////////////////////////////
     // current firmware in ISM43362 does not support secure connections //
     // so we are faking it as if it would work                          //
@@ -221,7 +221,7 @@ int ssl_read_internal(int sd, char *data, size_t size)
 {
     (void)sd;
     (void)data;
-    (void)size; //SSL_RESULT__WOULD_BLOCK
+    (void)size; // SSL_RESULT__WOULD_BLOCK
 
     // ISM43362 takes care of everything for us, just call the recv API
     return SOCK_recv(sd, data, size, 0);


### PR DESCRIPTION
## Description
- ssl_generic_init_internal() now returns an error code instead of simple enum.
- Propagate return accross callers.
- Update code accordingly.
- Add CryptographicException to type system.
- Improve processing of return from SSL_ServerInit and SSL_ClientInit to parse new return code. Added mapping to meaningfull CLR exceptions.
- Update declaration of System.Net assembly.

## Motivation and Context
- Following nanoframework/System.Net#407.
- Adds native support for surfacing the root cause of SSL/TLS initializations and authentication failures.
- Closes nanoframework/Home#1815.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [x] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
