### PR TITLE
Rework lock item in HeapBlock

### DIFF
--- a/src/CLR/Core/CLAUDE.md
+++ b/src/CLR/Core/CLAUDE.md
@@ -27,7 +27,10 @@ the rationale is in here:
   `SpawnStaticConstructor`, `ResolveGenericTypeParameter`,
   `InitializeLocals`.
 - `CLR_RT_HeapBlock.cpp` — `SetGenericInstanceType`, `TypeDescriptorsMatch`,
-  the `CLASS → GENERICINST` promotion path.
+  the `CLASS → GENERICINST` promotion path, `Relocate_Cls`.
+- `CLR_RT_HeapBlock_Lock.cpp` and `FindLockObject`/`LockObject` in
+  `Execution.cpp`, plus `HasObjectLockSlot`/`ObjectLock`/`SetObjectLock` in
+  `nanoCLR_Runtime__HeapBlock.h` (§13).
 
 Generics in this CLR are an active preview. Expect gaps. When something
 doesn't work, the first question is almost always *which generic context is
@@ -488,7 +491,102 @@ they're not generics-related.
 
 ---
 
-## 13. Build + debug workflow
+## 13. Object header aliasing - monitor lock vs generic TypeSpec
+
+`CLR_RT_HeapBlock::m_data` is a union, and two of its members overlap
+exactly:
+
+```
+m_data byte offset:      0    1    2    3  |  4    5    6    7
+                       --------------------+--------------------
+objectHeader           [    cls (4B)      ] | [   lock (ptr)   ]
+reflection             [kind(2)][levels(2)] | [ data.typeSpec  ]
+```
+
+`objectHeader.lock` and `reflection.data.typeSpec` are the *same word*.
+The pointer is not padded up to an 8-byte boundary because the whole
+runtime header compiles inside `#pragma pack(push, ..., 4)`
+(`nanoCLR_Runtime.h`). On 32-bit targets the overlap is total; on Win64
+`typeSpec` is the low dword of the 8-byte `lock`, with the high dword left
+zero by `HB_InitializeToZero`.
+
+`SetGenericInstanceType` writes the closed TypeSpec into that word for
+every generic instance, immediately after `SetObjectCls` has set
+`lock = nullptr` (`NewObject`, §7). A generic instance keeps
+`DATATYPE_CLASS`/`DATATYPE_VALUETYPE`; genericness is carried only by the
+`HB_GenericInstance` flag. The flag and the aliased write are set under the
+same condition, so `IsAGenericInstance()` is exactly the predicate *"this
+header word holds a TypeSpec."*
+
+### Why it cannot simply be un-aliased
+
+On 32-bit targets `m_data` is exactly 8 bytes (`cls` + `lock`). A third
+word grows **every** heap block from 12 to 16 bytes — a third of the whole
+managed heap. The object header has two 32-bit slots and generics took the
+second one.
+
+### The rule
+
+**A generic instance has no header lock slot.** `HasObjectLockSlot()` is
+the single predicate for this; `ObjectLock()` returns `nullptr` and
+`SetObjectLock()` is a no-op for anything it rejects.
+
+Generic instances are located by the thread-list search in
+`CLR_RT_ExecutionEngine::FindLockObject`, which walks
+`m_threadsReady`/`m_threadsWaiting` matching `lock->m_resource` by
+reference identity. That is **not** a fallback invented for generics — it
+is already the only lookup for everything that hits `default:` in the old
+datatype switch: `lock(someString)`, `lock(someArray)`, and every
+`[MethodImpl(Synchronized)]` *static* method (which locks a
+`DATATYPE_REFLECTION` block built in `CLR_RT_StackFrame`). Generic
+instances simply joined that set.
+
+The invariant it depends on — every live lock reachable from
+`m_threadsReady`/`m_threadsWaiting` — is already enforced by the GC:
+`Thread_Mark` runs on exactly those two lists and is the only thing that
+marks `lock->m_resource`. A lock reachable only from `m_threadsZombie`
+would already have had its resource collected.
+
+Consequences elsewhere:
+- `Relocate_Cls` must not relocate that word for a generic instance. This
+  is hardening rather than a live bug — lock nodes carry `HB_Event`, hence
+  `HB_Unmovable`, so compaction never moves them and the relocation is a
+  no-op for real locks.
+- `Profiler` dumping `ObjectLock()` gets `nullptr`, same as an unlocked
+  object.
+- The GC reachability marker never touches the header word (it walks
+  `ptr + 1` onward), so there is nothing to change there.
+
+A `CT_ASSERT` next to the union members pins
+`offsetof(ObjectHeader, lock) == offsetof(CLR_RT_ReflectionDef_Index, data)`
+so a packing change breaks the build instead of the runtime.
+
+### Rejected alternatives
+
+- **A `HB_HasLock` flag bit plus displacing the TypeSpec into the lock
+  node.** Architecturally the right destination and what the desktop CLR
+  does, but `m_id.type.flags` is a `CLR_UINT8` with all eight bits
+  assigned. The header offers `HB_Signaled`/`HB_SignalAutoReset` as
+  reclaimable, but those are wanted for the C# `async`/`await` work, and
+  freeing them means reworking `CLR_RT_HeapBlock_WaitForObject`,
+  `ManualResetEvent`, `AutoResetEvent`, `WaitHandle` and `Thread.Join`.
+- **A tag bit in the TypeSpec encoding (`(data << 1) | 1`) plus
+  displacement.** Exact and spends no flag bit, but costs a bit of
+  assembly-index range and needs save/restore pairing that must be exact
+  across `CreateInstance`, `ChangeOwner`, `DestroyOwner`, thread teardown
+  and AppDomain unload — a silent-corruption failure mode in exchange for
+  a lookup win that is single-digit iterations on these devices.
+- **Discriminating by inspecting the value.** Every variant is a
+  heuristic. Reading the pointee's `DATATYPE_LOCK_HEAD` tag or
+  round-tripping through `lock->m_resource` both dereference a value that
+  may not be a pointer — on an MMU-less MCU that returns garbage instead
+  of faulting. Validating it as a TypeSpec via `InitializeFromIndex`
+  avoids the dereference but reduces to "is the top byte a loaded assembly
+  index?", which holds only by memory-map coincidence.
+
+---
+
+## 14. Build + debug workflow
 
 ### Build the netcore CLR DLL
 
