### PR TITLE
Secure socket write now returns error

### DIFF
--- a/src/PAL/COM/sockets/ssl/MbedTLS/ssl_write_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/MbedTLS/ssl_write_internal.cpp
@@ -35,7 +35,7 @@ int ssl_write_internal(int sd, const char *data, size_t req_len)
     if (ret < 0)
     {
         // mbedtls_printf("mbedtls_ssl_write() returned -0x%04X\n", -ret);
-        return 0;
+        return SOCK_SOCKET_ERROR;
     }
 
     return req_len;


### PR DESCRIPTION
## Description
- Write operation now returns error instead of swalowing mbedTLS error.

## Motivation and Context
- Supporting nanoframework/System.Net#412.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- New unit test in System.Net

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
