### PR TITLE
Fix SPI crash when SPI created

### DIFF
--- a/src/System.Device.Spi/sys_dev_spi_native.cpp
+++ b/src/System.Device.Spi/sys_dev_spi_native.cpp
@@ -52,6 +52,9 @@ static const CLR_RT_MethodHandler method_lookup[] =
     Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeInit___VOID,
     Library_sys_dev_spi_native_System_Device_Spi_SpiDevice::NativeOpenDevice___I4,
     nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
 };
 
 const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_System_Device_Spi =


### PR DESCRIPTION
## Description
When SpiDevice created it would seem to hang.
Internally this caused a panic which was caused by incomplete managed/native jump table.
 
## Motivation and Context
- Fixes nanoFramework/Home#1826

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested locally with supplied test


## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