@@ -551,7 +649,7 @@ need step-by-step visibility into opcode dispatch.
 
 ---
 
-## 14. Known failure-mode catalog
+## 15. Known failure-mode catalog
 
 When you see one of these symptoms, this is where to look first.
 
@@ -586,6 +684,19 @@ When you see one of these symptoms, this is where to look first.
   encode the same closed type but hash differently, or vice versa. See §10.
 - Alternatively, the resumption logic on `SpawnStaticConstructor` lost the
   TypeSpec index (`m_genericTypeSpec.data` zeroed prematurely).
+
+**Access violation in `CLR_RT_HeapBlock_Lock::IncrementOwnership`, `lock`
+argument is a small value like `0x01000002`.**
+- That is not a corrupt pointer, it is a `CLR_RT_TypeSpec_Index`
+  (`assembly << 24 | index`) being read out of the aliased header word.
+  Something handed a generic instance's header to the monitor code. See
+  §13.
+
+**Generic dispatch or `MemberwiseClone` breaks after a `lock` on the same
+instance.**
+- The mirror image: a lock pointer was stored over the instance's closed
+  TypeSpec. Check that the write went through `SetObjectLock` rather than
+  touching `m_data.objectHeader.lock` directly. See §13.
 
 **`Dictionary<TKey,TValue>` constructor from an `IDictionary<,>` crashes.**
 - Specific instance of the suffix-only / signature-matcher bug. The

--- a/src/CLR/Core/CLAUDE.md
+++ b/src/CLR/Core/CLAUDE.md
@@ -496,7 +496,7 @@ they're not generics-related.
 `CLR_RT_HeapBlock::m_data` is a union, and two of its members overlap
 exactly:
 
-```
+```text
 m_data byte offset:      0    1    2    3  |  4    5    6    7
                        --------------------+--------------------
 objectHeader           [    cls (4B)      ] | [   lock (ptr)   ]

