### PR TITLE
Fix HB array storing generic types

### DIFF
--- a/src/CLR/CorLib/corlib_native_System_ReadOnlySpan_1.cpp
+++ b/src/CLR/CorLib/corlib_native_System_ReadOnlySpan_1.cpp
@@ -65,12 +65,11 @@ HRESULT Library_corlib_native_System_ReadOnlySpan_1::_ctor___VOID__VOIDptr__I4(C
     }
 
     // check if T is a reference type or contains references
-    NANOCLR_CHECK_HRESULT(
-        RuntimeHelpers::CheckReferenceOrContainsReferences(
-            element.Class,
-            element.DataType,
-            &parser,
-            isRefContainsRefs));
+    NANOCLR_CHECK_HRESULT(RuntimeHelpers::CheckReferenceOrContainsReferences(
+        element.Class,
+        element.DataType,
+        &parser,
+        isRefContainsRefs));
 
     if (isRefContainsRefs)
     {

--- a/src/CLR/CorLib/corlib_native_System_ReadOnlySpan_1.cpp
+++ b/src/CLR/CorLib/corlib_native_System_ReadOnlySpan_1.cpp
@@ -96,8 +96,13 @@ HRESULT Library_corlib_native_System_ReadOnlySpan_1::_ctor___VOID__VOIDptr__I4(C
 
     {
         CLR_RT_HeapBlock &refArray = thisSpan[FIELD___array];
-        NANOCLR_CHECK_HRESULT(
-            CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(refArray, length, objectRawPointer, element.Class));
+        // this ReadOnlySpan wraps raw unmanaged memory, not a managed array - no owner to keep alive/relocate
+        NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(
+            refArray,
+            length,
+            objectRawPointer,
+            element.Class,
+            nullptr));
     }
 
     // set length
@@ -175,8 +180,13 @@ HRESULT Library_corlib_native_System_ReadOnlySpan_1::NativeReadOnlySpanConstruct
         uintptr_t ptrToStartElement = (uintptr_t)sourceArray->GetElement(start);
 
         CLR_RT_HeapBlock &refArray = thisSpan[FIELD___array];
-        NANOCLR_CHECK_HRESULT(
-            CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(refArray, length, ptrToStartElement, sourceType));
+        // keep sourceArray (which owns the wrapped storage) alive and tracked across GC/compaction
+        NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(
+            refArray,
+            length,
+            ptrToStartElement,
+            sourceType,
+            sourceArray));
     }
 
     // set length

--- a/src/CLR/CorLib/corlib_native_System_Span_1.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Span_1.cpp
@@ -64,12 +64,11 @@ HRESULT Library_corlib_native_System_Span_1::_ctor___VOID__VOIDptr__I4(CLR_RT_St
     }
 
     // check if T is a reference type or contains references
-    NANOCLR_CHECK_HRESULT(
-        RuntimeHelpers::CheckReferenceOrContainsReferences(
-            element.Class,
-            element.DataType,
-            &parser,
-            isRefContainsRefs));
+    NANOCLR_CHECK_HRESULT(RuntimeHelpers::CheckReferenceOrContainsReferences(
+        element.Class,
+        element.DataType,
+        &parser,
+        isRefContainsRefs));
 
     if (isRefContainsRefs)
     {

--- a/src/CLR/CorLib/corlib_native_System_Span_1.cpp
+++ b/src/CLR/CorLib/corlib_native_System_Span_1.cpp
@@ -95,8 +95,13 @@ HRESULT Library_corlib_native_System_Span_1::_ctor___VOID__VOIDptr__I4(CLR_RT_St
 
     {
         CLR_RT_HeapBlock &refArray = thisSpan[FIELD___array];
-        NANOCLR_CHECK_HRESULT(
-            CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(refArray, length, objectRawPointer, element.Class));
+        // this Span wraps raw unmanaged memory, not a managed array - no owner to keep alive/relocate
+        NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(
+            refArray,
+            length,
+            objectRawPointer,
+            element.Class,
+            nullptr));
     }
 
     // set length
@@ -172,8 +177,13 @@ HRESULT Library_corlib_native_System_Span_1::NativeSpanConstructor___VOID__SZARR
         uintptr_t ptrToStartElement = (uintptr_t)sourceArray->GetElement(start);
 
         CLR_RT_HeapBlock &refArray = thisSpan[FIELD___array];
-        NANOCLR_CHECK_HRESULT(
-            CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(refArray, length, ptrToStartElement, sourceType));
+        // keep sourceArray (which owns the wrapped storage) alive and tracked across GC/compaction
+        NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(
+            refArray,
+            length,
+            ptrToStartElement,
+            sourceType,
+            sourceArray));
     }
 
     // set length

