### PR TITLE
Guard the default netifs against being created twice

### DIFF
--- a/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
+++ b/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
@@ -158,12 +158,6 @@ esp_err_t NF_ESP32_InitaliseWifi()
         esp_hosted_init();
 #endif
         // create Wi-Fi STA (ignoring return)
-        // guarded against re-creation: an initialisation that bails out on one of
-        // the returns further down leaves the netif created while
-        // IsWifiInitialised is still false, so the next attempt comes back here
-        // and would create a second default netif with the same key - the first
-        // one is leaked and the attach of the second one fails. NF_ESP32_DeinitWifi
-        // clears the pointer, so a clean re-init still creates it.
         if (wifiStaNetif == NULL)
         {
             wifiStaNetif = esp_netif_create_default_wifi_sta();
@@ -184,7 +178,6 @@ esp_err_t NF_ESP32_InitaliseWifi()
         if (expectedWifiMode & WIFI_MODE_AP)
         {
             // create AP (ignoring return)
-            // same guard against re-creation on a retry as for the station above
             if (wifiAPNetif == NULL)
             {
                 wifiAPNetif = esp_netif_create_default_wifi_ap();

--- a/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
+++ b/targets/ESP32/_Network/NF_ESP32_Wireless.cpp
@@ -158,7 +158,16 @@ esp_err_t NF_ESP32_InitaliseWifi()
         esp_hosted_init();
 #endif
         // create Wi-Fi STA (ignoring return)
-        wifiStaNetif = esp_netif_create_default_wifi_sta();
+        // guarded against re-creation: an initialisation that bails out on one of
+        // the returns further down leaves the netif created while
+        // IsWifiInitialised is still false, so the next attempt comes back here
+        // and would create a second default netif with the same key - the first
+        // one is leaked and the attach of the second one fails. NF_ESP32_DeinitWifi
+        // clears the pointer, so a clean re-init still creates it.
+        if (wifiStaNetif == NULL)
+        {
+            wifiStaNetif = esp_netif_create_default_wifi_sta();
+        }
 
         // Set static address if configured
         // ignore any errors
@@ -175,7 +184,11 @@ esp_err_t NF_ESP32_InitaliseWifi()
         if (expectedWifiMode & WIFI_MODE_AP)
         {
             // create AP (ignoring return)
-            wifiAPNetif = esp_netif_create_default_wifi_ap();
+            // same guard against re-creation on a retry as for the station above
+            if (wifiAPNetif == NULL)
+            {
+                wifiAPNetif = esp_netif_create_default_wifi_ap();
+            }
 
             // Remove DHCP server flag as not configured in sdkconfig, DHCP server done in managed code
             // Otherwise startup hangs


### PR DESCRIPTION
## Description

- The default STA and AP netifs are only created when the stored pointer is still `NULL`.

## Motivation and Context

`IsWifiInitialised` is set at the very end of `NF_ESP32_InitaliseWifi()`, while several `return` statements sit between the netif creation and that assignment - a failing `esp_wifi_init()`, `esp_wifi_set_mode()`, `esp_wifi_start()` or the AP configuration block. After such a failure the netifs exist but the module still considers itself uninitialised, so the next call re-enters the same branch and creates a second default netif for the same interface. The first one is leaked and esp_netif refuses to attach the second.

`NF_ESP32_DeinitWifi()` already sets both pointers back to `NULL`, so a clean de-init followed by an init still creates them.

- Fixes nanoFramework/Home#1844

## How Has This Been Tested?

- Built for an ESP32-S3 target against current `main`.
- Exercised on hardware where a Wi-Fi initialisation failure is followed by a retry, which previously left a leaked netif behind.

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
