### PR TITLE
Fix closed-generic .cctor ordering causing NullReferenceException

### DIFF
--- a/src/CLR/Core/CLAUDE.md
+++ b/src/CLR/Core/CLAUDE.md
@@ -5,6 +5,14 @@ knowledge, gotchas, and debugging context for generics support in the CLR core
 (type system, interpreter, execution engine) so the source files can stay
 focused on the algorithms.
 
+**Documentation policy:** source comments in this directory stay minimal —
+only what's needed to flag a non-obvious invariant at the point it matters.
+Deductions, root-cause analysis, design rationale, and "why not the other
+approach" belong here, not as comment blocks in the `.cpp`/`.h` files. If
+you find yourself writing more than a one-line comment in the source, put
+the explanation here instead and leave a short pointer (or nothing) in the
+code.
+
 If you are about to read or modify any of these and the comment looks terse,
 the rationale is in here:
 
@@ -13,7 +21,8 @@ the rationale is in here:
   `MethodRef_Instance::InitializeFromToken`, `ResolveMethodRef`.
 - `Interpreter.cpp` — `CEE_CALLVIRT`, `CEE_NEWOBJ`, `CEE_BOX`,
   `CEE_UNBOX_ANY`, `CEE_LDOBJ`, `CEE_STELEM_*`, `CEE_LDSFLD`/`CEE_STSFLD`/
-  `CEE_LDSFLDA`, and the `CEE_CONSTRAINED` prefix handler.
+  `CEE_LDSFLDA`, the `CEE_CONSTRAINED` prefix handler, and
+  `EnsureGenericCctorCompleted` (§9–§10 below).
 - `Execution.cpp` — `ExecutionEngine_RunGenericStaticConstructors`,
   `SpawnStaticConstructor`, `ResolveGenericTypeParameter`,
   `InitializeLocals`.
@@ -303,33 +312,78 @@ of the concrete type, which then breaks every subsequent read of that
 field.
 
 Field access on a generic type is also entangled with `.cctor` scheduling
-(§10). If the field-resolution helper reports "not found" but the type has
-a pending generic `.cctor`, the instruction reschedules and lets the
-`.cctor` complete the field-table initialization first.
+(§10). The interpreter enforces ECMA-335 §I.8.9.5 by calling
+`EnsureGenericCctorCompleted` **before** the field read/write. If the
+`.cctor` has not yet run, the helper pushes a stack frame for it on the
+current thread and the triggering opcode retries after the `.cctor`
+returns.
 
 ---
 
 ## 10. Generic `.cctor` lifecycle
 
-Implemented in `ExecutionEngine_RunGenericStaticConstructors`
-(`Execution.cpp`) and `SpawnStaticConstructor`.
+Two mechanisms cooperate:
 
