### PR TITLE
Improve error handling in SecureAccept and SsecureConnect

### DIFF
--- a/src/DeviceInterfaces/System.Net/sys_net_native.h
+++ b/src/DeviceInterfaces/System.Net/sys_net_native.h
@@ -136,6 +136,10 @@
 //     SslError_CertificateParseFailed = 7,
 //     SslError_OwnCertConfigFailed = 8,
 //     SslError_SetupFailed = 9,
+//     SslError_HandshakeBadContext = 10,
+//     SslError_HandshakeSetHostname = 11,
+//     SslError_HandshakeCertVerifyFailed = 12,
+//     SslError_HandshakeFailed = 13,
 // } SslError;
 
 struct Library_sys_net_native_System_Net_NetworkInformation_NetworkInterface

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
@@ -530,6 +530,7 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
             break;
 
         default:
+            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
             break;
     }
 

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
@@ -66,10 +66,11 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureAccept___STA
     CLR_INT32 timeout_ms = -1; // wait forever
     CLR_RT_HeapBlock hbTimeout;
 
-    int result = 0;
     CLR_INT32 handle;
     bool fRes = true;
     CLR_INT64 *timeout;
+    SslError sslErr;
+    int mbedtlsCode = 0;
 
     FAULT_ON_NULL(socket);
 
@@ -91,9 +92,9 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureAccept___STA
     // first make sure we have data to read or ability to write
     while (true)
     {
-        result = SSL_Accept(handle, sslContext);
+        sslErr = SSL_Accept(handle, sslContext, &mbedtlsCode);
 
-        if (result == SOCK_EWOULDBLOCK || result == SOCK_TRY_AGAIN)
+        if ((int)sslErr == SOCK_EWOULDBLOCK || (int)sslErr == SOCK_TRY_AGAIN)
         {
             // non-blocking - allow other threads to run while we wait for socket activity
             NANOCLR_CHECK_HRESULT(
@@ -107,7 +108,25 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureAccept___STA
 
     stack.PopValue(); // Timeout
 
-    NANOCLR_CHECK_HRESULT(ThrowOnError(stack, result));
+    switch (sslErr)
+    {
+        case SslError_None:
+            break;
+
+        case SslError_HandshakeBadContext:
+        case SslError_HandshakeSetHostname:
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_OPERATION);
+            break;
+
+        case SslError_HandshakeCertVerifyFailed:
+        case SslError_HandshakeFailed:
+            NANOCLR_CHECK_HRESULT(ThrowCryptographicError(stack, mbedtlsCode));
+            break;
+
+        default:
+            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
+            break;
+    }
 
     NANOCLR_NOCLEANUP();
 }
@@ -126,11 +145,12 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureConnect___ST
     CLR_RT_HeapBlock *socket = stack.Arg2().Dereference();
     CLR_RT_HeapBlock hbTimeout;
 
-    int result;
     const char *szName;
     CLR_INT32 handle;
     bool fRes = true;
     CLR_INT64 *timeout;
+    SslError sslErr;
+    int mbedtlsCode = 0;
 
     FAULT_ON_NULL(socket);
 
@@ -156,16 +176,18 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureConnect___ST
 
     while (true)
     {
-        result = SSL_Connect(handle, szName, sslContext);
+        sslErr = SSL_Connect(handle, szName, sslContext, &mbedtlsCode);
 
-        if (result == SOCK_EWOULDBLOCK || result == SOCK_TRY_AGAIN)
+        if ((int)sslErr == SOCK_EWOULDBLOCK || (int)sslErr == SOCK_TRY_AGAIN)
         {
             // non-blocking - allow other threads to run while we wait for socket activity
             NANOCLR_CHECK_HRESULT(
                 g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_Socket, fRes));
 
-            if (result < 0)
+            if ((int)sslErr < 0)
+            {
                 break;
+            }
         }
         else
         {
@@ -175,7 +197,25 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureConnect___ST
 
     stack.PopValue(); // Timeout
 
-    NANOCLR_CHECK_HRESULT(ThrowOnError(stack, result));
+    switch (sslErr)
+    {
+        case SslError_None:
+            break;
+
+        case SslError_HandshakeBadContext:
+        case SslError_HandshakeSetHostname:
+            NANOCLR_SET_AND_LEAVE(CLR_E_INVALID_OPERATION);
+            break;
+
+        case SslError_HandshakeCertVerifyFailed:
+        case SslError_HandshakeFailed:
+            NANOCLR_CHECK_HRESULT(ThrowCryptographicError(stack, mbedtlsCode));
+            break;
+
+        default:
+            NANOCLR_SET_AND_LEAVE(CLR_E_FAIL);
+            break;
+    }
 
     NANOCLR_NOCLEANUP();
 }

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
@@ -183,11 +183,6 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureConnect___ST
             // non-blocking - allow other threads to run while we wait for socket activity
             NANOCLR_CHECK_HRESULT(
                 g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_Socket, fRes));