--- a/src/CLR/Core/CLAUDE.md
+++ b/src/CLR/Core/CLAUDE.md
@@ -503,12 +503,29 @@ objectHeader           [    cls (4B)      ] | [   lock (ptr)   ]
 reflection             [kind(2)][levels(2)] | [ data.typeSpec  ]
 ```
 
-`objectHeader.lock` and `reflection.data.typeSpec` are the *same word*.
-The pointer is not padded up to an 8-byte boundary because the whole
-runtime header compiles inside `#pragma pack(push, ..., 4)`
-(`nanoCLR_Runtime.h`). On 32-bit targets the overlap is total; on Win64
-`typeSpec` is the low dword of the 8-byte `lock`, with the high dword left
-zero by `HB_InitializeToZero`.
+`reflection.data` is always at offset 4. Where `lock` lands depends on
+pointer size and packing, and follows the same three cases already spelled
+out by `CLR_RT_HeapBlock_Raw` at the top of the header:
+
+- **32-bit targets** (ARM/Xtensa/RISC-V) — pointer is 4 bytes, so `lock` is
+  at offset 4. The overlap is total.
+- **MSVC, including `_WIN64`** — the runtime headers compile inside
+  `#pragma pack(push, ..., 4)` (`nanoCLR_Runtime.h`), so the 8-byte pointer
+  is not padded up and still starts at offset 4. `typeSpec` is its low
+  dword; the high dword is left zero by `HB_InitializeToZero`, which is why
+  a stored TypeSpec reads back as a small value such as `0x0000000001000002`.
+- **`__LP64__`** (macOS/Linux, `targets/posix`) — that pack pragma is
+  `#if defined(_MSC_VER)` only, so the pointer aligns naturally to 8 and
+  `lock` sits at offset 8. **The two do not overlap here.**
+
+Two consequences. The bug does not reproduce on the 64-bit POSIX build, so
+do not use that target to verify a change in this area. And the `CT_ASSERT`
+pinning the overlap is guarded with `#if !defined(__LP64__)` — without the
+guard it fails the posix build, which is a real signal, not a nuisance.
+
+`HasObjectLockSlot()` is correct on all three: on LP64 it simply routes
+generic instances through the thread-list lookup they would not strictly
+need there.
 
 `SetGenericInstanceType` writes the closed TypeSpec into that word for
 every generic instance, immediately after `SetObjectCls` has set

--- a/src/CLR/Core/CLR_RT_HeapBlock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock.cpp
@@ -2752,7 +2752,12 @@ void CLR_RT_HeapBlock::Relocate_Obj()
 void CLR_RT_HeapBlock::Relocate_Cls()
 {
     NATIVE_PROFILE_CLR_CORE();
-    CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_data.objectHeader.lock);
+
+    // a generic instance keeps a TypeSpec in that word, not a pointer: see CLAUDE.md "Object header aliasing"
+    if (HasObjectLockSlot())
+    {
+        CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_data.objectHeader.lock);
+    }
 
     CLR_RT_GarbageCollector::Heap_Relocate(this + 1, DataSize() - 1);
 }

--- a/src/CLR/Core/CLR_RT_HeapBlock_Lock.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Lock.cpp
@@ -42,17 +42,8 @@ HRESULT CLR_RT_HeapBlock_Lock::CreateInstance(
 
         if (ptr)
         {
-            switch (ptr->DataType())
-            {
-                case DATATYPE_VALUETYPE:
-                case DATATYPE_CLASS:
-                    ptr->SetObjectLock(lock);
-                    break;
-
-                default:
-                    // the remaining data types aren't to be handled
-                    break;
-            }
+            // no-op for blocks without a header lock slot: see CLAUDE.md "Object header aliasing"
+            ptr->SetObjectLock(lock);
         }
     }
 