-- The crawler walks every assembly's `TypeSpec` table, filters to **closed**
-  generic instantiations (open TypeSpecs have no observable static state),
-  and schedules a `.cctor` for each one that has one.
-- Each closed type is hashed (via `FindOrCreateGenericStaticFields`); the
-  hash deduplicates so the same closed type is not initialized twice across
-  multiple TypeSpec rows that happen to encode the same closed
-  instantiation.
-- The crawler is **resumable**: after a `.cctor` completes, the helper picks
-  up at the next TypeSpec index. The current crawl position is stored on
-  the spawned delegate via field repurposing — `m_genericTypeSpec.data != 0`
-  on the delegate discriminates a generic-type `.cctor` from an ordinary
-  one, and the field carries the TypeSpec index for resumption.
-- The crawler runs lazily — generic `.cctor`s only fire when something
-  forces them (typically the first field access via `LDSFLD`/`STSFLD`).
-  This is why the field-access opcodes reschedule themselves when they
-  observe a pending `.cctor` (§9).
+**Interpreter-level demand gate** (`EnsureGenericCctorCompleted` in
+`Interpreter.cpp`). Enforces ECMA-335 §I.8.9.5: the first
+`NEWOBJ`/`LDSFLD`/`STSFLD`/`LDSFLDA`/static `CALL` touching a closed
+generic type checks whether the `.cctor` has completed. The declaring
+TypeSpec may be **closed** (`List<int>`) or **open** (`SZGenericArray‑
+Enumerator<!!0>::Empty` accessed inside `List<int>::GetEnumerator`, where
+`!!0` binds to `int` only through the caller's method context). The gate
+handles both: it does not require `IsClosedGenericType()`, it requires
+only that `ComputeHashForClosedGenericType(tsInst, contextTypeSpec,
+contextMethod)` resolves the arguments to a concrete closed form (a
+`0xFFFFFFFF` hash — still open after resolution — short-circuits to
+`S_OK`). This open case matters because the crawler never covers it (see
+below), so the demand gate is the *only* thing that runs those `.cctor`s.
+
+Call contract (identical at all five call sites — `NEWOBJ`, static
+`CALL`, `LDSFLD`, `LDSFLDA`, `STSFLD`):
+- `S_OK` — nothing to do, proceed with the opcode as normal.
+- `CLR_E_PROCESS_EXCEPTION` — a `.cctor` frame was just pushed on the
+  current thread. The caller must rewind `ip` by 3 bytes (1 opcode + 2
+  compressed token — same width for all five opcodes) and
+  `goto Execute_Restart` so the `.cctor` runs as a nested call; when it
+  returns (`Pop`), the triggering opcode re-decodes from the rewound `ip`
+  and retries, now seeing initialized fields.
+- `CLR_E_RESCHEDULE` — the `.cctor` is already scheduled (by the crawler
+  or a prior trigger) but not yet done, and we're not re-entering it from
+  within itself. Rewind `ip` by 3 and yield via
+  `NANOCLR_SET_AND_LEAVE(CLR_E_RESCHEDULE)` so the cctor thread gets a
+  chance to run it.
+
+Internally: the helper marks the `CLR_RT_GenericCctorExecutionRecord` as
+both `c_Scheduled` and `c_Executed` *before* pushing the `.cctor` frame —
+this ordering is what prevents infinite re-entrant triggering if the
+`.cctor` body itself touches the same closed type. When the record is
+already `c_Scheduled`-but-not-`c_Executed` (crawler got there first), the
+helper walks the current thread's call stack looking for a `.cctor` frame
+for the same generic type; finding one means we're already inside it
+(re-entrant access from the `.cctor`'s own body), so it returns `S_OK`
+instead of yielding — yielding here would deadlock, since the thread
+would be waiting on a `.cctor` that only it can run. The pushed `.cctor`
+frame is given the declaring TypeSpec as its generic-type context so any
+VAR references inside the `.cctor` body resolve correctly; when that
+TypeSpec is *open*, the caller's `methodSpec` is also copied onto the
+frame so the body's `!0` resolves two-level (`!0` → TypeSpec slot → MVAR
+→ concrete), landing on the same closed instantiation the triggering
+field access resolved to.
+
+**Crawler** (`SpawnGenericTypeStaticConstructorsHelper` in
+`Execution.cpp` and `SpawnStaticConstructor`). Walks every assembly's
+`TypeSpec` table in a second phase (after all regular `.cctor`s), filters
+to closed instantiations, and schedules their `.cctor`s on the dedicated
+`m_cctorThread`. The crawler is resumable via
+`CLR_RT_HeapBlock_Delegate::m_genericTypeSpec`. Because the demand gate
+above fires earlier, the crawler typically only picks up instantiations
+that were never touched by user code — most `.cctor`s will already be
+marked `c_Executed` by the time the crawler reaches them. The crawler
+only sees instantiations that appear as **closed TypeSpec rows in
+metadata**; closed types that arise solely from runtime VAR/MVAR binding
+(e.g. `SZGenericArrayEnumerator<int>`, materialised inside a generic
+method) have no such row and are therefore reached *only* by the demand
+gate's open-TypeSpec path.
 
 ---
 

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -1002,35 +1002,135 @@ HRESULT CLR_RT_Thread::Execute_DelegateInvoke(CLR_RT_StackFrame &stackArg)
     NANOCLR_NOCLEANUP();
 }
 
