### PR TITLE
Truncate the file before a StorageOperation write

### DIFF
--- a/src/HAL/nanoHAL_StorageOperation.cpp
+++ b/src/HAL/nanoHAL_StorageOperation.cpp
@@ -74,6 +74,15 @@ uint32_t HAL_StorageOperation(uint8_t operation, uint32_t dataLength, uint32_t o
             }
         }
 
+        // remove an existing file, so the write always starts from an empty one
+        // Open() below does not truncate: a stream driver that opens an existing
+        // file for R/W (the ESP32 littlefs driver uses "r+") keeps the previous
+        // length, so the first Append chunk fails the "seek(END) == offset" check
+        // below and no file larger than a single Wire Protocol packet can ever be
+        // overwritten
+        // the return value is ignored on purpose: a missing file is the normal case
+        volume->Delete(relativePath, false);
+
         // open the file (creates it, if it doesn't exist)
         if (FAILED(volume->Open(relativePath, fileHandle)))
         {

--- a/src/HAL/nanoHAL_StorageOperation.cpp
+++ b/src/HAL/nanoHAL_StorageOperation.cpp
@@ -53,6 +53,7 @@ uint32_t HAL_StorageOperation(uint8_t operation, uint32_t dataLength, uint32_t o
         char dirPath[FS_MAX_DIRECTORY_LENGTH];
         char *lastSeparator;
         int bytesWritten = 0;
+        HRESULT deleteResult;
 
         // extract parent directory from relative path and create it if needed
         snprintf(dirPath, sizeof(dirPath), "%s", relativePath);
@@ -80,8 +81,18 @@ uint32_t HAL_StorageOperation(uint8_t operation, uint32_t dataLength, uint32_t o
         // length, so the first Append chunk fails the "seek(END) == offset" check
         // below and no file larger than a single Wire Protocol packet can ever be
         // overwritten
-        // the return value is ignored on purpose: a missing file is the normal case
-        volume->Delete(relativePath, false);
+        deleteResult = volume->Delete(relativePath, false);
+
+        // nothing to remove is the normal case, and a driver without Delete keeps
+        // whatever semantics Open() has for it, as before this call. Any other
+        // failure leaves the previous content in place, and writing over it would
+        // produce a file with a stale tail
+        if (FAILED(deleteResult) && deleteResult != CLR_E_FILE_NOT_FOUND &&
+            deleteResult != CLR_E_NOT_SUPPORTED)
+        {
+            errorCode = StorageOperationErrorCode::WriteError;
+            goto done;
+        }
 
         // open the file (creates it, if it doesn't exist)
         if (FAILED(volume->Open(relativePath, fileHandle)))

--- a/src/HAL/nanoHAL_StorageOperation.cpp
+++ b/src/HAL/nanoHAL_StorageOperation.cpp
@@ -80,8 +80,7 @@ uint32_t HAL_StorageOperation(uint8_t operation, uint32_t dataLength, uint32_t o
 
         // a missing file, or a volume without Delete, is the normal case; any other failure would leave
         // the previous content in place and the write would produce a file with a stale tail
-        if (FAILED(deleteResult) && deleteResult != CLR_E_FILE_NOT_FOUND &&
-            deleteResult != CLR_E_NOT_SUPPORTED)
+        if (FAILED(deleteResult) && deleteResult != CLR_E_FILE_NOT_FOUND && deleteResult != CLR_E_NOT_SUPPORTED)
         {
             errorCode = StorageOperationErrorCode::WriteError;
             goto done;

--- a/src/HAL/nanoHAL_StorageOperation.cpp
+++ b/src/HAL/nanoHAL_StorageOperation.cpp
@@ -75,18 +75,11 @@ uint32_t HAL_StorageOperation(uint8_t operation, uint32_t dataLength, uint32_t o
             }
         }
 
-        // remove an existing file, so the write always starts from an empty one
-        // Open() below does not truncate: a stream driver that opens an existing
-        // file for R/W (the ESP32 littlefs driver uses "r+") keeps the previous
-        // length, so the first Append chunk fails the "seek(END) == offset" check
-        // below and no file larger than a single Wire Protocol packet can ever be
-        // overwritten
+        // Open() below doesn't truncate, so remove an existing file to start the write from an empty one
         deleteResult = volume->Delete(relativePath, false);
 
-        // nothing to remove is the normal case, and a driver without Delete keeps
-        // whatever semantics Open() has for it, as before this call. Any other
-        // failure leaves the previous content in place, and writing over it would
-        // produce a file with a stale tail
+        // a missing file, or a volume without Delete, is the normal case; any other failure would leave
+        // the previous content in place and the write would produce a file with a stale tail
         if (FAILED(deleteResult) && deleteResult != CLR_E_FILE_NOT_FOUND &&
             deleteResult != CLR_E_NOT_SUPPORTED)
         {


### PR DESCRIPTION
## Description

- `HAL_StorageOperation()` now removes the target file before opening it for a `StorageOperation_Write`.
- A failed removal is reported as `WriteError`, except for `CLR_E_FILE_NOT_FOUND` and `CLR_E_NOT_SUPPORTED`. The first is the normal case for a file that is not there yet; the second comes from a volume whose file system driver has no `Delete`, and for such a volume the write keeps whatever semantics `Open()` has for it, exactly as before.

## Motivation and Context

`Open()` carries no truncate semantics. A stream driver that opens an existing file for read/write keeps its previous length — the ESP32 littlefs driver selects `"r+"` whenever `stat()` finds the file. A file larger than a single Wire Protocol packet is transferred as one `Write` chunk followed by `Append` chunks, so:

- the `Write` chunk puts the first ~1 KB at position 0 and the file keeps its old, larger length;
- the first `Append` chunk seeks to the end, finds a position that no longer matches the offset it validates against, and returns `WriteError`.

The net effect is that no file larger than 1024 bytes can be overwritten on such a target — a second `nanoff --filedeployment` of the same file fails deterministically, while a first deployment onto a clean file system succeeds. The ESP32 implementation replaced by the common one called `remove()` at this exact point, so on that target this is a regression. The ChibiOS one opened the file with `LFS_O_RDWR | LFS_O_CREAT`, without `LFS_O_TRUNC` and without removing it first, so it carried the same defect already and this change fixes it there too.

- Fixes nanoFramework/Home#1840

## How Has This Been Tested?

- Tested on an ESP32-S3 target with littlefs on the internal `I:` drive, built against IDF 5.5.4.
- Before the change, deploying a ~26 KB file over Wire Protocol onto a device that already held it failed with `WriteError` on the very first file, on every retry.
- With the change, the same deployment onto the same device succeeds on the first attempt, and the file is replaced rather than partially overwritten.

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
