### PR TITLE
Improvements in RP2350 TRNG

### DIFF
--- a/targets/ChibiOS/_nf-overlay/os/hal/ports/RP/LLD/RNGv1/rng_lld.c
+++ b/targets/ChibiOS/_nf-overlay/os/hal/ports/RP/LLD/RNGv1/rng_lld.c
@@ -32,8 +32,9 @@
 #define TRNG_EHR_DATA4         (*(volatile uint32_t *)(TRNG_BASE + 0x124UL))
 #define TRNG_EHR_DATA5         (*(volatile uint32_t *)(TRNG_BASE + 0x128UL))
 #define TRNG_RND_SOURCE_ENABLE (*(volatile uint32_t *)(TRNG_BASE + 0x12CUL))
-#define TRNG_TRNG_SW_RESET     (*(volatile uint32_t *)(TRNG_BASE + 0x140UL))
-#define TRNG_RST_BITS_COUNTER  (*(volatile uint32_t *)(TRNG_BASE + 0x1BCUL))
+#define TRNG_SAMPLE_CNT1       (*(volatile uint32_t *)(TRNG_BASE + 0x130UL))
+#define TRNG_DEBUG_CONTROL     (*(volatile uint32_t *)(TRNG_BASE + 0x138UL))
+#define TRNG_BUSY              (*(volatile uint32_t *)(TRNG_BASE + 0x1B8UL))
 
 #define TRNG_RNG_ISR_VN_ERR       (1UL << 3)
 #define TRNG_RNG_ISR_CRNGT_ERR    (1UL << 2)
@@ -45,28 +46,12 @@
 #define TRNG_TRNG_VALID_EHR_VALID (1UL << 0)
 #define TRNG_RND_SRC_EN           (1UL << 0)
 
-#define c_RNG_TIMEOUT_VALUE_MS 500UL
-
 #endif
 
 /*===========================================================================*/
 /* Driver exported variables.                                                */
 /*===========================================================================*/
 
-#if defined(RP2350)
-
-static void trng_prepare_source(void)
-{
-    // Requirement: counter reset only takes effect while source is disabled.
-    TRNG_RND_SOURCE_ENABLE = 0;
-    TRNG_TRNG_SW_RESET = 1;
-    TRNG_TRNG_SW_RESET = 0;
-    TRNG_RST_BITS_COUNTER = 1;
-    TRNG_RNG_ICR = TRNG_RNG_ICR_ALL;
-    TRNG_RND_SOURCE_ENABLE = TRNG_RND_SRC_EN;
-}
-
-#endif
 /** @brief RNGD1 driver identifier.*/
 RNGDriver RNGD1;
 
@@ -94,14 +79,21 @@ void rng_lld_init(void)
 #if (RNG_USE_MUTUAL_EXCLUSION == TRUE)
     osalMutexObjectInit(&RNGD1.Lock);
 #endif
+
+    rp_peripheral_unreset(RESETS_ALLREG_TRNG);
+    
+    TRNG_RND_SOURCE_ENABLE = 0;
+    // Sample one ROSC bit into EHR every cycle
+    TRNG_SAMPLE_CNT1 = 0;
+    // Disable checks and bypass decorrelators
+    TRNG_DEBUG_CONTROL = -1;
+    TRNG_ICR = TRNG_RNG_ICR_ALL;
 }
 
 void rng_lld_start(void)
 {
 #if defined(RP2350)
-    // Ensure TRNG peripheral clock domain is enabled.
-    rp_peripheral_unreset(RESETS_ALLREG_TRNG);
-    trng_prepare_source();
+    TRNG_RND_SOURCE_ENABLE = TRNG_RND_SRC_EN;
 #endif
 
     RNGD1.State = RNG_READY;
@@ -111,7 +103,6 @@ void rng_lld_stop(void)
 {
 #if defined(RP2350)
     TRNG_RND_SOURCE_ENABLE = 0;
-    rp_peripheral_reset(RESETS_ALLREG_TRNG);
 #endif
 
     RNGD1.State = RNG_STOP;
@@ -119,6 +110,8 @@ void rng_lld_stop(void)
 
 bool rng_lld_generate(size_t size, uint8_t *out)
 {
+    RNGD1.State = RNG_ACTIVE;
+
 #if defined(RP2040)
 
     while (size > 0)
@@ -137,60 +130,53 @@ bool rng_lld_generate(size_t size, uint8_t *out)
         }
     }
 
+    RNGD1.State = RNG_READY;
+
     return true;
 
 #elif defined(RP2350)
 
     while (size > 0)
     {
-        for (uint32_t elapsed = 0; elapsed < c_RNG_TIMEOUT_VALUE_MS; elapsed++)
+        // Wait for 192 ROSC samples to fill EHR
+        while (TRNG_BUSY)
         {
-            uint32_t isr = TRNG_RNG_ISR;
-
-            if ((isr & (TRNG_RNG_ISR_AUTOCORR_ERR | TRNG_RNG_ISR_CRNGT_ERR | TRNG_RNG_ISR_VN_ERR)) != 0)
-            {
-                trng_prepare_source();
-                continue;
-            }
-
-            if ((TRNG_TRNG_VALID & TRNG_TRNG_VALID_EHR_VALID) != 0 || (isr & TRNG_RNG_ISR_EHR_VALID) != 0)
-            {
-                volatile uint32_t *ehrRegs[] = {
-                    &TRNG_EHR_DATA0,
-                    &TRNG_EHR_DATA1,
-                    &TRNG_EHR_DATA2,
-                    &TRNG_EHR_DATA3,
-                    &TRNG_EHR_DATA4,
-                    &TRNG_EHR_DATA5};
-
-                for (int r = 0; r < 6 && size > 0; r++)
-                {
-                    uint32_t word = *ehrRegs[r];
-                    for (size_t b = 0; b < sizeof(uint32_t) && size > 0; b++)
-                    {
-                        *out++ = (uint8_t)word;
-                        word >>= 8;
-                        size--;
-                    }
-                }
-
-                TRNG_RNG_ICR = TRNG_RNG_ISR_EHR_VALID;
-                goto next_chunk;
-            }
-
             osalThreadSleepMilliseconds(1);
         }
 
-        return false;
+        // Copy 6 EHR words
+        volatile uint32_t *ehrRegs[] = {
+            &TRNG_EHR_DATA0,
+            &TRNG_EHR_DATA1,
+            &TRNG_EHR_DATA2,
+            &TRNG_EHR_DATA3,
+            &TRNG_EHR_DATA4,
+            &TRNG_EHR_DATA5
+        };
 
-    next_chunk:;
+        for (int r = 0; r < 6 && size > 0; r++)
+        {
+            uint32_t word = *ehrRegs[r];
+
+            for (size_t b = 0; b < sizeof(uint32_t) && size > 0; b++)
+            {
+                *out++ = (uint8_t)word;
+                word >>= 8;
+                size--;
+            }
+        }
     }
+    
+    RNGD1.State = RNG_READY;
 
     return true;
 
 #else
     (void)size;
     (void)out;
+
+    RNGD1.State = RNG_READY;
+
     return false;
 #endif
 }

