### PR TITLE
Report the SD card capacity in GetSizeInfo

### DIFF
--- a/targets/ChibiOS/_FatFs/fatfs_FS_Driver.cpp
+++ b/targets/ChibiOS/_FatFs/fatfs_FS_Driver.cpp
@@ -166,13 +166,11 @@ HRESULT FATFS_FS_Driver::Format(const VOLUME_ID *volume, const char *volumeLabel
 
 HRESULT FATFS_FS_Driver::GetSizeInfo(const VOLUME_ID *volume, int64_t *totalSize, int64_t *totalFreeSpace)
 {
-    (void)totalSize;
-
     // FATFS *fsPtr = &fs;
     // char buffer[3];
     // DWORD freeClusters, freeSectors, totalSectors;
 
-    // FATFS *fs = GetFatFsByVolumeId(volume, false);
+    FATFS *fs = GetFatFsByVolumeId(volume, false);
 
     FileSystemVolume *currentVolume = FileSystemVolumeList::FindVolume(volume->volumeId);
 
@@ -194,8 +192,21 @@ HRESULT FATFS_FS_Driver::GetSizeInfo(const VOLUME_ID *volume, int64_t *totalSize
     //     *totalFreeSpace = (int64_t)freeSectors * FF_MAX_SS;
     // #endif
 
+    // -1 means "unknown" to the caller
     *totalSize = -1;
+
+    // free space would need f_getfree(), see above
     *totalFreeSpace = -1;
+
+    if (fs != NULL)
+    {
+        // capacity of the file system, from the mounted FATFS object, without walking the FAT
+#if FF_MAX_SS != FF_MIN_SS
+        *totalSize = (int64_t)(fs->n_fatent - 2) * fs->csize * fs->ssize;
+#else
+        *totalSize = (int64_t)(fs->n_fatent - 2) * fs->csize * FF_MAX_SS;
+#endif
+    }
 
     return S_OK;
 }

--- a/targets/ESP32/_common/Target_System_IO_FileSystem.c
+++ b/targets/ESP32/_common/Target_System_IO_FileSystem.c
@@ -45,11 +45,7 @@ static const char *TAG = "SDCard";
 
 sdmmc_card_t *card;
 
-// Drive letter the card in `card` is mounted under, 0 when it is not mounted.
-// There is a single `card` for the whole system while there can be several
-// slots, so without this binding a consumer could not tell its own volume from
-// another one and would report the characteristics of the first card for the
-// second slot.
+// drive letter the card above is mounted under, 0 when it is not mounted
 char cardDriveLetter;
 
 //
@@ -196,8 +192,7 @@ bool Storage_MountMMC(bool bit1Mode, int driveIndex)
         return false;
     }
 
-    // the letter is only stored on success: after a failure `card` is not valid
-    // and no volume may be bound to it
+    // only stored on success, a failed mount leaves no card to bind the volume to
     cardDriveLetter = INDEX0_DRIVE_LETTER[0] + driveIndex;
 
     return true;
@@ -259,8 +254,7 @@ bool Storage_MountSpi(int spiBus, uint32_t csPin, int driveIndex)
         return false;
     }
 
-    // the letter is only stored on success: after a failure `card` is not valid
-    // and no volume may be bound to it
+    // only stored on success, a failed mount leaves no card to bind the volume to
     cardDriveLetter = INDEX0_DRIVE_LETTER[0] + driveIndex;
 
     return true;

--- a/targets/ESP32/_common/Target_System_IO_FileSystem.c
+++ b/targets/ESP32/_common/Target_System_IO_FileSystem.c
@@ -45,6 +45,13 @@ static const char *TAG = "SDCard";
 
 sdmmc_card_t *card;
 
+// Drive letter the card in `card` is mounted under, 0 when it is not mounted.
+// There is a single `card` for the whole system while there can be several
+// slots, so without this binding a consumer could not tell its own volume from
+// another one and would report the characteristics of the first card for the
+// second slot.
+char cardDriveLetter;
+
 //
 //  Unmount SD card ( MMC/SDIO or SPI)
 //
@@ -62,6 +69,7 @@ bool Storage_UnMountSDCard(int driveIndex)
     }
 
     card = NULL;
+    cardDriveLetter = 0;
 
     return true;
 }