-// Helper function to handle generic .cctor rescheduling for static field operations
-// Returns CLR_E_RESCHEDULE if rescheduling is needed, CLR_E_WRONG_TYPE if hash is invalid,
-// or S_OK if no rescheduling is needed.
-static HRESULT HandleGenericCctorReschedule(
+// See CLAUDE.md "Generic .cctor lifecycle" for the call contract.
+static HRESULT EnsureGenericCctorCompleted(
     CLR_RT_TypeSpec_Instance &tsInst,
     CLR_RT_StackFrame *stack,
-    CLR_PMETADATA *pIp)
+    CLR_RT_Thread *th)
 {
+    // Accept closed instantiations and open ones that resolve to a closed form
+    // via the caller's generic context (VAR/MVAR) — the hash guard below rejects
+    // anything still open after resolution. Non-generic TypeSpecs are ignored.
+    if (!NANOCLR_INDEX_IS_VALID(tsInst.genericTypeDef))
+    {
+        return S_OK;
+    }
+
+    bool tsIsClosed = tsInst.IsClosedGenericType();
+
     CLR_UINT32 hash =
         g_CLR_RT_TypeSystem.ComputeHashForClosedGenericType(tsInst, &stack->m_genericTypeSpecStorage, &stack->m_call);
 
     if (hash == 0xFFFFFFFF)
     {
-        return CLR_E_WRONG_TYPE;
+        return S_OK;
     }
 
-    CLR_RT_GenericCctorExecutionRecord *cctorRecord = g_CLR_RT_TypeSystem.FindOrCreateGenericCctorRecord(hash, nullptr);
+    bool created = false;
+    CLR_RT_GenericCctorExecutionRecord *record = g_CLR_RT_TypeSystem.FindOrCreateGenericCctorRecord(hash, &created);
 
-    if (cctorRecord != nullptr && (cctorRecord->m_flags & CLR_RT_GenericCctorExecutionRecord::c_Scheduled) &&
-        !(cctorRecord->m_flags & CLR_RT_GenericCctorExecutionRecord::c_Executed))
+    if (record == nullptr)
     {
-        // .cctor is scheduled but not yet executed
-        // Rewind ip to before this instruction so it will be retried
-        // (1 byte for opcode + 2 bytes for compressed field token)
-        *pIp -= 3;
+        return S_OK;
+    }
+
+    if (record->m_flags & CLR_RT_GenericCctorExecutionRecord::c_Executed)
+    {
+        return S_OK;
+    }
+
+    if ((record->m_flags & CLR_RT_GenericCctorExecutionRecord::c_Scheduled) &&
+        !(record->m_flags & CLR_RT_GenericCctorExecutionRecord::c_Executed))
+    {
+        CLR_RT_StackFrame *frame = th->CurrentFrame();
+
+        while (frame->Caller() != nullptr)
+        {
+            if ((frame->m_call.target->flags & CLR_RECORD_METHODDEF::MD_StaticConstructor) &&
+                frame->m_call.genericType != nullptr && NANOCLR_INDEX_IS_VALID(*frame->m_call.genericType))
+            {
+                CLR_RT_TypeSpec_Instance frameTs;
+                if (frameTs.InitializeFromIndex(*frame->m_call.genericType) &&
+                    NANOCLR_INDEX_IS_VALID(frameTs.genericTypeDef) &&
+                    frameTs.genericTypeDef.data == tsInst.genericTypeDef.data)
+                {
+                    return S_OK;
+                }
+            }
+
+            frame = frame->Caller();
+        }
+
         return CLR_E_RESCHEDULE;
     }
 
-    return S_OK;
+    CLR_RT_TypeDef_Index typeDef = tsInst.genericTypeDef;
+    CLR_RT_Assembly *ownerAsm = g_CLR_RT_TypeSystem.m_assemblies[typeDef.Assembly() - 1];
+
+    if (!ownerAsm->HasStaticConstructor(typeDef))
+    {
+        record->m_flags |= CLR_RT_GenericCctorExecutionRecord::c_Executed;
+        return S_OK;
+    }
+
+    const CLR_RECORD_TYPEDEF *ownerTd = ownerAsm->GetTypeDef(typeDef.Type());
+    const CLR_RECORD_METHODDEF *md = ownerAsm->GetMethodDef(ownerTd->firstMethod);
+    int methodCount = ownerTd->virtualMethodCount + ownerTd->instanceMethodCount + ownerTd->staticMethodCount;
+
+    CLR_RT_MethodDef_Index cctorIndex;
+    bool foundCctor = false;
+
+    for (int i = 0; i < methodCount; i++, md++)
+    {
+        if (md->flags & CLR_RECORD_METHODDEF::MD_StaticConstructor)
+        {
+            cctorIndex.Set(ownerAsm->assemblyIndex, ownerTd->firstMethod + i);
+            foundCctor = true;
+            break;
+        }
+    }
+
+    if (!foundCctor)
+    {
+        record->m_flags |= CLR_RT_GenericCctorExecutionRecord::c_Executed;
+        return S_OK;
+    }
+
+    record->m_flags |= CLR_RT_GenericCctorExecutionRecord::c_Scheduled | CLR_RT_GenericCctorExecutionRecord::c_Executed;
+
+    CLR_RT_MethodDef_Instance cctorInst{};
+    if (!cctorInst.InitializeFromIndex(cctorIndex))
+    {
+        return CLR_E_WRONG_TYPE;
+    }
+
+    CLR_RT_TypeSpec_Index tsIndex;
+    tsIndex.data = tsInst.data;
+
+    cctorInst.m_typeSpecStorage = tsIndex;
+    cctorInst.genericType = &cctorInst.m_typeSpecStorage;
+
+    HRESULT hr = CLR_RT_StackFrame::Push(th, cctorInst, -1);
+
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    CLR_RT_StackFrame *cctorFrame = th->CurrentFrame();
+    cctorFrame->m_genericTypeSpecStorage = tsIndex;
+    cctorFrame->m_call.genericType = &cctorFrame->m_genericTypeSpecStorage;
+
+    // Open declaring TypeSpec (reached via VAR/MVAR, e.g.
+    // SZGenericArrayEnumerator<!!0>::Empty inside List<int>::GetEnumerator):
+    // propagate the caller's method generic context so the cctor body's VARs
+    // resolve two-level to the same closed form the field access resolved to.
+    if (!tsIsClosed)
+    {
+        cctorFrame->m_call.methodSpec = stack->m_call.methodSpec;
+    }
+
+    return CLR_E_PROCESS_EXCEPTION;
 }
 
 HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