--- a/targets/ChibiOS/_nf-overlay/os/hal/ports/RP/LLD/RNGv1/rng_lld.c
+++ b/targets/ChibiOS/_nf-overlay/os/hal/ports/RP/LLD/RNGv1/rng_lld.c
@@ -80,6 +80,8 @@ void rng_lld_init(void)
     osalMutexObjectInit(&RNGD1.Lock);
 #endif
 
+#if defined(RP2350)
+
     rp_peripheral_unreset(RESETS_ALLREG_TRNG);
 
     TRNG_RND_SOURCE_ENABLE = 0;
@@ -87,7 +89,9 @@ void rng_lld_init(void)
     TRNG_SAMPLE_CNT1 = 0;
     // Disable checks and bypass decorrelators
     TRNG_DEBUG_CONTROL = -1;
-    TRNG_ICR = TRNG_RNG_ICR_ALL;
+    TRNG_RNG_ICR = TRNG_RNG_ICR_ALL;
+
+#endif
 }
 
 void rng_lld_start(void)

--- a/targets/ChibiOS/_nf-overlay/os/hal/ports/RP/LLD/RNGv1/rng_lld.c
+++ b/targets/ChibiOS/_nf-overlay/os/hal/ports/RP/LLD/RNGv1/rng_lld.c
@@ -81,7 +81,7 @@ void rng_lld_init(void)
 #endif
 
     rp_peripheral_unreset(RESETS_ALLREG_TRNG);
-    
+
     TRNG_RND_SOURCE_ENABLE = 0;
     // Sample one ROSC bit into EHR every cycle
     TRNG_SAMPLE_CNT1 = 0;
@@ -145,14 +145,8 @@ bool rng_lld_generate(size_t size, uint8_t *out)
         }
 
         // Copy 6 EHR words
-        volatile uint32_t *ehrRegs[] = {
-            &TRNG_EHR_DATA0,
-            &TRNG_EHR_DATA1,
-            &TRNG_EHR_DATA2,
-            &TRNG_EHR_DATA3,
-            &TRNG_EHR_DATA4,
-            &TRNG_EHR_DATA5
-        };
+        volatile uint32_t *ehrRegs[] =
+            {&TRNG_EHR_DATA0, &TRNG_EHR_DATA1, &TRNG_EHR_DATA2, &TRNG_EHR_DATA3, &TRNG_EHR_DATA4, &TRNG_EHR_DATA5};
 
         for (int r = 0; r < 6 && size > 0; r++)
         {
@@ -166,7 +160,7 @@ bool rng_lld_generate(size_t size, uint8_t *out)
             }
         }
     }
-    
+
     RNGD1.State = RNG_READY;
 
     return true;


### PR DESCRIPTION
## Description
- Improved init code. Now performing essencial configs.
- Start doesn't not reset peripheral and waits forever.
- Simpler code in generate API.
- Clean-up unnesed registers and helper function.

## Motivation and Context
- Consecutive calls to TRNG surfaced the poor performance on init and generate code
- This implementation follows the bootom example from the RP2350 manual. 
- Simplistic approach, removing all wait times and long checks. 
- May occasionally not comply with NIST test and entropy checks.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