--- a/src/CLR/Core/CLAUDE.md
+++ b/src/CLR/Core/CLAUDE.md
@@ -839,3 +839,78 @@ instance.**
   pass 2 of `FindVirtualMethodDef`. If `MatchSignatureForVirtualDispatch`
   mishandles the VAR↔GENERICINST drain (specifically for multi-argument
   generics like `KeyValuePair<,>`), this is the symptom.
+
+---
+
+## 16. `Span<T>`/`ReadOnlySpan<T>` storage-pointer arrays and GC
+
+Not generics-specific, but the same "storage array split/mis-relocated/
+swept" family as §9, so documented the same way: rationale here, source
+stays terse.
+
+**Background.** `Span<T>`'s native backing (`corlib_native_System_Span_1.cpp`,
+`corlib_native_System_ReadOnlySpan_1.cpp`) doesn't reuse the wrapped
+`T[]`'s `CLR_RT_HeapBlock_Array` directly — it allocates a second, small
+"shell" `CLR_RT_HeapBlock_Array` via `CreateInstanceWithStorage` whose
+`ReflectionData().kind == REFLECTION_STORAGE_PTR`. The shell has no
+element storage of its own; `GetFirstElement()` returns a raw
+`m_StoragePointer` address that points into the *original* array's
+element data (or, for the `Span(void*, int)` ctor, into unmanaged
+memory). This lets slicing/wrapping avoid copying.
+
+**The bug.** Originally the shell held nothing but that raw address —
+no `CLR_RT_HeapBlock` reference back to the array that actually owns the
+memory. Two independent failures followed from that:
+1. **Reachability.** `ComputeReachabilityGraphForMultipleBlocks`'s
+   `DATATYPE_SZARRAY` case only marks an array's *elements* reachable,
+   and only when `m_fReference` is set (never true for a shell, since
+   `Span<T>` rejects reference-containing `T`). Nothing marked the
+   *owning* array reachable through the shell, so a temporary like
+   `new Span<int>(new int[n])` had no live reference to the backing
+   `int[]` once the constructor returned — `--forcegc` would sweep it,
+   filling it with `SENTINEL_RECOVERED` (`0xDFDFDFDF`,
+   `CLR_RT_HeapCluster::RecoverFromGC` in `CLR_RT_HeapCluster.cpp`) while
+   the shell's raw pointer kept pointing at that now-dead memory. This is
+   the `CopyTo_WithLargeArray_ShouldCopyAllElements` failure signature:
+   `Actual:<-538976289>` is `0xDFDFDFDF` as `int32`.
+2. **Compaction.** Even had the owner survived sweep, `m_StoragePointer`
+   is a bare address with no type tag — `CLR_RT_HeapBlock_Array::Relocate()`
+   had no way to know it needed adjusting when the owner's element data
+   physically moved, so it would go stale across `--compactionaftergc`
+   too.
+
+Both require `--forcegc --compactionaftergc` together to reproduce
+reliably; either flag alone can miss it depending on allocation timing —
+about 1 run in 9–10 failed under both flags before the fix, which is why
+a single clean run proves nothing here (loop 15–20×, see §14).
+
+**The fix.** `CreateInstanceWithStorage` now takes an `owner` reference
+(the array actually backing the memory — `nullptr` for the unmanaged-
+memory ctor) and allocates one extra `sizeof(CLR_RT_HeapBlock)` of
+storage beyond the shell's header (`extraBytes` threaded through
+`CLR_RT_HeapBlock_Array::CreateInstance` → `CLR_RT_ExecutionEngine::
+ExtractHeapBlocksForArray`). That slot — `StorageOwner()`, aliasing the
+same `&this[1]` address a normal array would use for element 0, which is
+otherwise unused on a storage-pointer shell — holds a real
+`SetObjectReference` to the owner. `ComputeReachabilityGraphForMultipleBlocks`
+marks it explicitly for `IsStoragePointer()` arrays, so the owner is
+reachable transitively through the shell like any other object
+reference. `CLR_RT_HeapBlock_Array::Relocate()` relocates that reference
+via the normal `Heap_Relocate(CLR_RT_HeapBlock*, 1)` path, then relocates
+`m_StoragePointer` itself via the generic `Heap_Relocate(void**)` address-
+range lookup — safe because that call only rewrites the stored address
+value by table lookup, it never dereferences memory at the (possibly
+not-yet-moved) target, so ordering within the compaction pass doesn't
+matter. A shell built over a shell (e.g. `Span.Slice` of a `Span`) chains
+correctly with no special-casing: each shell only tracks its immediate
+`sourceArray`, and marking/relocation recurse through the chain via the
+same generic per-object dispatch.
+
+**If you see `SENTINEL_RECOVERED` (`0xDFDFDFDF`) or a stale value read
+through a `Span<T>`/`ReadOnlySpan<T>`:**
+- Confirm it reproduces only with `--forcegc` (sweep) or needs
+  `--compactionaftergc` too (relocation) — tells you which of the two
+  mechanisms above is implicated.
+- Check that the shell's `StorageOwner()` was actually set (i.e. the
+  constructor path went through the array-backed `CreateInstanceWithStorage`
+  call, not the raw-pointer one, which intentionally has no owner).