@@ -183,7 +191,16 @@ bool Storage_MountMMC(bool bit1Mode, int driveIndex)
         errCode = esp_vfs_fat_sdmmc_mount(mountPoint, &host, &slot_config, &mount_config, &card);
     }
 
-    return LogMountResult(errCode);
+    if (!LogMountResult(errCode))
+    {
+        return false;
+    }
+
+    // the letter is only stored on success: after a failure `card` is not valid
+    // and no volume may be bound to it
+    cardDriveLetter = INDEX0_DRIVE_LETTER[0] + driveIndex;
+
+    return true;
 }
 #endif
 
@@ -237,7 +254,16 @@ bool Storage_MountSpi(int spiBus, uint32_t csPin, int driveIndex)
         errCode = esp_vfs_fat_sdspi_mount(mountPoint, &host, &slot_config, &mount_config, &card);
     }
 
-    return LogMountResult(errCode);
+    if (!LogMountResult(errCode))
+    {
+        return false;
+    }
+
+    // the letter is only stored on success: after a failure `card` is not valid
+    // and no volume may be bound to it
+    cardDriveLetter = INDEX0_DRIVE_LETTER[0] + driveIndex;
+
+    return true;
 }
 
 #endif

--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
@@ -10,11 +10,7 @@
 #if (HAL_USE_SDC == TRUE)
 #include <sdmmc_cmd.h>
 
-// The mounted card from Target_System_IO_FileSystem.c: its CSD was read at mount
-// time, so the capacity is available from there instantly, unlike a calculation
-// over the FAT which runs into f_getfree() (see GetSizeInfo). cardDriveLetter is
-// the volume the card belongs to: there is a single card per system, and without
-// that check a second slot would report the characteristics of the first card.
+// the mounted card and the volume it belongs to, from Target_System_IO_FileSystem.c
 extern "C" sdmmc_card_t *card;
 extern "C" char cardDriveLetter;
 #endif
