### PR TITLE
Improvements in Mbed TLS initialization

### DIFF
--- a/src/PAL/COM/sockets/ssl/MbedTLS/ssl_generic_init_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/MbedTLS/ssl_generic_init_internal.cpp
@@ -101,16 +101,7 @@ SslError ssl_generic_init_internal(
     }
 
     mbedtls_ssl_config_init(context->conf);
-
-    // create and init CTR_DRBG
-    // this needs to be freed in ssl_exit_context_internal
-    context->ctr_drbg = (mbedtls_ctr_drbg_context *)platform_malloc(sizeof(mbedtls_ctr_drbg_context));
-    if (context->ctr_drbg == NULL)
-    {
-        goto error;
-    }
-    mbedtls_ctr_drbg_init(context->ctr_drbg);
-
+    
     // create and init entropy context
     // this needs to be freed in ssl_exit_context_internal
     context->entropy = (mbedtls_entropy_context *)platform_malloc(sizeof(mbedtls_entropy_context));
@@ -138,6 +129,21 @@ SslError ssl_generic_init_internal(
         goto error;
     }
     mbedtls_x509_crt_init(context->ca_cert);
+
+    // create and init CTR_DRBG
+    // this needs to be freed in ssl_exit_context_internal
+    context->ctr_drbg = (mbedtls_ctr_drbg_context *)platform_malloc(sizeof(mbedtls_ctr_drbg_context));
+    if (context->ctr_drbg == NULL)
+    {
+        goto error;
+    }
+    mbedtls_ctr_drbg_init(context->ctr_drbg);
+
+    if (psa_crypto_init() != PSA_SUCCESS)
+    {
+        error = SslError_SetupFailed;
+        goto error;
+    }
 
     // TODO: review if we can add some instance-unique data to the custom argument below
     if (mbedtls_ctr_drbg_seed(context->ctr_drbg, mbedtls_entropy_func, context->entropy, NULL, 0) != 0)
@@ -191,6 +197,13 @@ SslError ssl_generic_init_internal(
 
 #if defined(PLATFORM_ESP32) && defined(CONFIG_MBEDTLS_DEBUG)
     mbedtls_esp_enable_debug_log(context->conf, CONFIG_MBEDTLS_DEBUG_LEVEL);
+#endif
+
+    // setup debug stuff
+    // only required if output debug is enabled in mbedtls_config.h
+#if defined(MBEDTLS_DEBUG_C) && defined(MBEDTLS_DEBUG_THRESHOLD)
+    mbedtls_debug_set_threshold(MBEDTLS_DEBUG_THRESHOLD);
+    mbedtls_ssl_conf_dbg(context->conf, nf_debug, stdout);
 #endif
 
     // CA root certs from store, if available
@@ -301,8 +314,6 @@ SslError ssl_generic_init_internal(
 
     mbedtls_ssl_conf_ca_chain(context->conf, context->ca_cert, NULL);
 
-    psa_crypto_init();
-
     // set certificate verification
     // the current options provided by Mbed TLS are only verify or don't verify
     if ((SslVerification)sslVerify == SslVerification_CertificateRequired)
@@ -310,13 +321,6 @@ SslError ssl_generic_init_internal(
         authMode = MBEDTLS_SSL_VERIFY_REQUIRED;
     }
     mbedtls_ssl_conf_authmode(context->conf, authMode);
-
-    // setup debug stuff
-    // only required if output debug is enabled in mbedtls_config.h
-#if defined(MBEDTLS_DEBUG_C) && defined(MBEDTLS_DEBUG_THRESHOLD)
-    mbedtls_debug_set_threshold(MBEDTLS_DEBUG_THRESHOLD);
-    mbedtls_ssl_conf_dbg(context->conf, nf_debug, stdout);
-#endif
 
     ret = mbedtls_ssl_setup(context->ssl, context->conf);
     if (ret != 0)

--- a/src/PAL/COM/sockets/ssl/MbedTLS/ssl_generic_init_internal.cpp
+++ b/src/PAL/COM/sockets/ssl/MbedTLS/ssl_generic_init_internal.cpp
@@ -101,7 +101,7 @@ SslError ssl_generic_init_internal(
     }
 
     mbedtls_ssl_config_init(context->conf);
-    
+
     // create and init entropy context
     // this needs to be freed in ssl_exit_context_internal
     context->entropy = (mbedtls_entropy_context *)platform_malloc(sizeof(mbedtls_entropy_context));


### PR DESCRIPTION
## Description
- Add check to crypto PSA init because return value was being ignored.
- Change order of call to initialization and config API.

## Motivation and Context
- Ignoring the return call for PAS init can mask an initialization failure that can manifest later on by obscure reasons. Dealing with the return value is the way to go.
- Now following Mbed TLS call order (from sample applications).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- System.Net unit tests.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
