### PR TITLE
Fix resolving VAR

### DIFF
--- a/src/CLR/Core/CLAUDE.md
+++ b/src/CLR/Core/CLAUDE.md
@@ -318,6 +318,72 @@ Field access on a generic type is also entangled with `.cctor` scheduling
 current thread and the triggering opcode retries after the `.cctor`
 returns.
 
+### Storage layout
+
+A static field declared on an open generic TypeDef has **two** heap-block
+slots:
+
+- **Assembly-wide slot** (`assembly->staticFields`), reserved by
+  `ResolveLink` for every static FieldDef regardless of whether the
+  declaring type is generic. For generic-declared fields this slot is
+  **dead storage** — `GetStaticFieldByFieldDef` returns `nullptr` for a
+  generic access and does *not* fall through to it. But the GC still
+  walks the whole assembly-static array (`GarbageCollector.cpp`
+  `Assembly_Mark`, `TypeSystem.cpp` `Heap_Relocate`), so the block must
+  be validly typed. `ResolveAllocateStaticFields` (`TypeSystem.cpp`)
+  initializes these with `allowUnresolvedVarFallback = true` — a bare
+  `static T` field (`DATATYPE_VAR` at slot 0) becomes a null OBJECT
+  block, the same shape as a `static T[]` field. Without the fallback,
+  the VAR would abort `ClrStartup` at `Execution.cpp` line 2134.
+
+- **Per-instantiation slot** (`crossReferenceTypeSpec[..].genericStaticFields`),
+  the live storage returned by `GetStaticFieldByFieldDef` for the
+  matching closed TypeSpec. Allocated by
+  `ResolveAllocateGenericTypeStaticFields` at startup (for closed
+  TypeSpec rows in metadata) and by `AllocateGenericStaticFieldsOnDemand`
+  at runtime (for instantiations reached only through VAR/MVAR binding —
+  same population gap the demand gate in §10 handles for `.cctor`s).
+  Both call `InitializeReference` with the **closed TypeSpec instance**,
+  so a bare-VAR field like `static T DefaultValue` in
+  `Foo<int>` is stamped `I4` and in `Foo<string>` is stamped OBJECT.
+  Passing no instance here would leave every VAR field wrongly typed as
+  the OBJECT block that `ExtractHeapBlocksForObjects` produced.
+
+### KNOWN LIMITATION — nested generic construction (deferred)
+
+A generic type whose `.cctor` constructs a **different** generic type
+parameterized by the holder's own type parameter is not yet supported.
+Canonical shape:
+
+```csharp
+static class Holder<T> {
+    static readonly Box<T> Field = new Box<T>();   // Box<!0> — open target
+}
+```
+
+`Holder<int>`'s `.cctor` emits `newobj Box<!0>::.ctor()` where `!0` is
+`Holder`'s `T`. `CEE_NEWOBJ` (`Interpreter.cpp`, §7) only knows how to
+prefer the caller's closed TypeSpec when caller and callee share a
+**typedef** (the `List<int>`-builds-`List<int>` case). Here the typedefs
+differ (`Holder` vs `Box`), so the pushed `Box::.ctor` frame inherits the
+**open** `Box<T>` as its `genericType`. Any `new T[]` / VAR use inside that
+ctor then fails to resolve `T`, the `.cctor` aborts before its `stsfld`,
+and the per-instantiation field stays null. Symptom: `NullReferenceException`
+on first use of the static field, even though the field slot was allocated.
+
+The demand gate (§10) and the bare-VAR storage fix above are **not** the
+problem — the `.cctor` is scheduled correctly; it dies inside its own body.
+
+A proper fix must resolve the callee's open type argument (`Box<!0>`) to the
+concrete closed form (`Box<int>`) via the caller's closed `genericType`, and
+flow that closed instantiation into **both** the `NewObject` object tag and
+the pushed ctor frame's `genericType` (so single-VAR cases can also lean on
+the `arrayElementType` chain in §5/§8). You cannot rely on a matching closed
+TypeSpec row already existing in metadata — it only exists when some other
+non-generic site happens to use the same closed instantiation. Repro:
+`Generic_StaticField_GenericHolder` in `NFUnitTestClasses/UnitTestGenericStaticTests.cs`
+(currently commented out with a pointer here).
+
 ---
 
 ## 10. Generic `.cctor` lifecycle

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -5852,7 +5852,11 @@ HRESULT CLR_RT_Assembly::ResolveAllocateStaticFields(CLR_RT_HeapBlock *pStaticFi
         {
             CLR_RT_FieldDef_CrossReference &res = crossReferenceFieldDef[i];
 
-            NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.InitializeReference(pStaticFields[res.offset], fd, this));
+            // Static fields declared on an open generic TypeDef live per-instantiation;
+            // this assembly-wide slot is dead storage. Allow VAR fallback so the slot
+            // is stamped as a null OBJECT rather than aborting startup.
+            NANOCLR_CHECK_HRESULT(
+                g_CLR_RT_ExecutionEngine.InitializeReference(pStaticFields[res.offset], fd, this, nullptr, true));
         }
     }
 
@@ -6013,9 +6017,11 @@ HRESULT CLR_RT_Assembly::ResolveAllocateGenericTypeStaticFields()
             CLR_INDEX fieldIndex = ownerTd->firstStaticField + i;
             fieldDefs[i].Set(ownerAsm->assemblyIndex, fieldIndex);
 
-            // Initialize the storage using the field definition
+            // Initialize the storage using the field definition, resolving VAR against
+            // the closed TypeSpec so bare-VAR fields get the concrete type argument.
             const CLR_RECORD_FIELDDEF *pFd = ownerAsm->GetFieldDef(fieldIndex);
-            g_CLR_RT_ExecutionEngine.InitializeReference(fields[i], pFd, ownerAsm);
+            NANOCLR_CHECK_HRESULT(
+                g_CLR_RT_ExecutionEngine.InitializeReference(fields[i], pFd, ownerAsm, &genericTypeInstance));
         }
 
         // Link this assembly's cross-reference to the global registry entry
@@ -6289,7 +6295,8 @@ HRESULT CLR_RT_Assembly::AllocateGenericStaticFieldsOnDemand(
         }
 #endif
 
-        g_CLR_RT_ExecutionEngine.InitializeReference(fields[i], pFd, ownerAsm);
+        // Resolve VAR against the closed TypeSpec so bare-VAR fields get the concrete type argument.
+        NANOCLR_CHECK_HRESULT(g_CLR_RT_ExecutionEngine.InitializeReference(fields[i], pFd, ownerAsm, &tsInstance));
     }
 
     // Link this assembly's cross-reference to the global registry entry

--- a/src/CLR/Core/TypeSystem.cpp
+++ b/src/CLR/Core/TypeSystem.cpp
@@ -5687,10 +5687,7 @@ struct MethodIndexLookup
 };
 
 static const MethodIndexLookup c_MethodIndexLookup[] = {
-#define MIL(nm, type, method)                                                                                          \
-    {                                                                                                                  \
-        nm, &g_CLR_RT_WellKnownTypes.type, &g_CLR_RT_WellKnownMethods.method                                           \
-    }
+#define MIL(nm, type, method) {nm, &g_CLR_RT_WellKnownTypes.type, &g_CLR_RT_WellKnownMethods.method}
 
     // clang-format off
 


### PR DESCRIPTION
## Description
- Improvements in resolving and allocating static fields with open types (VAR!).

## Motivation and Context
- Found when adding new unit tests to cover generic type resolution.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#245].

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