@@ -2354,6 +2454,38 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                         if (calleeInst.target->flags & CLR_RECORD_METHODDEF::MD_Static)
                         {
                             doInstanceResolution = false;
+
+                            {
+                                const CLR_RT_TypeSpec_Index *tsForCctor = calleeInst.genericType;
+                                if (tsForCctor == nullptr || !NANOCLR_INDEX_IS_VALID(*tsForCctor))
+                                {
+                                    tsForCctor =
+                                        (effectiveCallerGeneric && NANOCLR_INDEX_IS_VALID(*effectiveCallerGeneric))
+                                            ? effectiveCallerGeneric
+                                            : nullptr;
+                                }
+
+                                if (tsForCctor != nullptr)
+                                {
+                                    CLR_RT_TypeSpec_Instance tsInst;
+                                    if (tsInst.InitializeFromIndex(*tsForCctor))
+                                    {
+                                        hr = EnsureGenericCctorCompleted(tsInst, stack, th);
+                                        if (hr == CLR_E_PROCESS_EXCEPTION)
+                                        {
+                                            ip -= 3;
+                                            WRITEBACK(stack, evalPos, ip, fDirty);
+                                            goto Execute_Restart;
+                                        }
+                                        else if (hr == CLR_E_RESCHEDULE)
+                                        {
+                                            ip -= 3;
+                                            NANOCLR_SET_AND_LEAVE(CLR_E_RESCHEDULE);
+                                        }
+                                        NANOCLR_CHECK_HRESULT(hr);
+                                    }
+                                }
+                            }
                         }
                         else
                         {
@@ -2931,6 +3063,43 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                         NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                     }
 
