### PR TITLE
Add socket protocol+type validation

### DIFF
--- a/src/PAL/Lwip/lwIP_Sockets.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets.cpp
@@ -374,6 +374,14 @@ SOCK_SOCKET LWIP_SOCKETS_Driver::Socket(int family, int type, int protocol)
 {
     NATIVE_PROFILE_PAL_NETWORK();
 
+    // Validate socket type+protocol combination
+    if ((type == SOCK_SOCK_STREAM && protocol != SOCK_IPPROTO_TCP && protocol != SOCK_IPPROTO_IP) ||
+        (type == SOCK_SOCK_DGRAM && protocol != SOCK_IPPROTO_UDP && protocol != SOCK_IPPROTO_IP))
+    {
+        errorCode = EPROTONOSUPPORT;
+        return SOCK_SOCKET_ERROR;
+    }
+
     switch (family)
     {
         case SOCK_AF_INET:


### PR DESCRIPTION
## Description
- Now validates combination and throws on invalid ones.

## Motivation and Context
- Found when running  System.Net unit tests.
- lwIP silently ignores the protocol parameter for STREAM/DGRAM sockets, accepting invalid combinations.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running System.Net unit tests.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