--- a/src/CLR/Core/CLR_RT_HeapBlock_Array.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Array.cpp
@@ -10,7 +10,8 @@
 HRESULT CLR_RT_HeapBlock_Array::CreateInstance(
     CLR_RT_HeapBlock &reference,
     CLR_UINT32 length,
-    const CLR_RT_ReflectionDef_Index &reflex)
+    const CLR_RT_ReflectionDef_Index &reflex,
+    CLR_UINT32 extraBytes)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
@@ -52,7 +53,8 @@ HRESULT CLR_RT_HeapBlock_Array::CreateInstance(
             NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
         }
 
-        pArray = (CLR_RT_HeapBlock_Array *)g_CLR_RT_ExecutionEngine.ExtractHeapBlocksForArray(inst, length, reflex);
+        pArray = (CLR_RT_HeapBlock_Array *)g_CLR_RT_ExecutionEngine
+                     .ExtractHeapBlocksForArray(inst, length, reflex, extraBytes);
         CHECK_ALLOCATION(pArray);
 
         reference.SetObjectReference(pArray);
@@ -91,7 +93,8 @@ HRESULT CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(
     CLR_RT_HeapBlock &reference,
     CLR_UINT32 length,
     const uintptr_t storageAddress,
-    const CLR_RT_TypeDef_Index &cls)
+    const CLR_RT_TypeDef_Index &cls,
+    const CLR_RT_HeapBlock *owner)
 {
     NATIVE_PROFILE_CLR_CORE();
     NANOCLR_HEADER();
@@ -103,8 +106,8 @@ HRESULT CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(
     reflex.levels = 1;
     reflex.data.type = cls;
 
-    // create an instance with ZERO length because there is no need to allocate storage
-    NANOCLR_CHECK_HRESULT(CreateInstance(reference, 0, reflex));
+    // ZERO length: elements live in someone else's storage. extraBytes reserves the StorageOwner() slot.
+    NANOCLR_CHECK_HRESULT(CreateInstance(reference, 0, reflex, sizeof(CLR_RT_HeapBlock)));
 
     thisArray = reference.DereferenceArray();
 
@@ -113,6 +116,9 @@ HRESULT CLR_RT_HeapBlock_Array::CreateInstanceWithStorage(
 
     // adjust the number of elements with the provided length
     thisArray->m_numOfElements = length;
+
+    // see CLAUDE.md §16
+    thisArray->StorageOwner()->SetObjectReference(owner);
 
     NANOCLR_NOCLEANUP();
 }
@@ -226,11 +232,23 @@ HRESULT CLR_RT_HeapBlock_Array::ClearElements(int index, int length)
 void CLR_RT_HeapBlock_Array::Relocate()
 {
     NATIVE_PROFILE_CLR_CORE();
-    //
-    // If the array is full of reference types, relocate each of them.
-    //
-    if (m_fReference)
+
+    if (IsStoragePointer())
     {
+        // no owner => unmanaged-memory Span, nothing to relocate. See CLAUDE.md §16.
+        CLR_RT_HeapBlock *owner = StorageOwner();
+
+        if (owner->Dereference() != nullptr)
+        {
+            CLR_RT_GarbageCollector::Heap_Relocate(owner, 1);
+            CLR_RT_GarbageCollector::Heap_Relocate((void **)&m_StoragePointer);
+        }
+    }
+    else if (m_fReference)
+    {
+        //
+        // If the array is full of reference types, relocate each of them.
+        //
         CLR_RT_GarbageCollector::Heap_Relocate((CLR_RT_HeapBlock *)GetFirstElement(), m_numOfElements);
     }
 }

--- a/src/CLR/Core/CLR_RT_HeapBlock_Array.cpp
+++ b/src/CLR/Core/CLR_RT_HeapBlock_Array.cpp
@@ -53,8 +53,8 @@ HRESULT CLR_RT_HeapBlock_Array::CreateInstance(
             NANOCLR_SET_AND_LEAVE(CLR_E_WRONG_TYPE);
         }
 
-        pArray = (CLR_RT_HeapBlock_Array *)g_CLR_RT_ExecutionEngine
-                     .ExtractHeapBlocksForArray(inst, length, reflex, extraBytes);
+        pArray = (CLR_RT_HeapBlock_Array *)
+                     g_CLR_RT_ExecutionEngine.ExtractHeapBlocksForArray(inst, length, reflex, extraBytes);
         CHECK_ALLOCATION(pArray);
 
         reference.SetObjectReference(pArray);

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -1710,13 +1710,14 @@ CLR_INT32 CLR_RT_ExecutionEngine::GetNextThreadId()
 CLR_RT_HeapBlock *CLR_RT_ExecutionEngine::ExtractHeapBlocksForArray(
     CLR_RT_TypeDef_Instance &inst,
     CLR_UINT32 length,
-    const CLR_RT_ReflectionDef_Index &reflex)
+    const CLR_RT_ReflectionDef_Index &reflex,
+    CLR_UINT32 extraBytes)
 {
     NATIVE_PROFILE_CLR_CORE();
     NanoCLRDataType dt = (NanoCLRDataType)inst.target->dataType;
     const CLR_RT_DataTypeLookup &dtl = c_CLR_RT_DataTypeLookup[dt];
 
-    CLR_UINT32 totLength = (CLR_UINT32)(sizeof(CLR_RT_HeapBlock_Array) + length * dtl.m_sizeInBytes);
+    CLR_UINT32 totLength = (CLR_UINT32)(sizeof(CLR_RT_HeapBlock_Array) + length * dtl.m_sizeInBytes + extraBytes);
     CLR_UINT32 lengthHB = CONVERTFROMSIZETOHEAPBLOCKS(totLength);
 
     if (lengthHB > CLR_RT_HeapBlock::HB_MaxSize)

--- a/src/CLR/Core/GarbageCollector_ComputeReachabilityGraph.cpp
+++ b/src/CLR/Core/GarbageCollector_ComputeReachabilityGraph.cpp
@@ -232,14 +232,19 @@ bool CLR_RT_GarbageCollector::ComputeReachabilityGraphForMultipleBlocks(CLR_RT_H
                         break;
 
                     case DATATYPE_SZARRAY:
-                        //
-                        // If the array is full of reference types, mark each of them.
-                        //
                         {
                             CLR_RT_HeapBlock_Array *array = (CLR_RT_HeapBlock_Array *)ptr;
 
-                            if (array->m_fReference)
+                            if (array->IsStoragePointer())
                             {
+                                // keep the array owning the wrapped storage alive (e.g. a Span<T>'s
+                                // backing array) - see CreateInstanceWithStorage / StorageOwner()
+                                lst = array->StorageOwner();
+                                num = 1;
+                            }
+                            else if (array->m_fReference)
+                            {
+                                // If the array is full of reference types, mark each of them.
                                 lst = (CLR_RT_HeapBlock *)array->GetFirstElement();
                                 num = array->m_numOfElements;
                             }

--- a/src/CLR/Core/GarbageCollector_ComputeReachabilityGraph.cpp
+++ b/src/CLR/Core/GarbageCollector_ComputeReachabilityGraph.cpp
@@ -232,24 +232,24 @@ bool CLR_RT_GarbageCollector::ComputeReachabilityGraphForMultipleBlocks(CLR_RT_H
                         break;
 
                     case DATATYPE_SZARRAY:
-                        {
-                            CLR_RT_HeapBlock_Array *array = (CLR_RT_HeapBlock_Array *)ptr;
+                    {
+                        CLR_RT_HeapBlock_Array *array = (CLR_RT_HeapBlock_Array *)ptr;
 
-                            if (array->IsStoragePointer())
-                            {
-                                // keep the array owning the wrapped storage alive (e.g. a Span<T>'s
-                                // backing array) - see CreateInstanceWithStorage / StorageOwner()
-                                lst = array->StorageOwner();
-                                num = 1;
-                            }
-                            else if (array->m_fReference)
-                            {
-                                // If the array is full of reference types, mark each of them.
-                                lst = (CLR_RT_HeapBlock *)array->GetFirstElement();
-                                num = array->m_numOfElements;
-                            }
+                        if (array->IsStoragePointer())
+                        {
+                            // keep the array owning the wrapped storage alive (e.g. a Span<T>'s
+                            // backing array) - see CreateInstanceWithStorage / StorageOwner()
+                            lst = array->StorageOwner();
+                            num = 1;
                         }
-                        break;
+                        else if (array->m_fReference)
+                        {
+                            // If the array is full of reference types, mark each of them.
+                            lst = (CLR_RT_HeapBlock *)array->GetFirstElement();
+                            num = array->m_numOfElements;
+                        }
+                    }
+                    break;
 
                     case DATATYPE_REFLECTION:
                         break;

--- a/src/CLR/Include/nanoCLR_Runtime.h
+++ b/src/CLR/Include/nanoCLR_Runtime.h
@@ -4281,7 +4281,8 @@ struct CLR_RT_ExecutionEngine
     CLR_RT_HeapBlock *ExtractHeapBlocksForArray(
         CLR_RT_TypeDef_Instance &inst,
         CLR_UINT32 length,
-        const CLR_RT_ReflectionDef_Index &reflex);
+        const CLR_RT_ReflectionDef_Index &reflex,
+        CLR_UINT32 extraBytes = 0);
     CLR_RT_HeapBlock *ExtractHeapBlocksForClassOrValueTypes(
         CLR_UINT32 dataType,
         CLR_UINT32 flags,

--- a/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
+++ b/src/CLR/Include/nanoCLR_Runtime__HeapBlock.h
@@ -1899,7 +1899,8 @@ struct CLR_RT_HeapBlock_Array : public CLR_RT_HeapBlock
     static HRESULT CreateInstance(
         CLR_RT_HeapBlock &reference,
         CLR_UINT32 length,
-        const CLR_RT_ReflectionDef_Index &reflex);
+        const CLR_RT_ReflectionDef_Index &reflex,
+        CLR_UINT32 extraBytes = 0);
     static HRESULT CreateInstance(CLR_RT_HeapBlock &reference, CLR_UINT32 length, const CLR_RT_TypeDef_Index &cls);
     static HRESULT CreateInstance(
         CLR_RT_HeapBlock &reference,
@@ -1912,7 +1913,8 @@ struct CLR_RT_HeapBlock_Array : public CLR_RT_HeapBlock
         CLR_RT_HeapBlock &reference,
         CLR_UINT32 length,
         const uintptr_t storageAddress,
-        const CLR_RT_TypeDef_Index &cls);
+        const CLR_RT_TypeDef_Index &cls,
+        const CLR_RT_HeapBlock *owner);
 
     CLR_UINT8 *GetFirstElement()
     {
@@ -1951,6 +1953,12 @@ struct CLR_RT_HeapBlock_Array : public CLR_RT_HeapBlock
     bool IsStoragePointer()
     {
         return (ReflectionData().kind == REFLECTION_STORAGE_PTR);
+    }
+
+    // Valid only when IsStoragePointer() is true. See CLAUDE.md §16.
+    CLR_RT_HeapBlock *StorageOwner()
+    {
+        return (CLR_RT_HeapBlock *)&this[1];
     }
 
     HRESULT ClearElements(int index, int length);


### PR DESCRIPTION
## Description
- Now reserves one extra CLR_RT_HeapBlock-sized slot for a real object reference to the owning array.
- Fix GC reacheability to properly handling arrays using storage pointers.
- Fix constructor for Span<T> and ReadOnlySpan<T>.

## Motivation and Context
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoframework/CoreLibrary#245].

## Screenshots<!-- (IF APPLICABLE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