@@ -134,17 +125,8 @@ void CLR_RT_HeapBlock_Lock::ChangeOwner()
 
         if (ptr)
         {
-            switch (ptr->DataType())
-            {
-                case DATATYPE_VALUETYPE:
-                case DATATYPE_CLASS:
-                    ptr->SetObjectLock(nullptr);
-                    break;
-
-                default:
-                    // the remaining data types aren't to be handled
-                    break;
-            }
+            // no-op for blocks without a header lock slot: see CLAUDE.md "Object header aliasing"
+            ptr->SetObjectLock(nullptr);
         }
     }
 

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -3139,18 +3139,12 @@ CLR_RT_HeapBlock_Lock *CLR_RT_ExecutionEngine::FindLockObject(CLR_RT_HeapBlock &
     {
         CLR_RT_HeapBlock *ptr = object.Dereference();
 
-        if (ptr)
+        // for these the header slot is authoritative: nullptr means "not locked". Everything else
+        // (strings, arrays, generic instances) falls through to the thread list search below.
+        // See CLAUDE.md "Object header aliasing"
+        if (ptr && ptr->HasObjectLockSlot())
         {
-            switch (ptr->DataType())
-            {
-                case DATATYPE_VALUETYPE:
-                case DATATYPE_CLASS:
-                    return ptr->ObjectLock();
-
-                default:
-                    // the remaining data types aren't to be handled
-                    break;
-            }
+            return ptr->ObjectLock();
         }
     }
 

--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -749,10 +749,12 @@ struct CLR_RT_HeapBlock
 
         CLR_RT_ReflectionDef_Index reflection;
 
-        // this overlap is relied upon and must not change: see CLAUDE.md "Object header aliasing"
+        // same word except on LP64, where the pointer aligns to 8: see CLAUDE.md "Object header aliasing"
+#if !defined(__LP64__)
         CT_ASSERT_UNIQUE_NAME(
             offsetof(ObjectHeader, lock) == offsetof(CLR_RT_ReflectionDef_Index, data),
             objectHeaderLockAliasesReflectionData)
+#endif
 
         //--//
 

--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -749,6 +749,11 @@ struct CLR_RT_HeapBlock
 
         CLR_RT_ReflectionDef_Index reflection;
 
+        // this overlap is relied upon and must not change: see CLAUDE.md "Object header aliasing"
+        CT_ASSERT_UNIQUE_NAME(
+            offsetof(ObjectHeader, lock) == offsetof(CLR_RT_ReflectionDef_Index, data),
+            objectHeaderLockAliasesReflectionData)
+
         //--//
 
         struct BinaryBlob
@@ -1105,6 +1110,14 @@ struct CLR_RT_HeapBlock
         return ((DataFlags() & CLR_RT_HeapBlock::HB_GenericInstance) == CLR_RT_HeapBlock::HB_GenericInstance);
     }
 
+    // m_data.objectHeader.lock aliases m_data.reflection.data.typeSpec: see CLAUDE.md "Object header aliasing"
+    bool HasObjectLockSlot() const
+    {
+        const NanoCLRDataType dt = DataType();
+
+        return (dt == DATATYPE_CLASS || dt == DATATYPE_VALUETYPE) && !IsAGenericInstance();
+    }
+
     bool SameHeader(const CLR_RT_HeapBlock &right) const
     {
         return this->m_data.numeric.u8 == right.m_data.numeric.u8;
@@ -1195,11 +1208,14 @@ struct CLR_RT_HeapBlock
     }
     CLR_RT_HeapBlock_Lock *ObjectLock() const
     {
-        return m_data.objectHeader.lock;
+        return HasObjectLockSlot() ? m_data.objectHeader.lock : nullptr;
     }
     void SetObjectLock(CLR_RT_HeapBlock_Lock *lock)
     {
-        m_data.objectHeader.lock = lock;
+        if (HasObjectLockSlot())
+        {
+            m_data.objectHeader.lock = lock;
+        }
     }
 
     HRESULT SetObjectCls(const CLR_RT_TypeDef_Index &cls);


### PR DESCRIPTION
## Description
- Add new helper HasObjectLockSlot().
- Rework object lock and unlock to deal with generic types.
- Rework class relocation for locked generic HB.
- Add compiler guard to catch object header aliasing in the future.

## Motivation and Context
- Fixes nanoFramework/Home#1830

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#277]

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