-
-            if ((int)sslErr < 0)
-            {
-                break;
-            }
         }
         else
         {

--- a/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
+++ b/src/DeviceInterfaces/System.Net/sys_net_native_System_Net_Security_SslNative.cpp
@@ -67,7 +67,6 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureAccept___STA
     CLR_RT_HeapBlock hbTimeout;
 
     CLR_INT32 handle;
-    bool fRes = true;
     CLR_INT64 *timeout;
     SslError sslErr;
     int mbedtlsCode = 0;
@@ -89,22 +88,11 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureAccept___STA
 
     NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
 
-    // first make sure we have data to read or ability to write
-    while (true)
-    {
-        sslErr = SSL_Accept(handle, sslContext, &mbedtlsCode);
+    (void)timeout;
 
-        if ((int)sslErr == SOCK_EWOULDBLOCK || (int)sslErr == SOCK_TRY_AGAIN)
-        {
-            // non-blocking - allow other threads to run while we wait for socket activity
-            NANOCLR_CHECK_HRESULT(
-                g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_Socket, fRes));
-        }
-        else
-        {
-            break;
-        }
-    }
+    // ssl_accept_internal runs the handshake in blocking mode and loops internally
+    // on WANT_READ / WANT_WRITE, returning only on a terminal outcome
+    sslErr = SSL_Accept(handle, sslContext, &mbedtlsCode);
 
     stack.PopValue(); // Timeout
 
@@ -147,7 +135,6 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureConnect___ST
 
     const char *szName;
     CLR_INT32 handle;
-    bool fRes = true;
     CLR_INT64 *timeout;
     SslError sslErr;
     int mbedtlsCode = 0;
@@ -174,21 +161,11 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::SecureConnect___ST
 
     NANOCLR_CHECK_HRESULT(stack.SetupTimeoutFromTicks(hbTimeout, timeout));
 
-    while (true)
-    {
-        sslErr = SSL_Connect(handle, szName, sslContext, &mbedtlsCode);
+    (void)timeout;
 
-        if ((int)sslErr == SOCK_EWOULDBLOCK || (int)sslErr == SOCK_TRY_AGAIN)
-        {
-            // non-blocking - allow other threads to run while we wait for socket activity
-            NANOCLR_CHECK_HRESULT(
-                g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeout, Event_Socket, fRes));
-        }
-        else
-        {
-            break;
-        }
-    }
+    // ssl_connect_internal runs the handshake in blocking mode and loops internally
+    // on WANT_READ / WANT_WRITE, returning only on a terminal outcome
+    sslErr = SSL_Connect(handle, szName, sslContext, &mbedtlsCode);
 
     stack.PopValue(); // Timeout
 
@@ -550,6 +527,9 @@ HRESULT Library_sys_net_native_System_Net_Security_SslNative::InitHelper(CLR_RT_
         case SslError_ConfigDefaultsFailed:
         case SslError_SetupFailed:
             NANOCLR_CHECK_HRESULT(ThrowCryptographicError(stack, (int)sslError));
+            break;
+
+        default:
             break;
     }
 

