### PR TITLE
Add a direction change barrier to the littlefs stream driver

### DIFF
--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
@@ -282,15 +282,11 @@ HRESULT LITTLEFS_FS_Driver::Read(void *handle, uint8_t *buffer, int size, int *b
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
-    // direction change barrier, write to read: ANSI C requires an fflush or a
-    // file positioning call between a write and a read on the same update mode
-    // stream. The fseek to the current position flushes the pending write and
-    // makes the read legal.
-    if (fileHandle->lastOp == 2)
+    if (fileHandle->lastOp == LITTLEFS_LastOperation_Write)
     {
         fseek(fileHandle->file, 0, SEEK_CUR);
     }
-    fileHandle->lastOp = 1;
+    fileHandle->lastOp = LITTLEFS_LastOperation_Read;
 
     // read from the file
     readCount = fread(buffer, 1, size, fileHandle->file);
@@ -334,14 +330,11 @@ HRESULT LITTLEFS_FS_Driver::Write(void *handle, uint8_t *buffer, int size, int *
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
-    // direction change barrier, read to write: without a positioning call
-    // between an fread and an fwrite, stdio writes at the buffer position rather
-    // than at the logical file position.
-    if (fileHandle->lastOp == 1)
+    if (fileHandle->lastOp == LITTLEFS_LastOperation_Read)
     {
         fseek(fileHandle->file, 0, SEEK_CUR);
     }
-    fileHandle->lastOp = 2;
+    fileHandle->lastOp = LITTLEFS_LastOperation_Write;
 
     // write to the file
     writeCount = fwrite(buffer, 1, size, fileHandle->file);
@@ -416,8 +409,7 @@ HRESULT LITTLEFS_FS_Driver::Seek(void *handle, int64_t offset, uint32_t origin, 
         return CLR_E_FILE_IO;
     }
 
-    // a positioning call is a legal barrier for both directions (see lastOp)
-    fileHandle->lastOp = 0;
+    fileHandle->lastOp = LITTLEFS_LastOperation_None;
 
     // get the current position
     *position = ftell(fileHandle->file);
@@ -467,9 +459,7 @@ HRESULT LITTLEFS_FS_Driver::GetLength(void *handle, int64_t *length)
         return CLR_E_FILE_IO;
     }
 
-    // the restore above left the stream positioned, which is a barrier for both
-    // directions (see lastOp)
-    fileHandle->lastOp = 0;
+    fileHandle->lastOp = LITTLEFS_LastOperation_None;
 
     return S_OK;
 }
@@ -515,9 +505,7 @@ HRESULT LITTLEFS_FS_Driver::SetLength(void *handle, int64_t length)
         return CLR_E_FILE_IO;
     }
 
-    // the restore above left the stream positioned, which is a barrier for both
-    // directions (see lastOp)
-    fileHandle->lastOp = 0;
+    fileHandle->lastOp = LITTLEFS_LastOperation_None;
 
     // Synchronize the file state
     fflush(fileHandle->file);

--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
@@ -282,10 +282,11 @@ HRESULT LITTLEFS_FS_Driver::Read(void *handle, uint8_t *buffer, int size, int *b
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
-    if (fileHandle->lastOp == LITTLEFS_LastOperation_Write)
+    if (fileHandle->lastOp == LITTLEFS_LastOperation_Write && fseek(fileHandle->file, 0, SEEK_CUR) != 0)
     {
-        fseek(fileHandle->file, 0, SEEK_CUR);
+        NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
     }
+
     fileHandle->lastOp = LITTLEFS_LastOperation_Read;
 
     // read from the file
@@ -330,10 +331,11 @@ HRESULT LITTLEFS_FS_Driver::Write(void *handle, uint8_t *buffer, int size, int *
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
-    if (fileHandle->lastOp == LITTLEFS_LastOperation_Read)
+    if (fileHandle->lastOp == LITTLEFS_LastOperation_Read && fseek(fileHandle->file, 0, SEEK_CUR) != 0)
     {
-        fseek(fileHandle->file, 0, SEEK_CUR);
+        NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
     }
+
     fileHandle->lastOp = LITTLEFS_LastOperation_Write;
 
     // write to the file

--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
@@ -282,6 +282,16 @@ HRESULT LITTLEFS_FS_Driver::Read(void *handle, uint8_t *buffer, int size, int *b
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
+    // direction change barrier, write to read: ANSI C requires an fflush or a
+    // file positioning call between a write and a read on the same update mode
+    // stream. The fseek to the current position flushes the pending write and
+    // makes the read legal.
+    if (fileHandle->lastOp == 2)
+    {
+        fseek(fileHandle->file, 0, SEEK_CUR);
+    }
+    fileHandle->lastOp = 1;
+
     // read from the file
     readCount = fread(buffer, 1, size, fileHandle->file);
 
@@ -323,6 +333,15 @@ HRESULT LITTLEFS_FS_Driver::Write(void *handle, uint8_t *buffer, int size, int *
     }
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
+
+    // direction change barrier, read to write: without a positioning call
+    // between an fread and an fwrite, stdio writes at the buffer position rather
+    // than at the logical file position.
+    if (fileHandle->lastOp == 1)
+    {
+        fseek(fileHandle->file, 0, SEEK_CUR);
+    }
+    fileHandle->lastOp = 2;
 
     // write to the file
     writeCount = fwrite(buffer, 1, size, fileHandle->file);
@@ -397,6 +416,9 @@ HRESULT LITTLEFS_FS_Driver::Seek(void *handle, int64_t offset, uint32_t origin, 
         return CLR_E_FILE_IO;
     }
 
+    // a positioning call is a legal barrier for both directions (see lastOp)
+    fileHandle->lastOp = 0;
+
     // get the current position
     *position = ftell(fileHandle->file);
 
@@ -445,6 +467,10 @@ HRESULT LITTLEFS_FS_Driver::GetLength(void *handle, int64_t *length)
         return CLR_E_FILE_IO;
     }
 
+    // the restore above left the stream positioned, which is a barrier for both
+    // directions (see lastOp)
+    fileHandle->lastOp = 0;
+
     return S_OK;
 }
 
@@ -488,6 +514,10 @@ HRESULT LITTLEFS_FS_Driver::SetLength(void *handle, int64_t length)
         // Handle error
         return CLR_E_FILE_IO;
     }
