### PR TITLE
Size the USB-JTAG RX buffer to hold a full Wire Protocol frame

### DIFF
--- a/targets/ESP32/_common/WireProtocol_HAL_Interface.c
+++ b/targets/ESP32/_common/WireProtocol_HAL_Interface.c
@@ -161,11 +161,7 @@ static uint8_t WP_TransmitMessageTinyUsb(WP_Message *message)
 
 #include "driver/usb_serial_jtag.h"
 
-// must hold at least one full WP frame (32-byte header + WP_PACKET_SIZE payload
-// = 1056 bytes): the driver ISR drops RX bytes when the ring buffer is full,
-// which happens while the receiver task is busy processing the previous message
-// (e.g. Monitor_StorageOperation writing to SD during nanoff --filedeployment)
-#define USB_JTAG_BUFFER_SIZE 2048
+#define USB_JTAG_BUFFER_SIZE (sizeof(WP_Packet) + WP_PACKET_SIZE)
 
 static size_t UsbSerialWrite(const uint8_t *data, size_t dataSize, TickType_t xTicksToWait);
 static size_t UsbSerialRead(uint8_t *data, size_t dataSize, TickType_t xTicksToWait);

--- a/targets/ESP32/_common/WireProtocol_HAL_Interface.c
+++ b/targets/ESP32/_common/WireProtocol_HAL_Interface.c
@@ -161,7 +161,11 @@ static uint8_t WP_TransmitMessageTinyUsb(WP_Message *message)
 
 #include "driver/usb_serial_jtag.h"
 
-#define USB_JTAG_BUFFER_SIZE 256
+// must hold at least one full WP frame (32-byte header + WP_PACKET_SIZE payload
+// = 1056 bytes): the driver ISR drops RX bytes when the ring buffer is full,
+// which happens while the receiver task is busy processing the previous message
+// (e.g. Monitor_StorageOperation writing to SD during nanoff --filedeployment)
+#define USB_JTAG_BUFFER_SIZE 2048
 
 static size_t UsbSerialWrite(const uint8_t *data, size_t dataSize, TickType_t xTicksToWait);
 static size_t UsbSerialRead(uint8_t *data, size_t dataSize, TickType_t xTicksToWait);


### PR DESCRIPTION
## Description

- `USB_JTAG_BUFFER_SIZE` raised from 256 to 2048 bytes, so the RX ring holds a complete Wire Protocol frame.

## Motivation and Context

A full frame is 1056 bytes — a 32 byte header plus `WP_PACKET_SIZE` (1024) of payload — and did not fit in the 256 byte ring. The USB-Serial-JTAG driver ISR drops incoming bytes once the ring is full, which is what happens while the receiver task is busy with the previous message instead of draining the ring.

The result is that deploying files over the Wire Protocol to a target connected over USB-Serial-JTAG stalls or fails as soon as a file is large enough to be split into several packets, since the storage write for one packet overlaps the arrival of the next. Transfers where the task is idle between frames are unaffected, which is why this only shows up on larger files.

- Fixes nanoFramework/Home#1843

## How Has This Been Tested?

- Reproduced on an ESP32-S3 connected over USB-Serial-JTAG: deploying files of a few tens of kilobytes over the Wire Protocol stalled, while smaller transfers went through.
- Firmware carrying this change has been in use on that hardware since, and those deployments complete.
- Compile-checked against current `main` for `ESP32_S3_QUAD`.

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
