### PR TITLE
Improving socket protocol+type validation

### DIFF
--- a/src/PAL/Lwip/lwIP_Sockets.cpp
+++ b/src/PAL/Lwip/lwIP_Sockets.cpp
@@ -375,8 +375,27 @@ SOCK_SOCKET LWIP_SOCKETS_Driver::Socket(int family, int type, int protocol)
     NATIVE_PROFILE_PAL_NETWORK();
 
     // Validate socket type+protocol combination
-    if ((type == SOCK_SOCK_STREAM && protocol != SOCK_IPPROTO_TCP && protocol != SOCK_IPPROTO_IP) ||
-        (type == SOCK_SOCK_DGRAM && protocol != SOCK_IPPROTO_UDP && protocol != SOCK_IPPROTO_IP))
+    bool validTypeProtocol;
+
+    if (type == SOCK_SOCK_STREAM)
+    {
+        validTypeProtocol = (protocol == SOCK_IPPROTO_IP || protocol == SOCK_IPPROTO_TCP);
+    }
+    else if (type == SOCK_SOCK_DGRAM)
+    {
+        validTypeProtocol = (protocol == SOCK_IPPROTO_IP || protocol == SOCK_IPPROTO_UDP);
+    }
+    else if (type == SOCK_SOCK_RAW)
+    {
+        // Raw sockets require an explicit IP protocol number (0-255), SOCK_IPPROTO_IP (0) is not a valid choice
+        validTypeProtocol = (protocol > SOCK_IPPROTO_IP && protocol <= 255);
+    }
+    else
+    {
+        validTypeProtocol = false;
+    }
+
+    if (!validTypeProtocol)
     {
         errorCode = EPROTONOSUPPORT;
         return SOCK_SOCKET_ERROR;


### PR DESCRIPTION
## Description
-  The validation now covers all three socket types explicitly, rejects unknown type values that previously slid through unchecked, and requires RAW sockets to specify an explicit protocol number in 1-255 (excluding SOCK_IPPROTO_IP/0, which isn't meaningful for raw sockets).

## Motivation and Context
- Now covering raw protocol and all edge cases.
- Wasn't covering raw sockets, which are required by ESP32 config,
- Improvement on #3463 
- Review from @alberk8 prompted these improvements. Thank you!

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