@@ -93,7 +89,6 @@ HRESULT LITTLEFS_FS_Driver::Format(const VOLUME_ID *volume, const char *volumeLa
 
 HRESULT LITTLEFS_FS_Driver::GetSizeInfo(const VOLUME_ID *volume, int64_t *totalSize, int64_t *totalFreeSpace)
 {
-
     // FATFS *fsPtr = &fs;
     // char buffer[3];
     // DWORD freeClusters, freeSectors, totalSectors;
@@ -120,29 +115,21 @@ HRESULT LITTLEFS_FS_Driver::GetSizeInfo(const VOLUME_ID *volume, int64_t *totalS
     // //     *totalFreeSpace = (int64_t)freeSectors * FF_MAX_SS;
     // // #endif
 
-    // -1 means "unknown", which is how the caller reads it: UpdateVolumeInfo puts
-    // a zero into the managed field when an error is returned, so S_OK is always
-    // returned here.
+    // -1 means "unknown" to the caller
     *totalSize = -1;
 
-    // Free space is deliberately left unknown: the only way to it is f_getfree(),
-    // which walks the FAT and on large cards takes long enough to trip the
-    // watchdog. The card capacity needs no such walk, so it is reported.
+    // free space would need f_getfree(), which walks the FAT and trips the watchdog on large cards
     *totalFreeSpace = -1;
 
 #if (HAL_USE_SDC == TRUE)
 
-    // The driver also serves the internal flash, which has no CSD, so the card
-    // capacity only makes sense for the volume the card is actually mounted on
-    // (there can be several slots but only one card).
+    // the driver also serves the internal flash, which has no card behind it
     FileSystemVolume *currentVolume = FileSystemVolumeList::FindVolume(volume->volumeId);
 
     if (currentVolume != NULL && card != NULL && cardDriveLetter != 0 &&
         currentVolume->m_rootName[0] == cardDriveLetter)
     {
-        // csd.capacity is the number of sectors and csd.sector_size their size:
-        // this is the physical capacity of the card, not the capacity of the
-        // file system on it.
+        // physical capacity of the card, not of the file system on it
         *totalSize = (int64_t)card->csd.capacity * card->csd.sector_size;
     }
 

--- a/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
+++ b/targets/ESP32/_littlefs/littlefs_FS_Driver.cpp
@@ -7,6 +7,18 @@
 #include "littlefs_FS_Driver.h"
 #include <stdlib.h>
 
+#if (HAL_USE_SDC == TRUE)
+#include <sdmmc_cmd.h>
+
+// The mounted card from Target_System_IO_FileSystem.c: its CSD was read at mount
+// time, so the capacity is available from there instantly, unlike a calculation
+// over the FAT which runs into f_getfree() (see GetSizeInfo). cardDriveLetter is
+// the volume the card belongs to: there is a single card per system, and without
+// that check a second slot would report the characteristics of the first card.
+extern "C" sdmmc_card_t *card;
+extern "C" char cardDriveLetter;
+#endif
+
 extern FileSystemVolume *g_FS_Volumes;
 
 static int32_t RemoveAllFiles(const char *path);
@@ -81,7 +93,6 @@ HRESULT LITTLEFS_FS_Driver::Format(const VOLUME_ID *volume, const char *volumeLa
 
 HRESULT LITTLEFS_FS_Driver::GetSizeInfo(const VOLUME_ID *volume, int64_t *totalSize, int64_t *totalFreeSpace)
 {
-    (void)totalSize;
 
     // FATFS *fsPtr = &fs;
     // char buffer[3];
@@ -109,8 +120,37 @@ HRESULT LITTLEFS_FS_Driver::GetSizeInfo(const VOLUME_ID *volume, int64_t *totalS
     // //     *totalFreeSpace = (int64_t)freeSectors * FF_MAX_SS;
     // // #endif
 
+    // -1 means "unknown", which is how the caller reads it: UpdateVolumeInfo puts
+    // a zero into the managed field when an error is returned, so S_OK is always
+    // returned here.
     *totalSize = -1;
+
+    // Free space is deliberately left unknown: the only way to it is f_getfree(),
+    // which walks the FAT and on large cards takes long enough to trip the
+    // watchdog. The card capacity needs no such walk, so it is reported.
     *totalFreeSpace = -1;
+
+#if (HAL_USE_SDC == TRUE)
+
+    // The driver also serves the internal flash, which has no CSD, so the card
+    // capacity only makes sense for the volume the card is actually mounted on
+    // (there can be several slots but only one card).
+    FileSystemVolume *currentVolume = FileSystemVolumeList::FindVolume(volume->volumeId);
+
+    if (currentVolume != NULL && card != NULL && cardDriveLetter != 0 &&
+        currentVolume->m_rootName[0] == cardDriveLetter)
+    {
+        // csd.capacity is the number of sectors and csd.sector_size their size:
+        // this is the physical capacity of the card, not the capacity of the
+        // file system on it.
+        *totalSize = (int64_t)card->csd.capacity * card->csd.sector_size;
+    }
+
+#else
+
+    (void)volume;
+
+#endif
 
     return S_OK;
 }


### PR DESCRIPTION
## Description

- `GetSizeInfo()` reports the capacity of a mounted SD card, taken from the CSD that was read when the card was mounted.
- `Target_System_IO_FileSystem.c` records the drive letter the card is mounted under, and clears it on unmount and on a failed mount.
- Free space stays unknown, for the reason the existing comment gives.

## Motivation and Context

`GetSizeInfo()` is stubbed out: the FAT based calculation is commented out, with a note that `f_getfree()` takes long enough to hit the watchdog, and the function returns -1 for both values. As a result `DriveInfo.TotalSize` is always unknown on ESP32.

The capacity does not need that walk. `sdmmc_card_t` already holds the CSD, so `csd.capacity * csd.sector_size` is available immediately.

The driver also serves the internal flash, which has no CSD, so the capacity may only be reported for the volume the card is actually mounted on. There is a single `card` for the whole system while there can be several slots, hence the recorded drive letter.

- Fixes nanoFramework/Home#1847

## How Has This Been Tested?

- Built for an ESP32-S3 target against current `main`, including the link step.
- Exercised on hardware, where `DriveInfo.TotalSize` for the SD volume reports the card capacity instead of an unknown value, and the internal flash volume still reports unknown.

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dev Containers (changes related with Dev Containers, has no impact on code or features)
- [ ] Dependencies/declarations (update dependencies or assembly declarations and changes associated, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