--- a/src/PAL/COM/sockets/Sockets_debugger.cpp
+++ b/src/PAL/COM/sockets/Sockets_debugger.cpp
@@ -464,20 +464,13 @@ bool Sockets_LWIP_Driver::UpgradeToSsl(
 
             SSL_AddCertificateAuthority(g_DebuggerPort_SslCtx_Handle, (const char *)pCACert, caCertLen);
 
-            // Retry the TLS handshake while it signals a would-block condition.
-            // TLS negotiation requires multiple round trips; non-blocking sockets
-            // will return EWOULDBLOCK / TRY_AGAIN until all flights are complete.
-            do
-            {
-                mbedtlsCode = 0;
-
-                sslErr = SSL_Connect(
-                    g_Sockets_LWIP_Driver.m_SocketDebugStream,
-                    szTargetHost,
-                    g_DebuggerPort_SslCtx_Handle,
-                    &mbedtlsCode);
-            } while (sslErr == SslError_HandshakeFailed &&
-                     (mbedtlsCode == SOCK_EWOULDBLOCK || mbedtlsCode == SOCK_TRY_AGAIN));
+            // SSL_Connect runs the handshake in blocking mode and loops internally
+            // on WANT_READ / WANT_WRITE, returning only on a terminal outcome
+            sslErr = SSL_Connect(
+                g_Sockets_LWIP_Driver.m_SocketDebugStream,
+                szTargetHost,
+                g_DebuggerPort_SslCtx_Handle,
+                &mbedtlsCode);
 
             if (sslErr != SslError_None)
             {

--- a/src/PAL/COM/sockets/Sockets_debugger.cpp
+++ b/src/PAL/COM/sockets/Sockets_debugger.cpp
@@ -459,17 +459,17 @@ bool Sockets_LWIP_Driver::UpgradeToSsl(
                 g_DebuggerPort_SslCtx_Handle,
                 false) == SslError_None)
         {
-            int32_t ret;
+            int mbedtlsCode = 0;
 
             SSL_AddCertificateAuthority(g_DebuggerPort_SslCtx_Handle, (const char *)pCACert, caCertLen);
 
-            do
-            {
-                ret =
-                    SSL_Connect(g_Sockets_LWIP_Driver.m_SocketDebugStream, szTargetHost, g_DebuggerPort_SslCtx_Handle);
-            } while (ret == SOCK_EWOULDBLOCK || ret == SOCK_TRY_AGAIN);
+            SslError sslErr = SSL_Connect(
+                g_Sockets_LWIP_Driver.m_SocketDebugStream,
+                szTargetHost,
+                g_DebuggerPort_SslCtx_Handle,
+                &mbedtlsCode);
 
-            if (ret != 0)
+            if (sslErr != SslError_None)
             {
                 SSL_CloseSocket(g_Sockets_LWIP_Driver.m_SocketDebugStream);
                 SSL_ExitContext(g_DebuggerPort_SslCtx_Handle);
@@ -479,7 +479,7 @@ bool Sockets_LWIP_Driver::UpgradeToSsl(
                 g_Sockets_LWIP_Driver.m_usingSSL = TRUE;
             }
 
-            return ret == 0;
+            return sslErr == SslError_None;
         }
     }
 

--- a/src/PAL/COM/sockets/Sockets_debugger.cpp
+++ b/src/PAL/COM/sockets/Sockets_debugger.cpp
@@ -460,14 +460,24 @@ bool Sockets_LWIP_Driver::UpgradeToSsl(
                 false) == SslError_None)
         {
             int mbedtlsCode = 0;
+            SslError sslErr;
 
             SSL_AddCertificateAuthority(g_DebuggerPort_SslCtx_Handle, (const char *)pCACert, caCertLen);
 
-            SslError sslErr = SSL_Connect(
-                g_Sockets_LWIP_Driver.m_SocketDebugStream,
-                szTargetHost,
-                g_DebuggerPort_SslCtx_Handle,
-                &mbedtlsCode);
+            // Retry the TLS handshake while it signals a would-block condition.
+            // TLS negotiation requires multiple round trips; non-blocking sockets
+            // will return EWOULDBLOCK / TRY_AGAIN until all flights are complete.
+            do
+            {
+                mbedtlsCode = 0;
+
+                sslErr = SSL_Connect(
+                    g_Sockets_LWIP_Driver.m_SocketDebugStream,
+                    szTargetHost,
+                    g_DebuggerPort_SslCtx_Handle,
+                    &mbedtlsCode);
+            } while (sslErr == SslError_HandshakeFailed &&
+                     (mbedtlsCode == SOCK_EWOULDBLOCK || mbedtlsCode == SOCK_TRY_AGAIN));
 
             if (sslErr != SslError_None)
             {

--- a/src/PAL/COM/sockets/ssl/MbedTLS/ssl_accept_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/MbedTLS/ssl_accept_internal.cpp
@@ -22,13 +22,14 @@ SslError ssl_accept_internal(int sd, int contextHandle, int *mbedtlsCode)
     }
 
     context = (mbedTLS_NFContext *)g_SSL_Driver.ContextArray[contextHandle].Context;
-    ssl = context->ssl;
 
     // sanity check
-    if (ssl == NULL)
+    if (context == NULL || context->ssl == NULL)
     {
         return SslError_HandshakeBadContext;
     }
+
+    ssl = context->ssl;
 
     // set socket in network context
     context->server_fd->fd = sd;

--- a/src/PAL/COM/sockets/ssl/MbedTLS/ssl_accept_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/MbedTLS/ssl_accept_internal.cpp
@@ -6,17 +6,19 @@
 #include <ssl.h>
 #include "mbedtls.h"
 
-int ssl_accept_internal(int sd, int contextHandle)
+SslError ssl_accept_internal(int sd, int contextHandle, int *mbedtlsCode)
 {
     mbedTLS_NFContext *context;
     mbedtls_ssl_context *ssl;
     int nonblock = 0;
-    int ret = SOCK_SOCKET_ERROR;
+    int ret;
+
+    *mbedtlsCode = 0;
 
     // Check contextHandle range
     if ((contextHandle >= (int)ARRAYSIZE(g_SSL_Driver.ContextArray)) || (contextHandle < 0))
     {
-        goto error;
+        return SslError_HandshakeBadContext;
     }
 
     context = (mbedTLS_NFContext *)g_SSL_Driver.ContextArray[contextHandle].Context;
@@ -25,7 +27,7 @@ int ssl_accept_internal(int sd, int contextHandle)
     // sanity check
     if (ssl == NULL)
     {
-        return SOCK_SOCKET_ERROR;
+        return SslError_HandshakeBadContext;
     }
 
     // set socket in network context
@@ -46,7 +48,15 @@ int ssl_accept_internal(int sd, int contextHandle)
         {
             // SSL handshake failed
             // mbedtls_printf( " failed\n  ! mbedtls_ssl_handshake returned -0x%x\n\n", -ret );
-            goto error;
+            if (ret == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED)
+            {
+                // surface the verify result flags - more actionable than the raw mbedTLS code
+                *mbedtlsCode = (int)mbedtls_ssl_get_verify_result(context->ssl);
+                return SslError_HandshakeCertVerifyFailed;
+            }
+
+            *mbedtlsCode = ret;
+            return SslError_HandshakeFailed;
         }
     }
 
@@ -56,7 +66,5 @@ int ssl_accept_internal(int sd, int contextHandle)
     // Save SSL context against socket
     SOCKET_DRIVER.SetSocketSslData(sd, (void *)context);
 
-error:
-
-    return ret;
+    return SslError_None;
 }

