### PR TITLE
Sync SerialPort managed defaults to native and fix RX event detection

### DIFF
--- a/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -247,8 +247,6 @@ static void RxChar(UARTDriver *uartp, uint16_t c)
     // push char to the ring buffer
     // under heavy RX this can fail when full, in which case the new byte is dropped.
     // keep processing minimal in ISR path to avoid making the overload worse.
-    uint32_t previousLength = palUart->RxRingBuffer.Length();
-
     if (palUart->RxRingBuffer.Push((uint8_t)c) != 0)
     {
         // is there a read operation going on?
@@ -266,16 +264,16 @@ static void RxChar(UARTDriver *uartp, uint16_t c)
                 Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
             }
         }
-        else if (palUart->NewLineChar > 0 && c == palUart->NewLineChar)
-        {
-            // fire event for new line char found
-            Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
-        }
         else
         {
-            // no read operation ongoing, so fire an event, if the available bytes are above the threshold
-            if ((palUart->RxRingBuffer.Length() >= palUart->ReceivedBytesThreshold) &&
-                (previousLength < palUart->ReceivedBytesThreshold))
+            // no synchronous read pending: wake up a blocked ReadLine(), if the new line char was received
+            if (palUart->NewLineChar > 0 && c == palUart->NewLineChar)
+            {
+                Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
+            }
+
+            // fire an event for DataReceived, if the available bytes are at/above the threshold
+            if (palUart->RxRingBuffer.Length() >= palUart->ReceivedBytesThreshold)
             {
                 // Post a managed event with the port index and event code (check if there is a watch
                 // char in the buffer or just any char)
@@ -672,9 +670,6 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
         NANOCLR_CHECK_HRESULT(
             g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeoutTicks, Event_SerialPortIn, eventResult));
 
-        // clear the new line watch char
-        palUart->NewLineChar = 0;
-
         if (eventResult)
         {
             GLOBAL_LOCK();
@@ -915,6 +910,8 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     NF_PAL_UART *palUart;
     int32_t bufferSize;
     uint8_t watchChar;
+    int32_t receivedBytesThreshold;
+    const char *newLine;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock *pThis = stack.This();
@@ -1018,6 +1015,23 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     if (watchChar != 0)
     {
         palUart->WatchChar = watchChar;
+    }
+
+    // get received bytes threshold
+    // managed setter guarantees > 0 once explicitly set; a native value of 0 only happens if it was never set
+    receivedBytesThreshold = pThis[FIELD___receivedBytesThreshold].NumericByRef().s4;
+    palUart->ReceivedBytesThreshold = (receivedBytesThreshold > 0) ? (uint32_t)receivedBytesThreshold : 1;
+
+    // get "new line" and cache its last character, mirroring WatchChar
+    newLine = pThis[FIELD___newLine].RecoverString();
+    if (newLine != NULL)
+    {
+        uint32_t newLineLength = hal_strlen_s(newLine);
+
+        if (newLineLength > 0)
+        {
+            palUart->NewLineChar = newLine[newLineLength - 1];
+        }
     }
 
     // call the configure

--- a/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_target.h
+++ b/targets/ChibiOS/_nanoCLR/System.IO.Ports/sys_io_ser_native_target.h
@@ -124,7 +124,6 @@ void ConfigPins_UART8();
         Uart##num##_PAL.RxBytesToRead = 0;                                                                             \
         Uart##num##_PAL.WatchChar = 0;                                                                                 \
         Uart##num##_PAL.NewLineChar = 0;                                                                               \
-        Uart##num##_PAL.ReceivedBytesThreshold = 1;                                                                    \
         Uart##num##_PAL.SignalLevelsInverted = false;                                                                  \
     }
 

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -211,31 +211,34 @@ void uart_event_task_sys(void *pvParameters)
                                 Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
                             }
                         }