+                    {
+                        const CLR_RT_TypeSpec_Index *tsForCctor = nullptr;
+
+                        if (calleeInst.genericType != nullptr && NANOCLR_INDEX_IS_VALID(*calleeInst.genericType))
+                        {
+                            tsForCctor = calleeInst.genericType;
+                        }
+                        else if (stack->m_call.genericType != nullptr &&
+                                 NANOCLR_INDEX_IS_VALID(*stack->m_call.genericType))
+                        {
+                            tsForCctor = stack->m_call.genericType;
+                        }
+
+                        if (tsForCctor != nullptr)
+                        {
+                            CLR_RT_TypeSpec_Instance tsInst;
+                            if (tsInst.InitializeFromIndex(*tsForCctor))
+                            {
+                                hr = EnsureGenericCctorCompleted(tsInst, stack, th);
+
+                                if (hr == CLR_E_PROCESS_EXCEPTION)
+                                {
+                                    ip -= 3;
+                                    WRITEBACK(stack, evalPos, ip, fDirty);
+                                    goto Execute_Restart;
+                                }
+                                else if (hr == CLR_E_RESCHEDULE)
+                                {
+                                    ip -= 3;
+                                    NANOCLR_SET_AND_LEAVE(CLR_E_RESCHEDULE);
+                                }
+
+                                NANOCLR_CHECK_HRESULT(hr);
+                            }
+                        }
+                    }
+
                     evalPos++;
 
                     WRITEBACK(stack, evalPos, ip, fDirty);
