### PR TITLE
Transfer external RAM buffers through an internal RAM bounce buffer

### DIFF
--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
@@ -347,7 +347,15 @@ HRESULT LITTLEFS_FS_Driver::Read(void *handle, uint8_t *buffer, int size, int *b
 
         while (total < size)
         {
-            int pad = (int)(ftell(fileHandle->file) & 3);
+            long filePosition = ftell(fileHandle->file);
+
+            if (filePosition < 0)
+            {
+                NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
+            }
+
+            // keeps the pointer handed to the whole sector transfers 4 byte aligned
+            int pad = (int)(filePosition & 3);
 
             int chunk = size - total;
             if (chunk > c_ioBounceBufferSize - pad)
@@ -432,7 +440,15 @@ HRESULT LITTLEFS_FS_Driver::Write(void *handle, uint8_t *buffer, int size, int *
 
         while (total < size)
         {
-            int pad = (int)(ftell(fileHandle->file) & 3);
+            long filePosition = ftell(fileHandle->file);
+
+            if (filePosition < 0)
+            {
+                NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);
+            }
+
+            // keeps the pointer handed to the whole sector transfers 4 byte aligned
+            int pad = (int)(filePosition & 3);
 
             int chunk = size - total;
             if (chunk > c_ioBounceBufferSize - pad)

--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
@@ -8,32 +8,58 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <sdkconfig.h>
+
+#if CONFIG_SPIRAM
 #include <esp_heap_caps.h>
 #include <esp_memory_utils.h>
+#endif
 
 extern FileSystemVolume *g_FS_Volumes;
 
 static int32_t RemoveAllFiles(const char *path);
 static int NormalizePath(const char *root, const char *path, char *buffer, size_t bufferSize);
 
-// bounce buffer in internal RAM, for transfers of buffers backed by external RAM
-static uint8_t *s_ioBounceBuffer = NULL;
 static const int c_ioBounceBufferSize = 16 * 1024;
+
+#if CONFIG_SPIRAM
 
 // transfers below one sector are left to the stdio buffer, the bounce path would only add an ftell
 static const int c_ioBounceMinTransfer = 512;
 
-static uint8_t *GetIoBounceBuffer()
+// bounce buffer in internal RAM, for transfers of buffers backed by external RAM
+static uint8_t *s_ioBounceBuffer = NULL;
+
+// NULL when the transfer needs no bouncing, or when there is no internal RAM left: the caller then
+// takes the direct path
+static uint8_t *GetIoBounceBuffer(const void *buffer, int size)
 {
+    if (size < c_ioBounceMinTransfer || !esp_ptr_external_ram(buffer))
+    {
+        return NULL;
+    }
+
     if (s_ioBounceBuffer == NULL)
     {
         s_ioBounceBuffer =
             (uint8_t *)heap_caps_malloc(c_ioBounceBufferSize, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
     }
 
-    // NULL, when there is no internal RAM left, makes the caller fall back to the direct path
     return s_ioBounceBuffer;
 }
+
+#else
+
+// no external RAM on this target, a transfer never needs bouncing
+static uint8_t *GetIoBounceBuffer(const void *buffer, int size)
+{
+    (void)buffer;
+    (void)size;
+
+    return NULL;
+}
+
+#endif
 
 bool LITTLEFS_FS_Driver::LoadMedia(const void *driverInterface)
 {
@@ -306,10 +332,7 @@ HRESULT LITTLEFS_FS_Driver::Read(void *handle, uint8_t *buffer, int size, int *b
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
-    if (size >= c_ioBounceMinTransfer && esp_ptr_external_ram(buffer))
-    {
-        readBounce = GetIoBounceBuffer();
-    }
+    readBounce = GetIoBounceBuffer(buffer, size);
 
     if (readBounce != NULL)
     {
@@ -387,10 +410,7 @@ HRESULT LITTLEFS_FS_Driver::Write(void *handle, uint8_t *buffer, int size, int *
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
-    if (size >= c_ioBounceMinTransfer && esp_ptr_external_ram(buffer))
-    {
-        writeBounce = GetIoBounceBuffer();
-    }
+    writeBounce = GetIoBounceBuffer(buffer, size);
 
     if (writeBounce != NULL)
     {

--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
@@ -6,11 +6,40 @@
 #include <nf_sys_io_filesystem.h>
 #include "littlefs_FS_Driver.h"
 #include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <esp_heap_caps.h>
+#include <esp_memory_utils.h>
 
 extern FileSystemVolume *g_FS_Volumes;
 
 static int32_t RemoveAllFiles(const char *path);
 static int NormalizePath(const char *root, const char *path, char *buffer, size_t bufferSize);
+
+// Bounce buffer in internal RAM for transfers of buffers backed by external RAM.
+// The SDMMC host cannot DMA from or to external RAM: for a PSRAM buffer,
+// sdmmc_cmd falls back to single sector transfers through a 512 byte temporary
+// buffer (around 2 ms per sector), which caps file IO at roughly 150-250 KB/s.
+// The CLR managed heap lives in PSRAM, so every buffer coming from managed code
+// takes that path. Copying through this internal RAM buffer restores multi
+// sector DMA, and the extra memcpy is negligible next to the bus transfer.
+// File system driver calls are serialised by the CLR (SYNC_IO), so a single
+// shared buffer is enough.
+static uint8_t *s_ioBounceBuffer = NULL;
+static const int IO_BOUNCE_BUFFER_SIZE = 16 * 1024;
+
+static uint8_t *GetIoBounceBuffer()
+{
+    if (s_ioBounceBuffer == NULL)
+    {
+        s_ioBounceBuffer =
+            (uint8_t *)heap_caps_malloc(IO_BOUNCE_BUFFER_SIZE, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
+    }
+
+    // NULL, when there is no internal RAM left, makes the caller fall back to
+    // the direct slow path
+    return s_ioBounceBuffer;
+}
 
 bool LITTLEFS_FS_Driver::LoadMedia(const void *driverInterface)
 {
@@ -219,6 +248,13 @@ HRESULT LITTLEFS_FS_Driver::Open(const VOLUME_ID *volume, const char *path, void
     fileHandle->file = fopen(normalizedPath, flags);
     if (fileHandle->file != NULL)
     {
+        // NOTE: keep the stream BUFFERED (the default). newlib only has a direct
+        // large transfer path in fread for buffered streams - with _IONBF it
+        // degrades to byte sized refills. A large fwrite or fread on a buffered
+        // stream flushes the small stdio buffer and then transfers straight from
+        // the caller's pointer, which keeps the ftell based alignment in Read and
+        // Write exact.
+
         // store the handle
         handle = fileHandle;
 
@@ -269,6 +305,7 @@ HRESULT LITTLEFS_FS_Driver::Read(void *handle, uint8_t *buffer, int size, int *b
 
     unsigned int readCount = 0;
     LITTLEFS_FileHandle *fileHandle;
+    uint8_t *readBounce = NULL;
 
     if (handle == 0)
     {
@@ -282,8 +319,51 @@ HRESULT LITTLEFS_FS_Driver::Read(void *handle, uint8_t *buffer, int size, int *b
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
-    // read from the file
-    readCount = fread(buffer, 1, size, fileHandle->file);
+    // a buffer in external RAM is read through the internal RAM bounce buffer
+    // (see above). pad = (position & 3) keeps the pointer used for direct whole
+    // sector transfers 4 byte aligned. Small reads (< 512) go straight through:
+    // the stdio buffer serves them without touching the medium, while the bounce
+    // path would add an ftell on every call.
+    if (size >= 512 && esp_ptr_external_ram(buffer))
+    {
+        readBounce = GetIoBounceBuffer();
+    }
+
+    if (readBounce != NULL)
+    {
+        int total = 0;
+
+        while (total < size)
+        {
+            int pad = (int)(ftell(fileHandle->file) & 3);
+
+            int chunk = size - total;
+            if (chunk > IO_BOUNCE_BUFFER_SIZE - pad)
+            {
+                chunk = IO_BOUNCE_BUFFER_SIZE - pad;
+            }
+
+            unsigned int part = fread(readBounce + pad, 1, chunk, fileHandle->file);
+            if (part > 0)
+            {
+                memcpy(buffer + total, readBounce + pad, part);
+                total += part;
+            }
+
+            if (part < (unsigned int)chunk)
+            {
+                // end of file or an error, the checks below decide which
+                break;
+            }
+        }
+
+        readCount = total;
+    }
+    else
+    {
+        // read from the file
+        readCount = fread(buffer, 1, size, fileHandle->file);
+    }
 
     if (readCount > 0)
     {
@@ -311,6 +391,7 @@ HRESULT LITTLEFS_FS_Driver::Write(void *handle, uint8_t *buffer, int size, int *
 
     unsigned int writeCount = 0;
     LITTLEFS_FileHandle *fileHandle;
+    uint8_t *writeBounce = NULL;
 
     if (handle == 0)
     {
@@ -324,10 +405,47 @@ HRESULT LITTLEFS_FS_Driver::Write(void *handle, uint8_t *buffer, int size, int *
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
-    // write to the file
-    writeCount = fwrite(buffer, 1, size, fileHandle->file);
+    // a buffer in external RAM is written through the internal RAM bounce
+    // buffer, for the same reason as in Read
+    if (size >= 512 && esp_ptr_external_ram(buffer))
+    {
+        writeBounce = GetIoBounceBuffer();
+    }
 
-    if (writeCount < size)
+    if (writeBounce != NULL)
+    {
+        int total = 0;
+
+        while (total < size)
+        {
+            int pad = (int)(ftell(fileHandle->file) & 3);
+
+            int chunk = size - total;
+            if (chunk > IO_BOUNCE_BUFFER_SIZE - pad)
+            {
+                chunk = IO_BOUNCE_BUFFER_SIZE - pad;
+            }
+
+            memcpy(writeBounce + pad, buffer + total, chunk);
+
+            unsigned int part = fwrite(writeBounce + pad, 1, chunk, fileHandle->file);
+            total += part;
+
+            if (part < (unsigned int)chunk)
+            {
+                break;
+            }
+        }
+
+        writeCount = total;
+    }
+    else
+    {
+        // write to the file
+        writeCount = fwrite(buffer, 1, size, fileHandle->file);
+    }
+
+    if ((int)writeCount < size)
     {
         // failed to write the full buffer to the file
         NANOCLR_SET_AND_LEAVE(CLR_E_FILE_IO);

--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
@@ -16,28 +16,22 @@ extern FileSystemVolume *g_FS_Volumes;
 static int32_t RemoveAllFiles(const char *path);
 static int NormalizePath(const char *root, const char *path, char *buffer, size_t bufferSize);
 
-// Bounce buffer in internal RAM for transfers of buffers backed by external RAM.
-// The SDMMC host cannot DMA from or to external RAM: for a PSRAM buffer,
-// sdmmc_cmd falls back to single sector transfers through a 512 byte temporary
-// buffer (around 2 ms per sector), which caps file IO at roughly 150-250 KB/s.
-// The CLR managed heap lives in PSRAM, so every buffer coming from managed code
-// takes that path. Copying through this internal RAM buffer restores multi
-// sector DMA, and the extra memcpy is negligible next to the bus transfer.
-// File system driver calls are serialised by the CLR (SYNC_IO), so a single
-// shared buffer is enough.
+// bounce buffer in internal RAM, for transfers of buffers backed by external RAM
 static uint8_t *s_ioBounceBuffer = NULL;
-static const int IO_BOUNCE_BUFFER_SIZE = 16 * 1024;
+static const int c_ioBounceBufferSize = 16 * 1024;
+
+// transfers below one sector are left to the stdio buffer, the bounce path would only add an ftell
+static const int c_ioBounceMinTransfer = 512;
 
 static uint8_t *GetIoBounceBuffer()
 {
     if (s_ioBounceBuffer == NULL)
     {
         s_ioBounceBuffer =
-            (uint8_t *)heap_caps_malloc(IO_BOUNCE_BUFFER_SIZE, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
+            (uint8_t *)heap_caps_malloc(c_ioBounceBufferSize, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
     }
 
-    // NULL, when there is no internal RAM left, makes the caller fall back to
-    // the direct slow path
+    // NULL, when there is no internal RAM left, makes the caller fall back to the direct path
     return s_ioBounceBuffer;
 }
 
@@ -248,13 +242,6 @@ HRESULT LITTLEFS_FS_Driver::Open(const VOLUME_ID *volume, const char *path, void
     fileHandle->file = fopen(normalizedPath, flags);
     if (fileHandle->file != NULL)
     {
-        // NOTE: keep the stream BUFFERED (the default). newlib only has a direct
-        // large transfer path in fread for buffered streams - with _IONBF it
-        // degrades to byte sized refills. A large fwrite or fread on a buffered
-        // stream flushes the small stdio buffer and then transfers straight from
-        // the caller's pointer, which keeps the ftell based alignment in Read and
-        // Write exact.
-
         // store the handle
         handle = fileHandle;
 
@@ -319,12 +306,7 @@ HRESULT LITTLEFS_FS_Driver::Read(void *handle, uint8_t *buffer, int size, int *b
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
-    // a buffer in external RAM is read through the internal RAM bounce buffer
-    // (see above). pad = (position & 3) keeps the pointer used for direct whole
-    // sector transfers 4 byte aligned. Small reads (< 512) go straight through:
-    // the stdio buffer serves them without touching the medium, while the bounce
-    // path would add an ftell on every call.
-    if (size >= 512 && esp_ptr_external_ram(buffer))
+    if (size >= c_ioBounceMinTransfer && esp_ptr_external_ram(buffer))
     {
         readBounce = GetIoBounceBuffer();
     }
@@ -338,9 +320,9 @@ HRESULT LITTLEFS_FS_Driver::Read(void *handle, uint8_t *buffer, int size, int *b
             int pad = (int)(ftell(fileHandle->file) & 3);
 
             int chunk = size - total;
-            if (chunk > IO_BOUNCE_BUFFER_SIZE - pad)
+            if (chunk > c_ioBounceBufferSize - pad)
             {
-                chunk = IO_BOUNCE_BUFFER_SIZE - pad;
+                chunk = c_ioBounceBufferSize - pad;
             }
 
             unsigned int part = fread(readBounce + pad, 1, chunk, fileHandle->file);
@@ -405,9 +387,7 @@ HRESULT LITTLEFS_FS_Driver::Write(void *handle, uint8_t *buffer, int size, int *
 
     fileHandle = (LITTLEFS_FileHandle *)handle;
 
-    // a buffer in external RAM is written through the internal RAM bounce
-    // buffer, for the same reason as in Read
-    if (size >= 512 && esp_ptr_external_ram(buffer))
+    if (size >= c_ioBounceMinTransfer && esp_ptr_external_ram(buffer))
     {
         writeBounce = GetIoBounceBuffer();
     }
@@ -421,9 +401,9 @@ HRESULT LITTLEFS_FS_Driver::Write(void *handle, uint8_t *buffer, int size, int *
             int pad = (int)(ftell(fileHandle->file) & 3);
 
             int chunk = size - total;
-            if (chunk > IO_BOUNCE_BUFFER_SIZE - pad)
+            if (chunk > c_ioBounceBufferSize - pad)
             {
-                chunk = IO_BOUNCE_BUFFER_SIZE - pad;
+                chunk = c_ioBounceBufferSize - pad;
             }
 
             memcpy(writeBounce + pad, buffer + total, chunk);


### PR DESCRIPTION
## Description

- Transfers in `Read()` and `Write()` go through a bounce buffer in internal DMA-capable RAM when the caller's buffer lives in external RAM and the transfer is at least one sector.
- Smaller transfers and buffers in internal RAM keep going straight through, unchanged.

## Motivation and Context

The SDMMC host cannot DMA to or from external RAM. Handed a buffer in PSRAM, `sdmmc_cmd` falls back to transferring one sector at a time through a small internal temporary buffer, at roughly 2 ms per 512 byte sector, which caps file IO at about 150-250 KB/s. The CLR managed heap lives in PSRAM, so every buffer arriving from managed code takes that path, since the driver passes the caller's pointer straight to `fread`/`fwrite`.

Copying through an internal RAM buffer restores multi sector DMA. The extra memcpy is negligible next to the bus transfer, and file system driver calls are serialised by the CLR, so a single shared buffer is enough. It is allocated lazily and, if internal RAM has run out, the caller simply falls back to the direct path.

- Fixes nanoFramework/Home#1846

## How Has This Been Tested?

- Built for an ESP32-S3 target against current `main`, including the link step.
- Exercised on hardware with an ESP32-S3 and PSRAM, reading and writing files on an SD card from managed code.

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