-                        else if (palUart->NewLineChar > 0)
-                        {
-                            // try to find the new line char we're waiting for
-                            do
-                            {
-                                if (buffer[readCount - 1] == palUart->NewLineChar)
-                                {
-                                    // fire event for new line char found
-                                    Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
-
-                                    // done here
-                                    break;
-                                }
-                            } while (--readCount >= 0);
-                        }
                         else
                         {
-                            // no read operation ongoing, so fire an event, if the available bytes are above the
-                            // threshold
+                            // no synchronous read pending: wake up a blocked ReadLine(), if the new line char
+                            // was received in this chunk
+                            if (palUart->NewLineChar > 0)
+                            {
+                                int32_t newLineSearchIndex = readCount;
+
+                                do
+                                {
+                                    if (buffer[newLineSearchIndex - 1] == palUart->NewLineChar)
+                                    {
+                                        // fire event for new line char found
+                                        Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
+
+                                        // done here
+                                        break;
+                                    }
+                                } while (--newLineSearchIndex >= 0);
+                            }
+
+                            // fire an event for DataReceived, if the available bytes are at/above the threshold
                             if (palUart->RxRingBuffer.Length() >= palUart->ReceivedBytesThreshold)
                             {
-                                // post a managed event with the port index and event code (check if there is a watch
-                                // char in the buffer or just any char)
-                                // TODO: check if callbacks are registered so this is called only if there is anyone
-                                // listening otherwise don't bother
+                                // post a managed event with the port index and event code (check if there is a
+                                // watch char in the buffer or just any char)
+                                // TODO: check if callbacks are registered so this is called only if there is
+                                // anyone listening otherwise don't bother
                                 PostManagedEvent(
                                     EVENT_SERIAL,
                                     0,
@@ -665,9 +668,6 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
         NANOCLR_CHECK_HRESULT(
             g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeoutTicks, Event_SerialPortIn, eventResult));
 
-        // clear the new line watch char
-        palUart->NewLineChar = 0;
-
         if (eventResult)
         {
             GLOBAL_LOCK();
@@ -880,6 +880,8 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     esp_err_t esp_err;
     int32_t bufferSize;
     uint8_t watchChar;
+    int32_t receivedBytesThreshold;
+    const char *newLine;
 
     NF_PAL_UART *palUart;
 
@@ -940,7 +942,6 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     palUart->UartNum = uart_num;
     palUart->TxOngoingCount = 0;
     palUart->RxBytesToRead = 0;
-    palUart->NewLineChar = 0;
 
     // Install driver
     esp_err = uart_driver_install(
@@ -971,6 +972,24 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
         uart_enable_pattern_det_baud_intr(uart_num, watchChar, 1, 9, 0, 00);
         // Reset the pattern queue length to record at most 10 pattern positions.
         uart_pattern_queue_reset(uart_num, 10);
+    }
+
+    // get received bytes threshold
+    // managed setter guarantees > 0 once explicitly set; a native value of 0 only happens if it was never set
+    receivedBytesThreshold = pThis[FIELD___receivedBytesThreshold].NumericByRef().s4;
+    palUart->ReceivedBytesThreshold = (receivedBytesThreshold > 0) ? (uint32_t)receivedBytesThreshold : 1;
+
+    // get "new line" and cache its last character, mirroring WatchChar
+    palUart->NewLineChar = 0;
+    newLine = pThis[FIELD___newLine].RecoverString();
+    if (newLine != NULL)
+    {
+        uint32_t newLineLength = hal_strlen_s(newLine);
+
+        if (newLineLength > 0)
+        {
+            palUart->NewLineChar = newLine[newLineLength - 1];
+        }
     }
 
     // Create a task to handle UART event from ISR

--- a/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ESP32/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -215,7 +215,7 @@ void uart_event_task_sys(void *pvParameters)
                         {
                             // no synchronous read pending: wake up a blocked ReadLine(), if the new line char
                             // was received in this chunk
-                            if (palUart->NewLineChar > 0)
+                            if (palUart->NewLineChar > 0 && readCount > 0)
                             {
                                 int32_t newLineSearchIndex = readCount;
 

--- a/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/TI_SimpleLink/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -163,19 +163,19 @@ void SerialRxTask(UArg a0, UArg a1)
                     Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
                 }
             }
-            else if (palUart->NewLineChar > 0 && input == palUart->NewLineChar)
-            {
-                // fire event for new line char found
-                Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
-            }
             else
             {
-                // no read operation ongoing, so fire an event, if the available bytes are above the
-                // threshold
+                // no synchronous read pending: wake up a blocked ReadLine(), if the new line char was received
+                if (palUart->NewLineChar > 0 && input == palUart->NewLineChar)
+                {
+                    Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
+                }
+
+                // fire an event for DataReceived, if the available bytes are at/above the threshold
                 if (palUart->RxRingBuffer.Length() >= palUart->ReceivedBytesThreshold)
                 {
-                    // post a managed event with the port index and event code (check if this is the watch char or just
-                    // another another)
+                    // post a managed event with the port index and event code (check if this is the watch char or
+                    // just another)
                     PostManagedEvent(
                         EVENT_SERIAL,
                         0,
@@ -488,7 +488,7 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
     {
         // check if there is a full line available to read
         GLOBAL_LOCK();
-        newLineFound = GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line;
+        newLineFound = GetLineFromRxBuffer(pThis, &(palUart->RxRingBuffer), line);
         GLOBAL_UNLOCK();
 
         if (newLineFound)
@@ -523,9 +523,6 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
         // wait for event
         NANOCLR_CHECK_HRESULT(
             g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeoutTicks, Event_SerialPortIn, eventResult));
-
-        // clear the new line watch char
-        palUart->NewLineChar = 0;
 
         if (eventResult)
         {
@@ -730,6 +727,8 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
         uint8_t uartNum;
         int32_t bufferSize;
         uint8_t watchChar;
+        int32_t receivedBytesThreshold;
+        const char *newLine;
 
         // get a pointer to the managed object instance and check that it's not NULL
         CLR_RT_HeapBlock *pThis = stack.This();
@@ -782,8 +781,26 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
         {
             palUart->WatchChar = watchChar;
         }
-        // all the rest
+
+        // get received bytes threshold
+        // managed setter guarantees > 0 once explicitly set; a native value of 0 only happens if it was never set
+        receivedBytesThreshold = pThis[FIELD___receivedBytesThreshold].NumericByRef().s4;
+        palUart->ReceivedBytesThreshold = (receivedBytesThreshold > 0) ? (uint32_t)receivedBytesThreshold : 1;
+
+        // get "new line" and cache its last character, mirroring WatchChar
         palUart->NewLineChar = 0;
+        newLine = pThis[FIELD___newLine].RecoverString();
+        if (newLine != NULL)
+        {
+            uint32_t newLineLength = hal_strlen_s(newLine);
+
+            if (newLineLength > 0)
+            {
+                palUart->NewLineChar = newLine[newLineLength - 1];
+            }
+        }
+
+        // all the rest
         palUart->RxBytesToRead = 0;
         palUart->TxOngoingCount = 0;
     }

--- a/targets/ThreadX/ST/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ThreadX/ST/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -233,20 +233,21 @@ static void RxChar(UARTDriver *uartp, uint16_t c)
             Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
         }
     }
-    else if (palUart->NewLineChar > 0 && c == palUart->NewLineChar)
-    {
-        // fire event for new line char found
-        Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
-    }
     else
     {
-        // no read operation ongoing, so fire an event, if the available bytes are above the threshold
+        // no synchronous read pending: wake up a blocked ReadLine(), if the new line char was received
+        if (palUart->NewLineChar > 0 && c == palUart->NewLineChar)
+        {
+            Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
+        }
+
+        // fire an event for DataReceived, if the available bytes are at/above the threshold
         if (palUart->RxRingBuffer.Length() >= palUart->ReceivedBytesThreshold)
         {
             // Post a managed event with the port index and event code (check if there is a watch
             // char in the buffer or just any char)
-            // FIXME: check if callbacks are registered so this is called only if there is anyone listening otherwise
-            // don't bother.
+            // FIXME: check if callbacks are registered so this is called only if there is anyone listening
+            // otherwise don't bother.
             // TODO: For that to happen ChibiOS callback has to accept arg which we would passing the GpioPin
             // Notes: CLR_RT_HeapBlock (Gpio handler) See: http://www.chibios.com/forum/viewtopic.php?f=36&t=4798
             PostManagedEvent(
@@ -637,9 +638,6 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
         NANOCLR_CHECK_HRESULT(
             g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeoutTicks, Event_SerialPortIn, eventResult));
 
-        // clear the new line watch char
-        palUart->NewLineChar = 0;
-
         if (eventResult)
         {
             GLOBAL_LOCK();
@@ -880,6 +878,8 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     NF_PAL_UART *palUart;
     int32_t bufferSize;
     uint8_t watchChar;
+    int32_t receivedBytesThreshold;
+    const char *newLine;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock *pThis = stack.This();
@@ -975,6 +975,23 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     if (watchChar != 0)
     {
         palUart->WatchChar = watchChar;
+    }
+
+    // get received bytes threshold
+    // managed setter guarantees > 0 once explicitly set; a native value of 0 only happens if it was never set
+    receivedBytesThreshold = pThis[FIELD___receivedBytesThreshold].NumericByRef().s4;
+    palUart->ReceivedBytesThreshold = (receivedBytesThreshold > 0) ? (uint32_t)receivedBytesThreshold : 1;
+
+    // get "new line" and cache its last character, mirroring WatchChar
+    newLine = pThis[FIELD___newLine].RecoverString();
+    if (newLine != NULL)
+    {
+        uint32_t newLineLength = hal_strlen_s(newLine);
+
+        if (newLineLength > 0)
+        {
+            palUart->NewLineChar = newLine[newLineLength - 1];
+        }
     }
 
     // call the configure

--- a/targets/ThreadX/SiliconLabs/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ThreadX/SiliconLabs/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -773,6 +773,9 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     palUart->ReceivedBytesThreshold = (receivedBytesThreshold > 0) ? (uint32_t)receivedBytesThreshold : 1;
 
     // get "new line" and cache its last character, mirroring WatchChar
+    // not every port's init path resets NewLineChar (only USART1 does, via InitConfig_USART1), so clear it here
+    // first to avoid leaking a stale value from a previous Open() when the managed newLine is null or empty
+    palUart->NewLineChar = 0;
     newLine = pThis[FIELD___newLine].RecoverString();
     if (newLine != NULL)
     {

--- a/targets/ThreadX/SiliconLabs/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
+++ b/targets/ThreadX/SiliconLabs/_nanoCLR/System.IO.Ports/sys_io_ser_native_System_IO_Ports_SerialPort.cpp
@@ -124,19 +124,21 @@ static void UsartRxHandler(uint8_t index)
             Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
         }
     }
-    else if (palUart->NewLineChar > 0 && newChar == palUart->NewLineChar)
-    {
-        // fire event for new line char found
-        Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
-    }
     else
     {
-        // no read operation ongoing, so fire an event, if the available bytes are above the threshold
+        // no synchronous read pending: wake up a blocked ReadLine(), if the new line char was received
+        if (palUart->NewLineChar > 0 && newChar == palUart->NewLineChar)
+        {
+            Events_Set(SYSTEM_EVENT_FLAG_COM_IN);
+        }
+
+        // fire an event for DataReceived, if the available bytes are at/above the threshold
         if (palUart->RxRingBuffer.Length() >= palUart->ReceivedBytesThreshold)
         {
-            // post a managed event with the port index and event code (check if this is the watch char or just another
-            // char)
-            // TODO: check if callbacks are registered so this is called only if there is anyone listening otherwise
+            // post a managed event with the port index and event code (check if this is the watch char or just
+            // another char)
+            // TODO: check if callbacks are registered so this is called only if there is anyone listening
+            // otherwise
             PostManagedEvent(
                 EVENT_SERIAL,
                 0,
@@ -472,9 +474,6 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::ReadLine___STRING(
         NANOCLR_CHECK_HRESULT(
             g_CLR_RT_ExecutionEngine.WaitEvents(stack.m_owningThread, *timeoutTicks, Event_SerialPortIn, eventResult));
 
-        // clear the new line watch char
-        palUart->NewLineChar = 0;
-
         if (eventResult)
         {
             // disable interrupt to protect access to the Rx buffer
@@ -695,6 +694,8 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     NF_PAL_UART *palUart;
     int32_t bufferSize;
     uint8_t watchChar;
+    int32_t receivedBytesThreshold;
+    const char *newLine;
 
     // get a pointer to the managed object instance and check that it's not NULL
     CLR_RT_HeapBlock *pThis = stack.This();
@@ -764,6 +765,23 @@ HRESULT Library_sys_io_ser_native_System_IO_Ports_SerialPort::NativeInit___VOID(
     if (watchChar != 0)
     {
         palUart->WatchChar = watchChar;
+    }
+
+    // get received bytes threshold
+    // managed setter guarantees > 0 once explicitly set; a native value of 0 only happens if it was never set
+    receivedBytesThreshold = pThis[FIELD___receivedBytesThreshold].NumericByRef().s4;
+    palUart->ReceivedBytesThreshold = (receivedBytesThreshold > 0) ? (uint32_t)receivedBytesThreshold : 1;
+
+    // get "new line" and cache its last character, mirroring WatchChar
+    newLine = pThis[FIELD___newLine].RecoverString();
+    if (newLine != NULL)
+    {
+        uint32_t newLineLength = hal_strlen_s(newLine);
+
+        if (newLineLength > 0)
+        {
+            palUart->NewLineChar = newLine[newLineLength - 1];
+        }
     }
 
     // call the configure


### PR DESCRIPTION
## Description
- Sync ReceivedBytesThreshold and NewLine from managed fields in NativeInit___VOID.
- Remove the now redundant hardcoded ReceivedBytesThreshold = 1 from RP2040/RP2350 UART_INIT macro.
- Stop clearing NewLineChar back to 0 after each ReadLine() wait.
- Split the newline-wake and threshold-notify checks in the RX handlers, so a newline byte don't suppress the DataReceived event.
- Apply the fix consistently across ChibiOS, TI_SimpleLink, ThreadX/ST, ESP32 and ThreadX/SiliconLabs (FreeRTOS/NXP intentionally excluded, to be addressed separately).
- Fix a pre-existing missing closing parenthesis in TI_SimpleLink ReadLine().

## Motivation and Context
- ReceivedBytesThreshold defaulted to 0 in every target except RP2040/RP2350 (Pico), cause it was never synced from the managed field on Open().
- At 0, the edge-detection added in 6aa1c0c9178b3d8d4efc75656c35e6bfeba0ace7 (previousLength < threshold) can never be true (unsigned arithmetic), so DataReceived never fires.
- Managed setter reject threshold <= 0, so a native 0 only happens when it was never explicit set - a real, reachable default, not an edge case.
- NewLineChar had the same gap: only populated transiently during ReadLine(), cleared right after - not available for the rest of the time.
- We tried at first to keep an edge-detection approach (with a persistent "already posted" flag) to also cover a mode-switch case, but on real hardware it turns out to suppress DataReceived permanently once the buffer stops dropping bellow the threshold. So we dropped the edge-detection and went back to firing on every byte while above threshold, same as most of the other platforms was already doing.
- The naive, permanent NewLineChar sync would've caused a new regression too: newline bytes would've suppress DataReceived whenever no ReadLine() is pending, that's why the checks got splitted.
- The same threshold-0 exposure existed in the other platform copies of this driver - the fix needed to be ported everywhere, not only in ChibiOS.

Note: FreeRTOS/NXP is excluded: no threshold/WatchChar handling exist there at all; is a bigger effort, for a separate follow-up.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Runnig serial comm test app from samples on STM32 board.

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