@@ -3386,6 +3555,28 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
 
                     if (field.genericType && NANOCLR_INDEX_IS_VALID(*field.genericType))
                     {
+                        {
+                            CLR_RT_TypeSpec_Instance tsInst;
+                            if (tsInst.InitializeFromIndex(*field.genericType))
+                            {
+                                hr = EnsureGenericCctorCompleted(tsInst, stack, th);
+
+                                if (hr == CLR_E_PROCESS_EXCEPTION)
+                                {
+                                    ip -= 3;
+                                    WRITEBACK(stack, evalPos, ip, fDirty);
+                                    goto Execute_Restart;
+                                }
+                                else if (hr == CLR_E_RESCHEDULE)
+                                {
+                                    ip -= 3;
+                                    NANOCLR_SET_AND_LEAVE(CLR_E_RESCHEDULE);
+                                }
+
+                                NANOCLR_CHECK_HRESULT(hr);
+                            }
+                        }
+
                         // access static field of a generic instance
                         // Pass both TypeSpec context (for VAR resolution) and MethodDef context (for MVAR resolution)
                         ptr = field.assembly->GetStaticFieldByFieldDef(
@@ -3416,27 +3607,10 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     {
                         NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                     }
-                    else if (field.genericType && NANOCLR_INDEX_IS_VALID(*field.genericType))
-                    {
-                        CLR_RT_HeapBlock *obj = ptr;
-                        NanoCLRDataType dt;
-
-                        CLR_RT_TypeDescriptor::ExtractObjectAndDataType(obj, dt);
-
-                        // Field not found - but if this is a generic type with
-                        // a .cctor that's scheduled,
-                        // reschedule to allow the .cctor to complete field initialization
-                        if (obj == nullptr)
-                        {
-                            // Check if there's a pending .cctor for this generic type
-                            CLR_RT_TypeSpec_Instance tsInst;
-                            if (tsInst.InitializeFromIndex(*field.genericType))
-                            {
-                                NANOCLR_CHECK_HRESULT(HandleGenericCctorReschedule(tsInst, stack, &ip));
-                            }
-                        }
 
 #if defined(NANOCLR_TRACE_GENERICS)
+                    if (field.genericType && NANOCLR_INDEX_IS_VALID(*field.genericType))
+                    {
                         if (s_CLR_RT_fTrace_GenericFields >= c_CLR_RT_Trace_Verbose)
                         {
                             CLR_Debug::Printf(
@@ -3444,8 +3618,8 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                                 (uintptr_t)ptr,
                                 (int)ptr->DataType());
                         }
-#endif
                     }
+#endif
 
                     evalPos++;
                     CHECKSTACK(stack, evalPos);
@@ -3473,6 +3647,28 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
 
                     if (field.genericType && NANOCLR_INDEX_IS_VALID(*field.genericType))
                     {
+                        {
+                            CLR_RT_TypeSpec_Instance tsInst;
+                            if (tsInst.InitializeFromIndex(*field.genericType))
+                            {
+                                hr = EnsureGenericCctorCompleted(tsInst, stack, th);
+
+                                if (hr == CLR_E_PROCESS_EXCEPTION)
+                                {
+                                    ip -= 3;
+                                    WRITEBACK(stack, evalPos, ip, fDirty);
+                                    goto Execute_Restart;
+                                }
+                                else if (hr == CLR_E_RESCHEDULE)
+                                {
+                                    ip -= 3;
+                                    NANOCLR_SET_AND_LEAVE(CLR_E_RESCHEDULE);
+                                }
+
+                                NANOCLR_CHECK_HRESULT(hr);
+                            }
+                        }
+
                         // access static field of a generic instance
                         // Pass both TypeSpec context (for VAR resolution) and MethodDef context (for MVAR resolution)
                         ptr = field.assembly->GetStaticFieldByFieldDef(
@@ -3489,19 +3685,6 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
 
                     if (ptr == nullptr)
                     {
-                        // Field not found - but if this is a generic type with a .cctor that's scheduled,
-                        // reschedule to allow the .cctor to complete field initialization
-                        if (field.genericType && NANOCLR_INDEX_IS_VALID(*field.genericType))
-                        {
-                            // Check if there's a pending .cctor for this generic type
-                            CLR_RT_TypeSpec_Instance tsInst;
-                            if (tsInst.InitializeFromIndex(*field.genericType))
-                            {
-                                NANOCLR_CHECK_HRESULT(HandleGenericCctorReschedule(tsInst, stack, &ip));
-                            }
-                        }
-
-                        // Not a pending .cctor case - this is a real error
                         NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                     }
 
@@ -3548,6 +3731,28 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
 
                     if (field.genericType && NANOCLR_INDEX_IS_VALID(*field.genericType))
                     {
+                        {
+                            CLR_RT_TypeSpec_Instance tsInst;
+                            if (tsInst.InitializeFromIndex(*field.genericType))
+                            {
+                                hr = EnsureGenericCctorCompleted(tsInst, stack, th);
+
+                                if (hr == CLR_E_PROCESS_EXCEPTION)
+                                {
+                                    ip -= 3;
+                                    WRITEBACK(stack, evalPos, ip, fDirty);
+                                    goto Execute_Restart;
+                                }
+                                else if (hr == CLR_E_RESCHEDULE)
+                                {
+                                    ip -= 3;
+                                    NANOCLR_SET_AND_LEAVE(CLR_E_RESCHEDULE);
+                                }
+
+                                NANOCLR_CHECK_HRESULT(hr);
+                            }
+                        }
+
                         // access static field of a generic instance
                         // Pass both TypeSpec context (for VAR resolution) and MethodDef context (for MVAR resolution)
                         ptr = field.assembly->GetStaticFieldByFieldDef(
@@ -3564,19 +3769,6 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
 
                     if (ptr == nullptr)
                     {
-                        // Field not found - but if this is a generic type with a .cctor that's scheduled,
-                        // reschedule to allow the .cctor to complete field initialization
-                        if (field.genericType && NANOCLR_INDEX_IS_VALID(*field.genericType))
-                        {
-                            // Check if there's a pending .cctor for this generic type
-                            CLR_RT_TypeSpec_Instance tsInst;
-                            if (tsInst.InitializeFromIndex(*field.genericType))
-                            {
-                                NANOCLR_CHECK_HRESULT(HandleGenericCctorReschedule(tsInst, stack, &ip));
-                            }
-                        }
-
-                        // Not a pending .cctor case - this is a real error
                         NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
                     }
 

--- a/src/CLR/Core/Interpreter.cpp
+++ b/src/CLR/Core/Interpreter.cpp
@@ -1101,6 +1101,8 @@ static HRESULT EnsureGenericCctorCompleted(
     CLR_RT_MethodDef_Instance cctorInst{};
     if (!cctorInst.InitializeFromIndex(cctorIndex))
     {
+        record->m_flags &=
+            ~(CLR_RT_GenericCctorExecutionRecord::c_Scheduled | CLR_RT_GenericCctorExecutionRecord::c_Executed);
         return CLR_E_WRONG_TYPE;
     }
 
@@ -1114,6 +1116,8 @@ static HRESULT EnsureGenericCctorCompleted(
 
     if (FAILED(hr))
     {
+        record->m_flags &=
+            ~(CLR_RT_GenericCctorExecutionRecord::c_Scheduled | CLR_RT_GenericCctorExecutionRecord::c_Executed);
         return hr;
     }
 
@@ -3066,14 +3070,13 @@ HRESULT CLR_RT_Thread::Execute_IL(CLR_RT_StackFrame &stackArg)
                     {
                         const CLR_RT_TypeSpec_Index *tsForCctor = nullptr;
 
-                        if (calleeInst.genericType != nullptr && NANOCLR_INDEX_IS_VALID(*calleeInst.genericType))
-                        {
-                            tsForCctor = calleeInst.genericType;
-                        }
-                        else if (stack->m_call.genericType != nullptr &&
-                                 NANOCLR_INDEX_IS_VALID(*stack->m_call.genericType))
+                        if (stack->m_call.genericType != nullptr && NANOCLR_INDEX_IS_VALID(*stack->m_call.genericType))
                         {
                             tsForCctor = stack->m_call.genericType;
+                        }
+                        else if (calleeInst.genericType != nullptr && NANOCLR_INDEX_IS_VALID(*calleeInst.genericType))
+                        {
+                            tsForCctor = calleeInst.genericType;
                         }
 
                         if (tsForCctor != nullptr)


### PR DESCRIPTION
## Description
- Add EnsureGenericCctorCompleted() to force a closed generic type .cctor to run before its first use.
- Gate CEE_NEWOBJ, static CEE_CALL, CEE_LDSFLD, CEE_LDSFLDA, and CEE_STSFLD on the new check, removed the old post-access reschedule-on-null fallback.
- Extend the gate to open declaring TypeSpecs (e.g. SZGenericArrayEnumerator<!!0>) that resolve to a closed instantiation via the caller's method generic context.
- Update docs with the generic .cctor lifecycle and call contract.

## Motivation and Context
- Resolves nanoFramework/Home#1821
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests in System.Collections.
- [tested against nanoframework/CoreLibrary#245].

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
