### PR TITLE
Report program state in RTM builds

### DIFF
--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -638,10 +638,6 @@ HRESULT CLR_RT_ExecutionEngine::Execute(wchar_t *entryPointArgs, int maxContextS
 
     NANOCLR_CHECK_HRESULT(WaitForDebugger());
 
-    // set unconditionally (not only with source-level debugging): the state mask
-    // zero-value means "initialize", so an RTM build that never sets ProgramRunning
-    // is treated as stuck-in-initialize by debugger clients (nanoff refuses
-    // --filedeployment with E2002 and keeps rebooting the device)
     CLR_EE_DBG_SET_MASK(StateProgramRunning, StateMask);
 
     NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Delegate::CreateInstance(ref, g_CLR_RT_TypeSystem.m_entryPoint, NULL));

--- a/src/CLR/Core/Execution.cpp
+++ b/src/CLR/Core/Execution.cpp
@@ -638,9 +638,11 @@ HRESULT CLR_RT_ExecutionEngine::Execute(wchar_t *entryPointArgs, int maxContextS
 
     NANOCLR_CHECK_HRESULT(WaitForDebugger());
 
-#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+    // set unconditionally (not only with source-level debugging): the state mask
+    // zero-value means "initialize", so an RTM build that never sets ProgramRunning
+    // is treated as stuck-in-initialize by debugger clients (nanoff refuses
+    // --filedeployment with E2002 and keeps rebooting the device)
     CLR_EE_DBG_SET_MASK(StateProgramRunning, StateMask);
-#endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 
     NANOCLR_CHECK_HRESULT(CLR_RT_HeapBlock_Delegate::CreateInstance(ref, g_CLR_RT_TypeSystem.m_entryPoint, NULL));
 

--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -425,8 +425,10 @@ void ClrStartup(CLR_SETTINGS params)
 
         if (CLR_EE_DBG_IS_NOT(RebootPending))
         {
-#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
+            // state mask set unconditionally (see Execution.cpp / StateProgramRunning):
+            // debugger clients read state zero as "initialize"
             CLR_EE_DBG_SET_MASK(StateProgramExited, StateMask);
+#if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
             CLR_EE_DBG_EVENT_BROADCAST(CLR_DBG_Commands_c_Monitor_ProgramExit, 0, NULL, WP_Flags_c_NonCritical);
 #endif // #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
 

--- a/src/CLR/Startup/CLRStartup.cpp
+++ b/src/CLR/Startup/CLRStartup.cpp
@@ -425,8 +425,6 @@ void ClrStartup(CLR_SETTINGS params)
 
         if (CLR_EE_DBG_IS_NOT(RebootPending))
         {
-            // state mask set unconditionally (see Execution.cpp / StateProgramRunning):
-            // debugger clients read state zero as "initialize"
             CLR_EE_DBG_SET_MASK(StateProgramExited, StateMask);
 #if defined(NANOCLR_ENABLE_SOURCELEVELDEBUGGING)
             CLR_EE_DBG_EVENT_BROADCAST(CLR_DBG_Commands_c_Monitor_ProgramExit, 0, NULL, WP_Flags_c_NonCritical);


### PR DESCRIPTION
## Description

- `StateProgramRunning` and `StateProgramExited` are now set in every build, not only when `NANOCLR_ENABLE_SOURCELEVELDEBUGGING` is defined.
- The `CLR_DBG_Commands_c_Monitor_ProgramExit` broadcast stays behind that guard, since it is a debugging event rather than state.

## Motivation and Context

Both bits of the debugger state mask were guarded by `NANOCLR_ENABLE_SOURCELEVELDEBUGGING`, so an RTM build never reported either of them. On the client side `State.Initialize` is `0x00000000`, which makes a mask that never gains `ProgramRunning` (`0x00000400`) indistinguishable from a device that is still initializing. An RTM device therefore looks stuck before its program starts, for the entire time the program is actually running.

The visible effect is that `nanoff --filedeployment` against an RTM build fails with `E2002` and reboots the target repeatedly, while a debug build of the same firmware on the same hardware deploys normally.

- Fixes nanoFramework/Home#1842

## How Has This Been Tested?

- Reproduced on an ESP32-S3 target: with an RTM build, deploying files over the Wire Protocol did not go through, while a debug build of the same firmware on the same hardware deployed normally.
- Firmware carrying this change has been in use on that hardware since, with file deployment working on RTM builds.
- Compile-checked against current `main` for `ESP32_S3_QUAD`.

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