+
+    // the restore above left the stream positioned, which is a barrier for both
+    // directions (see lastOp)
+    fileHandle->lastOp = 0;
 
     // Synchronize the file state
     fflush(fileHandle->file);

--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.h
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.h
@@ -16,16 +16,22 @@ extern "C"
 {
 #endif
 
+    // direction of the last operation on a file, files are opened in update mode and ANSI C
+    // requires a positioning call between a read and a write on such a stream
+    enum LITTLEFS_LastOperation
+    {
+        // no operation yet, or the file was just positioned: both directions are legal
+        LITTLEFS_LastOperation_None = 0,
+        // last operation was a read: a write needs a positioning call first
+        LITTLEFS_LastOperation_Read = 1,
+        // last operation was a write: a read needs a positioning call first
+        LITTLEFS_LastOperation_Write = 2,
+    };
+
     struct LITTLEFS_FileHandle
     {
         FILE *file;
-        // Direction of the last operation: 0 - none or right after a seek,
-        // 1 - read, 2 - write. Files are opened in update mode ("r+"), and ANSI C
-        // requires an fflush or an fseek between a change of direction, otherwise
-        // the stdio buffer returns stale or misaligned data. The driver places
-        // that barrier itself (see Read and Write) rather than relying on the
-        // caller.
-        uint8_t lastOp;
+        LITTLEFS_LastOperation lastOp;
     };
 
     struct LITTLEFS_FindFileHandle

--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.h
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.h
@@ -19,6 +19,13 @@ extern "C"
     struct LITTLEFS_FileHandle
     {
         FILE *file;
+        // Direction of the last operation: 0 - none or right after a seek,
+        // 1 - read, 2 - write. Files are opened in update mode ("r+"), and ANSI C
+        // requires an fflush or an fseek between a change of direction, otherwise
+        // the stdio buffer returns stale or misaligned data. The driver places
+        // that barrier itself (see Read and Write) rather than relying on the
+        // caller.
+        uint8_t lastOp;
     };
 
     struct LITTLEFS_FindFileHandle


### PR DESCRIPTION
## Description

- `LITTLEFS_FileHandle` records the direction of the last operation on the handle.
- `Read()` and `Write()` issue `fseek(file, 0, SEEK_CUR)` when the direction changes.
- `Seek()`, and the position restore in `GetLength()` and `SetLength()`, clear the recorded direction, since a positioning call is a barrier in itself.

## Motivation and Context

`Open()` opens an existing file with `"r+"`, and `Read()` and `Write()` then call `fread()` and `fwrite()` on that stream with nothing in between. ANSI C requires a file positioning call or an `fflush()` between a write and a following read on an update mode stream, and a positioning call between a read and a following write. Without one the behaviour is undefined, and newlib in practice serves the second operation from the buffer state left by the first: a read after a write returns stale bytes, and a write after a read lands at the buffer position instead of the logical file position.

Any managed code that reads and writes through the same `FileStream` runs into this, a read-modify-write over an existing file being the obvious case.

- Fixes nanoFramework/Home#1845

## How Has This Been Tested?

- Built for an ESP32-S3 target against current `main`.
- Exercised on hardware with managed code that reads and writes the same file handle, where the reads previously returned stale data.

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