--- a/src/PAL/COM/sockets/ssl/MbedTLS/ssl_accept_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/MbedTLS/ssl_accept_internal.cpp
@@ -9,7 +9,6 @@
 SslError ssl_accept_internal(int sd, int contextHandle, int *mbedtlsCode)
 {
     mbedTLS_NFContext *context;
-    mbedtls_ssl_context *ssl;
     int nonblock = 0;
     int ret;
 
@@ -28,8 +27,6 @@ SslError ssl_accept_internal(int sd, int contextHandle, int *mbedtlsCode)
     {
         return SslError_HandshakeBadContext;
     }
-
-    ssl = context->ssl;
 
     // set socket in network context
     context->server_fd->fd = sd;

--- a/src/PAL/COM/sockets/ssl/MbedTLS/ssl_connect_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/MbedTLS/ssl_connect_internal.cpp
@@ -26,7 +26,7 @@ SslError ssl_connect_internal(int sd, const char *szTargetHost, int contextHandl
     // sd should already have been created
     // Now do the SSL negotiation
     context = (mbedTLS_NFContext *)g_SSL_Driver.ContextArray[contextHandle].Context;
-    if (context == NULL)
+    if (context == NULL || context->ssl == NULL)
     {
         return SslError_HandshakeBadContext;
     }

--- a/src/PAL/COM/sockets/ssl/MbedTLS/ssl_connect_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/MbedTLS/ssl_connect_internal.cpp
@@ -8,17 +8,18 @@
 #include <ssl.h>
 #include "mbedtls.h"
 
-int ssl_connect_internal(int sd, const char *szTargetHost, int contextHandle)
+SslError ssl_connect_internal(int sd, const char *szTargetHost, int contextHandle, int *mbedtlsCode)
 {
     mbedTLS_NFContext *context;
     int nonblock = 0;
+    int ret;
 
-    int ret = SOCK_SOCKET_ERROR;
+    *mbedtlsCode = 0;
 
     // Check contextHandle range
     if ((contextHandle >= (int)ARRAYSIZE(g_SSL_Driver.ContextArray)) || (contextHandle < 0))
     {
-        goto error;
+        return SslError_HandshakeBadContext;
     }
 
     // Retrieve SSL struct from g_SSL_Driver
@@ -27,7 +28,7 @@ int ssl_connect_internal(int sd, const char *szTargetHost, int contextHandle)
     context = (mbedTLS_NFContext *)g_SSL_Driver.ContextArray[contextHandle].Context;
     if (context == NULL)
     {
-        return false;
+        return SslError_HandshakeBadContext;
     }
 
     // set socket in network context
@@ -37,8 +38,8 @@ int ssl_connect_internal(int sd, const char *szTargetHost, int contextHandle)
     {
         if ((ret = mbedtls_ssl_set_hostname(context->ssl, szTargetHost)) != 0)
         {
-            // hostname_failed
-            goto error;
+            *mbedtlsCode = ret;
+            return SslError_HandshakeSetHostname;
         }
     }
 
@@ -54,7 +55,15 @@ int ssl_connect_internal(int sd, const char *szTargetHost, int contextHandle)
         {
             // SSL handshake failed
             // mbedtls_printf( " failed\n  ! mbedtls_ssl_handshake returned -0x%x\n\n", -ret );
-            goto error;
+            if (ret == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED)
+            {
+                // surface the verify result flags - more actionable than the raw mbedTLS code
+                *mbedtlsCode = (int)mbedtls_ssl_get_verify_result(context->ssl);
+                return SslError_HandshakeCertVerifyFailed;
+            }
+
+            *mbedtlsCode = ret;
+            return SslError_HandshakeFailed;
         }
     }
 
@@ -64,6 +73,5 @@ int ssl_connect_internal(int sd, const char *szTargetHost, int contextHandle)
     // store SSL context in sockets driver
     SOCKET_DRIVER.SetSocketSslData(sd, (void *)context);
 
-error:
-    return ret;
+    return SslError_None;
 }

--- a/src/PAL/COM/sockets/ssl/ssl.cpp
+++ b/src/PAL/COM/sockets/ssl/ssl.cpp
@@ -162,18 +162,18 @@ bool SSL_ExitContext(int contextHandle)
     return ssl_exit_context_internal(contextHandle);
 }
 
