### PR TITLE
Fix check of call to ChibiOS trngGenerate

### DIFF
--- a/targets/ChibiOS/_nanoCLR/mbedtls_entropy_hardware_pool.c
+++ b/targets/ChibiOS/_nanoCLR/mbedtls_entropy_hardware_pool.c
@@ -36,7 +36,7 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t 
 
     trngStart(&TRNGD1, NULL);
 
-    if (!trngGenerate(&TRNGD1, len, output))
+    if (trngGenerate(&TRNGD1, len, output) == true)
     {
         trngStop(&TRNGD1);
         return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
@@ -83,7 +83,8 @@ psa_status_t mbedtls_psa_external_get_random(
 
     trngStart(&TRNGD1, NULL);
 
-    if (!trngGenerate(&TRNGD1, output_size, output))
+    // trngGenerate returns true if an error occurred
+    if (trngGenerate(&TRNGD1, output_size, output) == true)
     {
         trngStop(&TRNGD1);
         return PSA_ERROR_HARDWARE_FAILURE;


### PR DESCRIPTION
## Description
- Turns out that this API returns TRUE on failure.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