-int SSL_Accept(SOCK_SOCKET socket, int contextHandle)
+SslError SSL_Accept(SOCK_SOCKET socket, int contextHandle, int *mbedtlsCode)
 {
     NATIVE_PROFILE_PAL_COM();
 
-    return ssl_accept_internal(socket, contextHandle);
+    return ssl_accept_internal(socket, contextHandle, mbedtlsCode);
 }
 
-int SSL_Connect(SOCK_SOCKET socket, const char *szTargetHost, int contextHandle)
+SslError SSL_Connect(SOCK_SOCKET socket, const char *szTargetHost, int contextHandle, int *mbedtlsCode)
 {
     NATIVE_PROFILE_PAL_COM();
 
-    return ssl_connect_internal(socket, szTargetHost, contextHandle);
+    return ssl_connect_internal(socket, szTargetHost, contextHandle, mbedtlsCode);
 }
 
 int SSL_Write(SOCK_SOCKET socket, const char *data, size_t size)

--- a/src/PAL/COM/sockets/ssl/ssl_functions.h
+++ b/src/PAL/COM/sockets/ssl/ssl_functions.h
@@ -41,8 +41,8 @@ int ssl_decode_private_key_internal(
     size_t keyLength,
     const unsigned char *pwd,
     size_t pwdLength);
-int ssl_connect_internal(int sd, const char *szTargetHost, int contextHandle);
-int ssl_accept_internal(int socket, int contextHandle);
+SslError ssl_connect_internal(int sd, const char *szTargetHost, int contextHandle, int *mbedtlsCode);
+SslError ssl_accept_internal(int socket, int contextHandle, int *mbedtlsCode);
 int ssl_read_internal(int socket, char *data, size_t size);
 int ssl_write_internal(int socket, const char *data, size_t size);
 int ssl_close_socket_internal(int sd);

--- a/src/PAL/COM/sockets/ssl/ssl_stubs.cpp
+++ b/src/PAL/COM/sockets/ssl/ssl_stubs.cpp
@@ -97,25 +97,27 @@ __nfweak bool SSL_ExitContext(int contextHandle)
     return TRUE;
 }
 
-__nfweak int SSL_Accept(SOCK_SOCKET socket, int contextHandle)
+__nfweak SslError SSL_Accept(SOCK_SOCKET socket, int contextHandle, int *mbedtlsCode)
 {
     (void)socket;
     (void)contextHandle;
+    (void)mbedtlsCode;
 
     NATIVE_PROFILE_PAL_COM();
 
-    return 0;
+    return SslError_None;
 }
 
-__nfweak int SSL_Connect(SOCK_SOCKET socket, const char *szTargetHost, int contextHandle)
+__nfweak SslError SSL_Connect(SOCK_SOCKET socket, const char *szTargetHost, int contextHandle, int *mbedtlsCode)
 {
     (void)socket;
     (void)szTargetHost;
     (void)contextHandle;
+    (void)mbedtlsCode;
 
     NATIVE_PROFILE_PAL_COM();
 
-    return 0;
+    return SslError_None;
 }
 
 __nfweak int SSL_Write(SOCK_SOCKET socket, const char *data, size_t size)

--- a/src/PAL/Include/nanoPAL_Sockets.h
+++ b/src/PAL/Include/nanoPAL_Sockets.h
@@ -692,6 +692,10 @@ enum SslError
     SslError_CertificateParseFailed = 7,
     SslError_OwnCertConfigFailed = 8,
     SslError_SetupFailed = 9,
+    SslError_HandshakeBadContext = 10,
+    SslError_HandshakeSetHostname = 11,
+    SslError_HandshakeCertVerifyFailed = 12,
+    SslError_HandshakeFailed = 13,
 };
 
 bool SSL_Initialize();
@@ -722,8 +726,8 @@ SslError SSL_ClientInit(
 
 bool SSL_AddCertificateAuthority(int sslContextHandle, const char *certificate, int certLength);
 bool SSL_ExitContext(int sslContextHandle);
-int SSL_Accept(int socket, int sslContextHandle);
-int SSL_Connect(int socket, const char *szTargetHost, int sslContextHandle);
+SslError SSL_Accept(int socket, int sslContextHandle, int *mbedtlsCode);
+SslError SSL_Connect(int socket, const char *szTargetHost, int sslContextHandle, int *mbedtlsCode);
 int SSL_Write(int socket, const char *Data, size_t size);
 int SSL_Read(int socket, char *Data, size_t size);
 int SSL_CloseSocket(int socket);


### PR DESCRIPTION
## Description
- Now returning detailed SSL error and mbedTLS error code.
- Update declarations and callers.
- Update return checks to use the new codes.
- Update enum declaration in System.Net.

## Motivation and Context
- Using the same approach as in #3460 
- Following nanoframework/System.Net#411.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
